### PR TITLE
feat: 工具注册表 + JSON Schema 校验 (#19)

### DIFF
--- a/docs/issue#0019.html
+++ b/docs/issue#0019.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0019</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/19">#19</a> &mdash; 工具注册表 + JSON Schema 校验（US-014） &mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 注册时预编译 Schema，坏 Schema 早失败</h3>
+      <p><strong>Ambiguity:</strong> 验收只要求 "每工具声明 JSON Schema 并校验"，未规定编译时机。</p>
+      <p><strong>Choice:</strong> <code>Register</code> 时即 <code>Compile</code> 并缓存 <code>*jsonschema.Schema</code>；非法 Schema 在注册即报错。</p>
+      <p><strong>Rationale:</strong> 每次调用重编译浪费且把配置错误推迟到运行时；预编译让 Schema 错误在启动期暴露，运行时校验零编译开销。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 空/缺失参数按空对象 <code>{}</code> 校验</h3>
+      <p><strong>Ambiguity:</strong> 模型可能对无参工具发 <code>""</code> 或省略 arguments，Schema 校验对 nil 行为未定义。</p>
+      <p><strong>Choice:</strong> <code>nonEmptyJSON</code> 把空参数归一为 <code>{}</code> 再校验。</p>
+      <p><strong>Rationale:</strong> 使 "只含可选属性" 的 Schema 通过，同时让 required 缺失仍被正确报错，行为可预测。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 校验失败返回 tool result 而非 Go error</h3>
+      <p><strong>Spec:</strong> 验收写 "校验失败产出字段级 error tool result"。</p>
+      <p><strong>Implemented:</strong> <code>Validate</code> 返回 <code>[]FieldError</code>，<code>ValidationErrorResult</code> 组装成 <code>AgentToolResult</code>（Details 携带结构化 <code>[]FieldError</code>，Terminate 留 nil）。</p>
+      <p><strong>Why:</strong> 契合 provider 层 "运行时失败编码进结果而非抛错" 的地基约定——校验失败应回喂给模型自我修正，不是中断循环。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 只收集叶子 cause 做字段级错误</h3>
+      <p><strong>Alternatives:</strong> (A) 只返回顶层 error.Error() 字符串；(B) 递归 ValidationError.Causes 取最具体的叶子。</p>
+      <p><strong>Pros/Cons:</strong> A 简单但信息笼统（"validation failed"）；B 需遍历树，但能给出 <code>/age: got string, want integer</code> 这类可定位反馈。</p>
+      <p><strong>Winner:</strong> B——验收明确要 "字段级"，叶子 cause 的 InstanceLocation 正好映射为 JSON pointer。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 每工具用独立 mem:// URL 编译</h3>
+      <p><strong>Alternatives:</strong> 共享一个 compiler/URL vs 每工具独立 resource URL。</p>
+      <p><strong>Pros/Cons:</strong> 共享省对象但 $id/$ref 可能冲突；独立 URL（<code>mem:///{name}.json</code>）隔离彻底。</p>
+      <p><strong>Winner:</strong> 独立 URL，避免跨工具 Schema 命名冲突，代价仅是每工具一个 compiler。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 校验用英文 message.Printer 输出</h3>
+      <p><strong>Assumption:</strong> <code>LocalizedString</code> 需非 nil printer，当前固定 <code>language.English</code>。</p>
+      <p><strong>Verify:</strong> 面向模型的错误文案用英文即可（模型无关语言）；若后续要中文面向用户展示，可换 printer。请确认英文错误文案可接受。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/smallnest/pigo
 
 go 1.27rc1
+
+require (
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+	golang.org/x/text v0.14.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -1,0 +1,219 @@
+// This file implements the tool registry (US-014): tools are registered by
+// name, and their arguments are validated against a per-tool JSON Schema
+// (santhosh-tekuri/jsonschema v6) before execution. Validation failures are
+// turned into a field-level error tool result rather than a Go error, so the
+// model receives actionable feedback in the loop.
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+)
+
+// schemaPrinter renders jsonschema error kinds. LocalizedString dereferences
+// the printer, so it must be non-nil.
+var schemaPrinter = message.NewPrinter(language.English)
+
+// ToolRegistry stores tools by name and validates call arguments against each
+// tool's declared JSON Schema. It is safe for concurrent use.
+type ToolRegistry struct {
+	mu       sync.RWMutex
+	tools    map[string]AgentTool
+	compiled map[string]*jsonschema.Schema
+}
+
+// NewToolRegistry returns an empty registry.
+func NewToolRegistry() *ToolRegistry {
+	return &ToolRegistry{
+		tools:    make(map[string]AgentTool),
+		compiled: make(map[string]*jsonschema.Schema),
+	}
+}
+
+// Register adds a tool, compiling its JSON Schema up front so bad schemas fail
+// at registration rather than on first call. A duplicate name is an error. A
+// tool whose Schema() is empty is registered with no validation.
+func (r *ToolRegistry) Register(tool AgentTool) error {
+	name := tool.Name()
+	if name == "" {
+		return fmt.Errorf("registry: tool has empty name")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.tools[name]; exists {
+		return fmt.Errorf("registry: tool %q already registered", name)
+	}
+	if raw := tool.Schema(); len(bytes.TrimSpace(raw)) > 0 && !bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		sch, err := compileSchema(name, raw)
+		if err != nil {
+			return fmt.Errorf("registry: tool %q schema: %w", name, err)
+		}
+		r.compiled[name] = sch
+	}
+	r.tools[name] = tool
+	return nil
+}
+
+// Get returns the tool registered under name and whether it was found.
+func (r *ToolRegistry) Get(name string) (AgentTool, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	t, ok := r.tools[name]
+	return t, ok
+}
+
+// List returns all registered tools sorted by name (stable ordering for
+// deterministic provider tool declarations).
+func (r *ToolRegistry) List() []AgentTool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]AgentTool, 0, len(r.tools))
+	for _, t := range r.tools {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name() < out[j].Name() })
+	return out
+}
+
+// FieldError is a single validation failure located at a JSON-pointer path
+// within the arguments.
+type FieldError struct {
+	Field   string `json:"field"`   // JSON pointer, e.g. "/path" or "" for root
+	Message string `json:"message"` // human-readable reason
+}
+
+// Validate checks args against the tool's compiled schema. It returns nil when
+// the tool has no schema or the arguments are valid; otherwise it returns the
+// flattened field-level errors. An unknown tool name is reported as a single
+// root-level error.
+func (r *ToolRegistry) Validate(name string, args json.RawMessage) []FieldError {
+	r.mu.RLock()
+	_, known := r.tools[name]
+	sch, hasSchema := r.compiled[name]
+	r.mu.RUnlock()
+
+	if !known {
+		return []FieldError{{Field: "", Message: fmt.Sprintf("unknown tool %q", name)}}
+	}
+	if !hasSchema {
+		return nil
+	}
+
+	var inst any
+	dec := json.NewDecoder(bytes.NewReader(nonEmptyJSON(args)))
+	dec.UseNumber()
+	if err := dec.Decode(&inst); err != nil {
+		return []FieldError{{Field: "", Message: fmt.Sprintf("arguments are not valid JSON: %v", err)}}
+	}
+
+	if err := sch.Validate(inst); err != nil {
+		var verr *jsonschema.ValidationError
+		if as := asValidationError(err); as != nil {
+			verr = as
+		}
+		if verr != nil {
+			return flattenValidationError(verr)
+		}
+		return []FieldError{{Field: "", Message: err.Error()}}
+	}
+	return nil
+}
+
+// ValidationErrorResult builds an error AgentToolResult describing the given
+// field errors, for the loop to hand back to the model (FR: field-level error
+// tool result). Terminate is left nil (a validation failure never ends the run).
+func ValidationErrorResult(toolName string, errs []FieldError) AgentToolResult {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Invalid arguments for tool %q:\n", toolName)
+	for _, e := range errs {
+		field := e.Field
+		if field == "" {
+			field = "(root)"
+		}
+		fmt.Fprintf(&b, "  - %s: %s\n", field, e.Message)
+	}
+	return AgentToolResult{
+		Content: ContentList{NewTextContent(strings.TrimRight(b.String(), "\n"))},
+		Details: errs,
+	}
+}
+
+// compileSchema compiles a raw JSON Schema document held in memory.
+func compileSchema(name string, raw json.RawMessage) (*jsonschema.Schema, error) {
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	c := jsonschema.NewCompiler()
+	// A synthetic in-memory URL; each tool gets its own so schemas never clash.
+	loc := "mem:///" + name + ".json"
+	if err := c.AddResource(loc, doc); err != nil {
+		return nil, err
+	}
+	return c.Compile(loc)
+}
+
+// flattenValidationError walks the ValidationError tree and returns one
+// FieldError per leaf cause (the most specific failures), falling back to the
+// node itself when it has no causes.
+func flattenValidationError(e *jsonschema.ValidationError) []FieldError {
+	var out []FieldError
+	var walk func(n *jsonschema.ValidationError)
+	walk = func(n *jsonschema.ValidationError) {
+		if len(n.Causes) == 0 {
+			out = append(out, FieldError{
+				Field:   jsonPointer(n.InstanceLocation),
+				Message: n.ErrorKind.LocalizedString(schemaPrinter),
+			})
+			return
+		}
+		for _, c := range n.Causes {
+			walk(c)
+		}
+	}
+	walk(e)
+	if len(out) == 0 {
+		out = append(out, FieldError{Field: jsonPointer(e.InstanceLocation), Message: e.Error()})
+	}
+	return out
+}
+
+// jsonPointer renders an instance-location path as a JSON pointer.
+func jsonPointer(loc []string) string {
+	if len(loc) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, tok := range loc {
+		b.WriteByte('/')
+		tok = strings.ReplaceAll(tok, "~", "~0")
+		tok = strings.ReplaceAll(tok, "/", "~1")
+		b.WriteString(tok)
+	}
+	return b.String()
+}
+
+// asValidationError extracts a *jsonschema.ValidationError from err if present.
+func asValidationError(err error) *jsonschema.ValidationError {
+	if verr, ok := err.(*jsonschema.ValidationError); ok {
+		return verr
+	}
+	return nil
+}
+
+// nonEmptyJSON treats empty arguments as an empty object so schemas with only
+// optional properties validate, and "required" violations are reported.
+func nonEmptyJSON(args json.RawMessage) []byte {
+	if len(bytes.TrimSpace(args)) == 0 {
+		return []byte("{}")
+	}
+	return args
+}

