### PR TITLE
Add OAuth and API key resolution

### DIFF
--- a/docs/issue#0032.html
+++ b/docs/issue#0032.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0032</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/32">#32</a> &mdash; OAuth 与 API key 解析（US-012）&mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 三层凭证解析顺序：OAuth &gt; 环境变量 &gt; 配置文件</h3>
+      <p><strong>Ambiguity:</strong> 验收要求"从环境变量与配置文件读 API key"+"OAuth 流程"，但未规定三者同时存在时的优先级。</p>
+      <p><strong>Choice:</strong> <code>CredentialStore.GetAPIKey</code> 按 OAuth token（自动刷新）→ env → config 依次解析，返回首个非空值。</p>
+      <p><strong>Rationale:</strong> OAuth 是显式配置的强凭证，env 是运行时注入（CI/容器），config 是持久默认；越"临时/显式"的越优先，符合运维直觉。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>TokenSource</code> 用 Leeway 提前刷新，签名匹配 <code>LoopConfig.GetAPIKey</code></h3>
+      <p><strong>Ambiguity:</strong> "token 过期时刷新返回新 token"未说明如何避免在过期边界处竞争。</p>
+      <p><strong>Choice:</strong> <code>TokenSource</code> 提供 30s 默认 Leeway，在真实过期前刷新；<code>GetAPIKey(ctx, provider) string</code> 与 <code>LoopConfig.GetAPIKey</code> 形状一致，可直接赋值接入 loop。</p>
+      <p><strong>Rationale:</strong> 复用现有 <code>streamAssistantResponse</code> 的动态 key 解析钩子（#25/US-003），无需改 loop；Leeway 规避边界抖动。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> OAuth 提供通用 <code>TokenSource</code> 而非绑定具体 provider 的完整授权码流程</h3>
+      <p><strong>Spec:</strong> "支持 OAuth 流程（至少覆盖一个 OAuth provider 作为样例）"。</p>
+      <p><strong>Implemented:</strong> 通用可注入 <code>Refresh</code> 的 <code>TokenSource</code> + <code>OAuthToken</code>，覆盖"短时 token 过期刷新"这一核心运行时契约；具体 provider 的浏览器授权码换取由上层装配 <code>Refresh</code> 闭包完成。</p>
+      <p><strong>Why:</strong> 授权码交换涉及浏览器重定向/回调，属 CLI 装配层职责；本 issue 聚焦 loop 侧的凭证解析与刷新，抽象出可注入点比硬编码单一 provider 更通用、更可测。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> OAuth 刷新失败时回退 env/config，而非直接报错</h3>
+      <p><strong>Alternatives:</strong> (A) 刷新失败即返回空/错误；(B) 刷新失败静默回退到 env/config 静态 key。</p>
+      <p><strong>Pros/Cons:</strong> A 语义清晰但一次 OAuth 抖动就中断可用的静态凭证；B 提升可用性但掩盖了 OAuth 故障。</p>
+      <p><strong>Winner:</strong> B——<code>GetAPIKey</code> 契约是"尽力返回可用 key"，与 loop 的静态 fallback 语义一致；OAuth 故障可由 <code>TokenSource.Token</code> 的显式错误单独观测。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 敏感值不写日志的保证目前靠约定，是否需要类型级封装</h3>
+      <p><strong>Assumption:</strong> 当前 API key/token 为普通 <code>string</code>，靠"错误信息只按 key 名/provider 引用"的约定避免泄露；未引入 redacted 包装类型。</p>
+      <p><strong>Verify:</strong> 若后续要防止误 <code>fmt.Printf("%v", cfg)</code> 泄露，可引入实现 <code>String()/GoString()</code> 打码的 <code>Secret</code> 类型。当前范围内是否足够？</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/auth.go
+++ b/internal/agent/auth.go
@@ -1,0 +1,235 @@
+// This file implements credential resolution (US-012): API key lookup from
+// environment variables and a config file (per provider), plus an OAuth token
+// source that refreshes short-lived tokens on expiry. The resolver satisfies
+// the LoopConfig.GetAPIKey shape (func(ctx, provider) string) so the agent loop
+// can obtain a fresh key per request.
+//
+// Security (FR: 敏感值不写入日志): secret values are never logged or embedded in
+// error messages. Errors and String()/redaction helpers reference credentials
+// by key name / provider only.
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// providerEnvVars maps a provider name to the environment variables checked (in
+// order) for its API key. The first non-empty value wins.
+var providerEnvVars = map[string][]string{
+	"anthropic":  {"ANTHROPIC_API_KEY", "CLAUDE_API_KEY"},
+	"openai":     {"OPENAI_API_KEY"},
+	"google":     {"GOOGLE_API_KEY", "GEMINI_API_KEY"},
+	"deepseek":   {"DEEPSEEK_API_KEY"},
+	"xai":        {"XAI_API_KEY"},
+	"groq":       {"GROQ_API_KEY"},
+	"openrouter": {"OPENROUTER_API_KEY"},
+	"mistral":    {"MISTRAL_API_KEY"},
+}
+
+// APIKeyConfig is the on-disk config-file shape: a map of provider name to API
+// key. It is parsed from JSON and holds only static keys (OAuth lives in
+// TokenSource). Values are secrets and must not be logged.
+type APIKeyConfig struct {
+	// Keys maps provider name → API key.
+	Keys map[string]string `json:"keys"`
+}
+
+// LoadAPIKeyConfig parses an APIKeyConfig from JSON bytes (e.g. a config file).
+func LoadAPIKeyConfig(data []byte) (*APIKeyConfig, error) {
+	var cfg APIKeyConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("auth: parse api key config: %w", err)
+	}
+	if cfg.Keys == nil {
+		cfg.Keys = make(map[string]string)
+	}
+	return &cfg, nil
+}
+
+// LoadAPIKeyConfigFile reads and parses an APIKeyConfig from a file path. A
+// missing file is not an error — it returns an empty config so env/OAuth can
+// still resolve keys.
+func LoadAPIKeyConfigFile(path string) (*APIKeyConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &APIKeyConfig{Keys: make(map[string]string)}, nil
+		}
+		return nil, fmt.Errorf("auth: read api key config %q: %w", path, err)
+	}
+	return LoadAPIKeyConfig(data)
+}
+
+// envAPIKey returns the API key for a provider from the environment, checking
+// the provider's known variable names in order, then a generic
+// <PROVIDER>_API_KEY fallback. Returns "" when none is set.
+func envAPIKey(provider string) string {
+	for _, name := range providerEnvVars[provider] {
+		if v := os.Getenv(name); v != "" {
+			return v
+		}
+	}
+	// Generic fallback for providers not in the table.
+	generic := strings.ToUpper(provider) + "_API_KEY"
+	return os.Getenv(generic)
+}
+
+// TokenSource yields an access token, refreshing it when expired. It models an
+// OAuth credential whose access token is short-lived (FR-15: getApiKey refreshes
+// on expiry). It is safe for concurrent use.
+type TokenSource struct {
+	mu           sync.Mutex
+	accessToken  string
+	expiry       time.Time
+	refreshToken string
+	// Refresh exchanges the current refresh token for a new access token. It
+	// returns the new access token, its expiry, and (optionally) a rotated
+	// refresh token. Required for a TokenSource to refresh; nil means the token
+	// is static and never refreshed.
+	Refresh func(ctx context.Context, refreshToken string) (OAuthToken, error)
+	// Now is injectable for testing; defaults to time.Now.
+	Now func() time.Time
+	// Leeway refreshes the token this long before its actual expiry to avoid
+	// racing the boundary. Defaults to 30s.
+	Leeway time.Duration
+}
+
+// OAuthToken is the result of an OAuth exchange/refresh. Values are secrets.
+type OAuthToken struct {
+	AccessToken  string
+	RefreshToken string
+	Expiry       time.Time
+}
+
+// NewTokenSource builds a TokenSource seeded with an initial token and a refresh
+// function. refresh may be nil for a static (never-expiring) token.
+func NewTokenSource(initial OAuthToken, refresh func(ctx context.Context, refreshToken string) (OAuthToken, error)) *TokenSource {
+	return &TokenSource{
+		accessToken:  initial.AccessToken,
+		expiry:       initial.Expiry,
+		refreshToken: initial.RefreshToken,
+		Refresh:      refresh,
+	}
+}
+
+func (t *TokenSource) now() time.Time {
+	if t.Now != nil {
+		return t.Now()
+	}
+	return time.Now()
+}
+
+func (t *TokenSource) leeway() time.Duration {
+	if t.Leeway > 0 {
+		return t.Leeway
+	}
+	return 30 * time.Second
+}
+
+// expired reports whether the access token is missing or within leeway of its
+// expiry. A zero expiry means "never expires" (static token).
+func (t *TokenSource) expired() bool {
+	if t.accessToken == "" {
+		return true
+	}
+	if t.expiry.IsZero() {
+		return false
+	}
+	return !t.now().Before(t.expiry.Add(-t.leeway()))
+}
+
+// Token returns a valid access token, refreshing it when expired. It errors if
+// a refresh is needed but no Refresh func is set, or if Refresh fails. The
+// returned error never contains the token value.
+func (t *TokenSource) Token(ctx context.Context) (string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if !t.expired() {
+		return t.accessToken, nil
+	}
+	if t.Refresh == nil {
+		return "", fmt.Errorf("auth: token expired and no refresh function configured")
+	}
+	tok, err := t.Refresh(ctx, t.refreshToken)
+	if err != nil {
+		return "", fmt.Errorf("auth: token refresh failed: %w", err)
+	}
+	t.accessToken = tok.AccessToken
+	t.expiry = tok.Expiry
+	if tok.RefreshToken != "" {
+		t.refreshToken = tok.RefreshToken
+	}
+	return t.accessToken, nil
+}
+
+// CredentialStore resolves API keys per provider from three layers, in order:
+// OAuth token source (if registered), environment variable, config file. It
+// implements the LoopConfig.GetAPIKey shape via GetAPIKey.
+//
+// It is safe for concurrent use.
+type CredentialStore struct {
+	mu      sync.RWMutex
+	config  *APIKeyConfig
+	sources map[string]*TokenSource // provider → OAuth token source
+}
+
+// NewCredentialStore builds a store over an optional config file. A nil config
+// is treated as empty.
+func NewCredentialStore(config *APIKeyConfig) *CredentialStore {
+	if config == nil {
+		config = &APIKeyConfig{Keys: make(map[string]string)}
+	}
+	return &CredentialStore{
+		config:  config,
+		sources: make(map[string]*TokenSource),
+	}
+}
+
+// RegisterOAuth registers an OAuth TokenSource for a provider. Once registered,
+// GetAPIKey prefers the (auto-refreshing) OAuth token over static keys.
+func (c *CredentialStore) RegisterOAuth(provider string, src *TokenSource) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sources[provider] = src
+}
+
+// GetAPIKey resolves the API key for a provider. Resolution order: OAuth token
+// (refreshed on expiry) → environment variable → config file. Returns "" when
+// no credential is available. This matches LoopConfig.GetAPIKey so it can be
+// assigned directly.
+//
+// On OAuth refresh failure it falls back to env/config rather than returning a
+// secret-bearing error; the empty return lets the caller fall back to a static
+// key. It never logs secret values.
+func (c *CredentialStore) GetAPIKey(ctx context.Context, provider string) string {
+	c.mu.RLock()
+	src := c.sources[provider]
+	cfgKey := ""
+	if c.config != nil {
+		cfgKey = c.config.Keys[provider]
+	}
+	c.mu.RUnlock()
+
+	if src != nil {
+		if tok, err := src.Token(ctx); err == nil && tok != "" {
+			return tok
+		}
+		// Refresh failed → fall through to static layers.
+	}
+	if env := envAPIKey(provider); env != "" {
+		return env
+	}
+	return cfgKey
+}
+
+// HasCredential reports whether any credential (OAuth/env/config) is available
+// for a provider, without exposing the value.
+func (c *CredentialStore) HasCredential(ctx context.Context, provider string) bool {
+	return c.GetAPIKey(ctx, provider) != ""
+}

