### PR TITLE
feat: EventStream 事件流机制 (#18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+.loop-state.json

--- a/docs/issue#0018.html
+++ b/docs/issue#0018.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0018</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block; font-size: 0.6875rem; font-weight: 500;
+      padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/18">#18</a> &mdash; EventStream 事件流机制（US-002） &mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Result 与 error 用同一个 resolvedCh + sync.Once 兑现</h3>
+      <p><strong>Ambiguity:</strong> 研究文档只说 "用 sync.Once + closed channel 表示就绪"，未定义失败路径如何表达。</p>
+      <p><strong>Choice:</strong> <code>SetResult</code> 与 <code>SetError</code> 共用一个 <code>resultOnce</code>，谁先调用谁生效，都 close 同一个 <code>resultCh</code>；<code>Result(ctx)</code> 返回 <code>(R, error)</code>。</p>
+      <p><strong>Rationale:</strong> agent loop 的终态可能是正常结束（agent_end→messages）或中断（aborted/error）。用统一的 once 保证结果只兑现一次，且 Result 的调用方一次拿到成功值或失败原因，语义清晰。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 保留 IsComplete/ExtractResult 回调，但允许显式 SetResult</h3>
+      <p><strong>Ambiguity:</strong> 研究文档提出两种等价路径（回调自动捕获 vs loop 内显式设置），未强制其一。</p>
+      <p><strong>Choice:</strong> 两者都支持——回调设为可选字段，Emit 时若命中 IsComplete 则自动 ExtractResult；provider 层可用回调，agent loop 可显式 SetResult。</p>
+      <p><strong>Rationale:</strong> 验收条件明确要求 "保留 isComplete/extractResult 回调字段"，同时显式 SetResult 更符合 Go 习惯，两条路径共存不冲突（都走 once）。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Close 无结果时兜底为 ErrStreamIncomplete</h3>
+      <p><strong>Spec:</strong> pi 的 <code>end(result?)</code> 允许无结果关闭，async iterator 自然终止。</p>
+      <p><strong>Implemented:</strong> <code>Close()</code> 若结果未兑现，用 <code>ErrStreamIncomplete</code> 兜底再关闭 channel。</p>
+      <p><strong>Why:</strong> Go 的 <code>Result(ctx)</code> 是阻塞调用，若生产者忘记 SetResult 就 Close，消费者会永久阻塞。兜底把 "异常结束" 显式化为可观测的 error，避免死锁。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 结果不走事件 channel，单独 resultCh 兑现</h3>
+      <p><strong>Alternatives:</strong> (A) 把最终结果作为最后一个事件推入 channel；(B) 独立 resultCh + sync.Once。</p>
+      <p><strong>Pros/Cons:</strong> A 实现简单，但消费者若提前 break 就永远拿不到结果，且类型 T≠R 无法共用 channel；B 多一个 channel，但消费与取结果解耦。</p>
+      <p><strong>Winner:</strong> B——研究文档明确 "不要把 result 也塞进事件 channel"，且 Result 可在不读完事件的情况下获取。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 默认 buffer=0 提供同步背压</h3>
+      <p><strong>Alternatives:</strong> 无缓冲（同步） vs 带缓冲 channel。</p>
+      <p><strong>Pros/Cons:</strong> 无缓冲精确对应 pi 的顺序 <code>await emit</code>，消费者慢则生产者阻塞（想要的背压）；缓冲会让生产者跑在消费者前面，事件与状态可能失步。</p>
+      <p><strong>Winner:</strong> 默认 0，但 <code>NewEventStream(buffer)</code> 保留调参余地（测试与 provider 层可按需加缓冲）。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> "listener settle 才算 run 结束" 语义暂简化</h3>
+      <p><strong>Assumption:</strong> 首版把 "channel 关闭即结束" 作为终点，未实现 pi 里 "agent_end 的 async listener settle 后才算结束" 的语义。</p>
+      <p><strong>Verify:</strong> 后续 runLoop（#23）接入时，确认消费方副作用是否需要在 Close 前同步完成；若需要，可能要加 listener 完成信号。研究文档已把此列为 "简化点"。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/smallnest/pigo
+
+go 1.27rc1

--- a/internal/agent/content.go
+++ b/internal/agent/content.go
@@ -1,0 +1,155 @@
+// Package agent defines the core data types and control flow for the pigo
+// agent harness, a Go reimplementation of the pi agent loop.
+//
+// This file defines the Content model: a sealed interface implemented by the
+// four content block kinds (text, thinking, toolCall, image). Because Go's
+// encoding/json cannot dispatch to an interface based on a discriminant field,
+// containers holding []Content implement custom UnmarshalJSON that peeks at the
+// "type" field and decodes into the concrete struct. Mirrors pi's discriminated
+// union (packages/ai/src/types.ts) as interface + type switch.
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Content is a sealed interface implemented by every content block kind.
+// Consumers dispatch with a type switch. The interface is sealed via the
+// unexported isContent marker so no type outside this package can satisfy it.
+type Content interface {
+	isContent()
+}
+
+// Content type discriminants, matching pi's wire format.
+const (
+	ContentTypeText     = "text"
+	ContentTypeThinking = "thinking"
+	ContentTypeToolCall = "toolCall"
+	ContentTypeImage    = "image"
+)
+
+// TextContent is a plain text block.
+type TextContent struct {
+	Type          string `json:"type"`
+	Text          string `json:"text"`
+	TextSignature string `json:"textSignature,omitempty"`
+}
+
+// ThinkingContent is a reasoning/thinking block. Never folded into text.
+type ThinkingContent struct {
+	Type              string `json:"type"`
+	Thinking          string `json:"thinking"`
+	ThinkingSignature string `json:"thinkingSignature,omitempty"`
+	Redacted          bool   `json:"redacted,omitempty"`
+}
+
+// ToolCallContent is a request from the model to invoke a tool. Arguments are
+// kept as raw JSON so validation (JSON Schema) and shaping happen downstream.
+type ToolCallContent struct {
+	Type             string          `json:"type"`
+	ID               string          `json:"id"`
+	Name             string          `json:"name"`
+	Arguments        json.RawMessage `json:"arguments"`
+	ThoughtSignature string          `json:"thoughtSignature,omitempty"`
+}
+
+// ImageContent is an image block (base64 data + mime type).
+type ImageContent struct {
+	Type     string `json:"type"`
+	Data     string `json:"data"`
+	MimeType string `json:"mimeType"`
+}
+
+func (TextContent) isContent()     {}
+func (ThinkingContent) isContent() {}
+func (ToolCallContent) isContent() {}
+func (ImageContent) isContent()    {}
+
+// Constructors set the Type discriminant so callers never desync it.
+
+// NewTextContent returns a TextContent with the type discriminant set.
+func NewTextContent(text string) TextContent {
+	return TextContent{Type: ContentTypeText, Text: text}
+}
+
+// NewThinkingContent returns a ThinkingContent with the type discriminant set.
+func NewThinkingContent(thinking string) ThinkingContent {
+	return ThinkingContent{Type: ContentTypeThinking, Thinking: thinking}
+}
+
+// NewToolCallContent returns a ToolCallContent with the type discriminant set.
+func NewToolCallContent(id, name string, arguments json.RawMessage) ToolCallContent {
+	return ToolCallContent{Type: ContentTypeToolCall, ID: id, Name: name, Arguments: arguments}
+}
+
+// NewImageContent returns an ImageContent with the type discriminant set.
+func NewImageContent(data, mimeType string) ImageContent {
+	return ImageContent{Type: ContentTypeImage, Data: data, MimeType: mimeType}
+}
+
+// decodeContent peeks at the "type" field of a JSON object and decodes it into
+// the matching concrete Content struct. This is the single dispatch point used
+// by every container that holds Content (messages, tool results, session
+// entries, provider parsing).
+func decodeContent(raw json.RawMessage) (Content, error) {
+	var probe struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return nil, fmt.Errorf("content: peek type: %w", err)
+	}
+	switch probe.Type {
+	case ContentTypeText:
+		var c TextContent
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return nil, err
+		}
+		return c, nil
+	case ContentTypeThinking:
+		var c ThinkingContent
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return nil, err
+		}
+		return c, nil
+	case ContentTypeToolCall:
+		var c ToolCallContent
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return nil, err
+		}
+		return c, nil
+	case ContentTypeImage:
+		var c ImageContent
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return nil, err
+		}
+		return c, nil
+	case "":
+		return nil, fmt.Errorf("content: missing type discriminant")
+	default:
+		return nil, fmt.Errorf("content: unknown type %q", probe.Type)
+	}
+}
+
+// ContentList is a slice of Content with discriminated JSON (un)marshalling.
+// Fields typed []Content in messages use this so decoding dispatches on "type".
+type ContentList []Content
+
+// UnmarshalJSON decodes a JSON array of content blocks, dispatching each element
+// on its "type" discriminant.
+func (cl *ContentList) UnmarshalJSON(data []byte) error {
+	var raws []json.RawMessage
+	if err := json.Unmarshal(data, &raws); err != nil {
+		return err
+	}
+	out := make(ContentList, 0, len(raws))
+	for i, raw := range raws {
+		c, err := decodeContent(raw)
+		if err != nil {
+			return fmt.Errorf("content[%d]: %w", i, err)
+		}
+		out = append(out, c)
+	}
+	*cl = out
+	return nil
+}

--- a/internal/agent/event.go
+++ b/internal/agent/event.go
@@ -1,0 +1,105 @@
+package agent
+
+// AgentEvent is the sealed interface implemented by every event the loop emits.
+// Consumers dispatch with a type switch, consistent with Content. pigo covers
+// all 10 of pi's event types (PRD FR-24).
+type AgentEvent interface {
+	isAgentEvent()
+	// EventType returns the discriminant string, useful for logging and for
+	// serialising events to the stream-json/stdio protocol (US-020).
+	EventType() string
+}
+
+// Event type discriminants.
+const (
+	EventAgentStart          = "agent_start"
+	EventAgentEnd            = "agent_end"
+	EventTurnStart           = "turn_start"
+	EventTurnEnd             = "turn_end"
+	EventMessageStart        = "message_start"
+	EventMessageUpdate       = "message_update"
+	EventMessageEnd          = "message_end"
+	EventToolExecutionStart  = "tool_execution_start"
+	EventToolExecutionUpdate = "tool_execution_update"
+	EventToolExecutionEnd    = "tool_execution_end"
+)
+
+// AgentStartEvent is emitted once when a loop run begins.
+type AgentStartEvent struct{}
+
+// AgentEndEvent is emitted once when a loop run ends, carrying the messages
+// newly produced during this run (the EventStream result).
+type AgentEndEvent struct {
+	Messages []AgentMessage
+}
+
+// TurnStartEvent marks the start of a turn (a single assistant response cycle).
+type TurnStartEvent struct{}
+
+// TurnEndEvent marks the end of a turn, with the assistant message and any tool
+// results produced during it.
+type TurnEndEvent struct {
+	Message     AssistantMessage
+	ToolResults []ToolResultMessage
+}
+
+// MessageStartEvent is emitted when a message begins streaming.
+type MessageStartEvent struct {
+	Message AgentMessage
+}
+
+// MessageUpdateEvent is emitted for each streaming delta, carrying the current
+// partial message and the raw provider-level event that produced it.
+type MessageUpdateEvent struct {
+	Message               AgentMessage
+	AssistantMessageEvent any
+}
+
+// MessageEndEvent is emitted when a message finishes streaming.
+type MessageEndEvent struct {
+	Message AgentMessage
+}
+
+// ToolExecutionStartEvent is emitted before a tool runs.
+type ToolExecutionStartEvent struct {
+	ToolCallID string
+	ToolName   string
+	Args       any
+}
+
+// ToolExecutionUpdateEvent carries a partial result during tool execution.
+type ToolExecutionUpdateEvent struct {
+	ToolCallID    string
+	ToolName      string
+	PartialResult AgentToolResult
+}
+
+// ToolExecutionEndEvent is emitted when a tool finishes.
+type ToolExecutionEndEvent struct {
+	ToolCallID string
+	ToolName   string
+	Result     AgentToolResult
+	IsError    bool
+}
+
+func (AgentStartEvent) isAgentEvent()          {}
+func (AgentEndEvent) isAgentEvent()            {}
+func (TurnStartEvent) isAgentEvent()           {}
+func (TurnEndEvent) isAgentEvent()             {}
+func (MessageStartEvent) isAgentEvent()        {}
+func (MessageUpdateEvent) isAgentEvent()       {}
+func (MessageEndEvent) isAgentEvent()          {}
+func (ToolExecutionStartEvent) isAgentEvent()  {}
+func (ToolExecutionUpdateEvent) isAgentEvent() {}
+func (ToolExecutionEndEvent) isAgentEvent()    {}
+
+func (AgentStartEvent) EventType() string          { return EventAgentStart }
+func (AgentEndEvent) EventType() string            { return EventAgentEnd }
+func (TurnStartEvent) EventType() string           { return EventTurnStart }
+func (TurnEndEvent) EventType() string             { return EventTurnEnd }
+func (MessageStartEvent) EventType() string        { return EventMessageStart }
+func (MessageUpdateEvent) EventType() string       { return EventMessageUpdate }
+func (MessageEndEvent) EventType() string          { return EventMessageEnd }
+func (ToolExecutionStartEvent) EventType() string  { return EventToolExecutionStart }
+func (ToolExecutionUpdateEvent) EventType() string { return EventToolExecutionUpdate }
+func (ToolExecutionEndEvent) EventType() string    { return EventToolExecutionEnd }

