### PR TITLE
共享 transport driver（SSE+retry+双看门狗）

### DIFF
--- a/docs/issue#0026.html
+++ b/docs/issue#0026.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0026</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/26">#26</a> &mdash; 共享 transport driver（SSE+retry+双看门狗）&mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Decoder 接口用 <code>[]StreamEvent</code>，StreamEvent 别名 AssistantMessageEvent</h3>
+      <p><strong>Ambiguity:</strong> 验收写 <code>Decode(payload []byte) ([]StreamEvent, error)</code>，但仓库中 StreamEvent 未独立定义。</p>
+      <p><strong>Choice:</strong> <code>type StreamEvent = AssistantMessageEvent</code>（类型别名），Decoder 返回 <code>[]StreamEvent</code>。</p>
+      <p><strong>Rationale:</strong> 延续 #25 决策——复用 AssistantMessageEvent，不造平行事件类型；别名让验收签名字面成立又零成本融入现有流。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 连接前置于 goroutine 外，dual failure 边界落在首次 connect</h3>
+      <p><strong>Ambiguity:</strong> "cannot build the stream" 的边界在哪一步？</p>
+      <p><strong>Choice:</strong> <code>StreamRequest</code> 同步完成首次 <code>connect</code>（含 retry），失败即 return error；成功后才起 <code>pump</code> goroutine，此后所有失败走终态 StreamErrorEvent。</p>
+      <p><strong>Rationale:</strong> 与 FR-13/#25 双失败模型精确对齐——"建流前"失败是唯一的返回错误，一旦流开始则错误骑在流上。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> content-stall 看门狗 = idle×1.2</h3>
+      <p><strong>Ambiguity:</strong> 验收给了 idle 默认 5m 与可调环境变量，但 stall 只写 "idle×1.2"。</p>
+      <p><strong>Choice:</strong> stall = <code>idle × 1.2</code>，任意字节 reset idle，成功 flush 一个事件 reset stall。</p>
+      <p><strong>Rationale:</strong> idle 防"完全无字节"，stall 防"有 keep-alive 但无实质内容进展"；1.2 倍留出慢速但推进的流的余量。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> connect-only retry，不做流内重连重放</h3>
+      <p><strong>Spec:</strong> "connect-only 重连绝不重放已消费流"。</p>
+      <p><strong>Implemented:</strong> retry 仅发生在 <code>connect</code> 阶段（首个响应头到达前）；一旦 <code>pump</code> 开始消费流，读错误直接终态化，<b>不</b>尝试重连。</p>
+      <p><strong>Why:</strong> "绝不重放已消费流"的最强保证就是流开始后完全不重连；每次 connect 用全新 <code>NewRequest</code> 构造，天然不重放 POST body。这比"重连但跳过已消费部分"更安全且更简单。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 看门狗用 timer + reader goroutine + done channel，而非 SetReadDeadline</h3>
+      <p><strong>Alternatives:</strong> (A) 独立 reader goroutine + select 双 timer + done 退出信号；(B) <code>net.Conn.SetReadDeadline</code> 直接在 body 上设超时。</p>
+      <p><strong>Pros/Cons:</strong> A 与传输层无关（对任意 io.Reader 生效，httptest 可测），但需 done channel 防 goroutine 泄漏；B 更省 goroutine 但要拿到底层 conn、且无法区分 idle vs stall 两种超时。</p>
+      <p><strong>Winner:</strong> A——双看门狗语义要求两个独立计时器，SetReadDeadline 只能表达单一超时；done channel 已在 pump 返回时 close，reader 不会泄漏（race 测试通过）。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 4xx（非 429）是否需要 typed body 解析</h3>
+      <p><strong>Assumption:</strong> 当前非 429/503/529 的 4xx/5xx 直接读前 4KB body 拼进 error 文案返回，不解析 provider 特定的 JSON 错误结构。</p>
+      <p><strong>Verify:</strong> 请确认 provider（#27 Anthropic/OpenAI）实现时，结构化 API 错误（如 <code>{"error":{"type":...}}</code>）的解析放在各 provider 的 Decoder/调用方，而非共享 transport 层。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/transport.go
+++ b/internal/agent/transport.go
@@ -1,0 +1,375 @@
+// This file implements the shared transport driver (US-007 support): a
+// provider-agnostic layer that turns an HTTP request into a stream of
+// StreamEvents. Each provider degenerates to a stateful Decoder; the transport
+// owns HTTP + SSE line parsing + retry + dual watchdogs + the dual failure
+// model.
+//
+// The design mirrors pi's providerio: the transport never returns a runtime
+// failure as a Go error once streaming has begun — it rides the stream as a
+// terminal StreamErrorEvent. Only the earliest "cannot build the stream" case
+// (bad request construction) is a returned error.
+package agent
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// StreamEvent is the transport-level alias for AssistantMessageEvent. Decoders
+// produce these; the transport forwards them onto the stream. (Decision #25:
+// reuse AssistantMessageEvent rather than a parallel event type.)
+type StreamEvent = AssistantMessageEvent
+
+// Decoder is the per-provider stateful SSE payload decoder. The transport calls
+// Decode for every complete SSE data payload (one event's worth of bytes) and
+// Finish once the stream ends so the decoder can flush any buffered terminal
+// event.
+type Decoder interface {
+	// Decode turns one SSE data payload into zero or more StreamEvents. A
+	// returned error is treated as a runtime stream failure (terminal error
+	// event), never a panic.
+	Decode(payload []byte) ([]StreamEvent, error)
+	// Finish flushes any trailing state, returning a final batch of events.
+	Finish() ([]StreamEvent, error)
+}
+
+// defaultIdleTimeout is the watchdog idle window; PIGO_STREAM_IDLE_TIMEOUT
+// (a Go duration string, e.g. "3m") overrides it.
+const defaultIdleTimeout = 5 * time.Minute
+
+// idleTimeout resolves the configured idle watchdog window.
+func idleTimeout() time.Duration {
+	if v := os.Getenv("PIGO_STREAM_IDLE_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultIdleTimeout
+}
+
+// TransportConfig configures a single StreamRequest run.
+type TransportConfig struct {
+	// Client is the HTTP client; defaults to http.DefaultClient when nil.
+	Client *http.Client
+	// NewRequest builds a fresh *http.Request for each connection attempt. It is
+	// called once per connect (initial + reconnects) so retries never replay a
+	// consumed body — the caller owns idempotent request construction.
+	NewRequest func(ctx context.Context) (*http.Request, error)
+	// Decoder converts SSE payloads to StreamEvents (required).
+	Decoder Decoder
+	// MaxConnectRetries bounds connect-only retries (default 2).
+	MaxConnectRetries int
+}
+
+// StreamRequest runs cfg as a transport stream. Per the dual failure model it
+// returns an error only when the very first request cannot be built or the
+// initial connection can never be established; every runtime failure once
+// streaming begins rides the returned stream as a terminal StreamErrorEvent.
+func StreamRequest(ctx context.Context, cfg TransportConfig) (*AssistantMessageEventStream, error) {
+	if cfg.NewRequest == nil {
+		return nil, errors.New("transport: NewRequest is required")
+	}
+	if cfg.Decoder == nil {
+		return nil, errors.New("transport: Decoder is required")
+	}
+	client := cfg.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	maxRetries := cfg.MaxConnectRetries
+	if maxRetries == 0 {
+		maxRetries = 2
+	}
+
+	// Connect once up front so a "cannot even build the stream" failure surfaces
+	// as a returned error (the only early-error case per FR-13).
+	resp, err := connect(ctx, client, cfg.NewRequest, maxRetries)
+	if err != nil {
+		return nil, err
+	}
+
+	stream := NewAssistantMessageEventStream(0)
+	go pump(ctx, stream, resp, cfg.Decoder)
+	return stream, nil
+}
+
+// connect performs the initial connection with retry. It only retries when the
+// server explicitly signals a retryable condition (429/503/529); it never
+// replays a consumed stream, so retrying at connect time is always safe.
+func connect(ctx context.Context, client *http.Client, newReq func(context.Context) (*http.Request, error), maxRetries int) (*http.Response, error) {
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		req, err := newReq(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("transport: build request: %w", err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = classifyTransportError(err)
+			if !isRetryableNetErr(err) || attempt == maxRetries {
+				return nil, lastErr
+			}
+			if !sleepBackoff(ctx, attempt, 0) {
+				return nil, ctx.Err()
+			}
+			continue
+		}
+		if resp.StatusCode == http.StatusTooManyRequests ||
+			resp.StatusCode == http.StatusServiceUnavailable ||
+			resp.StatusCode == 529 {
+			wait := retryAfter(resp.Header)
+			resp.Body.Close()
+			lastErr = fmt.Errorf("transport: upstream %d", resp.StatusCode)
+			if attempt == maxRetries {
+				return nil, lastErr
+			}
+			if !sleepBackoff(ctx, attempt, wait) {
+				return nil, ctx.Err()
+			}
+			continue
+		}
+		if resp.StatusCode >= 400 {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			resp.Body.Close()
+			return nil, fmt.Errorf("transport: upstream %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+		return resp, nil
+	}
+	return nil, lastErr
+}
+
+// pump drives the SSE read loop with dual watchdogs, decoding payloads and
+// forwarding events onto the stream. All runtime failures become a terminal
+// error event; pump always closes the stream.
+func pump(ctx context.Context, stream *AssistantMessageEventStream, resp *http.Response, dec Decoder) {
+	defer stream.Close()
+	defer resp.Body.Close()
+
+	idle := idleTimeout()
+	// content-stall watchdog is slightly slacker than idle (idle×1.2) so a slow
+	// but progressing stream is not killed by the stall guard.
+	stall := time.Duration(float64(idle) * 1.2)
+
+	// The watchdog fires by cancelling a derived context; reads race against it.
+	watchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// done stops the reader goroutine so it never blocks on a send after pump
+	// returns (watchdog / abort paths), avoiding a goroutine leak.
+	done := make(chan struct{})
+	defer close(done)
+	lines := make(chan string)
+	readErr := make(chan error, 1)
+	go readLines(resp.Body, lines, readErr, done)
+
+	var dataBuf strings.Builder
+	idleTimer := time.NewTimer(idle)
+	stallTimer := time.NewTimer(stall)
+	defer idleTimer.Stop()
+	defer stallTimer.Stop()
+
+	emit := func(events []StreamEvent) bool {
+		for _, ev := range events {
+			if err := stream.Emit(watchCtx, ev); err != nil {
+				return false
+			}
+		}
+		return true
+	}
+
+	fail := func(msg string, err error) {
+		stream.Emit(context.Background(), StreamErrorEvent{
+			Message: AssistantMessage{
+				RoleField:    RoleAssistant,
+				StopReason:   StopReasonError,
+				ErrorMessage: msg,
+			},
+			Err: err,
+		})
+	}
+
+	flush := func() bool {
+		if dataBuf.Len() == 0 {
+			return true
+		}
+		payload := dataBuf.String()
+		dataBuf.Reset()
+		if payload == "[DONE]" {
+			return true
+		}
+		events, err := dec.Decode([]byte(payload))
+		if err != nil {
+			fail("decode error: "+err.Error(), err)
+			return false
+		}
+		return emit(events)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			fail("stream aborted", ctx.Err())
+			return
+		case <-idleTimer.C:
+			fail("idle timeout: no data received", errStreamIdle)
+			return
+		case <-stallTimer.C:
+			fail("content stall timeout", errStreamStall)
+			return
+		case err := <-readErr:
+			if err != nil && !errors.Is(err, io.EOF) {
+				fail("read error: "+classifyTransportError(err).Error(), err)
+				return
+			}
+			// Clean EOF: flush any buffered payload, then finish the decoder.
+			if !flush() {
+				return
+			}
+			finalEvents, ferr := dec.Finish()
+			if ferr != nil {
+				fail("finish error: "+ferr.Error(), ferr)
+				return
+			}
+			emit(finalEvents)
+			return
+		case line, ok := <-lines:
+			if !ok {
+				continue
+			}
+			// Any byte resets the idle watchdog; a flushed event resets stall.
+			resetTimer(idleTimer, idle)
+			line = strings.TrimRight(line, "\r\n")
+			switch {
+			case line == "":
+				// Blank line = event boundary: flush accumulated data.
+				if !flush() {
+					return
+				}
+				resetTimer(stallTimer, stall)
+			case strings.HasPrefix(line, ":"):
+				// Comment / keep-alive: ignore payload, watchdog already reset.
+			case strings.HasPrefix(line, "data:"):
+				dataBuf.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			default:
+				// Non-data field (event:, id:, etc.) — ignored for our decoders.
+			}
+		}
+	}
+}
+
+// readLines reads the body line by line, pushing each onto lines and the final
+// error (io.EOF on clean close) onto readErr. It stops promptly when done is
+// closed so pump can return on a watchdog/abort without leaking this goroutine.
+func readLines(r io.Reader, lines chan<- string, readErr chan<- error, done <-chan struct{}) {
+	br := bufio.NewReader(r)
+	for {
+		line, err := br.ReadString('\n')
+		if line != "" {
+			select {
+			case lines <- line:
+			case <-done:
+				return
+			}
+		}
+		if err != nil {
+			select {
+			case readErr <- err:
+			case <-done:
+			}
+			return
+		}
+	}
+}
+
+// resetTimer stops and re-arms t to fire after d.
+func resetTimer(t *time.Timer, d time.Duration) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+	t.Reset(d)
+}
+
+// Sentinel errors for watchdog classification.
+var (
+	errStreamIdle  = errors.New("stream idle timeout")
+	errStreamStall = errors.New("stream content stall")
+)
+
+// retryAfter parses a Retry-After header (seconds or HTTP-date), returning 0
+// when absent/unparseable.
+func retryAfter(h http.Header) time.Duration {
+	v := h.Get("Retry-After")
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// sleepBackoff waits for the retry delay (Retry-After if given, else
+// exponential), honoring ctx cancellation. Returns false if ctx was cancelled.
+func sleepBackoff(ctx context.Context, attempt int, retryAfter time.Duration) bool {
+	d := retryAfter
+	if d == 0 {
+		d = time.Duration(1<<uint(attempt)) * time.Second
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// isRetryableNetErr reports whether a client.Do error is a transient network
+// condition worth reconnecting for (timeout / temporary).
+func isRetryableNetErr(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
+}
+
+// classifyTransportError maps a low-level error to a typed, descriptive error
+// using net.Error / errors.Is classification.
+func classifyTransportError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) {
+		return fmt.Errorf("transport: canceled: %w", err)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("transport: deadline exceeded: %w", err)
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return fmt.Errorf("transport: network timeout: %w", err)
+		}
+		return fmt.Errorf("transport: network error: %w", err)
+	}
+	return fmt.Errorf("transport: %w", err)
+}

--- a/internal/agent/transport_test.go
+++ b/internal/agent/transport_test.go
@@ -1,0 +1,249 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// jsonDecoder is a trivial Decoder: each payload is a JSON object with a "text"
+// field yielding a StreamTextEvent, or {"done":true} yielding a StreamDoneEvent.
+type jsonDecoder struct {
+	finished bool
+}
+
+func (d *jsonDecoder) Decode(payload []byte) ([]StreamEvent, error) {
+	var m struct {
+		Text string `json:"text"`
+		Done bool   `json:"done"`
+		Bad  bool   `json:"bad"`
+	}
+	if err := json.Unmarshal(payload, &m); err != nil {
+		return nil, err
+	}
+	if m.Bad {
+		return nil, fmt.Errorf("decoder rejected payload")
+	}
+	if m.Done {
+		return []StreamEvent{StreamDoneEvent{Message: AssistantMessage{RoleField: RoleAssistant, StopReason: StopReasonEndTurn}}}, nil
+	}
+	return []StreamEvent{StreamTextEvent{Partial: AssistantMessage{RoleField: RoleAssistant}}}, nil
+}
+
+func (d *jsonDecoder) Finish() ([]StreamEvent, error) {
+	d.finished = true
+	return nil, nil
+}
+
+// sseServer returns an httptest server that writes the given SSE body.
+func sseServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Errorf("server write: %v", err)
+		}
+	}))
+}
+
+func newReqFn(url string) func(context.Context) (*http.Request, error) {
+	return func(ctx context.Context) (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader("{}"))
+	}
+}
+
+// TestTransportSSEParsing verifies data accumulation, blank-line flush, [DONE]
+// discard, and ":" keep-alive handling.
+func TestTransportSSEParsing(t *testing.T) {
+	body := ": keep-alive comment\n" +
+		"data: {\"text\":\"hi\"}\n" +
+		"\n" +
+		"data: [DONE]\n" +
+		"\n" +
+		"data: {\"done\":true}\n" +
+		"\n"
+	srv := sseServer(t, body)
+	defer srv.Close()
+
+	dec := &jsonDecoder{}
+	stream, err := StreamRequest(context.Background(), TransportConfig{
+		NewRequest: newReqFn(srv.URL),
+		Decoder:    dec,
+	})
+	if err != nil {
+		t.Fatalf("StreamRequest: %v", err)
+	}
+
+	var kinds []string
+	for ev := range stream.Events() {
+		kinds = append(kinds, ev.EventKind())
+	}
+	final, resErr := stream.Result(context.Background())
+	if resErr != nil {
+		t.Fatalf("result error: %v", resErr)
+	}
+	// text (from first data) then done; [DONE] payload must be discarded.
+	if len(kinds) != 2 || kinds[0] != StreamEventText || kinds[1] != StreamEventDone {
+		t.Errorf("event kinds = %v, want [text done]", kinds)
+	}
+	if final.StopReason != StopReasonEndTurn {
+		t.Errorf("final stop reason = %q, want end_turn", final.StopReason)
+	}
+	if !dec.finished {
+		t.Errorf("decoder Finish() was not called on clean EOF")
+	}
+}
+
+// TestTransportDecodeErrorRidesStream confirms a decode failure becomes a
+// terminal error event, not a returned error.
+func TestTransportDecodeErrorRidesStream(t *testing.T) {
+	body := "data: {\"bad\":true}\n\n"
+	srv := sseServer(t, body)
+	defer srv.Close()
+
+	stream, err := StreamRequest(context.Background(), TransportConfig{
+		NewRequest: newReqFn(srv.URL),
+		Decoder:    &jsonDecoder{},
+	})
+	if err != nil {
+		t.Fatalf("decode failure must NOT be a returned error: %v", err)
+	}
+	final, _ := stream.Result(context.Background())
+	if final.StopReason != StopReasonError {
+		t.Errorf("expected terminal error message, got stopReason=%q", final.StopReason)
+	}
+}
+
+// TestTransportEarlyBuildFailure verifies a request-build failure is a returned
+// error (the only early-error case).
+func TestTransportEarlyBuildFailure(t *testing.T) {
+	_, err := StreamRequest(context.Background(), TransportConfig{
+		NewRequest: func(ctx context.Context) (*http.Request, error) {
+			return nil, fmt.Errorf("cannot build")
+		},
+		Decoder: &jsonDecoder{},
+	})
+	if err == nil {
+		t.Fatal("request-build failure must return an error")
+	}
+}
+
+// TestTransportMissingConfig checks required-field validation.
+func TestTransportMissingConfig(t *testing.T) {
+	if _, err := StreamRequest(context.Background(), TransportConfig{Decoder: &jsonDecoder{}}); err == nil {
+		t.Error("missing NewRequest must error")
+	}
+	if _, err := StreamRequest(context.Background(), TransportConfig{NewRequest: newReqFn("http://x")}); err == nil {
+		t.Error("missing Decoder must error")
+	}
+}
+
+// TestTransportRetryOn503 verifies the connect retry path honors a retryable
+// status and eventually succeeds without replaying a consumed stream.
+func TestTransportRetryOn503(t *testing.T) {
+	t.Setenv("PIGO_STREAM_IDLE_TIMEOUT", "5s")
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("data: {\"done\":true}\n\n"))
+	}))
+	defer srv.Close()
+
+	stream, err := StreamRequest(context.Background(), TransportConfig{
+		NewRequest: newReqFn(srv.URL),
+		Decoder:    &jsonDecoder{},
+	})
+	if err != nil {
+		t.Fatalf("retry should succeed: %v", err)
+	}
+	final, _ := stream.Result(context.Background())
+	if final.StopReason != StopReasonEndTurn {
+		t.Errorf("final stop reason = %q, want end_turn", final.StopReason)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Errorf("expected 2 attempts (1 failed + 1 ok), got %d", got)
+	}
+}
+
+// TestTransportRetryExhausted verifies a persistently retryable status returns
+// an early error after exhausting retries.
+func TestTransportRetryExhausted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	_, err := StreamRequest(context.Background(), TransportConfig{
+		NewRequest:        newReqFn(srv.URL),
+		Decoder:           &jsonDecoder{},
+		MaxConnectRetries: 1,
+	})
+	if err == nil {
+		t.Fatal("exhausted retries must return an error")
+	}
+}
+
+// TestTransportIdleWatchdog verifies the idle watchdog fires a terminal error
+// when the server stalls without sending data.
+func TestTransportIdleWatchdog(t *testing.T) {
+	t.Setenv("PIGO_STREAM_IDLE_TIMEOUT", "100ms")
+	hold := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-hold // never send any data
+	}))
+	defer srv.Close()
+	defer close(hold)
+
+	stream, err := StreamRequest(context.Background(), TransportConfig{
+		NewRequest: newReqFn(srv.URL),
+		Decoder:    &jsonDecoder{},
+	})
+	if err != nil {
+		t.Fatalf("StreamRequest: %v", err)
+	}
+
+	done := make(chan AssistantMessage, 1)
+	go func() {
+		final, _ := stream.Result(context.Background())
+		done <- final
+	}()
+	select {
+	case final := <-done:
+		if final.StopReason != StopReasonError {
+			t.Errorf("idle watchdog must produce terminal error, got %q", final.StopReason)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("idle watchdog did not fire")
+	}
+}
+
+// TestRetryAfterParsing covers seconds and absent header parsing.
+func TestRetryAfterParsing(t *testing.T) {
+	h := http.Header{}
+	if d := retryAfter(h); d != 0 {
+		t.Errorf("absent Retry-After = %v, want 0", d)
+	}
+	h.Set("Retry-After", "3")
+	if d := retryAfter(h); d != 3*time.Second {
+		t.Errorf("Retry-After 3 = %v, want 3s", d)
+	}
+}


### PR DESCRIPTION
## Summary
- 新增 provider 无关的 `StreamRequest` 传输层，各 provider 退化为有状态 `Decoder`
- SSE 行解析：`bufio.Reader.ReadString('\n')` 逐行累积 `data:`、空行 flush、丢 `[DONE]`、`:` 前缀 keep-alive
- 双看门狗：idle（默认 5m，`PIGO_STREAM_IDLE_TIMEOUT` 可调）+ content-stall（idle×1.2）
- retry 仅 429/503/529、认 `Retry-After`、每次 connect 用全新请求绝不重放 POST；流开始后不重连
- typed error 分类（net.Error / errors.Is：canceled / deadline / timeout / network）
- dual failure：建流/首连失败返回 error，运行时失败骑终态 StreamErrorEvent

Closes #26

## Test plan
- [x] go build / vet 通过
- [x] go test -race ./internal/agent/ 通过（SSE 解析、decode 错误终态化、early build failure、retry on 503、retry exhausted、idle watchdog、Retry-After 解析）