### PR TITLE
Unified Provider interface + dual failure model (US-007)

### DIFF
--- a/docs/issue#0025.html
+++ b/docs/issue#0025.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0025</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/25">#25</a> &mdash; Provider 接口 + dual failure model（US-007） &mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> StreamCompletion 返回 <code>*AssistantMessageEventStream</code> 而非裸 <code>&lt;-chan&gt;</code></h3>
+      <p><strong>Ambiguity:</strong> issue 验收写 <code>(&lt;-chan StreamEvent, error)</code>，但 #18/#20 已确立 EventStream 泛型作为流抽象。</p>
+      <p><strong>Choice:</strong> 返回 <code>(*AssistantMessageEventStream, error)</code>——EventStream 内部即含 <code>chan T</code>（Events() 暴露 <code>&lt;-chan&gt;</code>）外加 Result/Error 语义。</p>
+      <p><strong>Rationale:</strong> 与已落地的 StreamFn 契约完全一致，Provider 可经 <code>StreamFnFromProvider</code> 零成本适配进 loop，避免两套流类型。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 新增 CompletionRequest 聚合入参</h3>
+      <p><strong>Ambiguity:</strong> 验收要 "输入 model + context + options"，未规定是散参还是聚合。</p>
+      <p><strong>Choice:</strong> <code>CompletionRequest{Model, Context LlmContext, Config StreamConfig}</code> 聚合三者。</p>
+      <p><strong>Rationale:</strong> 单一结构体便于未来扩展字段而不破坏接口签名；与 StreamFn 的散参经 adapter 桥接。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 事件类型复用 AssistantMessageEvent，不新造 StreamEvent</h3>
+      <p><strong>Spec:</strong> 验收命名为 <code>StreamEvent</code> / <code>StreamEventError</code>。</p>
+      <p><strong>Implemented:</strong> 复用 #20 已建的 <code>AssistantMessageEvent</code>（含 <code>StreamErrorEvent</code> 终态事件）。</p>
+      <p><strong>Why:</strong> 同一套 delta 事件已在 provider.go 定义并被 loop 消费，另造一套会割裂类型系统；StreamErrorEvent 正是验收要的 "流内终态 error 事件"。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Model.ThinkingLevels 用 json:"-" 排除序列化</h3>
+      <p><strong>Alternatives:</strong> (A) 序列化 ThinkingLevelMap；(B) json:"-" 排除。</p>
+      <p><strong>Pros/Cons:</strong> A 让 Model 完整可 JSON 往返但 <code>map[level]*string</code> 序列化语义含糊（nil 指针 vs 缺键）；B 保持 Model JSON 干净，thinking 映射作为运行时能力表由 provider 代码持有。</p>
+      <p><strong>Winner:</strong> B——ThinkingLevelMap 的三态（nil/缺键/值）是内存语义，不适合走 JSON；Model 的 JSON 面向 UI 展示能力标记即可。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Model 能力字段集合是否够用</h3>
+      <p><strong>Assumption:</strong> 当前 Model 含 provider/id/displayName/contextWindow/maxOutputTokens/supportsThinking/supportsTools/thinkingLevels。</p>
+      <p><strong>Verify:</strong> 后续具体 provider（#26 Anthropic、#27 OpenAI）实现时若需更多能力标记（如 supportsVision、pricing），可增量补字段。请确认当前字段集覆盖近期需求。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/provider_interface.go
+++ b/internal/agent/provider_interface.go
@@ -1,0 +1,71 @@
+// This file defines the unified Provider interface and its dual failure model
+// (US-007). A Provider turns a CompletionRequest into a stream of
+// AssistantMessageEvents. Failures follow the same contract as StreamFn (FR-13):
+//
+//   - "cannot even build the stream" (bad config, missing model) → returned error.
+//   - any runtime failure once streaming has begun → a terminal StreamErrorEvent
+//     carrying an assistant message with stopReason=error/aborted, after which
+//     the stream is closed. It is never a returned error.
+//
+// Model carries provider-agnostic capability metadata so the loop and UI can
+// reason about a model without knowing the concrete provider.
+package agent
+
+import "context"
+
+// Model is provider-agnostic metadata describing a single model's identity and
+// capabilities. Providers construct these; the loop/UI consume them.
+type Model struct {
+	// Provider is the provider name (e.g. "anthropic", "openai").
+	Provider string `json:"provider"`
+	// ID is the provider-specific model id (e.g. "claude-opus-4-8").
+	ID string `json:"id"`
+	// DisplayName is a human-friendly label; falls back to ID when empty.
+	DisplayName string `json:"displayName,omitempty"`
+	// ContextWindow is the maximum input+output token window, 0 if unknown.
+	ContextWindow int `json:"contextWindow,omitempty"`
+	// MaxOutputTokens is the max tokens the model may emit per response, 0 if
+	// unknown.
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty"`
+	// SupportsThinking reports whether the model exposes a reasoning/thinking
+	// channel.
+	SupportsThinking bool `json:"supportsThinking,omitempty"`
+	// SupportsTools reports whether the model can call tools.
+	SupportsTools bool `json:"supportsTools,omitempty"`
+	// ThinkingLevels maps unified thinking levels to this model's wire values.
+	// nil when the model does not support thinking (decision #10).
+	ThinkingLevels ThinkingLevelMap `json:"-"`
+}
+
+// CompletionRequest is the provider-agnostic input to StreamCompletion: the
+// model id, the shaped LLM context, and per-request options.
+type CompletionRequest struct {
+	// Model is the provider-specific model id to complete against.
+	Model string
+	// Context is the shaped request (system prompt, LLM-bound messages, tools).
+	Context LlmContext
+	// Config carries per-request options (API key, thinking level, extras).
+	Config StreamConfig
+}
+
+// Provider is the unified streaming interface implemented by every backend. It
+// hides per-vendor differences behind a single AssistantMessageEvent stream.
+type Provider interface {
+	// Name returns the provider's identifier (matches Model.Provider).
+	Name() string
+	// Models lists the models this provider can serve.
+	Models() []Model
+	// StreamCompletion streams a completion for req. Per the dual failure model
+	// it returns an error only for the earliest "cannot build the stream" case;
+	// all runtime failures ride the returned stream as a terminal error event.
+	StreamCompletion(ctx context.Context, req CompletionRequest) (*AssistantMessageEventStream, error)
+}
+
+// StreamFnFromProvider adapts a Provider to the loop's StreamFn contract so a
+// Provider can drive streamAssistantResponse directly. The two failure models
+// are identical, so the adaptation is a straight delegation.
+func StreamFnFromProvider(p Provider) StreamFn {
+	return func(ctx context.Context, model string, llm LlmContext, cfg StreamConfig) (*AssistantMessageEventStream, error) {
+		return p.StreamCompletion(ctx, CompletionRequest{Model: model, Context: llm, Config: cfg})
+	}
+}