--- a/internal/agent/auth_test.go
+++ b/internal/agent/auth_test.go
@@ -1,0 +1,172 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestEnvAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-env")
+	if got := envAPIKey("anthropic"); got != "sk-ant-env" {
+		t.Errorf("env key = %q, want sk-ant-env", got)
+	}
+	// Unknown provider uses generic <PROVIDER>_API_KEY fallback.
+	t.Setenv("FOOBAR_API_KEY", "sk-foobar")
+	if got := envAPIKey("foobar"); got != "sk-foobar" {
+		t.Errorf("generic env key = %q, want sk-foobar", got)
+	}
+	if got := envAPIKey("nonesuch"); got != "" {
+		t.Errorf("missing env key = %q, want empty", got)
+	}
+}
+
+func TestLoadAPIKeyConfig(t *testing.T) {
+	cfg, err := LoadAPIKeyConfig([]byte(`{"keys":{"openai":"sk-openai-cfg"}}`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Keys["openai"] != "sk-openai-cfg" {
+		t.Errorf("config key = %q", cfg.Keys["openai"])
+	}
+	if _, err := LoadAPIKeyConfig([]byte(`not json`)); err == nil {
+		t.Fatal("bad JSON must error")
+	}
+}
+
+func TestLoadAPIKeyConfigFileMissing(t *testing.T) {
+	cfg, err := LoadAPIKeyConfigFile("/no/such/path/keys.json")
+	if err != nil {
+		t.Fatalf("missing file must not error: %v", err)
+	}
+	if len(cfg.Keys) != 0 {
+		t.Errorf("missing file must yield empty keys, got %v", cfg.Keys)
+	}
+}
+
+// TestCredentialStoreResolutionOrder verifies OAuth > env > config precedence.
+func TestCredentialStoreResolutionOrder(t *testing.T) {
+	cfg, _ := LoadAPIKeyConfig([]byte(`{"keys":{"anthropic":"sk-cfg","openai":"sk-openai-cfg"}}`))
+	store := NewCredentialStore(cfg)
+
+	// Neutralize any ambient keys so config-only resolution is deterministic.
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("CLAUDE_API_KEY", "")
+
+	// Config-only provider resolves from config.
+	if got := store.GetAPIKey(context.Background(), "openai"); got != "sk-openai-cfg" {
+		t.Errorf("openai (config) = %q, want sk-openai-cfg", got)
+	}
+
+	// Env overrides config.
+	t.Setenv("ANTHROPIC_API_KEY", "sk-env")
+	if got := store.GetAPIKey(context.Background(), "anthropic"); got != "sk-env" {
+		t.Errorf("anthropic (env>config) = %q, want sk-env", got)
+	}
+
+	// OAuth overrides env + config.
+	store.RegisterOAuth("anthropic", NewTokenSource(
+		OAuthToken{AccessToken: "oauth-token", Expiry: time.Now().Add(time.Hour)}, nil))
+	if got := store.GetAPIKey(context.Background(), "anthropic"); got != "oauth-token" {
+		t.Errorf("anthropic (oauth>env) = %q, want oauth-token", got)
+	}
+
+	// Unknown provider → empty.
+	if got := store.GetAPIKey(context.Background(), "ghost"); got != "" {
+		t.Errorf("ghost = %q, want empty", got)
+	}
+}
+
+// TestTokenSourceRefresh verifies an expired token triggers a refresh returning
+// a new token.
+func TestTokenSourceRefresh(t *testing.T) {
+	now := time.Now()
+	refreshCount := 0
+	src := NewTokenSource(
+		OAuthToken{AccessToken: "old", RefreshToken: "refresh-1", Expiry: now.Add(-time.Minute)},
+		func(ctx context.Context, rt string) (OAuthToken, error) {
+			refreshCount++
+			if rt != "refresh-1" {
+				t.Errorf("refresh token = %q, want refresh-1", rt)
+			}
+			return OAuthToken{AccessToken: "new", RefreshToken: "refresh-2", Expiry: now.Add(time.Hour)}, nil
+		},
+	)
+	src.Now = func() time.Time { return now }
+
+	tok, err := src.Token(context.Background())
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if tok != "new" {
+		t.Errorf("token = %q, want new (refreshed)", tok)
+	}
+	if refreshCount != 1 {
+		t.Errorf("refresh count = %d, want 1", refreshCount)
+	}
+
+	// Second call within validity does not refresh again.
+	if _, err := src.Token(context.Background()); err != nil {
+		t.Fatalf("token 2: %v", err)
+	}
+	if refreshCount != 1 {
+		t.Errorf("refresh count after valid reuse = %d, want 1", refreshCount)
+	}
+}
+
+func TestTokenSourceNoRefreshFunc(t *testing.T) {
+	now := time.Now()
+	// Expired token with no Refresh func → error.
+	src := NewTokenSource(OAuthToken{AccessToken: "old", Expiry: now.Add(-time.Minute)}, nil)
+	src.Now = func() time.Time { return now }
+	if _, err := src.Token(context.Background()); err == nil {
+		t.Fatal("expired token without refresh must error")
+	}
+
+	// Static token (zero expiry) never expires.
+	static := NewTokenSource(OAuthToken{AccessToken: "static"}, nil)
+	tok, err := static.Token(context.Background())
+	if err != nil || tok != "static" {
+		t.Errorf("static token = %q, err = %v", tok, err)
+	}
+}
+
+func TestTokenSourceRefreshError(t *testing.T) {
+	now := time.Now()
+	src := NewTokenSource(
+		OAuthToken{AccessToken: "old", Expiry: now.Add(-time.Minute)},
+		func(ctx context.Context, rt string) (OAuthToken, error) {
+			return OAuthToken{}, context.DeadlineExceeded
+		},
+	)
+	src.Now = func() time.Time { return now }
+	_, err := src.Token(context.Background())
+	if err == nil {
+		t.Fatal("refresh error must propagate")
+	}
+	// Error must not leak the (empty) token but should mention refresh.
+	if got := err.Error(); got == "" {
+		t.Error("expected non-empty error")
+	}
+}
+
+// TestCredentialStoreOAuthRefreshFallback verifies a failing OAuth refresh
+// falls back to env/config rather than returning empty when a static key exists.
+func TestCredentialStoreOAuthRefreshFallback(t *testing.T) {
+	cfg, _ := LoadAPIKeyConfig([]byte(`{"keys":{"anthropic":"sk-cfg-fallback"}}`))
+	store := NewCredentialStore(cfg)
+	now := time.Now()
+	src := NewTokenSource(
+		OAuthToken{AccessToken: "old", Expiry: now.Add(-time.Minute)},
+		func(ctx context.Context, rt string) (OAuthToken, error) {
+			return OAuthToken{}, context.DeadlineExceeded
+		},
+	)
+	src.Now = func() time.Time { return now }
+	store.RegisterOAuth("anthropic", src)
+
+	if got := store.GetAPIKey(context.Background(), "anthropic"); got != "sk-cfg-fallback" {
+		t.Errorf("refresh-failed fallback = %q, want sk-cfg-fallback", got)
+	}
+}


### PR DESCRIPTION
## Summary
- `CredentialStore` resolves API keys per provider: OAuth > env var > config file
- `TokenSource` refreshes short-lived OAuth tokens on expiry (with leeway)
- `LoadAPIKeyConfig`/`LoadAPIKeyConfigFile` read per-provider keys from JSON
- `GetAPIKey(ctx, provider) string` matches `LoopConfig.GetAPIKey` for direct wiring
- Secrets referenced by key name / provider only — never logged

Closes #32

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./internal/agent/` — env lookup, config parse, resolution order, token refresh, refresh error, OAuth fallback