--- a/internal/agent/event_stream.go
+++ b/internal/agent/event_stream.go
@@ -1,0 +1,121 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// EventStream is the Go equivalent of pi's EventStream<T,R>: a producer pushes
+// events onto a channel while a consumer ranges over them, and a terminal event
+// yields a final result R. It replaces pi's async generator (event-stream.ts).
+//
+// Design (research §2.2):
+//   - Iteration: Events() returns <-chan T for `for ev := range s.Events()`.
+//   - Result: Result(ctx) blocks until the producer sets a result (or the
+//     stream fails/cancels). The result is NOT sent on the event channel, so a
+//     consumer that stops reading events can still obtain it.
+//   - Cancellation: the producer selects on ctx.Done() when sending, so a
+//     consumer that stops reading never leaks the producer goroutine.
+//
+// pi's isComplete/extractResult callbacks are retained as optional fields so a
+// producer can let the stream detect the terminal event itself; a producer may
+// instead call SetResult explicitly (more Go-idiomatic). Either path resolves
+// Result exactly once.
+type EventStream[T any, R any] struct {
+	ch chan T
+
+	// IsComplete reports whether an event is the terminal one. Optional: if
+	// set, Emit auto-captures the result via ExtractResult when it returns true.
+	IsComplete func(event T) bool
+	// ExtractResult derives the final result from the terminal event. Required
+	// when IsComplete is set.
+	ExtractResult func(event T) R
+
+	resultOnce sync.Once
+	result     R
+	resultErr  error
+	resultCh   chan struct{} // closed once result (or resultErr) is set
+}
+
+// ErrStreamIncomplete is returned by Result when the event channel closed
+// without any result being set (the producer ended abnormally without a
+// terminal event).
+var ErrStreamIncomplete = errors.New("agent: event stream ended without a result")
+
+// NewEventStream constructs an EventStream with the given channel buffer size.
+// A buffer of 0 gives fully synchronous back-pressure (each Emit blocks until a
+// consumer receives), matching pi's sequential `await emit(...)`.
+func NewEventStream[T any, R any](buffer int) *EventStream[T, R] {
+	if buffer < 0 {
+		buffer = 0
+	}
+	return &EventStream[T, R]{
+		ch:       make(chan T, buffer),
+		resultCh: make(chan struct{}),
+	}
+}
+
+// Events returns the receive-only event channel. Ranging over it terminates
+// when the producer calls Close.
+func (s *EventStream[T, R]) Events() <-chan T { return s.ch }
+
+// Emit sends an event to consumers, honoring cancellation. If ctx is cancelled
+// before the event is received, Emit returns ctx.Err() and the event is
+// dropped. When IsComplete is configured and reports true for the event, the
+// result is captured (once) before the send.
+func (s *EventStream[T, R]) Emit(ctx context.Context, event T) error {
+	if s.IsComplete != nil && s.IsComplete(event) && s.ExtractResult != nil {
+		s.SetResult(s.ExtractResult(event))
+	}
+	select {
+	case s.ch <- event:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// SetResult records the final result. Only the first call wins; later calls
+// (including SetError) are no-ops. Safe to call before Close.
+func (s *EventStream[T, R]) SetResult(result R) {
+	s.resultOnce.Do(func() {
+		s.result = result
+		close(s.resultCh)
+	})
+}
+
+// SetError records a terminal error as the stream's outcome. Only the first
+// call among SetResult/SetError wins.
+func (s *EventStream[T, R]) SetError(err error) {
+	s.resultOnce.Do(func() {
+		s.resultErr = err
+		close(s.resultCh)
+	})
+}
+
+// Close closes the event channel, ending consumer iteration. If no result was
+// set, Result will report ErrStreamIncomplete. Call exactly once from the
+// producer after the last Emit.
+func (s *EventStream[T, R]) Close() {
+	// Ensure a waiting Result never blocks forever if the producer forgot to
+	// set a result.
+	s.resultOnce.Do(func() {
+		s.resultErr = ErrStreamIncomplete
+		close(s.resultCh)
+	})
+	close(s.ch)
+}
+
+// Result blocks until the producer sets a result/error, ctx is cancelled, or
+// the stream closes without a result. It is safe to call concurrently and
+// returns the same outcome on every call.
+func (s *EventStream[T, R]) Result(ctx context.Context) (R, error) {
+	select {
+	case <-s.resultCh:
+		return s.result, s.resultErr
+	case <-ctx.Done():
+		var zero R
+		return zero, ctx.Err()
+	}
+}

--- a/internal/agent/event_stream_test.go
+++ b/internal/agent/event_stream_test.go
@@ -1,0 +1,121 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestEventStreamNormalCompletion drives a producer that emits events and sets
+// a result, then verifies the consumer sees every event and Result yields the
+// captured value.
+func TestEventStreamNormalCompletion(t *testing.T) {
+	s := NewEventStream[AgentEvent, []AgentMessage](0)
+	want := []AgentMessage{
+		UserMessage{RoleField: RoleUser, Content: ContentList{NewTextContent("hi")}},
+	}
+
+	go func() {
+		ctx := context.Background()
+		_ = s.Emit(ctx, TurnStartEvent{})
+		_ = s.Emit(ctx, AgentEndEvent{Messages: want})
+		s.SetResult(want)
+		s.Close()
+	}()
+
+	var got int
+	for range s.Events() {
+		got++
+	}
+	if got != 2 {
+		t.Fatalf("want 2 events, got %d", got)
+	}
+	res, err := s.Result(context.Background())
+	if err != nil {
+		t.Fatalf("result: %v", err)
+	}
+	if len(res) != 1 || res[0].Role() != RoleUser {
+		t.Fatalf("result payload wrong: %+v", res)
+	}
+}
+
+// TestEventStreamIsCompleteCallback verifies the isComplete/extractResult
+// callbacks auto-capture the result on the terminal event.
+func TestEventStreamIsCompleteCallback(t *testing.T) {
+	s := NewEventStream[AgentEvent, []AgentMessage](4)
+	s.IsComplete = func(e AgentEvent) bool { return e.EventType() == EventAgentEnd }
+	s.ExtractResult = func(e AgentEvent) []AgentMessage { return e.(AgentEndEvent).Messages }
+
+	msgs := []AgentMessage{AssistantMessage{RoleField: RoleAssistant}}
+	go func() {
+		ctx := context.Background()
+		_ = s.Emit(ctx, MessageStartEvent{})
+		_ = s.Emit(ctx, AgentEndEvent{Messages: msgs})
+		s.Close()
+	}()
+
+	for range s.Events() {
+	}
+	res, err := s.Result(context.Background())
+	if err != nil {
+		t.Fatalf("result: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("want 1 msg from extractResult, got %d", len(res))
+	}
+}
+
+// TestEventStreamCancellation verifies that a cancelled context unblocks a
+// producer stuck on Emit (consumer stopped reading) and that Result returns the
+// context error.
+func TestEventStreamCancellation(t *testing.T) {
+	s := NewEventStream[AgentEvent, []AgentMessage](0)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	emitErr := make(chan error, 1)
+	go func() {
+		// First emit has no consumer; it blocks until cancel.
+		emitErr <- s.Emit(ctx, TurnStartEvent{})
+	}()
+
+	// Give the producer a moment to block on the send, then cancel.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-emitErr:
+		if err == nil {
+			t.Fatal("expected Emit to return ctx error on cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Emit did not unblock after cancel (goroutine leak)")
+	}
+
+	// Result with a cancelled context returns promptly with the ctx error.
+	if _, err := s.Result(ctx); err == nil {
+		t.Fatal("expected Result to return ctx error")
+	}
+}
+
+// TestEventStreamIncompleteClose verifies Close without a result yields
+// ErrStreamIncomplete.
+func TestEventStreamIncompleteClose(t *testing.T) {
+	s := NewEventStream[AgentEvent, []AgentMessage](1)
+	s.Close()
+	if _, err := s.Result(context.Background()); err != ErrStreamIncomplete {
+		t.Fatalf("want ErrStreamIncomplete, got %v", err)
+	}
+}
+
+// TestEventStreamSetErrorWins verifies SetError is reported and later SetResult
+// is ignored (first outcome wins).
+func TestEventStreamSetErrorWins(t *testing.T) {
+	s := NewEventStream[AgentEvent, []AgentMessage](1)
+	sentinel := context.Canceled
+	s.SetError(sentinel)
+	s.SetResult(nil)
+	s.Close()
+	if _, err := s.Result(context.Background()); err != sentinel {
+		t.Fatalf("want sentinel error, got %v", err)
+	}
+}

--- a/internal/agent/hooks.go
+++ b/internal/agent/hooks.go
@@ -1,0 +1,43 @@
+package agent
+
+// ThinkingLevel is the unified reasoning-effort enum (agent layer). It keeps
+// pi's full 6 levels; providers map it to their own wire format via a
+// per-model ThinkingLevelMap (decision #10).
+type ThinkingLevel string
+
+const (
+	ThinkingOff     ThinkingLevel = "off"
+	ThinkingMinimal ThinkingLevel = "minimal"
+	ThinkingLow     ThinkingLevel = "low"
+	ThinkingMedium  ThinkingLevel = "medium"
+	ThinkingHigh    ThinkingLevel = "high"
+	ThinkingXHigh   ThinkingLevel = "xhigh"
+)
+
+// ThinkingLevelMap maps a unified level to a provider-specific wire value.
+// A nil value means "supported but disabled at this level"; an absent key means
+// "this level is not supported by the model". The pointer is what distinguishes
+// those two cases, so it must stay *string.
+type ThinkingLevelMap map[ThinkingLevel]*string
+
+// AfterToolCallResult is the optional override returned by the afterToolCall
+// hook. Every field is a pointer so the loop can distinguish "not provided"
+// (nil) from "provided, possibly zero" — pi expresses this with `??`, Go needs
+// pointers. Fields are applied with field-level replacement, no deep merge
+// (FR-5).
+type AfterToolCallResult struct {
+	Content   *ContentList
+	Details   *any
+	Terminate *bool
+	IsError   *bool
+}
+
+// AgentLoopTurnUpdate is the optional result of the prepareNextTurn hook: it can
+// swap the context, model, or thinking level for the next turn. Pointer fields
+// distinguish "not provided" from an explicit value; ThinkingLevel is
+// three-state (nil = keep, &"off" = disable, &level = set).
+type AgentLoopTurnUpdate struct {
+	Context       *AgentContext
+	Model         *string
+	ThinkingLevel *ThinkingLevel
+}

--- a/internal/agent/message.go
+++ b/internal/agent/message.go
@@ -1,0 +1,160 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Message roles, matching pi's wire format.
+const (
+	RoleUser       = "user"
+	RoleAssistant  = "assistant"
+	RoleToolResult = "toolResult"
+)
+
+// Message is the sealed interface implemented by the three message roles.
+// AgentMessage (the loop's message abstraction) is simply Message: custom
+// message kinds implement the same interface and convertToLlm filters out any
+// that are not LLM-bound. This deliberately replaces pi's declaration merging,
+// which has no Go equivalent.
+type Message interface {
+	isMessage()
+	// Role returns the discriminant ("user" | "assistant" | "toolResult").
+	Role() string
+}
+
+// AgentMessage is the loop-level message type. It is the same as Message; the
+// alias documents intent at call sites that deal with the loop rather than raw
+// LLM messages.
+type AgentMessage = Message
+
+// Usage reports token accounting for an assistant response.
+type Usage struct {
+	InputTokens  int `json:"inputTokens"`
+	OutputTokens int `json:"outputTokens"`
+}
+
+// UserMessage is input from the user. Content is restricted at construction to
+// text/image blocks (runtime constraint, not a separate interface).
+type UserMessage struct {
+	RoleField string      `json:"role"`
+	Content   ContentList `json:"content"`
+	Timestamp int64       `json:"timestamp"`
+}
+
+func (UserMessage) isMessage()     {}
+func (m UserMessage) Role() string { return RoleUser }
+
+// AssistantMessage is a model response. Content may hold text/thinking/toolCall
+// blocks. StopReason follows pi's set (end_turn/tool_use/length/error/aborted).
+type AssistantMessage struct {
+	RoleField    string      `json:"role"`
+	Content      ContentList `json:"content"`
+	API          string      `json:"api,omitempty"`
+	Provider     string      `json:"provider,omitempty"`
+	Model        string      `json:"model,omitempty"`
+	Usage        *Usage      `json:"usage,omitempty"`
+	StopReason   string      `json:"stopReason,omitempty"`
+	ErrorMessage string      `json:"errorMessage,omitempty"`
+	Timestamp    int64       `json:"timestamp"`
+
+	// Optional diagnostics, kept for cross-provider replay/observability.
+	ResponseModel string `json:"responseModel,omitempty"`
+	ResponseID    string `json:"responseId,omitempty"`
+}
+
+func (AssistantMessage) isMessage()     {}
+func (m AssistantMessage) Role() string { return RoleAssistant }
+
+// ToolCalls returns the tool call blocks in this assistant message, in order.
+func (m AssistantMessage) ToolCalls() []ToolCallContent {
+	var calls []ToolCallContent
+	for _, c := range m.Content {
+		if tc, ok := c.(ToolCallContent); ok {
+			calls = append(calls, tc)
+		}
+	}
+	return calls
+}
+
+// ToolResultMessage carries the outcome of executing a single tool call.
+// Content is restricted to text/image blocks at construction.
+type ToolResultMessage struct {
+	RoleField  string      `json:"role"`
+	ToolCallID string      `json:"toolCallId"`
+	ToolName   string      `json:"toolName"`
+	Content    ContentList `json:"content"`
+	Details    any         `json:"details,omitempty"`
+	IsError    bool        `json:"isError"`
+	Timestamp  int64       `json:"timestamp"`
+}
+
+func (ToolResultMessage) isMessage()     {}
+func (m ToolResultMessage) Role() string { return RoleToolResult }
+
+// StopReason values, matching pi.
+const (
+	StopReasonEndTurn = "end_turn"
+	StopReasonToolUse = "tool_use"
+	StopReasonLength  = "length"
+	StopReasonError   = "error"
+	StopReasonAborted = "aborted"
+)
+
+// MessageList is a slice of Message with discriminated JSON (un)marshalling,
+// dispatching on the "role" field. Used by AgentContext and session persistence.
+type MessageList []Message
+
+// UnmarshalJSON decodes a JSON array of messages, dispatching each element on
+// its "role" discriminant.
+func (ml *MessageList) UnmarshalJSON(data []byte) error {
+	var raws []json.RawMessage
+	if err := json.Unmarshal(data, &raws); err != nil {
+		return err
+	}
+	out := make(MessageList, 0, len(raws))
+	for i, raw := range raws {
+		m, err := decodeMessage(raw)
+		if err != nil {
+			return fmt.Errorf("message[%d]: %w", i, err)
+		}
+		out = append(out, m)
+	}
+	*ml = out
+	return nil
+}
+
+// decodeMessage peeks at the "role" field and decodes into the matching
+// concrete message struct.
+func decodeMessage(raw json.RawMessage) (Message, error) {
+	var probe struct {
+		Role string `json:"role"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return nil, fmt.Errorf("peek role: %w", err)
+	}
+	switch probe.Role {
+	case RoleUser:
+		var m UserMessage
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return nil, err
+		}
+		return m, nil
+	case RoleAssistant:
+		var m AssistantMessage
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return nil, err
+		}
+		return m, nil
+	case RoleToolResult:
+		var m ToolResultMessage
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return nil, err
+		}
+		return m, nil
+	case "":
+		return nil, fmt.Errorf("missing role discriminant")
+	default:
+		return nil, fmt.Errorf("unknown role %q", probe.Role)
+	}
+}

--- a/internal/agent/tool.go
+++ b/internal/agent/tool.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// AgentContext is the input state for a loop run: system prompt, conversation
+// messages, and the tools available to the model.
+type AgentContext struct {
+	SystemPrompt string      `json:"systemPrompt"`
+	Messages     MessageList `json:"messages"`
+	Tools        []AgentTool `json:"-"`
+}
+
+// ToolExecutionMode selects how a tool is executed relative to others in a batch.
+type ToolExecutionMode string
+
+const (
+	// ToolExecutionParallel allows the tool to run concurrently with others.
+	ToolExecutionParallel ToolExecutionMode = "parallel"
+	// ToolExecutionSequential forces the whole batch to run serially.
+	ToolExecutionSequential ToolExecutionMode = "sequential"
+)
+
+// ToolUpdateFunc receives a partial result during tool execution; the loop
+// turns each call into a tool_execution_update event.
+type ToolUpdateFunc func(partial AgentToolResult)
+
+// AgentTool is a tool the model can invoke. Schema is the JSON Schema used to
+// validate arguments before execution (US-014).
+type AgentTool interface {
+	Name() string
+	Description() string
+	// Schema returns the JSON Schema (as raw JSON) for the tool's arguments.
+	Schema() json.RawMessage
+	// ExecutionMode reports whether this tool forces sequential execution.
+	ExecutionMode() ToolExecutionMode
+	// Execute runs the tool. onUpdate may be nil.
+	Execute(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error)
+}
+
+// AgentToolCall is a decoded request to invoke a tool (the loop-level view of a
+// ToolCallContent block).
+type AgentToolCall struct {
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// AgentToolResult is the outcome of executing a tool.
+//
+// Details uses `any` in the first version (matching pi's internal
+// AgentToolResult<any>); a generic form can be added later. Terminate is a
+// *bool so "not set" is distinguishable from an explicit false — the loop only
+// signals early termination when every result in a batch has Terminate=true.
+type AgentToolResult struct {
+	Content   ContentList `json:"content"`
+	Details   any         `json:"details,omitempty"`
+	Terminate *bool       `json:"terminate,omitempty"`
+}

--- a/internal/agent/types_test.go
+++ b/internal/agent/types_test.go
@@ -1,0 +1,131 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestContentListRoundTrip(t *testing.T) {
+	in := ContentList{
+		NewTextContent("hello"),
+		NewThinkingContent("pondering"),
+		NewToolCallContent("call_1", "read", json.RawMessage(`{"path":"a.go"}`)),
+		NewImageContent("YmFzZTY0", "image/png"),
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out ContentList
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out) != 4 {
+		t.Fatalf("want 4 blocks, got %d", len(out))
+	}
+	if _, ok := out[0].(TextContent); !ok {
+		t.Errorf("block 0: want TextContent, got %T", out[0])
+	}
+	if _, ok := out[1].(ThinkingContent); !ok {
+		t.Errorf("block 1: want ThinkingContent, got %T", out[1])
+	}
+	tc, ok := out[2].(ToolCallContent)
+	if !ok {
+		t.Fatalf("block 2: want ToolCallContent, got %T", out[2])
+	}
+	if tc.ID != "call_1" || tc.Name != "read" {
+		t.Errorf("toolCall fields lost: %+v", tc)
+	}
+	if string(tc.Arguments) != `{"path":"a.go"}` {
+		t.Errorf("arguments lost: %s", tc.Arguments)
+	}
+	if _, ok := out[3].(ImageContent); !ok {
+		t.Errorf("block 3: want ImageContent, got %T", out[3])
+	}
+}
+
+func TestContentUnknownTypeRejected(t *testing.T) {
+	var out ContentList
+	err := json.Unmarshal([]byte(`[{"type":"bogus"}]`), &out)
+	if err == nil {
+		t.Fatal("expected error for unknown content type")
+	}
+}
+
+func TestContentMissingTypeRejected(t *testing.T) {
+	var out ContentList
+	err := json.Unmarshal([]byte(`[{"text":"no type"}]`), &out)
+	if err == nil {
+		t.Fatal("expected error for missing type discriminant")
+	}
+}
+
+func TestMessageListRoundTrip(t *testing.T) {
+	term := true
+	_ = term
+	in := MessageList{
+		UserMessage{RoleField: RoleUser, Content: ContentList{NewTextContent("hi")}, Timestamp: 1},
+		AssistantMessage{
+			RoleField:  RoleAssistant,
+			Content:    ContentList{NewTextContent("ok"), NewToolCallContent("c1", "ls", json.RawMessage(`{}`))},
+			StopReason: StopReasonToolUse,
+			Timestamp:  2,
+		},
+		ToolResultMessage{RoleField: RoleToolResult, ToolCallID: "c1", ToolName: "ls", Content: ContentList{NewTextContent("file.go")}, Timestamp: 3},
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out MessageList
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("want 3 messages, got %d", len(out))
+	}
+	if out[0].Role() != RoleUser {
+		t.Errorf("msg 0: want user, got %s", out[0].Role())
+	}
+	am, ok := out[1].(AssistantMessage)
+	if !ok {
+		t.Fatalf("msg 1: want AssistantMessage, got %T", out[1])
+	}
+	if calls := am.ToolCalls(); len(calls) != 1 || calls[0].Name != "ls" {
+		t.Errorf("assistant ToolCalls wrong: %+v", calls)
+	}
+	if out[2].Role() != RoleToolResult {
+		t.Errorf("msg 2: want toolResult, got %s", out[2].Role())
+	}
+}
+
+func TestMessageUnknownRoleRejected(t *testing.T) {
+	var out MessageList
+	if err := json.Unmarshal([]byte(`[{"role":"system"}]`), &out); err == nil {
+		t.Fatal("expected error for unknown role")
+	}
+}
+
+// TestAgentEventCoverage asserts all 10 event types report a distinct,
+// non-empty discriminant (PRD FR-24).
+func TestAgentEventCoverage(t *testing.T) {
+	events := []AgentEvent{
+		AgentStartEvent{}, AgentEndEvent{}, TurnStartEvent{}, TurnEndEvent{},
+		MessageStartEvent{}, MessageUpdateEvent{}, MessageEndEvent{},
+		ToolExecutionStartEvent{}, ToolExecutionUpdateEvent{}, ToolExecutionEndEvent{},
+	}
+	seen := map[string]bool{}
+	for _, e := range events {
+		et := e.EventType()
+		if et == "" {
+			t.Errorf("%T has empty EventType", e)
+		}
+		if seen[et] {
+			t.Errorf("duplicate event type %q", et)
+		}
+		seen[et] = true
+	}
+	if len(seen) != 10 {
+		t.Fatalf("want 10 distinct event types, got %d", len(seen))
+	}
+}

--- a/tasks/prd-pigo-agent.md
+++ b/tasks/prd-pigo-agent.md
@@ -1,0 +1,404 @@
+# PRD: pigo — 用 Go 复刻 pi Agent Harness
+
+## Introduction
+
+pigo 是用 Go 语言重新实现的 pi agent harness。目标是把 pi（一套 TypeScript/Node.js 实现的、可自我扩展的编码 agent）的**设计思路和核心控制流严格复刻到 Go**，形成一个原生编译、单二进制分发、无 Node 运行时依赖的编码 agent。
+
+pi 本身是一个 monorepo，分为五层：`pi-ai`（多厂商 LLM 统一 API）、`pi-agent-core`（agent 运行时 / loop）、`pi-tui`（终端 UI）、`pi-coding-agent`（面向用户的 `pi` CLI）、`pi-orchestrator`（多 agent 编排）。pigo 将逐层对标这套分层。
+
+关键约束（源自前期技术讨论）：
+- **agent loop 严格复刻 pi**：双层循环 + 三段式工具执行（prepare → execute → finalize）+ 完整钩子体系（beforeToolCall / afterToolCall / prepareNextTurn / shouldStopAfterTurn / getSteeringMessages / getFollowUpMessages）。这是 pi 最核心、最值得原样保留的资产。
+- **语言差异需重新设计而非直译**：TS 的 async generator → Go channel；Promise.all 保序并行 → goroutine + 按 index 回填；discriminated union → interface + type switch；typebox 运行时泛型校验 → JSON Schema 运行时校验。
+- **TUI 参考 zero（Gitlawb/zero，Go 实现的类似 agent），不自研差分渲染**，底层可用 charmbracelet/bubbletea 生态。
+- **Provider 层的接口设计参考 pi，具体 Go 实现可参考 zero**。
+
+读者假设：本文面向初级开发者或 AI agent，术语首次出现时给出解释。
+
+参考代码：
+- pi agent: /Users/chaoyuepan/ai/pi
+- zero (go coding agent): https://github.com/Gitlawb/zero
+
+## Goals
+
+- 用 Go 实现一个可运行的编码 agent，命令行下能完成多轮对话 + 工具调用（读写文件、执行命令、搜索）。
+- **严格复刻 pi 的 agent loop 控制流**：双层循环、三段式工具执行、全部六个钩子的语义与调用时机与 pi 一致。
+- 提供统一的 `Provider` 抽象，支持多厂商 LLM（对齐 pi 的 provider 覆盖面），首要保证流式响应正确。
+- 工具参数用 **JSON Schema 运行时校验**，对齐 pi 的 typebox 设计意图（模型给的参数在执行前被校验/拒绝）。
+- 提供交互式 TUI（参考 zero 的 Go 实现）与 headless/stdio 两种运行模式。
+- 全量对标 pi：会话持久化、配置系统、多 agent 编排（orchestrator）、MCP、sandbox/安全等能力纳入路线图（分阶段交付）。
+- 单二进制分发，无 Node 运行时依赖。
+
+## User Stories
+
+> 编号规则：US-NNN。每个 US 尽量可在一个专注的开发会话内完成，且可独立实现。UI 相关 story 需包含"可视化验证"。pigo 是命令行/TUI 项目，"浏览器验证"不适用，改为"在真实终端运行验证"。
+
+### 阶段一：核心 loop 与类型基座（对标 pi-agent-core）
+
+### US-001: 定义核心消息与上下文类型
+**Description:** 作为开发者，我需要在 Go 中定义与 pi 对齐的核心类型，作为整个 loop 的数据基座。
+
+**Acceptance Criteria:**
+- [ ] 定义 `Message` 相关类型：user / assistant / toolResult 三种角色，assistant 消息 content 支持 text / thinking / toolCall 块（对应 pi 的 discriminated union，用 interface + type switch 或 tagged struct 实现）
+- [ ] 定义 `AgentContext`（systemPrompt / messages / tools）、`AgentTool`、`AgentToolCall`、`AgentToolResult`、`AgentEvent`
+- [ ] `AgentEvent` 覆盖 pi 的全部事件类型：agent_start / agent_end / turn_start / turn_end / message_start / message_update / message_end / tool_execution_start / tool_execution_update / tool_execution_end
+- [ ] `AgentToolResult` 含 content / details / terminate 字段，语义与 pi 一致
+- [ ] `go build ./...` 通过，`go vet` 无告警
+
+### US-002: 实现流式事件通道（对标 EventStream / async generator）
+**Description:** 作为开发者，我需要一个基于 channel 的事件流机制，替代 pi 的 async generator，用于 loop 向外发送事件。
+
+**Acceptance Criteria:**
+- [ ] 提供 `EventSink`（emit 单个事件）与事件流读取端，基于 `chan AgentEvent` 实现
+- [ ] 支持 context 取消（`context.Context` / abort signal 等价物）
+- [ ] loop 结束时能返回最终 `[]AgentMessage`（对应 pi EventStream 的 result）
+- [ ] 有单元测试覆盖：正常结束、取消中断两种路径
+- [ ] `go test ./...` 通过
+
+### US-003: 实现单个 assistant 响应的流式处理
+**Description:** 作为开发者，我需要复刻 pi 的 `streamAssistantResponse`，把上下文转换为 provider 请求并流式回填 partial 消息。
+
+**Acceptance Criteria:**
+- [ ] 调用前执行 `transformContext`（可选）与 `convertToLlm`，与 pi 顺序一致
+- [ ] 通过 `getApiKey` 动态解析 API key（支持过期 token 场景），解析不到时回退到静态 key
+- [ ] 流式过程中把 partial assistant 消息实时更新进 context，并发出 message_start / message_update / message_end 事件
+- [ ] done / error 事件后返回最终 assistant 消息（含 stopReason）
+- [ ] 有单元测试用 fake provider 覆盖流式回填
+- [ ] `go test ./...` 通过
+
+### US-004: 实现工具调用三段式（prepare → execute → finalize）
+**Description:** 作为开发者，我需要严格复刻 pi 的工具执行三段式，含 beforeToolCall / afterToolCall 钩子。
+
+**Acceptance Criteria:**
+- [ ] `prepare`：查工具注册表 → `prepareArguments`（可选）→ JSON Schema 校验参数 → `beforeToolCall` 钩子（返回 block 则不执行，产出 error tool result）
+- [ ] `execute`：调用工具，支持通过 update callback 发出 tool_execution_update；抛错时转为 error tool result 而非 panic
+- [ ] `finalize`：`afterToolCall` 钩子可按字段覆盖 content / details / isError / terminate（无深合并，与 pi 一致）
+- [ ] 工具未找到、参数校验失败、abort 均产出对应的 error tool result
+- [ ] 有单元测试覆盖：正常执行、block、校验失败、afterToolCall 覆盖、terminate
+- [ ] `go test ./...` 通过
+
+### US-005: 实现并行与串行工具执行
+**Description:** 作为开发者，我需要复刻 pi 的两种工具执行模式，并保证并行时结果保序。
+
+**Acceptance Criteria:**
+- [ ] `sequential` 模式：逐个 prepare→execute→finalize，遇 abort 中断
+- [ ] `parallel` 模式：先顺序 prepare，再并发执行允许的工具（goroutine），最终 tool-result 消息按 assistant 源顺序输出（保序）
+- [ ] 任一工具的 `executionMode == "sequential"` 或全局配置为 sequential 时，整批走串行
+- [ ] `terminate`：仅当整批每个 finalized 结果都 terminate=true 时才提示终止（与 pi 一致）
+- [ ] 有单元测试验证并行保序与整批 terminate 语义
+- [ ] `go test ./...` 通过
+
+### US-006: 实现双层主循环（runLoop）
+**Description:** 作为开发者，我需要严格复刻 pi 的双层 agent 循环，串起流式响应、工具执行与钩子。
+
+**Acceptance Criteria:**
+- [ ] 内层循环：处理 pending/steering 消息 → 流式 assistant 响应 → 执行工具调用 → 回灌结果，直到无更多 tool call
+- [ ] 外层循环：内层结束后拉取 `getFollowUpMessages`，有则作为 pending 继续，无则退出
+- [ ] 每轮 turn_end 后调用 `prepareNextTurn`（可替换 context / model / thinkingLevel）与 `shouldStopAfterTurn`（返回 true 则发 agent_end 并退出）
+- [ ] `getSteeringMessages` 在每轮工具执行后被拉取并注入下一轮之前
+- [ ] `stopReason == "length"`（输出被 token 上限截断）时，该消息的所有 tool call 一律判失败，提示模型重发（复刻 `failToolCallsFromTruncatedMessage`）
+- [ ] stopReason 为 error / aborted 时发 turn_end + agent_end 并退出
+- [ ] 提供 `agentLoop`（新 prompt 启动）与 `agentLoopContinue`（从现有 context 续跑）两个入口，续跑入口校验最后一条消息不是 assistant
+- [ ] 有集成测试用 fake provider 驱动一次"文本→工具调用→文本"的完整多轮
+- [ ] `go test ./...` 通过
+
+### 阶段二：Provider 层（对标 pi-ai）
+
+### US-007: 定义 Provider 接口与流式契约
+**Description:** 作为开发者，我需要一个统一的 `Provider` 接口，屏蔽各厂商差异。
+
+**Acceptance Criteria:**
+- [ ] 定义 `Provider` 接口，核心方法为流式 completion（输入 model + context + options，输出事件流）
+- [ ] 流式契约与 pi 的 `StreamFn` 一致：不通过抛错/reject 表达请求失败，而是在流内以事件 + 终态 assistant 消息（stopReason=error/aborted + errorMessage）表达
+- [ ] 定义 `Model` 元数据结构（provider / id / 能力标记如是否支持 thinking / 上下文窗口等）
+- [ ] `go build ./...` 通过
+
+### US-008: 实现 Anthropic provider（流式）
+**Description:** 作为用户，我希望 pigo 能通过 Anthropic Claude 完成对话与工具调用。
+
+**Acceptance Criteria:**
+- [ ] 实现 Anthropic Messages API 的流式请求，正确解析 text / thinking / tool_use 增量
+- [ ] 正确上报 usage（输入/输出 token）
+- [ ] 正确映射 stopReason（含 length / tool_use / end_turn）
+- [ ] 网络错误、限流、鉴权失败以流内终态 error 消息表达而非 panic
+- [ ] 有针对 SSE 解析的单元测试（用录制的 fixture）
+- [ ] `go test ./...` 通过
+
+### US-009: 实现 OpenAI 兼容 provider（流式）
+**Description:** 作为用户，我希望 pigo 支持 OpenAI 及 OpenAI 兼容接口（含大量第三方网关）。
+
+**Acceptance Criteria:**
+- [ ] 实现 OpenAI Chat Completions（或 Responses）流式，解析 tool_calls 增量与文本增量
+- [ ] 支持自定义 base URL（覆盖 OpenAI 兼容的第三方 provider）
+- [ ] stopReason / usage 映射正确
+- [ ] 有 SSE 解析单元测试
+- [ ] `go test ./...` 通过
+
+### US-010: 实现 Google Gemini provider（流式）
+**Description:** 作为用户，我希望 pigo 支持 Google Gemini。
+
+**Acceptance Criteria:**
+- [ ] 实现 Gemini 流式 generateContent，解析文本与 functionCall
+- [ ] stopReason / usage 映射正确
+- [ ] 有单元测试
+- [ ] `go test ./...` 通过
+
+### US-011: 模型注册表与 provider 目录
+**Description:** 作为开发者，我需要一个模型注册表，把 model id 解析到对应 provider 与能力元数据。
+
+**Acceptance Criteria:**
+- [ ] 提供 `model-registry`，支持按 id 查询 Model 元数据与其 Provider
+- [ ] 模型清单可由数据文件生成（对标 pi 的 `models.generated`），支持内置默认清单
+- [ ] 未知 model id 返回明确错误
+- [ ] 有单元测试
+- [ ] `go test ./...` 通过
+
+### US-012: OAuth 与 API key 解析
+**Description:** 作为用户，我希望 pigo 支持 API key 与 OAuth 两种鉴权，并能处理短时 token 过期。
+
+**Acceptance Criteria:**
+- [ ] 支持从环境变量与配置文件读取 API key（按 provider）
+- [ ] 支持 OAuth 流程（对标 pi 的 oauth；至少覆盖一个 OAuth provider 作为样例）
+- [ ] token 过期时 `getApiKey` 能刷新并返回新 token
+- [ ] 敏感值不写入日志（按 key 名引用而非明文）
+- [ ] `go test ./...` 通过
+
+### US-013: 扩展更多 provider（对齐 pi 覆盖面）
+**Description:** 作为用户，我希望 pigo 覆盖 pi 支持的主要 provider（Bedrock、Mistral、DeepSeek、xAI、Groq、OpenRouter 等）。
+
+**Acceptance Criteria:**
+- [ ] 每个新增 provider 复用统一 `Provider` 接口，仅实现差异部分
+- [ ] 至少再交付 3 个 provider（优先 Bedrock、OpenRouter、DeepSeek），其余登记在 Open Questions/路线图
+- [ ] 每个 provider 有最小流式单元测试
+- [ ] `go test ./...` 通过
+
+### 阶段三：工具系统（对标 coding-agent/core/tools）
+
+### US-014: 工具注册表与 JSON Schema 校验
+**Description:** 作为开发者，我需要工具注册表，并在执行前用 JSON Schema 校验模型给的参数。
+
+**Acceptance Criteria:**
+- [ ] 提供 `Registry`：按 name 注册/查询工具
+- [ ] 每个工具声明 JSON Schema 参数定义；执行前用 schema 校验库（如 santhosh-tekuri/jsonschema）校验
+- [ ] 校验失败产出明确的 error tool result（含字段级错误信息）
+- [ ] 有单元测试覆盖：合法参数、缺字段、类型错误
+- [ ] `go test ./...` 通过
+
+### US-015: read 工具
+**Description:** 作为用户，我希望 agent 能读取文件内容。
+
+**Acceptance Criteria:**
+- [ ] 支持按路径读取，支持行 offset/limit（对标 pi 的 read）
+- [ ] 输出带行号；超大文件截断并提示
+- [ ] 路径越界/不存在返回明确错误
+- [ ] 有单元测试
+- [ ] `go test ./...` 通过
+
+### US-016: write 工具
+**Description:** 作为用户，我希望 agent 能创建/覆盖文件。
+
+**Acceptance Criteria:**
+- [ ] 支持写入指定路径，必要时创建父目录
+- [ ] 覆盖已存在文件前的行为与 pi 一致（记录/提示）
+- [ ] 写入失败返回明确错误
+- [ ] 有单元测试
+- [ ] `go test ./...` 通过
+
+### US-017: edit 工具（含 diff）
+**Description:** 作为用户，我希望 agent 能对文件做精确的字符串替换编辑。
+
+**Acceptance Criteria:**
+- [ ] 支持 old_string → new_string 精确替换，old_string 不唯一时报错
+- [ ] 支持 replace_all 选项
+- [ ] 返回 diff 供 UI 渲染
+- [ ] 有单元测试覆盖：唯一匹配、非唯一匹配报错、replace_all
+- [ ] `go test ./...` 通过
+
+### US-018: bash 工具
+**Description:** 作为用户，我希望 agent 能执行 shell 命令。
+
+**Acceptance Criteria:**
+- [ ] 执行命令并流式返回 stdout/stderr（通过 tool_execution_update）
+- [ ] 支持超时与取消（context 取消能杀掉子进程）
+- [ ] 退出码非 0 时结果标记 isError 并携带输出
+- [ ] 有单元测试
+- [ ] `go test ./...` 通过
+
+### US-019: grep / find / ls 搜索工具
+**Description:** 作为用户，我希望 agent 能搜索文件内容与遍历目录。
+
+**Acceptance Criteria:**
+- [ ] grep：按 pattern 搜索文件内容，支持 glob 过滤
+- [ ] find：按文件名 glob 查找
+- [ ] ls：列目录，区分文件/目录
+- [ ] 尊重 .gitignore（对标 pi 用 ignore 库的行为）
+- [ ] 有单元测试
+- [ ] `go test ./...` 通过
+
+### 阶段四：CLI / 交互模式（对标 coding-agent）
+
+### US-020: headless / stdio 运行模式
+**Description:** 作为用户，我希望能以非交互方式（print / stdio）运行 pigo，便于脚本与 CI 集成。
+
+**Acceptance Criteria:**
+- [ ] 提供 print 模式：接收一个 prompt，运行 agent，输出最终结果到 stdout
+- [ ] 提供 stream-json / stdio 协议模式（对标 pi 的 rpc / print-mode），事件以行分隔 JSON 输出
+- [ ] 退出码正确反映成功/失败
+- [ ] 有端到端测试（用 fake provider）
+- [ ] 在真实终端运行验证：`pigo -p "读取 README 并总结"` 能产出结果
+
+### US-021: 系统提示词与上下文装配
+**Description:** 作为开发者，我需要复刻 pi 的系统提示词装配，包括注入项目级 AGENTS.md。
+
+**Acceptance Criteria:**
+- [ ] 组装 system prompt：基础指令 + 环境信息（cwd / OS / 时间等）
+- [ ] 从根目录到子目录按"通用→具体"顺序注入 AGENTS.md（对标 zero/pi 的 monorepo 行为）
+- [ ] 有单元测试验证 AGENTS.md 注入顺序
+- [ ] `go test ./...` 通过
+
+### US-022: 交互式 TUI（参考 zero）
+**Description:** 作为用户，我希望有一个交互式终端界面来与 agent 对话。
+
+**Acceptance Criteria:**
+- [ ] 基于成熟 Go TUI 库（bubbletea 生态或参考 zero 的实现），不自研差分渲染
+- [ ] 显示对话 transcript：用户输入、assistant 文本、工具调用、工具结果
+- [ ] 支持流式增量渲染（订阅 loop 的 message_update / tool_execution_update 事件）
+- [ ] 支持中断当前运行（Ctrl+C 触发 abort，agent 优雅停止）
+- [ ] 支持运行中输入 steering 消息（对接 getSteeringMessages）
+- [ ] 在真实终端运行验证：能完成一次含工具调用的多轮对话
+- [ ] `go build ./...` 通过
+
+### US-023: 配置系统
+**Description:** 作为用户，我希望通过分层配置控制 pigo 的行为（provider、model、工具开关等）。
+
+**Acceptance Criteria:**
+- [ ] 支持分层配置解析（默认 < 全局 < 项目 < 环境变量/命令行），对标 pi/zero 的 config resolution
+- [ ] 配置项含：默认 model、provider 凭据、工具执行模式、思考等级
+- [ ] 配置文件缺失/字段非法给出明确报错
+- [ ] 有单元测试覆盖分层覆盖顺序
+- [ ] `go test ./...` 通过
+
+### US-024: 会话持久化
+**Description:** 作为用户，我希望 pigo 能保存并恢复会话历史。
+
+**Acceptance Criteria:**
+- [ ] 会话以本地文件（如 JSONL）持久化，含消息与元数据
+- [ ] 支持列出、恢复、续跑历史会话（对接 agentLoopContinue）
+- [ ] 恢复后 transcript 能在 TUI 正确重放
+- [ ] 有单元测试覆盖写入/读取/续跑
+- [ ] `go test ./...` 通过
+
+### 阶段五：全量对标（对标 orchestrator / MCP / sandbox）
+
+### US-025: MCP 客户端支持
+**Description:** 作为用户，我希望 pigo 能连接 MCP（Model Context Protocol）服务器以扩展工具。
+
+**Acceptance Criteria:**
+- [ ] 实现 MCP 客户端，支持 stdio 传输
+- [ ] 能发现 MCP server 暴露的工具并注册进 Registry
+- [ ] MCP 工具调用走统一的三段式执行路径
+- [ ] 有集成测试（用一个最小 MCP server）
+- [ ] `go test ./...` 通过
+
+### US-026: 沙箱 / 权限约束
+**Description:** 作为用户，我希望对文件、进程、网络访问有可配置的权限约束（pi 本身无内置权限系统，此处参考 zero 的 sandbox 设计增强）。
+
+**Acceptance Criteria:**
+- [ ] 提供权限策略配置（允许/拒绝的路径、命令、网络）
+- [ ] 通过 beforeToolCall 钩子接入权限检查，拒绝时产出 error tool result
+- [ ] 支持 secret redaction（工具输出中的密钥打码）
+- [ ] 有单元测试覆盖：拒绝越权路径、拒绝越权命令
+- [ ] `go test ./...` 通过
+
+### US-027: 多 agent 编排（对标 orchestrator）
+**Description:** 作为用户，我希望能编排多个 agent 协作（sub-agent / swarm），标记为实验性。
+
+**Acceptance Criteria:**
+- [ ] 支持派生 sub-agent（独立 context + 工具集），父 agent 通过工具调用触发
+- [ ] sub-agent 的最终结果作为工具结果回灌父 agent
+- [ ] 支持并发运行多个 sub-agent
+- [ ] 有集成测试（用 fake provider 驱动一次父→子→父）
+- [ ] `go test ./...` 通过
+
+## Functional Requirements
+
+- FR-1: 系统必须实现双层 agent 循环，内层处理"流式响应→工具调用→结果回灌"，外层处理 follow-up 消息，控制流与 pi 的 `runLoop` 一致。
+- FR-2: 系统必须以三段式（prepare → execute → finalize）执行每个工具调用。
+- FR-3: 系统必须在 prepare 阶段用 JSON Schema 校验工具参数，校验失败时产出 error tool result 而非执行工具。
+- FR-4: 系统必须支持 beforeToolCall 钩子，返回 block 时阻止工具执行并产出 error tool result。
+- FR-5: 系统必须支持 afterToolCall 钩子，按字段（content/details/isError/terminate）覆盖工具结果，不做深合并。
+- FR-6: 系统必须支持 prepareNextTurn 钩子，可替换下一轮的 context / model / thinkingLevel。
+- FR-7: 系统必须支持 shouldStopAfterTurn 钩子，返回 true 时发出 agent_end 并退出循环。
+- FR-8: 系统必须支持 getSteeringMessages，在每轮工具执行后注入消息到下一轮之前。
+- FR-9: 系统必须支持 getFollowUpMessages，在内层循环结束后决定是否继续。
+- FR-10: 当 assistant 消息 stopReason 为 length（token 截断）时，系统必须将该消息的全部 tool call 判为失败并提示模型重发。
+- FR-11: 系统必须支持 sequential 与 parallel 两种工具执行模式，parallel 模式下 tool-result 消息按 assistant 源顺序输出。
+- FR-12: 系统必须仅在整批工具结果全部 terminate=true 时才提示提前终止。
+- FR-13: 系统必须提供统一 Provider 接口，请求失败通过流内终态 error/aborted 消息表达，而非抛错。
+- FR-14: 系统必须以流式方式处理 assistant 响应，实时更新 partial 消息并发出 message_update 事件。
+- FR-15: 系统必须支持通过 getApiKey 动态解析 API key，以处理短时 token 过期。
+- FR-16: 系统必须提供模型注册表，将 model id 解析到 Provider 与能力元数据。
+- FR-17: 系统必须实现 read / write / edit / bash / grep / find / ls 内置工具。
+- FR-18: 系统必须支持 headless（print / stdio）与交互式 TUI 两种运行模式。
+- FR-19: 系统必须装配系统提示词，并按"通用→具体"顺序注入根到子目录的 AGENTS.md。
+- FR-20: 系统必须支持分层配置解析（默认 < 全局 < 项目 < 环境/命令行）。
+- FR-21: 系统必须支持会话本地持久化与恢复续跑。
+- FR-22: 系统必须支持 context 取消（abort），中断时 loop 与运行中的工具/子进程优雅停止。
+- FR-23: 系统必须编译为单二进制，无 Node 运行时依赖。
+- FR-24: 系统必须提供基于 channel 的事件流机制，覆盖 pi 的全部 AgentEvent 类型。
+- FR-25: 系统应支持 MCP 客户端（stdio 传输）以扩展工具。
+- FR-26: 系统应提供可配置的权限/沙箱约束，通过 beforeToolCall 接入。
+- FR-27: 系统应支持多 agent 编排（sub-agent / swarm，实验性）。
+
+## Non-Goals (Out of Scope)
+
+- 不复刻 pi 的自研差分渲染 TUI（改用成熟 Go TUI 库 / 参考 zero）。
+- 不直接翻译 pi 的 TypeScript 代码（语言特性差异导致直译不可行；只复刻设计与控制流）。
+- 首版不追求 provider 数量 100% 对齐 pi（先核心厂商 + 至少 6 个 provider，其余登记路线图）。
+- 不实现 pi 的 HTML 导出、图像生成/处理（photon）、终端图片渲染等外围能力（后续可选）。
+- 不实现浏览器相关验证（pigo 为 CLI/TUI，验证在真实终端进行）。
+- 不提供托管服务或云端 orchestrator（orchestrator 仅本地多进程/多 agent）。
+- 不承诺与 pi 的会话文件格式二进制兼容。
+
+## Design Considerations
+
+- **分层与 pi 一一对应**，便于对照移植：
+  | pi (TS) | pigo (Go) |
+  |---|---|
+  | packages/ai | internal/llm（Provider 接口 + 各厂商实现，流式） |
+  | packages/agent | internal/agent（loop.go：双层循环 + 三段式工具） |
+  | coding-agent/core/tools | internal/tools（Registry + read/bash/edit/write/grep/find/ls） |
+  | packages/tui | internal/tui（bubbletea / 参考 zero，不自研差分渲染） |
+  | coding-agent 会话/配置 | internal/sessions、internal/config |
+  | packages/orchestrator | internal/swarm（实验性） |
+- **语言映射约定**：async generator → chan；Promise.all 保序 → goroutine + index 回填；discriminated union → interface + type switch；typebox 泛型校验 → JSON Schema 运行时校验；可选回调 → struct 中的 func 字段（nil 判断）。
+- **可直接逐段翻译的参考**：pi 的 `packages/agent/src/agent-loop.ts`（runLoop / streamAssistantResponse / prepare/execute/finalize / failToolCallsFromTruncatedMessage）与 `packages/agent/src/types.ts`（AgentContext / AgentTool / AgentEvent / AgentLoopConfig 的钩子契约）。
+- **Go 工程实现的第二参考**：Gitlawb/zero（Go 实现的类 agent），其 provider 流式 HTTP transport、TUI、sandbox 已有成熟 Go 实现。
+
+## Technical Considerations
+
+- 语言：Go（建议 1.22+）。目标单二进制、跨平台。
+- JSON Schema 校验库候选：`santhosh-tekuri/jsonschema`。
+- TUI 库候选：`charmbracelet/bubbletea` + `lipgloss` / `bubbles`，或参考 zero 的实现选型。
+- 流式：HTTP + SSE 解析需自实现或用轻量库，注意断流重连与超时（对标 pi 的 streaming resilience）。
+- 并发：工具并行执行用 goroutine + WaitGroup，结果按 index 回填保序；全程贯穿 `context.Context` 以支持取消。
+- 安全：密钥仅按 key 名引用，禁止写入日志；工具输出支持 secret redaction。
+- 目录约定：代码实现位于 `/Users/chaoyuepan/ai/pigo`，建议采用 `cmd/pigo`（入口）+ `internal/*`（各层）的标准 Go 布局。
+- 测试：全程用 fake/faux provider（对标 pi 的 `providers/faux.ts`）驱动 loop 集成测试，避免依赖真实 API key。
+
+## Success Metrics
+
+- pigo 能在真实终端完成一次"读文件 → 执行命令 → 编辑文件"的多轮任务，全程工具调用正确。
+- agent loop 的六个钩子与截断保护行为，均有单元/集成测试覆盖并通过。
+- 至少 6 个 provider 的流式响应通过 fixture 单元测试。
+- 单二进制在 macOS 与 Linux 上均可构建运行，无 Node 依赖。
+- 核心包（internal/agent、internal/tools、internal/llm）测试覆盖率达到团队约定阈值（建议 ≥70%）。
+
+## Open Questions
+
+- provider 覆盖面的优先级排序：除 Anthropic/OpenAI/Gemini 外，先做哪 3 个（当前假设 Bedrock / OpenRouter / DeepSeek）？
+- 会话文件格式是否需要与 pi 的 JSONL 保持字段级可互读，还是仅需 pigo 内部自洽？
+- MCP 是否需要支持 HTTP/SSE 传输，还是首版仅 stdio 即可？
+- sandbox 的隔离强度：仅进程内策略检查（beforeToolCall），还是需要引入 OS 级隔离（namespace / seccomp / 容器）？
+- 多 agent 编排是否需要跨进程 IPC（对标 pi orchestrator 的 rpc-process），还是首版单进程内 goroutine 即可？
+- 是否需要复刻 pi 的 skills / plugins / slash-commands 扩展体系，还是纳入后续独立 PRD？
+- thinking/reasoning 等级如何跨 provider 归一（不同厂商对 thinking 的支持差异较大）？

--- a/tasks/research-pi-agent-loop-go-mapping.md
+++ b/tasks/research-pi-agent-loop-go-mapping.md
@@ -1,0 +1,290 @@
+# 研究摘要：pi agent-loop / types → Go 映射
+
+> Wayfinder ticket #2 的产出。源码精读自 `/Users/chaoyuepan/ai/pi`：
+> `packages/agent/src/agent-loop.ts`、`packages/agent/src/types.ts`、
+> `packages/ai/src/types.ts`、`packages/ai/src/utils/event-stream.ts`。
+> 目的：为 pigo 的 US-001..006 提供 TS→Go 映射建议、控制流复刻要点与易错点。
+
+---
+
+## 1. 数据类型层（对应 US-001）
+
+### 1.1 消息与内容块（discriminated union → interface + type switch）
+
+pi 的 content 块是 tagged union（`type` 字段判别）：
+
+| pi (TS) | 字段 | Go 建议 |
+|---|---|---|
+| `TextContent` | `type:"text"`, `text`, `textSignature?` | `TextContent struct` |
+| `ThinkingContent` | `type:"thinking"`, `thinking`, `thinkingSignature?`, `redacted?` | `ThinkingContent struct` |
+| `ToolCall` | `type:"toolCall"`, `id`, `name`, `arguments`, `thoughtSignature?` | `ToolCallContent struct` |
+| `ImageContent` | `type:"image"`, `data`, `mimeType` | `ImageContent struct` |
+
+**映射方向**：定义密封接口 `Content interface { isContent()}`，每个 struct 实现它；消费端用 `switch c := c.(type)` 分派。**不要**用 `map[string]any` + 字符串判别（丢类型安全，正是要摆脱的）。
+
+**JSON 序列化易错点**：Go 的 `encoding/json` 不会自动按 `type` 字段反序列化到接口。需要：
+- 每个 content struct 带 `Type string json:"type"` 字面量字段；
+- 自定义 `UnmarshalJSON`（在容器层，如 `AssistantMessage.Content []Content`）先 peek `type` 再分派到具体 struct。会话持久化（US-024）与 provider 解析都依赖这个。
+
+三种消息角色（`Message = UserMessage | AssistantMessage | ToolResultMessage`）：
+
+- `UserMessage`: `role:"user"`, `content`（string 或 `[]TextContent|ImageContent`）, `timestamp`
+- `AssistantMessage`: `role:"assistant"`, `content:[]（Text|Thinking|ToolCall）`, `api`, `provider`, `model`, `usage`, `stopReason`, `errorMessage?`, `timestamp`（+ `responseModel/responseId/diagnostics` 可选）
+- `ToolResultMessage`: `role:"toolResult"`, `toolCallId`, `toolName`, `content:[]（Text|Image）`, `details?`, `isError`, `timestamp`
+
+> **注意 content 的类型收窄**：assistant 的 content 可含 thinking/toolCall，user/toolResult 的 content 只能是 text/image。Go 里可以用同一个 `Content` 接口但在构造/校验时约束，或分两个接口。建议单一接口 + 运行时约束，避免接口爆炸。
+
+**`AgentMessage` 的可扩展性**：pi 用 TS declaration merging 让 app 注入自定义消息类型（`CustomAgentMessages`）。Go 没有等价物 → 建议 `AgentMessage` 直接就是 `Message` 接口，自定义消息类型让其实现同一接口；`convertToLlm` 负责把非 LLM 消息过滤/转换掉。**不要**试图复刻 declaration merging。
+
+### 1.2 AgentToolResult / terminate 语义
+
+```
+AgentToolResult<T> { content []（Text|Image）; details T; terminate?: bool }
+```
+
+Go：`details` 用泛型 `AgentToolResult[T any]` 或 `any`。pi 内部大量 `AgentToolResult<any>` → pigo 首版用 `any` 更省事，泛型可后加。`terminate` 是**批级**提示（见 §3.4）。
+
+### 1.3 AgentEvent（→ US-001 事件类型全集）
+
+10 种事件，pigo 必须全覆盖（PRD FR-24）：
+
+`agent_start` / `agent_end{messages}` / `turn_start` / `turn_end{message, toolResults}` /
+`message_start{message}` / `message_update{message, assistantMessageEvent}` / `message_end{message}` /
+`tool_execution_start{toolCallId, toolName, args}` / `tool_execution_update{...partialResult}` /
+`tool_execution_end{toolCallId, toolName, result, isError}`
+
+Go：`AgentEvent interface { isAgentEvent() }` + 10 个 struct，或带 `Type` 字段的单 struct（事件多为 UI 消费，单 struct + 可空字段也可接受，但 type switch 更安全）。**建议接口 + type switch**，与 content 保持一致风格。
+
+---
+
+## 2. 事件流机制（对应 US-002：async generator → channel）
+
+### 2.1 EventStream 的本质
+
+pi 的 `EventStream<T,R>`（`event-stream.ts`）是一个"边推事件、边异步迭代、并在某个终止事件上解析出最终结果 R"的结构：
+
+- `push(event)`：若 `isComplete(event)` 为真则记录 `extractResult(event)` 作为最终结果；派发给等待的消费者或入队。
+- `end(result?)`：关闭流，唤醒所有等待者。
+- `[Symbol.asyncIterator]`：消费端 `for await`。
+- `result(): Promise<R>`：拿最终结果。
+
+两个实例化：
+- **agent 层**：`isComplete = (e)=> e.type==="agent_end"`，`extractResult = (e)=> e.messages`（即 `EventStream<AgentEvent, AgentMessage[]>`）。
+- **provider 层**：`AssistantMessageEventStream`，`isComplete = done|error`，`extractResult` 取 `message`（done）或 `error`（error）。
+
+### 2.2 Go 映射
+
+**核心决策**：一个 struct 包一个 `chan AgentEvent` + 一个 `result` 兑现机制。
+
+```go
+type EventStream[T any, R any] struct {
+    ch      chan T
+    result  R
+    resultCh chan struct{} // closed 时 result 就绪
+    // ...
+}
+```
+
+建议实现要点：
+- **迭代**：`Events() <-chan T` 供 `for ev := range s.Events()`。async iterator → range over channel 是最自然的映射。
+- **最终结果**：`Result(ctx) (R, error)`；用一个 `sync.Once` + closed channel 表示就绪。**不要**把 result 也塞进事件 channel（消费者可能不读完）。
+- **push/end 的等价物**：生产者 goroutine 往 `ch` 写，写完 `close(ch)`；在 close 前把满足 `isComplete` 的事件对应的 result 存好。pi 的 `isComplete/extractResult` 回调可保留为 struct 上的 func 字段，或直接在 agent loop 里显式设置 result（更 Go-idiomatic）。
+- **取消**（PRD FR-22 / US-002 验收）：贯穿 `context.Context`。生产者 goroutine `select { case ch<-ev: case <-ctx.Done(): return }`，避免消费者停读时 goroutine 泄漏。abort 时 loop 走 aborted 终态（见 §3.5）。
+
+**易错点**：
+- TS 的 async generator 是**拉模型**（消费者驱动 `next()`），channel 是**推模型**。若消费者慢，生产者会阻塞在 `ch<-`——这其实是想要的背压。但 emit 在 pi 里是 `await emit(...)`（顺序 await），Go 里 `ch<-ev` 天然顺序阻塞，语义一致。✅
+- pi 的 `emit` 可能返回 Promise（listener 是 async 的），`agent_end` 的 listener settle 才算 run 结束（见 `AgentState.isStreaming` 注释）。Go 里若 emit 只是 `ch<-`，则"listener settle"语义需另想——首版可简化为"channel 关闭即结束"，把 listener 副作用留给消费方自己 sync。**记录为简化点**。
+
+---
+
+## 3. Agent Loop 控制流（对应 US-003/004/005/006）
+
+### 3.1 入口（US-006 验收：两个入口）
+
+- `agentLoop(prompts, context, config, signal?, streamFn?)`：新 prompt 启动。把 prompts 加进 context，发 `agent_start`→`turn_start`→(每个 prompt 的 message_start/message_end)，再进 `runLoop`。
+- `agentLoopContinue(context, config, ...)`：从现有 context 续跑。**校验**：`messages` 非空，且最后一条 role ≠ `assistant`（否则 provider 会拒）。发 `agent_start`→`turn_start` 后进 `runLoop`。
+
+两者都返回 `EventStream<AgentEvent, AgentMessage[]>`；内部 `runAgentLoop*` 跑完把 `newMessages` 作为 `end()` 结果。
+
+**Go**：`func AgentLoop(...) *EventStream[AgentEvent, []AgentMessage]`；内部起 goroutine 跑 `runLoop`，完成后设置 result 并 close。`newMessages` 累积的是"本次调用新产生的消息"（prompt 版含初始 prompt，续跑版不含既有 context 消息）——**这个区分要保留**，`shouldStopAfterTurn`/结果都依赖它。
+
+### 3.2 双层循环骨架（US-006 核心）
+
+```
+pending = getSteeringMessages() || []          // 启动前先捞（用户可能在等待时输入了）
+外层 for {
+    hasMoreToolCalls = true
+    内层 for hasMoreToolCalls || len(pending)>0 {
+        非首轮 → emit turn_start
+        注入 pending（每条 emit message_start/message_end，push 进 context & newMessages），清空 pending
+        msg = streamAssistantResponse(...)     // §3.3
+        newMessages.push(msg)
+        if msg.stopReason ∈ {error, aborted} { emit turn_end{msg,[]}; emit agent_end; return }
+        toolCalls = msg.content 里的 toolCall
+        toolResults = []
+        hasMoreToolCalls = false
+        if len(toolCalls)>0 {
+            batch = (msg.stopReason=="length")
+                      ? failToolCallsFromTruncatedMessage(toolCalls)   // §3.6
+                      : executeToolCalls(...)                          // §3.4
+            toolResults = batch.messages
+            hasMoreToolCalls = !batch.terminate
+            for r in toolResults { push 进 context & newMessages }
+        }
+        emit turn_end{msg, toolResults}
+        snap = prepareNextTurn({msg,toolResults,context,newMessages})  // 可换 context/model/thinking
+        应用 snap（见 §3.7）
+        if shouldStopAfterTurn({...}) { emit agent_end; return }
+        pending = getSteeringMessages() || []   // 每轮工具执行后重新捞 steering
+    }
+    // agent 本会停在这，检查 follow-up
+    followUp = getFollowUpMessages() || []
+    if len(followUp)>0 { pending = followUp; continue }  // 回内层
+    break
+}
+emit agent_end{newMessages}
+```
+
+**复刻要点**：
+- **首轮不发 turn_start**（入口已发过一次）——`firstTurn` 标志。Go 里同样一个 bool。
+- **steering vs follow-up 的差异**：steering 在每轮工具执行后注入（agent 还在干活时插话）；follow-up 在 agent 本要停下时才注入（排队等 agent 干完）。两者都进 `pending` 走同一注入路径，但捞取时机不同。
+- 内层退出条件 `hasMoreToolCalls || pending>0`：没有更多工具调用**且**没有待注入消息时退内层。
+
+### 3.3 streamAssistantResponse（US-003）
+
+顺序（**严格保持**）：
+1. `transformContext(messages, signal)`（可选）— AgentMessage[]→AgentMessage[]，用于上下文裁剪/注入。契约：**不得抛错**，失败返回安全回退。
+2. `convertToLlm(messages)` — AgentMessage[]→Message[]，过滤 UI-only 消息。同样**不得抛错**。
+3. 组 `llmContext{systemPrompt, messages, tools}`。
+4. **解析 API key**：`resolvedApiKey = (getApiKey ? await getApiKey(provider) : undefined) || config.apiKey`。这是处理短时 token 过期的关键（US-003/US-012、FR-15）。
+5. 调 `streamFn(model, llmContext, {...config, apiKey, signal})`（默认 `streamSimple`）。
+6. 遍历返回的事件流：
+   - `start`：拿 `partial`，**push 进 context.messages**（占位），发 `message_start`。
+   - `text_*/thinking_*/toolcall_*`：用 `event.partial` **替换** context 里最后一条，发 `message_update{assistantMessageEvent, message}`。
+   - `done`/`error`：取 `response.result()` 作为 finalMessage，替换/追加进 context，发 `message_end`，返回。
+7. 流自然结束（未见 done/error）也兜底取 `result()`。
+
+**Go 映射**：
+- `streamFn` = `StreamFn` 接口/函数类型，返回 `*AssistantMessageEventStream`。
+- **partial 回填**：pi 靠"push 占位 + 替换最后一条"。Go 里对 `context.Messages []AgentMessage` 做 `msgs[len-1] = partial`——注意并发：loop 是单 goroutine 消费 provider 流，context.messages 只此处改，无需锁。但如果 TUI 另一 goroutine 读 messages，需要外层同步（记录为 §5 并发注意）。
+- `addedPartial` bool 处理"provider 没发 start 就直接 done"的边界。**保留**。
+
+**契约（US-003 / FR-13）**：streamFn **不通过抛错表达请求失败**，而是在流内发 error 事件 + 终态 assistant 消息（`stopReason=error/aborted` + `errorMessage`）。Go 里 `StreamFn` 签名**不返回 error**（或返回的 error 仅限"无法建流"这种极早期失败）；运行时失败编码进事件流。这是整个 provider 层的地基（US-007 会再确认）。
+
+### 3.4 工具三段式 prepare→execute→finalize（US-004）
+
+**prepare**（`prepareToolCall`）：
+1. 查注册表 `tools.find(name)`；找不到 → immediate error result（"Tool X not found"）。
+2. `prepareArguments(args)`（可选 shim，raw→schema-shaped）。pi 有个小优化：返回值 `===` 原值就不新建对象（Go 里可忽略此优化，直接用返回值）。
+3. `validateToolArguments`（JSON Schema 校验，US-014）。抛错 → catch 成 immediate error result。
+4. `beforeToolCall({assistantMessage, toolCall, args, context}, signal)`（可选钩子）：
+   - `signal.aborted` → immediate error "Operation aborted"。
+   - 返回 `{block:true}` → immediate error result（`reason` 或默认文案）。
+5. 都过 → 返回 `prepared{toolCall, tool, args}`。
+6. 整个 try 块的任何异常 → immediate error result。
+
+**execute**（`executePreparedToolCall`）：
+- 调 `tool.execute(id, args, signal, onUpdate)`。
+- `onUpdate(partialResult)` → 发 `tool_execution_update`。pi 用 `acceptingUpdates` 标志 + 收集 update 的 Promise，execute 返回后 `await Promise.all(updateEvents)` 确保 update 事件在 end 前都发完，且 execute 结束后忽略迟到的 update。
+- 抛错 → error tool result（不 panic）。
+
+**Go 映射（execute 的 onUpdate）**：pi 的"收集 update promise 再 await 全部"是为了顺序性。Go 里 `onUpdate` 若直接 `ch<-updateEvent` 是同步阻塞的，天然有序，可**简化掉 acceptingUpdates + Promise.all**。但要防"execute 已返回后 tool 仍调 onUpdate"——用一个 `atomic.Bool` 或在 execute 返回后关闭一个 `done` channel，onUpdate 里 select 检测。**记录为简化点 + 边界防护**。
+
+**finalize**（`finalizeExecutedToolCall`）：
+- `afterToolCall({assistantMessage, toolCall, args, result, isError, context}, signal)`（可选钩子）返回覆盖：
+  - `content ?? result.content`、`details ?? result.details`、`terminate ?? result.terminate`、`isError ?? isError`。
+  - **字段级替换，无深合并**（FR-5）。Go 里因为没有 `??`，要显式判 nil/未设置：用**指针字段**（`*[]Content`, `*bool`）区分"未提供"与"提供了零值"。这是 Go 复刻此语义的关键——`AfterToolCallResult` 的字段必须是指针或 `*T`，否则无法区分"没返回 content"和"返回了空 content"。
+  - afterToolCall 抛错 → 整个结果变 error result。
+
+immediate 结果**跳过 execute/finalize**（不触发 afterToolCall）——注意 immediate 分支不走 finalize。
+
+### 3.5 并行与串行（US-005）
+
+**模式选择**（`executeToolCalls`）：`config.toolExecution==="sequential"` **或** 任一 toolCall 对应的 tool `executionMode==="sequential"` → 走串行；否则并行。默认 parallel。
+
+**sequential**：逐个 prepare→execute→finalize，每个立即发 `tool_execution_end` + 造 tool-result 消息 + 发 message_start/end。**每步后检查 `signal.aborted`，中断则 break**。
+
+**parallel**（保序是重点，US-005 验收）：
+1. **顺序** prepare 所有 toolCall（先发 `tool_execution_start`）。immediate 结果直接入 `finalizedCalls`；prepared 的包成一个 thunk（闭包）入 `finalizedCalls`（保持在数组里的**位置**=assistant 源顺序）。
+2. `Promise.all(finalizedCalls.map(执行 thunk 或原样))` → 并发执行，但结果数组**按原 index 保序**。
+3. 按序造 tool-result 消息 + 发 message 事件。
+
+**Go 映射（保序并发）**——这是 PRD 明确点名的 async 映射：
+```go
+results := make([]FinalizedToolCallOutcome, len(entries))
+var wg sync.WaitGroup
+for i, e := range entries {
+    if e.immediate { results[i] = e.outcome; continue }
+    wg.Add(1)
+    go func(i int, e entry) {
+        defer wg.Done()
+        executed := executePrepared(e.prepared, ...)   // 内部发 tool_execution_update
+        results[i] = finalize(executed, ...)
+        emitToolExecutionEnd(results[i])               // 见下方顺序性警告
+    }(i, e)
+}
+wg.Wait()
+// 再按 i 顺序造 tool-result 消息 & 发 message 事件
+```
+- **保序靠按 index 回填 `results[i]`**（正是 PRD 说的"goroutine + index 回填"）。✅
+- **顺序性微妙点**：pi 的 parallel 里 `tool_execution_end` 在**完成顺序**发（thunk 内部），而 tool-result **message** 事件在**源顺序**发（Promise.all 之后）。若 pigo 想 100% 复刻，`tool_execution_end` 可在 goroutine 内发（完成序），message 事件循环外按序发。但多 goroutine 并发 `emit`（ch<-）会竞争 channel——**需要 emit 加锁或改为完成序也走收集后统一发**。首版建议：**tool_execution_end 也收集后按源序发**（比 pi 少一点实时性，但 emit 无并发竞争，更安全）。**记录为可接受偏差**。
+- prepare 阶段每步后 `signal.aborted` 检查 → break（与 pi 一致）。
+
+### 3.6 截断保护 failToolCallsFromTruncatedMessage（US-006 / FR-10）
+
+当 `stopReason==="length"`（输出被 token 上限截断），该消息的**所有** toolCall 一律判失败：逐个发 `tool_execution_start` → 造固定文案的 error result（"...hit the output token limit...re-issue with complete arguments"）→ 发 `tool_execution_end` + tool-result 消息。返回 `{messages, terminate:false}`。
+
+**为什么**：流式 tool-call 参数用"尽力 JSON 抢救解析器"收尾，截断的消息可能产出**能 parse、能校验、但静默不完整**的参数，执行不安全。直译即可，无并发。
+
+### 3.7 prepareNextTurn 应用 & shouldStopAfterTurn（US-006 / FR-6,7）
+
+`prepareNextTurn` 返回 `{context?, model?, thinkingLevel?}`：
+- `context ?? currentContext`
+- `model ?? config.model`
+- `reasoning`：`thinkingLevel===undefined` → 保持；`==="off"` → undefined；否则 → thinkingLevel。
+
+**Go 映射**：`AgentLoopTurnUpdate` 字段用指针区分"未提供"（thinkingLevel 有三态：未提供/off/具体值——必须用 `*ThinkingLevel` 或专门的哨兵）。这又是一处**指针字段区分三态**的地方，和 §3.4 afterToolCall 同一类易错点。
+
+`shouldStopAfterTurn` 返回 true → 发 `agent_end` 退出（在捞 steering/follow-up 之前）。
+
+---
+
+## 4. 钩子契约总表（US-006，全部"不得抛错"）
+
+| 钩子 | 时机 | 作用 | 契约 |
+|---|---|---|---|
+| `transformContext` | 每次 LLM 调用前，convertToLlm 之前 | AgentMessage[]→AgentMessage[]，裁剪/注入 | 不抛，失败回退原值 |
+| `convertToLlm` | 每次 LLM 调用前 | AgentMessage[]→Message[]，过滤 UI-only | 不抛，返回安全回退 |
+| `getApiKey` | 每次 LLM 调用，解析 key | 短时 token 刷新 | 不抛，无 key 返 undefined |
+| `beforeToolCall` | prepare 校验后、execute 前 | 返回 block 阻止执行 | 收 signal，自行响应 abort |
+| `afterToolCall` | execute 后、发 end 事件前 | 字段级覆盖结果（无深合并） | 收 signal |
+| `prepareNextTurn` | turn_end 后、决定是否再请求前 | 换 context/model/thinking | 不抛 |
+| `shouldStopAfterTurn` | turn_end 后 | true 则 agent_end 退出 | 不抛 |
+| `getSteeringMessages` | 每轮工具执行后 | 运行中插话 | 不抛，无则 [] |
+| `getFollowUpMessages` | agent 本要停时 | 排队等干完再继续 | 不抛，无则 [] |
+
+> pi 是 6 个"核心钩子"（PRD 列的 beforeToolCall/afterToolCall/prepareNextTurn/shouldStopAfterTurn/getSteeringMessages/getFollowUpMessages），另有 transformContext/convertToLlm/getApiKey 三个上下文/请求处理回调。pigo 都要有。
+
+**Go 映射**：全部作为 `AgentLoopConfig` 上的 **func 字段**（nil 判断 = "未提供"，正是 PRD 说的"可选回调 → struct 中 func 字段 + nil 判断"）。调用前 `if config.BeforeToolCall != nil`。"不得抛错"契约在 Go 里对应"不 panic"——但 Go 惯例是返回 error，此处应遵循 pi：钩子签名可返回 error，loop 捕获并转成安全回退/error tool result，而非 panic 逃逸。
+
+---
+
+## 5. Go 化的横切注意点
+
+1. **三态区分（最高频易错点）**：`afterToolCall` 的覆盖字段、`prepareNextTurn` 的 thinkingLevel 都需区分"未提供/零值/具体值"。TS 靠 `undefined` + `??`，Go 必须用**指针字段**（`*bool`、`*[]Content`、`*ThinkingLevel`）。定义 `AfterToolCallResult` / `AgentLoopTurnUpdate` 时统一用指针。
+2. **context.messages 的就地修改**：streamAssistantResponse 里"push 占位 + 替换最后一条"是就地改 slice。单 loop goroutine 内安全；若 TUI 并发读，需外层加锁或用 channel 传快照。
+3. **emit 并发**：parallel 工具执行若在多 goroutine 里 emit，channel 写会竞争——首版建议所有 emit 都在 loop 主 goroutine 串行发（工具结果收集后按序 emit），牺牲一点实时性换正确性。
+4. **abort 贯穿**：`context.Context` 从入口传到 streamFn、tool.execute、各钩子。abort 时：streamFn 走 aborted 终态消息；prepare 各检查点产 "Operation aborted" error result；sequential 每步后 break。
+5. **timestamp**：pi 用 `Date.now()`（ms）。Go 用 `time.Now().UnixMilli()`，保持 ms 以便会话文件跨读（US-024 决策待定，见 ticket #5）。
+6. **可直译 vs 需重设计**：
+   - **可近乎直译**（控制流骨架）：runLoop 双层循环、prepare/execute/finalize 分支、failToolCallsFromTruncatedMessage、prepareNextTurn 应用逻辑。
+   - **需重新设计**（语言差异）：EventStream（generator→channel）、parallel 保序（Promise.all→WaitGroup+index）、三态字段（undefined→指针）、content/event union（→interface+type switch + 自定义 JSON）、declaration merging（→放弃，统一接口）。
+
+---
+
+## 6. 对下游 ticket / 雾区的影响
+
+- **"核心类型精确 Go 签名"（Not yet specified）现在可成 ticket**：§1 已给出全部 struct 字段与接口设计方向，可据此起草 `internal/agent/types.go` 的精确签名 ticket（US-001）。
+- **"Provider 通用 transport"** 仍需 zero 调研（ticket #3）输入 SSE/重连细节，暂不 graduate。
+- **thinking 归一（ticket #10）** 与本摘要 §3.7 的 thinkingLevel 三态相关：pi 的 ThinkingLevel = off|minimal|low|medium|high|xhigh，agent 层已有归一枚举，provider 层如何映射是 #10 要定的。
+- **US-002 EventStream** 的 Go 设计方向（§2.2）已足够成实现 ticket。

--- a/tasks/research-zero-transport-tui-sandbox.md
+++ b/tasks/research-zero-transport-tui-sandbox.md
@@ -1,0 +1,148 @@
+# 研究摘要：zero（Go 类 agent）的 transport / TUI / sandbox
+
+> Wayfinder ticket #3 的产出。源码精读自本地 `/Users/chaoyuepan/ai/zero`
+> （charm.land v2 版 bubbletea/lipgloss/bubbles；原始仓库 https://github.com/Gitlawb/zero）。
+> 目的：为 pigo 的 provider transport（US-007~013）、TUI（US-022）、sandbox（US-026）三个决策提供 Go 实现输入。
+> 解锁 wayfinder ticket #7（sandbox 强度）与 #11（TUI 选型）。
+
+---
+
+## A. Provider Transport 层（→ US-007~013、Provider 通用 transport 雾区）
+
+### A.1 架构
+
+- **统一接口**：`internal/zeroruntime/types.go:209`
+  ```go
+  type Provider interface {
+      StreamCompletion(ctx, CompletionRequest) (<-chan StreamEvent, error)
+  }
+  ```
+- **共享 transport 包** `internal/providers/providerio/`：一个 SSE scanner + 一个 HTTP client + 统一 retry/auth/错误分类/redaction/看门狗。各 provider 退化为**纯 schema mapper**。
+- **各 provider 适配器**：anthropic / openai(chat) / openai/codex(responses) / gemini，只做各自 wire schema 的 JSON 解码，HTTP/SSE 机制全委托 providerio。
+- **工厂** `factory.go:39` 按 provider kind 分派。
+
+### A.2 关键设计（值得 pigo 借鉴）
+
+1. **transport/schema 分层**（最干净的部分）：一个 SSE scanner（`scanSSEPayloads` providerio.go:210，基于 `bufio.Scanner`，逐行累积 `data:`、blank line flush、丢 `[DONE]`、`:` 前缀当 keep-alive）；providers 只映射 schema。**pigo 应直接采用这个分层** —— 正好填补地图上「Provider 通用 transport 抽象」雾区。
+2. **错误在流内表达（dual failure model）**：pre-flight/marshal 错误走返回值 `error`（同步，channel 活动前）；**连接后的一切失败**（HTTP 非 2xx、坏 JSON、上游错误、idle/stall 超时）编码为终态 `StreamEventError` 事件再关 channel。**这正好印证 pi 的 `StreamFn` 契约**（FR-13：请求失败以流内终态 error/aborted 消息表达而非抛错）—— pi 和 zero 在这点上一致，pigo 的 `Provider` 接口可放心照此设计，且可比 pi 更明确地区分「建流前错误=返回 error」与「建流后错误=流内事件」。
+3. **幂等感知的 retry**（retry.go）：只重试 429/503/529，**从不重放已发出的 POST**（completion 非幂等，避免重复计费）；backoff `attempt*400ms`，认 `Retry-After`，capped 30s。401 只刷新重试一次（auth.go）。
+4. **双看门狗**（providerio.go:256）：idle watchdog（默认 5m 真静默 → `ErrStreamIdle`）+ content-stall watchdog（心跳在但无真数据 idle×1.2 → `ErrStreamStalled`，针对 gpt-5.x/ollama 心跳但不出内容的挂起）；keep-alive 注释重置计时器；`ZERO_STREAM_IDLE_TIMEOUT` 可调。
+5. **agent 层 connect-only 重连**（`internal/agent/reconnect.go`）：只重试**连接**、绝不重放已消费的流（避免重复文本）；`maxStreamReconnects=2`。另有「无可见文本已提交时才整体重发」的 stall retry（loop.go:305）—— 精心 gate 以免重复正文。
+6. **StreamEvent 事件模型**：flat struct + `Type` 判别，类型含 `text/reasoning/tool-call-start/delta/end/tool-call-dropped/usage/done/error`。**channel-based**（非 iterator/callback）+ 消费侧可选 callback 层（`CollectStreamWithOptions`）。thinking/reasoning 单独事件、绝不折进正文；`ReasoningBlocks`/signature 保留以便跨 provider replay。
+
+### A.3 与 pi 的对照结论
+
+- **pi 的 StreamFn（不返回 error，失败进流）与 zero 的 dual model 一致**。pigo `Provider` 接口建议：`StreamCompletion(ctx, req) (<-chan StreamEvent, error)`，返回的 error 仅限建流前失败；运行时失败进流内终态事件。这比 §研究1（pi 映射）§3.3 的「StreamFn 不返回 error」更精确，采纳 zero 的 dual 划分。
+- **channel-based 流**与 §研究1 的 EventStream（chan）映射方向一致，互相印证。
+
+### A.4 避免 / 重新考虑
+
+- `DisableKeepAlives` 对整个 darwin 平台（providerio.go:171）过于粗暴（每请求全新 TCP+TLS）；pigo 可用 per-conn 健康检查或 HTTP/2 替代。
+- `bufio.Scanner` 16MB 行上限（超长单 SSE 行会 `ErrTooLong` 杀流）；用 `bufio.Reader.ReadString('\n')` 避免硬上限。
+- 字符串匹配错误分类（`shouldReconnect`、`upstreamFailureMarkers`）脆弱；优先 typed error（`net.Error`/`errors.Is`）。
+- 四个适配器的 `stream()` 脚手架大量复制；pigo 可抽成共享 driver + per-provider decoder。
+- Gemini 缺 OAuth 401 刷新路径（不一致）。
+
+---
+
+## B. TUI 层（→ US-022；解锁 ticket #11 TUI 选型）
+
+### B.1 架构：单一 monolithic bubbletea Model
+
+- **只有一个 `tea.Model`**（`internal/tui/model.go:60`），Elm 三件套（Init/Update/View）都在这一个类型上。**无嵌套子 Model** —— "子组件" 是普通 state struct 字段（composerState、planPanelState 等），由 `updateModel` 手动分派的 `(m) handleX(msg)` 方法更新。只嵌了 `textinput` 和 `spinner` 两个 bubbles 组件。**没用 `viewport`**，滚动手写。
+- 用的是 **charm.land v2** 版（`bubbletea/v2 v2.0.7`、`lipgloss/v2`、`bubbles/v2`）+ `chroma/v2`（高亮）+ `go-udiff`（diff 文本，在 tools 层非 TUI）。
+
+### B.2 事件桥（agent goroutine → bubbletea loop）—— 最值得借鉴
+
+- agent 跑在一个 `tea.Cmd` goroutine 里（`agent.Run` 阻塞调用），**但流式事件不走 Cmd 返回值**。
+- 模型注册 agent 回调（OnText/OnReasoning/OnToolCallStart/Delta/OnPermissionRequest/...），回调**同步**被 agent loop 调用，内部把 typed `tea.Msg` 推给 `runtimeMessageSink`。
+- `runtimeMessageSink` 在 `Run()` 里接到 `program.Send(msg)` —— **这就是 channel 桥**：`program.Send` 是 bubbletea 线程安全的注入点，把 goroutine 的消息送回单一 Update loop。Cmd 只返回终态结果。
+- **对 pigo 的直接意义**：pigo 的 loop 发的 `AgentEvent`（§研究1 §2）在 TUI 模式下，正好通过一个 `func(AgentEvent)` sink → `program.Send` 桥接进 bubbletea。这解决了「loop 的 channel 事件流如何进 TUI 事件循环」这个 US-022 核心问题。
+
+### B.3 流式渲染要点
+
+- **streaming text 不进 transcript rows**：`m.streamingText` 单独存，`View` 里以 "pending interim" item 每帧重渲染；**开着的 ``` 代码块缓冲到闭合 fence 才渲染**（避免逐 token 重新高亮闪烁），按 prefix SHA-256 缓存。
+- **tool-call-in-progress**：增量 O(fragment) JSON decoder（`streaming_decoder.go`，避免 O(n²) 重扫）抽出文件路径+尾部内容行，渲染 "writing" 块；结果 card 落地时清掉 live 块。
+- **runID 戳 + stale-run guard**：每个 msg 带 runID，`msg.runID != m.activeRunID` 直接丢弃 —— 取消旧 run、启新 run 时防迟到消息污染状态。**关键正确性模式**。
+- **屏幕 diff 完全交给 bubbletea**：无手写 cursor/framebuffer diff（grep `\x1b[2J`/cursor-up 全空）。`View` 返回字符串，bubbletea renderer 做增量重绘。代码 +/- diff 是**内容**（`go-udiff` 生成文本，TUI 只做样式），非屏幕 diff。**印证 PRD「不自研差分渲染」可行**。
+
+### B.4 对 pigo 的建议（→ #11 TUI 选型决策的输入）
+
+**借鉴**：单 Model + 平铺 state struct（避免子 Model 转发税）；callback→`program.Send` 桥；runID stale guard；interim 流式块与 committed rows 分离 + 代码块 fence 缓冲；增量 tool-call decoder；两阶段确认（Ctrl+C/Esc）；queue-one-follow-up steering（见 B.5）。
+
+**避免**：177KB 的 model.go god-file（保留单 Model 思路但**拆文件**）；手写滚动 viewport（优先用 stock `bubbles/viewport`，除非要 zero 的逐行选择/hover）；fade/ripple 动画机制（非必要，先上静态 spinner + elapsed clock）；**绝不**手写 unified-diff 文本（用 go-udiff）或屏幕帧 diff（返回字符串让 bubbletea diff）。
+
+**选型倾向**：charm.land/bubbletea v2 生态可用（zero 已验证 v2 可行），但需确认 v2 稳定性/API；保守选择是 `github.com/charmbracelet/bubbletea`（v1，更稳）。这一取舍留给 #11 与你敲定。
+
+### B.5 中断与 steering（与 pi loop 语义的映射）
+
+- **Ctrl+C** 两阶段：非 pending 且 composer 有文本 → 清 composer；否则 cancelRun + 武装退出确认（`tea.Tick` 过期），窗口内二次 Ctrl+C 退出。
+- **Esc** 两阶段取消确认。**cancelRun** 调 `context.CancelFunc`，记录部分答案 + "Run cancelled." 标记，阻塞的 permission/askUser goroutine 靠 `ctx.Done()` 解除。
+- **steering = queue-next-turn，非 mid-turn 注入**：agent 运行时提交的 prompt 存进 `m.queuedMessage`（单条），当前 run 结束后作为新 run 启动。
+  - **与 pi 的差异（重要）**：pi 的 `getSteeringMessages` 是**每轮工具执行后注入到下一轮之前**（agent 还在干活时插话，同一 run 内）；zero 的 queue-next-turn 是**等整个 run 结束才启新 run**。pi 的 steering 更细粒度。pigo 若要严格复刻 pi，TUI 层的 `getSteeringMessages` 应在**当前 run 内每轮后**喂入队列的消息，而非 zero 的「结束后启新 run」。**记录为 pigo 需按 pi 语义实现、不照搬 zero 的点**。
+
+---
+
+## C. Sandbox / 权限 / redaction 层（→ US-026；解锁 ticket #7 sandbox 强度）
+
+### C.1 隔离强度：**两层解耦** —— 进程内策略 + 可选 OS 级隔离
+
+zero 同时有两者，且**刻意解耦**：进程内策略门**永远**跑；OS 隔离 best-effort、可降级。
+
+**Layer A — 进程内策略引擎（always-on）**：`internal/sandbox/engine.go:277` `Evaluate(ctx, Request) Decision`，纯 Go 的 allow/prompt/deny 评估（路径校验、网络分类、破坏性命令检查、grant 查询），任何执行前跑。**这一层就是 pigo v1 要的 `beforeToolCall` 门。**
+
+**Layer B — OS 级隔离（per-platform，`selectPlatformBackend`）**：macOS `sandbox-exec`(Seatbelt/SBPL)；Linux bubblewrap(`bwrap`)；Windows restricted-token + WFP + ACL。Landlock 是**未接线的 stub**（`linux_helper.go:137` 返回 "not implemented"）—— Linux 唯一活的是 bubblewrap。额外 Linux seccomp BPF（AF_UNIX/网络 deny）。
+
+**降级带底线**：OS backend 不可用时降到 `EnforcementDegraded/Disabled`，**但进程内策略门 + 逐命令审批仍生效**。—— **这正是 pigo「OS 隔离作为后续步骤」要的语义：Go 门是地板，OS 隔离是叠加。**
+
+### C.2 策略表达与执行点
+
+- **Policy schema**（`types.go:151`）：`Mode`(disabled/enforce)、`Network`(allow/deny)、`EnforceWorkspace`、细粒度 `AllowRead/DenyRead/AllowWrite/DenyWrite []string`（DenyWrite 最高优先；每条 home 展开+绝对化+符号链接解析）、`BlockUnixSockets`、`MonitorDenials`。默认：enforce + NetworkDeny + EnforceWorkspace。
+- **read-all / write-jail 默认姿态**：全盘可读、写限于 workspace + 额外 roots；secrets 靠 `DenyRead` 隐藏；保护元数据目录 `.git/.zero/.agents`。
+- **配置安全细节**：额外写 root **只认全局用户配置 + CLI，不认项目配置**（防恶意 repo 给自己放开写权限）。config→policy overlay 只开不关。
+- **执行门（两处，都在执行前）**：
+  - `internal/tools/registry.go:136` `RunWithOptions` 调 `Sandbox.Evaluate`，`ActionDeny` 硬返回 error result，`ActionPrompt` 未授权返回 "approval required"。**这是权威门**：每个 tool run 都过 registry。
+  - `internal/agent/loop.go:860` loop 也调 `Evaluate`（preflight）驱动交互式审批 UX。
+- **shell 命令分析用真 AST**（`mvdan.cc/sh/v3/syntax`，`analyzer.go`）非纯正则：走 AST 分类 interactive/destructive/network，解 wrapper 前缀（sudo/env/bash -c）并递归 `sh -c`。正则只在解析失败时兜底。
+
+### C.3 secret redaction：正则 + 已知 key 注册表（两个互补包）
+
+- **`internal/redaction`**（主 scrubber，结构化 + 正则）：~40 个精确敏感 key 名 + 段启发式 + 保守结构规则（避免 `max_tokens`/`public_key` 误伤）；值正则（sk-/sk-ant-api/ghp_/glpat-/AIza/xox./AKIA/JWT）；结构正则（PEM、`"key":"val"`、`KEY=val`、Authorization 头、URL query/userinfo）；`RedactValue` 反射深走 map/struct/slice 带 cycle 检测。
+- **`internal/secrets/scanner.go`**（窄而高精度、零依赖，专用于 shell/tool 输出）：`\b`-anchored 正则，longest-match-first 替换为 `[REDACTED:<type>]`。
+- **接线点（单一 choke point）**：`registry.go:117` 一个 `defer scrubResultSecrets(result)` 在**每条返回路径**上跑 redaction（Output/Summary/Preview/Meta）。bash 工具额外跑 `secrets.Redact`。
+- `internal/securefile`（AES-256-GCM 加密**存储**，仅 credstore 用）—— 是凭据落盘加密，非输出脱敏；pigo 仅在持久化凭据时相关。
+
+### C.4 与 tool 执行路径的集成 = pi 的 beforeToolCall 等价物
+
+- **sandbox 门本身就是 `beforeToolCall` 等价物**（registry.go:136，tool.Run 前调 Evaluate）。
+- zero **另有**一套通用 `beforeTool`/`afterTool` 外部 hook 系统（loop.go:1002/1068）—— 用户配置的外部 hook，与 sandbox 门是**两回事**。
+- loop 内顺序：filters → pre-permission reject → 命令前缀 grant → **Sandbox.Evaluate preflight** → 交互审批 → **beforeTool hooks** → `registry.RunWithOptions`（再跑 Evaluate 作权威门）→ afterTool hooks → 边界 secret scrub。
+- **grants**：可持久化或 session-scoped，scope 按 tool/file/dir/host（`~/.config/zero/sandbox-grants.json`，0600，**明文**）；命令前缀 grant 支持 "always allow git status"。
+
+### C.5 对 pigo 的建议（→ #7 sandbox 强度决策的输入）
+
+**借鉴**：
+- **解耦两层架构** —— `Evaluate(ctx, Request) → Decision{Action, Risk, Reason, Block}` 纯函数，就是 pigo v1 的 `beforeToolCall` 门，独立于任何 OS backend 且可独立测试。
+- **registry 单 choke-point 执行 + `defer` scrub** —— 不散在各 tool，保证无 tool 能绕过门或漏 secret。
+- **tool 声明 `SideEffect` + AST shell 分析器**（`mvdan.cc/sh/v3`）替代纯正则做风险分类。
+- **redaction 设计**：已知 key 注册表 + 精度优先正则 + 误伤规避 + longest-match-first；两包分工（结构化 redaction / 窄输出 secrets）。
+- **read-all/write-jail 姿态 + 保护 `.git` 等 + 每路径符号链接解析**（否则 symlink 前缀绕过 deny）。
+- **grant 模型**（session vs 持久、file/dir/host/tool scope + 命令前缀 grant）。
+- **降级带底线**：OS 隔离不可用时保留进程内门 + 逐命令审批，绝不 fail-open。**直接匹配 pigo「OS 隔离作后续」。**
+- **配置安全**：额外写 root 只认全局/CLI 不认项目配置。
+
+**避免 / 延后**：
+- **不要一上来做四个 OS backend**（Seatbelt SBPL 生成、bwrap 参数、Windows WFP+ACL+restricted-token、WSL 检测都是大维护面）—— PRD 已正确延后，v1 先上进程内门。
+- **Landlock 是坑**（zero 自己都 stub 了，且表达不了 DenyRead/DenyWrite）；将来加 Linux 隔离走 bubblewrap，别从 Landlock 起。
+- macOS Seatbelt 脆弱（sandbox-exec 已废弃、`cd` 误报 ENOTDIR、denial monitor 某些 OS 版本静默失效）。
+- grant store 明文 JSON（grants 不是 secret 无需加密，但凭据持久化要走 securefile 模式）。
+- **不要混淆两个 "beforeTool"**：pigo v1 sandbox 门单独就满足 `beforeToolCall`；通用外部 hook 系统是可分离的后续特性。
+
+---
+
+## D. 对下游 ticket / 雾区的影响
+
+- **解锁 ticket #7（sandbox 强度）**：C.5 已给出明确输入。倾向结论：**v1 = 进程内 `Evaluate` 门（接 beforeToolCall）+ redaction 单 choke-point + AST shell 分析；OS 隔离（首选 bubblewrap/Seatbelt）作后续阶段，降级带底线**。待 #7 与你确认。
+- **解锁 ticket #11（TUI 选型）**：B.4 已给出输入。倾向：单 Model + callback→program.Send 桥 + runID guard + stock viewport；bubbletea v1 vs charm.land v2 的稳定性取舍留给 #11。
+- **graduate 雾区「Provider 通用 transport 抽象」**：A.1/A.2 已足够锐利 —— 可成 ticket（providerio 式共享层：SSE scanner + HTTP client + retry/auth/看门狗 + dual failure model）。
+- **新发现的复刻差异**：zero 的 steering 是 queue-next-turn，**与 pi 的 per-turn steering 语义不同**；pigo 须按 pi 实现（B.5）。这条影响 US-022 与 loop（US-006 已复刻 pi 语义，TUI 层对接时勿照搬 zero）。


### PR DESCRIPTION
## Summary
- EventStream[T,R]：chan T + sync.Once + resultCh 兑现结果，替代 pi 的 async generator
- Events() 供 `for ev := range` 迭代；Result(ctx) 解耦取结果，不塞进事件 channel
- 保留 IsComplete/ExtractResult 回调，Emit 命中终态事件自动捕获结果
- Emit 在发送时 select ctx.Done()，支持取消且不泄漏生产者 goroutine
- Close 无结果时兜底 ErrStreamIncomplete

Closes #18

## Test plan
- [x] go build ./... 通过
- [x] go vet ./... 无告警
- [x] go test ./internal/agent/ 通过（正常结束/回调捕获/取消/未兑现关闭/error 优先）