### PR TITLE
streamAssistantResponse streaming backfill (US-003)

### DIFF
--- a/docs/issue#0020.html
+++ b/docs/issue#0020.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0020</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/20">#20</a> &mdash; streamAssistantResponse 流式回填（US-003） &mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 用 sealed interface + EventKind() 建模 provider delta 事件</h3>
+      <p><strong>Ambiguity:</strong> pi 用 TS discriminated union 表达流式 delta；Go 无原生等价物。</p>
+      <p><strong>Choice:</strong> <code>AssistantMessageEvent</code> 密封接口（未导出 <code>isAssistantMessageEvent()</code>）+ <code>EventKind()</code> 判别串，6 种事件 start/text/thinking/toolcall/done/error。</p>
+      <p><strong>Rationale:</strong> 密封接口锁死实现集合，loop 用 type switch 穷尽分发；EventKind 供 MessageUpdateEvent 透传给消费者，无需反射。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> "push placeholder + replace last" 回填部分消息</h3>
+      <p><strong>Ambiguity:</strong> 验收要 "partial 实时回填到 context"，但未定义首个 delta 前 context 尚无占位消息时的处理。</p>
+      <p><strong>Choice:</strong> <code>addedPartial</code> 布尔：首个 delta 时 append 占位，之后替换末位；done/error 时 <code>finalizeMessage</code> 同样兼顾 "没有 start 直接 done" 的边界。</p>
+      <p><strong>Rationale:</strong> 保证 context 里始终只有一条 assistant 消息随流增长，最终被终态消息原位替换，不会重复 append。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 终态用 <code>AssistantMessage{}</code> 零值而非 nil</h3>
+      <p><strong>Spec:</strong> pi 中 message 可为 null/undefined，失败路径返回空。</p>
+      <p><strong>Implemented:</strong> <code>AssistantMessage</code> 是具体 struct（非接口），作为 <code>EventStream[_, AssistantMessage]</code> 的 R 类型不可为 nil。取消/失败路径返回 <code>AssistantMessage{}, err</code>；空判用 <code>final.RoleField == ""</code> 而非 <code>== nil</code>。</p>
+      <p><strong>Why:</strong> Go 类型系统约束——具体 struct 无 nil 态，零值 + 字段判空是等价且类型安全的表达。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 早期 build 失败合成终态消息 vs 返回 error</h3>
+      <p><strong>Alternatives:</strong> (A) StreamFn 早期失败时 <code>streamAssistantResponse</code> 直接返回 Go error；(B) 合成 stopReason=error 的终态 assistant 消息，返回 nil error。</p>
+      <p><strong>Pros/Cons:</strong> A 让 loop 需双路径处理错误；B 统一——所有失败（早期/运行时）都表现为一条终态 assistant 消息，loop 只有一条记录路径。</p>
+      <p><strong>Winner:</strong> B（<code>newErrorAssistantMessage</code>），契合 FR-13 provider 契约 "运行时失败编码进消息而非抛错"。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> thinking/toolcall delta 目前与 text 走同一 MessageUpdateEvent 路径</h3>
+      <p><strong>Assumption:</strong> 三种非终态 delta（text/thinking/toolcall）都回填 partial 并发 message_update，仅靠 AssistantMessageEvent 区分。</p>
+      <p><strong>Verify:</strong> 后续若 UI 需对 thinking/toolcall 做差异化渲染（如折叠 thinking），消费者可从 <code>MessageUpdateEvent.AssistantMessageEvent</code> 的 EventKind 区分，暂无需在 loop 层分流。请确认此分工可接受。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -1,0 +1,114 @@
+// This file defines the provider streaming abstraction (US-003/US-007 base):
+// the StreamFn contract, the per-delta AssistantMessageEvent set, and the
+// AssistantMessageEventStream (a specialization of EventStream) that a provider
+// pushes deltas onto while yielding a final AssistantMessage.
+//
+// Contract (FR-13): a StreamFn never expresses a request failure by returning
+// an error. Runtime failures are encoded as an error event plus a terminal
+// assistant message (stopReason=error/aborted + errorMessage). The returned
+// error is reserved for the earliest "could not even build the stream" case.
+package agent
+
+import "context"
+
+// AssistantMessageEvent is the sealed interface for provider stream deltas. The
+// loop dispatches on EventKind; the raw event is also surfaced to consumers via
+// MessageUpdateEvent.AssistantMessageEvent.
+type AssistantMessageEvent interface {
+	isAssistantMessageEvent()
+	// EventKind returns the delta discriminant.
+	EventKind() string
+}
+
+// AssistantMessageEvent kinds.
+const (
+	StreamEventStart    = "start"
+	StreamEventText     = "text"
+	StreamEventThinking = "thinking"
+	StreamEventToolCall = "toolcall"
+	StreamEventDone     = "done"
+	StreamEventError    = "error"
+)
+
+// StreamStartEvent carries the initial (usually empty) partial message.
+type StreamStartEvent struct{ Partial AssistantMessage }
+
+// StreamTextEvent carries the partial message after a text delta.
+type StreamTextEvent struct{ Partial AssistantMessage }
+
+// StreamThinkingEvent carries the partial after a thinking delta.
+type StreamThinkingEvent struct{ Partial AssistantMessage }
+
+// StreamToolCallEvent carries the partial after a tool-call delta.
+type StreamToolCallEvent struct{ Partial AssistantMessage }
+
+// StreamDoneEvent is the terminal success event; Message is the final response.
+type StreamDoneEvent struct{ Message AssistantMessage }
+
+// StreamErrorEvent is the terminal failure event; Message carries the terminal
+// assistant message (stopReason=error/aborted + errorMessage).
+type StreamErrorEvent struct {
+	Message AssistantMessage
+	Err     error
+}
+
+func (StreamStartEvent) isAssistantMessageEvent()    {}
+func (StreamTextEvent) isAssistantMessageEvent()     {}
+func (StreamThinkingEvent) isAssistantMessageEvent() {}
+func (StreamToolCallEvent) isAssistantMessageEvent() {}
+func (StreamDoneEvent) isAssistantMessageEvent()     {}
+func (StreamErrorEvent) isAssistantMessageEvent()    {}
+
+func (StreamStartEvent) EventKind() string    { return StreamEventStart }
+func (StreamTextEvent) EventKind() string     { return StreamEventText }
+func (StreamThinkingEvent) EventKind() string { return StreamEventThinking }
+func (StreamToolCallEvent) EventKind() string { return StreamEventToolCall }
+func (StreamDoneEvent) EventKind() string     { return StreamEventDone }
+func (StreamErrorEvent) EventKind() string    { return StreamEventError }
+
+// AssistantMessageEventStream is the provider-level stream: deltas of type
+// AssistantMessageEvent with a final AssistantMessage result. isComplete fires
+// on done/error; extractResult takes the terminal event's message.
+type AssistantMessageEventStream = EventStream[AssistantMessageEvent, AssistantMessage]
+
+// NewAssistantMessageEventStream builds a provider stream wired with the
+// done/error completion callbacks.
+func NewAssistantMessageEventStream(buffer int) *AssistantMessageEventStream {
+	s := NewEventStream[AssistantMessageEvent, AssistantMessage](buffer)
+	s.IsComplete = func(e AssistantMessageEvent) bool {
+		k := e.EventKind()
+		return k == StreamEventDone || k == StreamEventError
+	}
+	s.ExtractResult = func(e AssistantMessageEvent) AssistantMessage {
+		switch ev := e.(type) {
+		case StreamDoneEvent:
+			return ev.Message
+		case StreamErrorEvent:
+			return ev.Message
+		default:
+			return AssistantMessage{}
+		}
+	}
+	return s
+}
+
+// LlmContext is the shaped request handed to a StreamFn: the system prompt, the
+// LLM-bound messages (UI-only messages already filtered), and the tools.
+type LlmContext struct {
+	SystemPrompt string
+	Messages     MessageList
+	Tools        []AgentTool
+}
+
+// StreamConfig carries per-request settings for a StreamFn.
+type StreamConfig struct {
+	APIKey        string
+	ThinkingLevel ThinkingLevel
+	// Extra holds provider-specific options; opaque to the loop.
+	Extra map[string]any
+}
+
+// StreamFn produces a provider stream for a model + shaped context. Per the
+// contract it returns an error only for early "cannot build the stream"
+// failures; all runtime failures ride the returned stream as error events.
+type StreamFn func(ctx context.Context, model string, llm LlmContext, cfg StreamConfig) (*AssistantMessageEventStream, error)