--- a/internal/agent/registry_test.go
+++ b/internal/agent/registry_test.go
@@ -1,0 +1,136 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// stubTool is a minimal AgentTool for registry tests.
+type stubTool struct {
+	name   string
+	schema string
+}
+
+func (s stubTool) Name() string                     { return s.name }
+func (s stubTool) Description() string              { return "stub" }
+func (s stubTool) Schema() json.RawMessage          { return json.RawMessage(s.schema) }
+func (s stubTool) ExecutionMode() ToolExecutionMode { return ToolExecutionParallel }
+func (s stubTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+	return AgentToolResult{Content: ContentList{NewTextContent("ok")}}, nil
+}
+
+const personSchema = `{
+  "type": "object",
+  "properties": {
+    "name": {"type": "string"},
+    "age":  {"type": "integer"}
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}`
+
+func newTestRegistry(t *testing.T) *ToolRegistry {
+	t.Helper()
+	r := NewToolRegistry()
+	if err := r.Register(stubTool{name: "person", schema: personSchema}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	return r
+}
+
+func TestRegistryRegisterAndGet(t *testing.T) {
+	r := newTestRegistry(t)
+	tool, ok := r.Get("person")
+	if !ok || tool.Name() != "person" {
+		t.Fatalf("Get(person) failed: %v %v", tool, ok)
+	}
+	if _, ok := r.Get("missing"); ok {
+		t.Error("Get(missing) should report not found")
+	}
+	if got := r.List(); len(got) != 1 || got[0].Name() != "person" {
+		t.Errorf("List wrong: %+v", got)
+	}
+}
+
+func TestRegistryDuplicateRejected(t *testing.T) {
+	r := newTestRegistry(t)
+	if err := r.Register(stubTool{name: "person", schema: personSchema}); err == nil {
+		t.Fatal("expected duplicate registration to error")
+	}
+}
+
+func TestRegistryValidArgs(t *testing.T) {
+	r := newTestRegistry(t)
+	errs := r.Validate("person", json.RawMessage(`{"name":"ada","age":36}`))
+	if errs != nil {
+		t.Fatalf("valid args reported errors: %+v", errs)
+	}
+}
+
+func TestRegistryMissingRequiredField(t *testing.T) {
+	r := newTestRegistry(t)
+	errs := r.Validate("person", json.RawMessage(`{"age":36}`))
+	if len(errs) == 0 {
+		t.Fatal("expected error for missing required field 'name'")
+	}
+}
+
+func TestRegistryTypeError(t *testing.T) {
+	r := newTestRegistry(t)
+	errs := r.Validate("person", json.RawMessage(`{"name":"ada","age":"old"}`))
+	if len(errs) == 0 {
+		t.Fatal("expected type error for age")
+	}
+	// The offending field should be located at /age.
+	found := false
+	for _, e := range errs {
+		if e.Field == "/age" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a field error at /age, got %+v", errs)
+	}
+}
+
+func TestRegistryUnknownTool(t *testing.T) {
+	r := newTestRegistry(t)
+	errs := r.Validate("nope", json.RawMessage(`{}`))
+	if len(errs) != 1 || errs[0].Field != "" {
+		t.Fatalf("expected single root error for unknown tool, got %+v", errs)
+	}
+}
+
+func TestRegistryNoSchemaSkipsValidation(t *testing.T) {
+	r := NewToolRegistry()
+	if err := r.Register(stubTool{name: "free", schema: ""}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if errs := r.Validate("free", json.RawMessage(`{"anything":true}`)); errs != nil {
+		t.Fatalf("no-schema tool should skip validation, got %+v", errs)
+	}
+}
+
+func TestValidationErrorResultShape(t *testing.T) {
+	r := newTestRegistry(t)
+	errs := r.Validate("person", json.RawMessage(`{"age":36}`))
+	res := ValidationErrorResult("person", errs)
+	if len(res.Content) == 0 {
+		t.Fatal("expected content in validation error result")
+	}
+	if _, ok := res.Details.([]FieldError); !ok {
+		t.Errorf("expected Details to carry []FieldError, got %T", res.Details)
+	}
+	if res.Terminate != nil {
+		t.Error("validation failure must not terminate the run")
+	}
+}
+
+func TestRegistryBadSchemaRejectedAtRegister(t *testing.T) {
+	r := NewToolRegistry()
+	err := r.Register(stubTool{name: "bad", schema: `{"type": 123}`})
+	if err == nil {
+		t.Fatal("expected invalid schema to fail at registration")
+	}
+}


### PR DESCRIPTION
## Summary
- ToolRegistry 按 name 注册/查询/列出工具，并发安全（RWMutex）
- 注册时预编译 JSON Schema（santhosh-tekuri/jsonschema v6），非法 Schema 在注册即报错
- Validate 校验参数，失败返回字段级 []FieldError（JSON pointer 定位到 /age 等）
- ValidationErrorResult 组装为 error tool result（Details 携带结构化 []FieldError，Terminate 留 nil）
- 空/缺失参数归一为 {} 校验；无 Schema 工具跳过校验

Closes #19

## Test plan
- [x] go build ./... 通过
- [x] go vet ./... 无告警
- [x] go test ./internal/agent/ 通过（合法/缺 required/类型错误/未知工具/坏 Schema/无 Schema/结果形状）