--- a/internal/agent/provider_interface_test.go
+++ b/internal/agent/provider_interface_test.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeProvider is a minimal Provider for interface tests.
+type fakeProvider struct {
+	name     string
+	models   []Model
+	buildErr error
+	events   []AssistantMessageEvent
+}
+
+func (p fakeProvider) Name() string    { return p.name }
+func (p fakeProvider) Models() []Model { return p.models }
+func (p fakeProvider) StreamCompletion(ctx context.Context, req CompletionRequest) (*AssistantMessageEventStream, error) {
+	if p.buildErr != nil {
+		return nil, p.buildErr
+	}
+	s := NewAssistantMessageEventStream(0)
+	go func() {
+		for _, ev := range p.events {
+			if err := s.Emit(ctx, ev); err != nil {
+				s.SetError(err)
+				break
+			}
+		}
+		s.Close()
+	}()
+	return s, nil
+}
+
+func TestProviderEarlyBuildFailureReturnsError(t *testing.T) {
+	p := fakeProvider{name: "test", buildErr: errors.New("no such model")}
+	_, err := p.StreamCompletion(context.Background(), CompletionRequest{Model: "ghost"})
+	if err == nil {
+		t.Fatal("early build failure must return an error")
+	}
+}
+
+func TestProviderRuntimeFailureRidesStream(t *testing.T) {
+	errMsg := AssistantMessage{RoleField: RoleAssistant, StopReason: StopReasonError, ErrorMessage: "upstream 500"}
+	p := fakeProvider{
+		name:   "test",
+		events: []AssistantMessageEvent{StreamErrorEvent{Message: errMsg}},
+	}
+	stream, err := p.StreamCompletion(context.Background(), CompletionRequest{Model: "m"})
+	if err != nil {
+		t.Fatalf("runtime failure must NOT be a returned error: %v", err)
+	}
+	final, resErr := stream.Result(context.Background())
+	if resErr != nil {
+		t.Fatalf("stream result error: %v", resErr)
+	}
+	if final.StopReason != StopReasonError || final.ErrorMessage != "upstream 500" {
+		t.Errorf("terminal error message wrong: %+v", final)
+	}
+}
+
+func TestStreamFnFromProviderDelegates(t *testing.T) {
+	done := AssistantMessage{RoleField: RoleAssistant, StopReason: StopReasonEndTurn}
+	p := fakeProvider{name: "test", events: []AssistantMessageEvent{StreamDoneEvent{Message: done}}}
+	fn := StreamFnFromProvider(p)
+	stream, err := fn(context.Background(), "m", LlmContext{}, StreamConfig{})
+	if err != nil {
+		t.Fatalf("delegation error: %v", err)
+	}
+	final, _ := stream.Result(context.Background())
+	if final.StopReason != StopReasonEndTurn {
+		t.Errorf("delegated stream result wrong: %+v", final)
+	}
+}
+
+func TestModelMetadata(t *testing.T) {
+	m := Model{Provider: "anthropic", ID: "claude-opus-4-8", SupportsThinking: true, ContextWindow: 200000}
+	if m.Provider != "anthropic" || m.ID != "claude-opus-4-8" {
+		t.Errorf("model identity wrong: %+v", m)
+	}
+	if !m.SupportsThinking || m.ContextWindow != 200000 {
+		t.Errorf("model capability wrong: %+v", m)
+	}
+}


### PR DESCRIPTION
## Summary
- Define `Provider` interface: `Name()`, `Models()`, `StreamCompletion(ctx, CompletionRequest)`
- `CompletionRequest` aggregates model + LlmContext + StreamConfig
- `Model` capability metadata (provider/id/contextWindow/maxOutputTokens/supportsThinking/supportsTools/thinkingLevels)
- Dual failure model: early build failure → returned error; runtime failure → terminal StreamErrorEvent on the stream
- `StreamFnFromProvider` adapts a Provider into the loop's StreamFn

Closes #25

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./internal/agent/ (early build error / runtime error rides stream / adapter / model metadata)