--- a/internal/agent/stream_response.go
+++ b/internal/agent/stream_response.go
@@ -1,0 +1,167 @@
+// This file implements streamAssistantResponse (US-003): it shapes the context
+// into a provider request, resolves the API key dynamically, drives the
+// provider stream, and back-fills the partial assistant message into the
+// context while emitting message_start / message_update / message_end events.
+package agent
+
+import (
+	"context"
+)
+
+// LoopConfig holds the pluggable behavior of the agent loop. Every hook is
+// optional (nil = use the default). The pointer/func-field pattern mirrors pi's
+// optional callbacks.
+type LoopConfig struct {
+	// Model is the model id passed to StreamFn.
+	Model string
+	// APIKey is the static fallback key when GetAPIKey is nil or returns "".
+	APIKey string
+	// ThinkingLevel is the reasoning effort for requests.
+	ThinkingLevel ThinkingLevel
+	// Stream produces the provider stream. Required (defaults are wired by
+	// callers/tests, e.g. a fake provider).
+	Stream StreamFn
+
+	// TransformContext optionally rewrites the message list before conversion
+	// (context trimming/injection). Contract: must not error; on failure return
+	// a safe fallback. Runs first.
+	TransformContext func(ctx context.Context, msgs MessageList) MessageList
+	// ConvertToLlm optionally filters UI-only messages. Defaults to identity.
+	// Contract: must not error.
+	ConvertToLlm func(msgs MessageList) MessageList
+	// GetAPIKey optionally resolves a fresh key per request (handles short-lived
+	// token expiry). Falls back to APIKey when nil or empty.
+	GetAPIKey func(ctx context.Context, provider string) string
+	// Provider is the provider name passed to GetAPIKey.
+	Provider string
+
+	// Extra is forwarded to StreamConfig.Extra.
+	Extra map[string]any
+}
+
+// emitFunc emits a loop-level AgentEvent honoring cancellation.
+type emitFunc func(ctx context.Context, ev AgentEvent) error
+
+// streamAssistantResponse runs one assistant turn: it builds the request from
+// agentCtx, streams the provider response, back-fills the partial into
+// agentCtx.Messages, and returns the final assistant message. The sequence
+// (transformContext → convertToLlm → resolve key → stream → drain) is kept
+// identical to pi. It never returns an error for a request failure — such
+// failures arrive as a terminal assistant message with stopReason error/aborted.
+func streamAssistantResponse(ctx context.Context, agentCtx *AgentContext, cfg LoopConfig, emit emitFunc) (AssistantMessage, error) {
+	// 1. transformContext (optional, must not error).
+	msgs := agentCtx.Messages
+	if cfg.TransformContext != nil {
+		msgs = cfg.TransformContext(ctx, msgs)
+	}
+	// 2. convertToLlm (filter UI-only; default identity).
+	if cfg.ConvertToLlm != nil {
+		msgs = cfg.ConvertToLlm(msgs)
+	}
+	// 3. shape the LLM context.
+	llm := LlmContext{
+		SystemPrompt: agentCtx.SystemPrompt,
+		Messages:     msgs,
+		Tools:        agentCtx.Tools,
+	}
+	// 4. resolve API key dynamically, fall back to static.
+	key := cfg.APIKey
+	if cfg.GetAPIKey != nil {
+		if dyn := cfg.GetAPIKey(ctx, cfg.Provider); dyn != "" {
+			key = dyn
+		}
+	}
+	// 5. build the provider stream.
+	stream, err := cfg.Stream(ctx, cfg.Model, llm, StreamConfig{
+		APIKey:        key,
+		ThinkingLevel: cfg.ThinkingLevel,
+		Extra:         cfg.Extra,
+	})
+	if err != nil {
+		// Early "cannot build stream" failure: synthesize a terminal message so
+		// the loop has a uniform assistant message to record.
+		return newErrorAssistantMessage(cfg, err), nil
+	}
+
+	// 6. drain the stream, back-filling the partial into the context.
+	addedPartial := false
+	backfill := func(partial AssistantMessage) {
+		if !addedPartial {
+			agentCtx.Messages = append(agentCtx.Messages, partial)
+			addedPartial = true
+		} else {
+			agentCtx.Messages[len(agentCtx.Messages)-1] = partial
+		}
+	}
+
+	for ev := range stream.Events() {
+		switch e := ev.(type) {
+		case StreamStartEvent:
+			backfill(e.Partial)
+			if err := emit(ctx, MessageStartEvent{Message: e.Partial}); err != nil {
+				return AssistantMessage{}, err
+			}
+		case StreamTextEvent:
+			backfill(e.Partial)
+			if err := emit(ctx, MessageUpdateEvent{Message: e.Partial, AssistantMessageEvent: e}); err != nil {
+				return AssistantMessage{}, err
+			}
+		case StreamThinkingEvent:
+			backfill(e.Partial)
+			if err := emit(ctx, MessageUpdateEvent{Message: e.Partial, AssistantMessageEvent: e}); err != nil {
+				return AssistantMessage{}, err
+			}
+		case StreamToolCallEvent:
+			backfill(e.Partial)
+			if err := emit(ctx, MessageUpdateEvent{Message: e.Partial, AssistantMessageEvent: e}); err != nil {
+				return AssistantMessage{}, err
+			}
+		case StreamDoneEvent:
+			finalizeMessage(agentCtx, e.Message, &addedPartial)
+			if err := emit(ctx, MessageEndEvent{Message: e.Message}); err != nil {
+				return AssistantMessage{}, err
+			}
+			return e.Message, nil
+		case StreamErrorEvent:
+			finalizeMessage(agentCtx, e.Message, &addedPartial)
+			if err := emit(ctx, MessageEndEvent{Message: e.Message}); err != nil {
+				return AssistantMessage{}, err
+			}
+			return e.Message, nil
+		}
+	}
+
+	// 7. stream ended without done/error: fall back to the stream result.
+	final, resErr := stream.Result(ctx)
+	if resErr != nil {
+		return newErrorAssistantMessage(cfg, resErr), nil
+	}
+	finalizeMessage(agentCtx, final, &addedPartial)
+	if err := emit(ctx, MessageEndEvent{Message: final}); err != nil {
+		return AssistantMessage{}, err
+	}
+	return final, nil
+}
+
+// finalizeMessage replaces the placeholder partial with the final message, or
+// appends it if the provider sent done/error without a prior start.
+func finalizeMessage(agentCtx *AgentContext, final AssistantMessage, addedPartial *bool) {
+	if *addedPartial {
+		agentCtx.Messages[len(agentCtx.Messages)-1] = final
+	} else {
+		agentCtx.Messages = append(agentCtx.Messages, final)
+		*addedPartial = true
+	}
+}
+
+// newErrorAssistantMessage builds a terminal assistant message for an early
+// failure that never produced a provider stream.
+func newErrorAssistantMessage(cfg LoopConfig, err error) AssistantMessage {
+	return AssistantMessage{
+		RoleField:    RoleAssistant,
+		Model:        cfg.Model,
+		Provider:     cfg.Provider,
+		StopReason:   StopReasonError,
+		ErrorMessage: err.Error(),
+	}
+}

