### PR TITLE
Three-phase tool execution: prepare/execute/finalize (US-004)

### DIFF
--- a/docs/issue#0021.html
+++ b/docs/issue#0021.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0021</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/21">#21</a> &mdash; 工具三段式 prepare→execute→finalize（US-004） &mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 三段拆为三个独立函数 + 短路结果指针</h3>
+      <p><strong>Ambiguity:</strong> 验收要求 prepare→execute→finalize，但未规定内部函数边界。</p>
+      <p><strong>Choice:</strong> <code>prepareToolCall</code> 返回 <code>(tool, args, *AgentToolResult, isError)</code>——非 nil result 即短路（未找到/校验失败/block/abort），直接进 finalize 不 execute；<code>runTool</code> 负责 execute+panic 恢复；<code>finalizeToolCall</code> 负责 afterToolCall 覆盖 + 事件 + 组装消息。</p>
+      <p><strong>Rationale:</strong> 让 "所有失败路径都走 finalize（因此都过 afterToolCall 钩子并发 end 事件）" 这一 pi 语义显式化，避免每个错误分支各自组装消息。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> block 默认文案 + 可选 Content/Details 覆盖</h3>
+      <p><strong>Ambiguity:</strong> 验收只说 "block 产出 error result"，未规定 result 内容。</p>
+      <p><strong>Choice:</strong> <code>BeforeToolCallDecision</code> 带可选 <code>*Content/*Details</code>：不设则用默认 "blocked by beforeToolCall" 文案，设了则用调用方的（权限系统可给出拒绝原因）。</p>
+      <p><strong>Rationale:</strong> 权限/沙箱场景（FR-26）需要向模型解释为何拒绝，硬编码文案不够。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 所有失败编码为 error tool result，不返回 Go error</h3>
+      <p><strong>Spec:</strong> 验收写 "抛错时转为 error tool result 而非 panic"。</p>
+      <p><strong>Implemented:</strong> <code>executeToolCall</code> 签名 <code>(ToolResultMessage, bool)</code>——完全不返回 error。未找到/校验/block/abort/tool error/panic 六种失败一律产 IsError=true 的消息。</p>
+      <p><strong>Why:</strong> 契合 provider 层地基约定——失败回喂模型自我修正，loop 只有一条消息记录路径，无双路径错误处理。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> afterToolCall 字段级覆盖用四个 if 而非反射/合并</h3>
+      <p><strong>Alternatives:</strong> (A) 逐字段 nil 判断覆盖；(B) 反射/深合并。</p>
+      <p><strong>Pros/Cons:</strong> A 直白、与 pi "无深合并" 语义一致，每个指针字段独立三态；B 更 "通用" 但引入深合并语义，恰是 pi 明确拒绝的。</p>
+      <p><strong>Winner:</strong> A——验收明确 "无深合并，与 pi 一致"，四个 if 正好表达字段级替换。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 本 issue 只做单个工具三段式，批量并行/串行留给 US-005（#22）</h3>
+      <p><strong>Assumption:</strong> <code>executeToolCall</code> 处理单次调用；<code>ToolExecutionMode</code>（parallel/sequential）与整批 terminate 语义（仅全 true 才终止）属 US-005 范畴，本 issue 未编排批量。</p>
+      <p><strong>Verify:</strong> 请确认单工具三段式与批量编排的拆分符合预期——#22 将在此之上加 sequential/parallel 保序与整批 terminate 判定。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/tool_executor.go
+++ b/internal/agent/tool_executor.go
@@ -1,0 +1,202 @@
+// This file implements the three-phase tool execution (US-004): prepare →
+// execute → finalize, with the beforeToolCall / afterToolCall hooks. It mirrors
+// pi's agent-loop tool handling: a tool call is looked up in the registry, its
+// arguments are (optionally) prepared and schema-validated, the beforeToolCall
+// hook may block it, the tool runs (streaming partial updates), and the
+// afterToolCall hook may override the result field-by-field (no deep merge).
+//
+// Every failure mode (unknown tool, validation failure, block, abort, tool
+// error/panic) is turned into an error tool result rather than a Go error, so
+// the loop always has a ToolResultMessage to feed back to the model.
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// PrepareArgumentsFunc optionally rewrites a tool's raw arguments before schema
+// validation (e.g. injecting defaults). An error aborts the call with an error
+// result. Optional (nil = identity).
+type PrepareArgumentsFunc func(ctx context.Context, toolName string, args json.RawMessage) (json.RawMessage, error)
+
+// BeforeToolCallDecision is the optional result of the beforeToolCall hook. When
+// Block is true the tool is not executed and an error result is produced;
+// Content/Details override the default block message when set.
+type BeforeToolCallDecision struct {
+	Block   bool
+	Content *ContentList
+	Details *any
+}
+
+// BeforeToolCallFunc runs after validation and may block the call (permission /
+// sandbox checks, FR-4/FR-26). Returning nil allows the call. Optional.
+type BeforeToolCallFunc func(ctx context.Context, call AgentToolCall) *BeforeToolCallDecision
+
+// AfterToolCallFunc runs after execution and may override the result
+// field-by-field via AfterToolCallResult (FR-5, no deep merge). Optional.
+type AfterToolCallFunc func(ctx context.Context, call AgentToolCall, result AgentToolResult, isError bool) *AfterToolCallResult
+
+// ToolExecutorConfig holds the registry and the optional per-phase hooks. Every
+// hook is optional (nil = default behavior).
+type ToolExecutorConfig struct {
+	Registry         *ToolRegistry
+	PrepareArguments PrepareArgumentsFunc
+	BeforeToolCall   BeforeToolCallFunc
+	AfterToolCall    AfterToolCallFunc
+}
+
+// executeToolCall runs one tool call through prepare → execute → finalize and
+// returns the resulting ToolResultMessage plus whether the batch should
+// terminate. emit may be nil (no events). It never returns a Go error: every
+// failure is encoded into the returned message with IsError=true.
+func executeToolCall(ctx context.Context, cfg ToolExecutorConfig, call AgentToolCall, emit emitFunc) (ToolResultMessage, bool) {
+	// 1. prepare: lookup, prepareArguments, validate, beforeToolCall.
+	tool, args, prep, isError := prepareToolCall(ctx, cfg, call)
+	if prep != nil {
+		// Prepare short-circuited (unknown tool / prepare error / validation /
+		// block / abort): finalize the error result without executing.
+		return finalizeToolCall(ctx, cfg, call, *prep, isError, emit)
+	}
+
+	// 2. execute.
+	if emit != nil {
+		if err := emit(ctx, ToolExecutionStartEvent{ToolCallID: call.ID, ToolName: call.Name, Args: args}); err != nil {
+			return errorToolResult(call, "aborted before execution: "+err.Error()), false
+		}
+	}
+	result, isError := runTool(ctx, tool, call, args, emit)
+
+	// 3. finalize: afterToolCall overrides.
+	return finalizeToolCall(ctx, cfg, call, result, isError, emit)
+}
+
+// prepareToolCall performs the prepare phase. On success it returns the tool and
+// the (possibly rewritten) arguments with a nil result. On any short-circuit it
+// returns a non-nil *AgentToolResult and the isError flag.
+func prepareToolCall(ctx context.Context, cfg ToolExecutorConfig, call AgentToolCall) (AgentTool, json.RawMessage, *AgentToolResult, bool) {
+	if ctx.Err() != nil {
+		r := errorResult(fmt.Sprintf("tool %q aborted before execution", call.Name))
+		return nil, nil, &r, true
+	}
+
+	// Registry lookup.
+	tool, ok := cfg.Registry.Get(call.Name)
+	if !ok {
+		r := errorResult(fmt.Sprintf("unknown tool %q", call.Name))
+		return nil, nil, &r, true
+	}
+
+	// prepareArguments (optional).
+	args := call.Arguments
+	if cfg.PrepareArguments != nil {
+		prepared, err := cfg.PrepareArguments(ctx, call.Name, args)
+		if err != nil {
+			r := errorResult(fmt.Sprintf("prepareArguments for %q failed: %v", call.Name, err))
+			return nil, nil, &r, true
+		}
+		args = prepared
+	}
+
+	// JSON Schema validation.
+	if errs := cfg.Registry.Validate(call.Name, args); len(errs) > 0 {
+		r := ValidationErrorResult(call.Name, errs)
+		return nil, nil, &r, true
+	}
+
+	// beforeToolCall hook (may block).
+	if cfg.BeforeToolCall != nil {
+		if dec := cfg.BeforeToolCall(ctx, AgentToolCall{ID: call.ID, Name: call.Name, Arguments: args}); dec != nil && dec.Block {
+			r := AgentToolResult{}
+			if dec.Content != nil {
+				r.Content = *dec.Content
+			} else {
+				r.Content = ContentList{NewTextContent(fmt.Sprintf("tool %q blocked by beforeToolCall", call.Name))}
+			}
+			if dec.Details != nil {
+				r.Details = *dec.Details
+			}
+			return nil, nil, &r, true
+		}
+	}
+
+	return tool, args, nil, false
+}
+
+// runTool executes the tool, converting a returned error or a panic into an
+// error result instead of propagating it (FR: never panic).
+func runTool(ctx context.Context, tool AgentTool, call AgentToolCall, args json.RawMessage, emit emitFunc) (result AgentToolResult, isError bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			result = errorResult(fmt.Sprintf("tool %q panicked: %v", call.Name, r))
+			isError = true
+		}
+	}()
+
+	onUpdate := func(partial AgentToolResult) {
+		if emit == nil {
+			return
+		}
+		_ = emit(ctx, ToolExecutionUpdateEvent{ToolCallID: call.ID, ToolName: call.Name, PartialResult: partial})
+	}
+
+	res, err := tool.Execute(ctx, call.ID, args, onUpdate)
+	if err != nil {
+		return errorResult(fmt.Sprintf("tool %q failed: %v", call.Name, err)), true
+	}
+	return res, false
+}
+
+// finalizeToolCall applies the afterToolCall hook (field-level override, no deep
+// merge), emits the tool_execution_end event, and builds the ToolResultMessage.
+// It returns the message and whether this result requests termination.
+func finalizeToolCall(ctx context.Context, cfg ToolExecutorConfig, call AgentToolCall, result AgentToolResult, isError bool, emit emitFunc) (ToolResultMessage, bool) {
+	if cfg.AfterToolCall != nil {
+		if ov := cfg.AfterToolCall(ctx, call, result, isError); ov != nil {
+			if ov.Content != nil {
+				result.Content = *ov.Content
+			}
+			if ov.Details != nil {
+				result.Details = *ov.Details
+			}
+			if ov.Terminate != nil {
+				result.Terminate = ov.Terminate
+			}
+			if ov.IsError != nil {
+				isError = *ov.IsError
+			}
+		}
+	}
+
+	if emit != nil {
+		_ = emit(ctx, ToolExecutionEndEvent{ToolCallID: call.ID, ToolName: call.Name, Result: result, IsError: isError})
+	}
+
+	terminate := result.Terminate != nil && *result.Terminate
+	return ToolResultMessage{
+		RoleField:  RoleToolResult,
+		ToolCallID: call.ID,
+		ToolName:   call.Name,
+		Content:    result.Content,
+		Details:    result.Details,
+		IsError:    isError,
+	}, terminate
+}
+
+// errorResult builds an error AgentToolResult carrying a single text block.
+func errorResult(msg string) AgentToolResult {
+	return AgentToolResult{Content: ContentList{NewTextContent(msg)}}
+}
+
+// errorToolResult builds an error ToolResultMessage directly (used when a call
+// is aborted outside the normal finalize path).
+func errorToolResult(call AgentToolCall, msg string) ToolResultMessage {
+	return ToolResultMessage{
+		RoleField:  RoleToolResult,
+		ToolCallID: call.ID,
+		ToolName:   call.Name,
+		Content:    ContentList{NewTextContent(msg)},
+		IsError:    true,
+	}
+}

--- a/internal/agent/tool_executor_test.go
+++ b/internal/agent/tool_executor_test.go
@@ -1,0 +1,189 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// execTool is a configurable AgentTool for executor tests.
+type execTool struct {
+	name   string
+	schema string
+	run    func(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error)
+	mode   ToolExecutionMode
+}
+
+func (t execTool) Name() string        { return t.name }
+func (t execTool) Description() string { return "exec" }
+func (t execTool) Schema() json.RawMessage {
+	if t.schema == "" {
+		return nil
+	}
+	return json.RawMessage(t.schema)
+}
+func (t execTool) ExecutionMode() ToolExecutionMode {
+	if t.mode == "" {
+		return ToolExecutionParallel
+	}
+	return t.mode
+}
+func (t execTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+	return t.run(ctx, id, args, onUpdate)
+}
+
+func newExecCfg(t *testing.T, tool AgentTool) ToolExecutorConfig {
+	t.Helper()
+	r := NewToolRegistry()
+	if err := r.Register(tool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	return ToolExecutorConfig{Registry: r}
+}
+
+func textOf(msg ToolResultMessage) string {
+	if len(msg.Content) == 0 {
+		return ""
+	}
+	if tc, ok := msg.Content[0].(TextContent); ok {
+		return tc.Text
+	}
+	return ""
+}
+
+func TestExecutorNormal(t *testing.T) {
+	tool := execTool{name: "echo", run: func(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+		return AgentToolResult{Content: ContentList{NewTextContent("done")}}, nil
+	}}
+	cfg := newExecCfg(t, tool)
+
+	var events []AgentEvent
+	emit := func(ctx context.Context, ev AgentEvent) error { events = append(events, ev); return nil }
+	msg, term := executeToolCall(context.Background(), cfg, AgentToolCall{ID: "1", Name: "echo"}, emit)
+
+	if msg.IsError || textOf(msg) != "done" {
+		t.Fatalf("normal result wrong: %+v", msg)
+	}
+	if term {
+		t.Error("normal result should not terminate")
+	}
+	wantKinds := []string{EventToolExecutionStart, EventToolExecutionEnd}
+	if len(events) != 2 || events[0].EventType() != wantKinds[0] || events[1].EventType() != wantKinds[1] {
+		t.Errorf("events wrong: %+v", events)
+	}
+}
+
+func TestExecutorUnknownTool(t *testing.T) {
+	cfg := ToolExecutorConfig{Registry: NewToolRegistry()}
+	msg, _ := executeToolCall(context.Background(), cfg, AgentToolCall{ID: "1", Name: "ghost"}, nil)
+	if !msg.IsError {
+		t.Fatalf("unknown tool should be error result: %+v", msg)
+	}
+}
+
+func TestExecutorValidationFailure(t *testing.T) {
+	schema := `{"type":"object","properties":{"n":{"type":"integer"}},"required":["n"],"additionalProperties":false}`
+	tool := execTool{name: "need", schema: schema, run: func(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+		t.Fatal("execute must not run on validation failure")
+		return AgentToolResult{}, nil
+	}}
+	cfg := newExecCfg(t, tool)
+	msg, _ := executeToolCall(context.Background(), cfg, AgentToolCall{ID: "1", Name: "need", Arguments: json.RawMessage(`{}`)}, nil)
+	if !msg.IsError {
+		t.Fatalf("validation failure should be error result: %+v", msg)
+	}
+}
+
+func TestExecutorBlock(t *testing.T) {
+	tool := execTool{name: "echo", run: func(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+		t.Fatal("execute must not run when blocked")
+		return AgentToolResult{}, nil
+	}}
+	cfg := newExecCfg(t, tool)
+	cfg.BeforeToolCall = func(ctx context.Context, call AgentToolCall) *BeforeToolCallDecision {
+		return &BeforeToolCallDecision{Block: true}
+	}
+	msg, _ := executeToolCall(context.Background(), cfg, AgentToolCall{ID: "1", Name: "echo"}, nil)
+	if !msg.IsError {
+		t.Fatalf("blocked call should be error result: %+v", msg)
+	}
+}
+
+func TestExecutorToolError(t *testing.T) {
+	tool := execTool{name: "boom", run: func(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+		return AgentToolResult{}, errors.New("kaboom")
+	}}
+	cfg := newExecCfg(t, tool)
+	msg, _ := executeToolCall(context.Background(), cfg, AgentToolCall{ID: "1", Name: "boom"}, nil)
+	if !msg.IsError {
+		t.Fatalf("tool error should be error result: %+v", msg)
+	}
+}
+
+func TestExecutorPanicRecovered(t *testing.T) {
+	tool := execTool{name: "panic", run: func(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+		panic("oops")
+	}}
+	cfg := newExecCfg(t, tool)
+	msg, _ := executeToolCall(context.Background(), cfg, AgentToolCall{ID: "1", Name: "panic"}, nil)
+	if !msg.IsError {
+		t.Fatalf("panic should be recovered into error result: %+v", msg)
+	}
+}
+
+func TestExecutorAfterToolCallOverride(t *testing.T) {
+	tool := execTool{name: "echo", run: func(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+		return AgentToolResult{Content: ContentList{NewTextContent("orig")}}, nil
+	}}
+	cfg := newExecCfg(t, tool)
+	newContent := ContentList{NewTextContent("overridden")}
+	isErr := true
+	term := true
+	cfg.AfterToolCall = func(ctx context.Context, call AgentToolCall, result AgentToolResult, isError bool) *AfterToolCallResult {
+		return &AfterToolCallResult{Content: &newContent, IsError: &isErr, Terminate: &term}
+	}
+	msg, terminate := executeToolCall(context.Background(), cfg, AgentToolCall{ID: "1", Name: "echo"}, nil)
+	if textOf(msg) != "overridden" {
+		t.Errorf("content override failed: %q", textOf(msg))
+	}
+	if !msg.IsError {
+		t.Error("isError override failed")
+	}
+	if !terminate {
+		t.Error("terminate override failed")
+	}
+}
+
+func TestExecutorUpdateCallback(t *testing.T) {
+	tool := execTool{name: "stream", run: func(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+		onUpdate(AgentToolResult{Content: ContentList{NewTextContent("partial")}})
+		return AgentToolResult{Content: ContentList{NewTextContent("final")}}, nil
+	}}
+	cfg := newExecCfg(t, tool)
+	var updates int
+	emit := func(ctx context.Context, ev AgentEvent) error {
+		if ev.EventType() == EventToolExecutionUpdate {
+			updates++
+		}
+		return nil
+	}
+	executeToolCall(context.Background(), cfg, AgentToolCall{ID: "1", Name: "stream"}, emit)
+	if updates != 1 {
+		t.Errorf("expected 1 update event, got %d", updates)
+	}
+}
+
+func TestExecutorAbortedContext(t *testing.T) {
+	tool := execTool{name: "echo", run: func(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+		t.Fatal("execute must not run when context already cancelled")
+		return AgentToolResult{}, nil
+	}}
+	cfg := newExecCfg(t, tool)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	msg, _ := executeToolCall(ctx, cfg, AgentToolCall{ID: "1", Name: "echo"}, nil)
+	if !msg.IsError {
+		t.Fatalf("aborted call should be error result: %+v", msg)
+	}
+}


### PR DESCRIPTION
## Summary
- Implement `executeToolCall` with prepare → execute → finalize phases
- prepare: registry lookup → optional prepareArguments → JSON Schema validation → beforeToolCall (block → error result)
- execute: streams tool_execution_update via callback; recovers tool error/panic into error result (never panics)
- finalize: afterToolCall field-level override of content/details/isError/terminate (no deep merge)
- All failure modes (unknown tool / validation / block / abort / error / panic) become error tool results

Closes #21

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./internal/agent/ (normal/unknown/validation/block/error/panic/afterToolCall/update/abort)