--- a/internal/agent/stream_response_test.go
+++ b/internal/agent/stream_response_test.go
@@ -1,0 +1,173 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+// fakeStream builds a StreamFn that replays a fixed sequence of events, pushing
+// each onto an AssistantMessageEventStream from a producer goroutine.
+func fakeStream(events []AssistantMessageEvent) StreamFn {
+	return func(ctx context.Context, model string, llm LlmContext, cfg StreamConfig) (*AssistantMessageEventStream, error) {
+		s := NewAssistantMessageEventStream(0)
+		go func() {
+			for _, ev := range events {
+				if err := s.Emit(ctx, ev); err != nil {
+					s.SetError(err)
+					s.Close()
+					return
+				}
+			}
+			s.Close()
+		}()
+		return s, nil
+	}
+}
+
+// drives streamAssistantResponse with a synchronous emit that records events.
+func runStream(t *testing.T, agentCtx *AgentContext, cfg LoopConfig) (AssistantMessage, []AgentEvent) {
+	t.Helper()
+	var got []AgentEvent
+	emit := func(ctx context.Context, ev AgentEvent) error {
+		got = append(got, ev)
+		return nil
+	}
+	msg, err := streamAssistantResponse(context.Background(), agentCtx, cfg, emit)
+	if err != nil {
+		t.Fatalf("streamAssistantResponse: %v", err)
+	}
+	return msg, got
+}
+
+func TestStreamResponseBackfillAndEvents(t *testing.T) {
+	partial0 := AssistantMessage{RoleField: RoleAssistant}
+	partial1 := AssistantMessage{RoleField: RoleAssistant, Content: ContentList{NewTextContent("hel")}}
+	final := AssistantMessage{RoleField: RoleAssistant, Content: ContentList{NewTextContent("hello")}, StopReason: StopReasonEndTurn}
+
+	cfg := LoopConfig{
+		Model: "fake",
+		Stream: fakeStream([]AssistantMessageEvent{
+			StreamStartEvent{Partial: partial0},
+			StreamTextEvent{Partial: partial1},
+			StreamDoneEvent{Message: final},
+		}),
+	}
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+
+	msg, events := runStream(t, agentCtx, cfg)
+
+	if msg.StopReason != StopReasonEndTurn {
+		t.Errorf("final stopReason = %q, want end_turn", msg.StopReason)
+	}
+	// Context should hold the user message + the final assistant message (the
+	// placeholder was replaced, not appended twice).
+	if len(agentCtx.Messages) != 2 {
+		t.Fatalf("context messages = %d, want 2: %+v", len(agentCtx.Messages), agentCtx.Messages)
+	}
+	last, ok := agentCtx.Messages[1].(AssistantMessage)
+	if !ok || len(last.Content) != 1 {
+		t.Fatalf("last message not final assistant: %+v", agentCtx.Messages[1])
+	}
+	// Event order: message_start, message_update, message_end.
+	wantKinds := []string{EventMessageStart, EventMessageUpdate, EventMessageEnd}
+	if len(events) != len(wantKinds) {
+		t.Fatalf("event count = %d, want %d: %+v", len(events), len(wantKinds), events)
+	}
+	for i, w := range wantKinds {
+		if events[i].EventType() != w {
+			t.Errorf("event[%d] = %q, want %q", i, events[i].EventType(), w)
+		}
+	}
+}
+
+func TestStreamResponseErrorEvent(t *testing.T) {
+	errMsg := AssistantMessage{RoleField: RoleAssistant, StopReason: StopReasonError, ErrorMessage: "boom"}
+	cfg := LoopConfig{
+		Model:  "fake",
+		Stream: fakeStream([]AssistantMessageEvent{StreamErrorEvent{Message: errMsg}}),
+	}
+	agentCtx := &AgentContext{}
+	msg, events := runStream(t, agentCtx, cfg)
+	if msg.StopReason != StopReasonError || msg.ErrorMessage != "boom" {
+		t.Errorf("want error terminal message, got %+v", msg)
+	}
+	// No start event was sent; error should still append the terminal message.
+	if len(agentCtx.Messages) != 1 {
+		t.Fatalf("context messages = %d, want 1", len(agentCtx.Messages))
+	}
+	if events[len(events)-1].EventType() != EventMessageEnd {
+		t.Errorf("last event = %q, want message_end", events[len(events)-1].EventType())
+	}
+}
+
+func TestStreamResponseDynamicAPIKey(t *testing.T) {
+	var seenKey string
+	streamFn := func(ctx context.Context, model string, llm LlmContext, cfg StreamConfig) (*AssistantMessageEventStream, error) {
+		seenKey = cfg.APIKey
+		s := NewAssistantMessageEventStream(0)
+		go func() {
+			_ = s.Emit(ctx, StreamDoneEvent{Message: AssistantMessage{RoleField: RoleAssistant, StopReason: StopReasonEndTurn}})
+			s.Close()
+		}()
+		return s, nil
+	}
+	cfg := LoopConfig{
+		Model:     "fake",
+		APIKey:    "static-key",
+		Provider:  "test",
+		Stream:    streamFn,
+		GetAPIKey: func(ctx context.Context, provider string) string { return "dynamic-key" },
+	}
+	runStream(t, &AgentContext{}, cfg)
+	if seenKey != "dynamic-key" {
+		t.Errorf("dynamic key not used: got %q", seenKey)
+	}
+
+	// Empty dynamic key falls back to static.
+	cfg.GetAPIKey = func(ctx context.Context, provider string) string { return "" }
+	runStream(t, &AgentContext{}, cfg)
+	if seenKey != "static-key" {
+		t.Errorf("fallback to static key failed: got %q", seenKey)
+	}
+}
+
+func TestStreamResponseTransformAndConvertOrder(t *testing.T) {
+	var order []string
+	cfg := LoopConfig{
+		Model: "fake",
+		TransformContext: func(ctx context.Context, msgs MessageList) MessageList {
+			order = append(order, "transform")
+			return msgs
+		},
+		ConvertToLlm: func(msgs MessageList) MessageList {
+			order = append(order, "convert")
+			return msgs
+		},
+		Stream: func(ctx context.Context, model string, llm LlmContext, cfg StreamConfig) (*AssistantMessageEventStream, error) {
+			order = append(order, "stream")
+			s := NewAssistantMessageEventStream(0)
+			go func() {
+				_ = s.Emit(ctx, StreamDoneEvent{Message: AssistantMessage{RoleField: RoleAssistant}})
+				s.Close()
+			}()
+			return s, nil
+		},
+	}
+	runStream(t, &AgentContext{}, cfg)
+	if len(order) != 3 || order[0] != "transform" || order[1] != "convert" || order[2] != "stream" {
+		t.Errorf("call order wrong: %v", order)
+	}
+}
+
+func TestStreamResponseEarlyBuildFailure(t *testing.T) {
+	cfg := LoopConfig{
+		Model: "fake",
+		Stream: func(ctx context.Context, model string, llm LlmContext, cfg StreamConfig) (*AssistantMessageEventStream, error) {
+			return nil, context.DeadlineExceeded
+		},
+	}
+	msg, _ := runStream(t, &AgentContext{}, cfg)
+	if msg.StopReason != StopReasonError {
+		t.Errorf("early build failure should yield error message, got %+v", msg)
+	}
+}


### PR DESCRIPTION
## Summary
- Add provider stream abstraction: `AssistantMessageEvent` sealed interface (6 kinds), `StreamFn` contract, `AssistantMessageEventStream`
- Implement `streamAssistantResponse`: transformContext → convertToLlm → dynamic API key resolution → stream → drain with partial backfill
- Emit message_start / message_update / message_end; return terminal assistant message with stopReason
- Fake-provider tests cover streaming backfill, error terminal, dynamic key fallback, hook order, early build failure

Closes #20

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./internal/agent/