### PR TITLE
Add grep/find/ls search tools honoring .gitignore

### DIFF
--- a/docs/issue#0038.html
+++ b/docs/issue#0038.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0038</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/38">#38</a> &mdash; grep/find/ls 搜索工具（US-019）&mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 自实现最小化 .gitignore 匹配器</h3>
+      <p><strong>Ambiguity:</strong> 验收要"尊重 .gitignore"，未规定支持哪些语法子集。</p>
+      <p><strong>Choice:</strong> 实现常见子集——注释/空行、前导 <code>/</code> 锚定、尾随 <code>/</code> 仅目录、<code>!</code> 反选、按 base name 或路径 <code>filepath.Match</code>；非锚定 pattern 匹配任意路径段（目录被忽略则其下全部隐藏）。后规则覆盖前规则。</p>
+      <p><strong>Rationale:</strong> 覆盖绝大多数真实 .gitignore；坚持零外部依赖（不引入 go-gitignore 库）；显式记录不支持 <code>**</code> 跨段与嵌套 .gitignore。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 三工具共享 <code>resolveWithin</code> 边界策略，均为 parallel</h3>
+      <p><strong>Ambiguity:</strong> 验收未提路径边界与并发模式。</p>
+      <p><strong>Choice:</strong> 复用与 ReadTool 一致的 Root + <code>filepath.Rel</code> 越界拒绝；grep/find/ls 只读 → <code>ToolExecutionParallel</code>。</p>
+      <p><strong>Rationale:</strong> 与既有工具（read/write/edit）一致的边界与并发语义，减少认知负担；只读工具并发安全可提升批量效率。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 结果上限 <code>searchMaxResults=1000</code></h3>
+      <p><strong>Ambiguity:</strong> 验收未提结果规模上限。</p>
+      <p><strong>Choice:</strong> grep 匹配、find 命中均在达到 1000 时经 <code>filepath.SkipAll</code> 提前终止，grep 附 <code>[truncated]</code> 提示。</p>
+      <p><strong>Rationale:</strong> 防止宽泛查询淹没模型上下文；与 read 工具的 2000 行上限同理。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 仅读取 Root 级单个 .gitignore，不支持嵌套/全局 gitignore</h3>
+      <p><strong>Spec:</strong> "尊重 .gitignore"。</p>
+      <p><strong>Implemented:</strong> 只加载 <code>root/.gitignore</code>；不递归读取子目录 .gitignore，不读全局 core.excludesfile，不解析 <code>**</code> 跨段。始终额外硬跳过 <code>.git/</code>。</p>
+      <p><strong>Why:</strong> 单文件覆盖工具级搜索的主要场景；完整 gitignore 语义（嵌套、全局、**）复杂度高，对 MVP 属过度设计，可后续增强。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 三个独立工具 vs 单一多模式工具</h3>
+      <p><strong>Alternatives:</strong> (A) grep/find/ls 各自独立工具；(B) 单 search 工具带 mode 参数。</p>
+      <p><strong>Pros/Cons:</strong> A schema 清晰、模型选型直观、与 pi 工具粒度一致；B 工具数少但参数条件耦合、schema 复杂。</p>
+      <p><strong>Winner:</strong> A——独立工具边界清晰，共享 helper（resolveWithin/gitignore）已消除重复。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 是否需要嵌套/全局 .gitignore 支持</h3>
+      <p><strong>Assumption:</strong> Root 级单一 .gitignore 足够。</p>
+      <p><strong>Verify:</strong> 若仓库大量使用子目录 .gitignore 或全局 excludesfile，搜索结果可能包含本应忽略的文件；是否需要升级匹配器？</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> grep 是否需要二进制文件检测</h3>
+      <p><strong>Assumption:</strong> 逐行扫描所有非忽略文件。</p>
+      <p><strong>Verify:</strong> 二进制文件（图片/可执行）会被逐行扫描且可能产生乱码匹配；是否需要 NUL 字节嗅探跳过二进制？</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/search_tool.go
+++ b/internal/agent/search_tool.go
@@ -1,0 +1,436 @@
+// This file implements the search tools (US-019): grep (search file contents by
+// regexp with optional glob filtering), find (locate files by name glob), and ls
+// (list a directory, distinguishing files from directories). All three resolve
+// paths against a Root with the same boundary guard as the other tools and skip
+// paths ignored by the workspace .gitignore. They are read-only → parallel.
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// searchMaxResults caps the number of matches/entries any single search returns
+// so a broad query cannot flood the model's context.
+const searchMaxResults = 1000
+
+// resolveWithin resolves p against root and verifies it stays within it. It is
+// the shared boundary policy used by all search tools (mirrors ReadTool).
+func resolveWithin(root, p string) (string, error) {
+	if root == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("cannot determine working directory: %w", err)
+		}
+		root = wd
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("invalid root: %w", err)
+	}
+	var full string
+	if filepath.IsAbs(p) {
+		full = filepath.Clean(p)
+	} else {
+		full = filepath.Join(absRoot, p)
+	}
+	rel, err := filepath.Rel(absRoot, full)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q is outside the workspace root", p)
+	}
+	return full, nil
+}
+
+// gitignore is a minimal .gitignore matcher. It supports the common subset:
+// blank lines and #-comments are skipped; a leading "/" anchors to the root;
+// a trailing "/" matches directories only; "!" negation re-includes; and plain
+// patterns match by base name or path via filepath.Match. It is intentionally
+// not a full gitignore implementation (no "**" spanning, no nested .gitignore).
+type gitignore struct {
+	rules []ignoreRule
+}
+
+type ignoreRule struct {
+	pattern  string
+	negate   bool
+	dirOnly  bool
+	anchored bool
+}
+
+// loadGitignore reads root/.gitignore. A missing file yields an empty matcher
+// (matches nothing), never an error.
+func loadGitignore(root string) *gitignore {
+	gi := &gitignore{}
+	data, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	if err != nil {
+		return gi
+	}
+	sc := bufio.NewScanner(strings.NewReader(string(data)))
+	for sc.Scan() {
+		line := strings.TrimRight(sc.Text(), " ")
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		r := ignoreRule{}
+		if strings.HasPrefix(line, "!") {
+			r.negate = true
+			line = line[1:]
+		}
+		if strings.HasSuffix(line, "/") {
+			r.dirOnly = true
+			line = strings.TrimSuffix(line, "/")
+		}
+		if strings.HasPrefix(line, "/") {
+			r.anchored = true
+			line = strings.TrimPrefix(line, "/")
+		}
+		if line == "" {
+			continue
+		}
+		r.pattern = line
+		gi.rules = append(gi.rules, r)
+	}
+	return gi
+}
+
+// ignored reports whether relPath (slash-separated, relative to root) is ignored.
+// isDir refines dir-only rules. Later rules win, so a negation can re-include.
+func (g *gitignore) ignored(relPath string, isDir bool) bool {
+	relPath = filepath.ToSlash(relPath)
+	base := relPath
+	if i := strings.LastIndex(relPath, "/"); i >= 0 {
+		base = relPath[i+1:]
+	}
+	result := false
+	for _, r := range g.rules {
+		if r.dirOnly && !isDir {
+			continue
+		}
+		var match bool
+		if r.anchored || strings.Contains(r.pattern, "/") {
+			match, _ = filepath.Match(r.pattern, relPath)
+		} else {
+			match, _ = filepath.Match(r.pattern, base)
+			if !match {
+				// A non-anchored pattern also matches any path component,
+				// so an ignored directory hides everything beneath it.
+				for _, seg := range strings.Split(relPath, "/") {
+					if ok, _ := filepath.Match(r.pattern, seg); ok {
+						match = true
+						break
+					}
+				}
+			}
+		}
+		if match {
+			result = !r.negate
+		}
+	}
+	return result
+}
+
+// GrepTool searches file contents by regexp under Root, honoring .gitignore.
+type GrepTool struct {
+	// Root bounds the search; empty defaults to the current working directory.
+	Root string
+}
+
+type grepToolArgs struct {
+	// Pattern is the regexp to search for (Go regexp syntax).
+	Pattern string `json:"pattern"`
+	// Path optionally scopes the search to a subdirectory (relative to Root).
+	Path string `json:"path,omitempty"`
+	// Glob optionally filters files by base-name glob (e.g. "*.go").
+	Glob string `json:"glob,omitempty"`
+}
+
+func (t *GrepTool) Name() string { return "grep" }
+func (t *GrepTool) Description() string {
+	return "Search file contents by regular expression under the workspace, " +
+		"optionally filtering files by glob. Skips .gitignore'd paths."
+}
+func (t *GrepTool) ExecutionMode() ToolExecutionMode { return ToolExecutionParallel }
+func (t *GrepTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "pattern": {"type": "string", "description": "Regular expression to search for."},
+    "path":    {"type": "string", "description": "Subdirectory to scope the search to (relative to the workspace root)."},
+    "glob":    {"type": "string", "description": "Filter files by base-name glob, e.g. *.go."}
+  },
+  "required": ["pattern"],
+  "additionalProperties": false
+}`)
+}
+
+func (t *GrepTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+	var a grepToolArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return errorResult(fmt.Sprintf("grep: invalid arguments: %v", err)), nil
+	}
+	if a.Pattern == "" {
+		return errorResult("grep: pattern is required"), nil
+	}
+	re, err := regexp.Compile(a.Pattern)
+	if err != nil {
+		return errorResult(fmt.Sprintf("grep: invalid pattern: %v", err)), nil
+	}
+	root, err := resolveWithin(t.Root, "")
+	if err != nil {
+		return errorResult("grep: " + err.Error()), nil
+	}
+	start := root
+	if a.Path != "" {
+		if start, err = resolveWithin(t.Root, a.Path); err != nil {
+			return errorResult("grep: " + err.Error()), nil
+		}
+	}
+	gi := loadGitignore(root)
+
+	var matches []string
+	count := 0
+	walkErr := filepath.WalkDir(start, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries
+		}
+		rel, _ := filepath.Rel(root, path)
+		if rel == "." {
+			return nil
+		}
+		if rel == ".git" || strings.HasPrefix(rel, ".git"+string(filepath.Separator)) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if gi.ignored(rel, d.IsDir()) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if a.Glob != "" {
+			if ok, _ := filepath.Match(a.Glob, d.Name()); !ok {
+				return nil
+			}
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return nil
+		}
+		defer f.Close()
+		sc := bufio.NewScanner(f)
+		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		lineNo := 0
+		for sc.Scan() {
+			lineNo++
+			line := sc.Text()
+			if re.MatchString(line) {
+				matches = append(matches, fmt.Sprintf("%s:%d:%s", rel, lineNo, line))
+				count++
+				if count >= searchMaxResults {
+					return filepath.SkipAll
+				}
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return errorResult(fmt.Sprintf("grep: %v", walkErr)), nil
+	}
+
+	msg := fmt.Sprintf("%d match(es) for %q", len(matches), a.Pattern)
+	if len(matches) > 0 {
+		msg += "\n" + strings.Join(matches, "\n")
+	}
+	if count >= searchMaxResults {
+		msg += fmt.Sprintf("\n[truncated at %d matches]", searchMaxResults)
+	}
+	return AgentToolResult{
+		Content: ContentList{NewTextContent(msg)},
+		Details: map[string]any{"matches": len(matches)},
+	}, nil
+}
+
+// FindTool locates files by base-name glob under Root, honoring .gitignore.
+type FindTool struct {
+	// Root bounds the search; empty defaults to the current working directory.
+	Root string
+}
+
+type findToolArgs struct {
+	// Glob is the base-name glob to match (e.g. "*.go").
+	Glob string `json:"glob"`
+	// Path optionally scopes the search to a subdirectory (relative to Root).
+	Path string `json:"path,omitempty"`
+}
+
+func (t *FindTool) Name() string { return "find" }
+func (t *FindTool) Description() string {
+	return "Find files by base-name glob under the workspace. Skips .gitignore'd paths."
+}
+func (t *FindTool) ExecutionMode() ToolExecutionMode { return ToolExecutionParallel }
+func (t *FindTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "glob": {"type": "string", "description": "Base-name glob to match, e.g. *.go."},
+    "path": {"type": "string", "description": "Subdirectory to scope the search to (relative to the workspace root)."}
+  },
+  "required": ["glob"],
+  "additionalProperties": false
+}`)
+}
+
+func (t *FindTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+	var a findToolArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return errorResult(fmt.Sprintf("find: invalid arguments: %v", err)), nil
+	}
+	if a.Glob == "" {
+		return errorResult("find: glob is required"), nil
+	}
+	root, err := resolveWithin(t.Root, "")
+	if err != nil {
+		return errorResult("find: " + err.Error()), nil
+	}
+	start := root
+	if a.Path != "" {
+		if start, err = resolveWithin(t.Root, a.Path); err != nil {
+			return errorResult("find: " + err.Error()), nil
+		}
+	}
+	gi := loadGitignore(root)
+
+	var found []string
+	walkErr := filepath.WalkDir(start, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		if rel == "." {
+			return nil
+		}
+		if rel == ".git" || strings.HasPrefix(rel, ".git"+string(filepath.Separator)) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if gi.ignored(rel, d.IsDir()) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if ok, _ := filepath.Match(a.Glob, d.Name()); ok {
+			found = append(found, rel)
+			if len(found) >= searchMaxResults {
+				return filepath.SkipAll
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return errorResult(fmt.Sprintf("find: %v", walkErr)), nil
+	}
+	sort.Strings(found)
+
+	msg := fmt.Sprintf("%d file(s) matching %q", len(found), a.Glob)
+	if len(found) > 0 {
+		msg += "\n" + strings.Join(found, "\n")
+	}
+	return AgentToolResult{
+		Content: ContentList{NewTextContent(msg)},
+		Details: map[string]any{"count": len(found)},
+	}, nil
+}
+
+// LsTool lists the entries of a directory, distinguishing files from directories.
+type LsTool struct {
+	// Root bounds the listing; empty defaults to the current working directory.
+	Root string
+}
+
+type lsToolArgs struct {
+	// Path is the directory to list, relative to Root (empty = Root itself).
+	Path string `json:"path,omitempty"`
+}
+
+func (t *LsTool) Name() string { return "ls" }
+func (t *LsTool) Description() string {
+	return "List a directory's entries, marking directories with a trailing slash."
+}
+func (t *LsTool) ExecutionMode() ToolExecutionMode { return ToolExecutionParallel }
+func (t *LsTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "path": {"type": "string", "description": "Directory to list, relative to the workspace root."}
+  },
+  "additionalProperties": false
+}`)
+}
+
+func (t *LsTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+	var a lsToolArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return errorResult(fmt.Sprintf("ls: invalid arguments: %v", err)), nil
+	}
+	full, err := resolveWithin(t.Root, a.Path)
+	if err != nil {
+		return errorResult("ls: " + err.Error()), nil
+	}
+	info, err := os.Stat(full)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return errorResult(fmt.Sprintf("ls: %q does not exist", a.Path)), nil
+		}
+		return errorResult(fmt.Sprintf("ls: cannot stat %q: %v", a.Path, err)), nil
+	}
+	if !info.IsDir() {
+		return errorResult(fmt.Sprintf("ls: %q is not a directory", a.Path)), nil
+	}
+	entries, err := os.ReadDir(full)
+	if err != nil {
+		return errorResult(fmt.Sprintf("ls: cannot read %q: %v", a.Path, err)), nil
+	}
+
+	var dirs, files []string
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs = append(dirs, e.Name()+"/")
+		} else {
+			files = append(files, e.Name())
+		}
+	}
+	sort.Strings(dirs)
+	sort.Strings(files)
+	lines := append(dirs, files...)
+
+	label := a.Path
+	if label == "" {
+		label = "."
+	}
+	msg := fmt.Sprintf("%s (%d dir(s), %d file(s))", label, len(dirs), len(files))
+	if len(lines) > 0 {
+		msg += "\n" + strings.Join(lines, "\n")
+	}
+	return AgentToolResult{
+		Content: ContentList{NewTextContent(msg)},
+		Details: map[string]any{"dirs": len(dirs), "files": len(files)},
+	}, nil
+}

--- a/internal/agent/search_tool_test.go
+++ b/internal/agent/search_tool_test.go
@@ -1,0 +1,187 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runSearch(t *testing.T, tool AgentTool, args map[string]any) AgentToolResult {
+	t.Helper()
+	raw, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	res, gerr := tool.Execute(context.Background(), "call-1", raw, nil)
+	if gerr != nil {
+		t.Fatalf("execute returned go error: %v", gerr)
+	}
+	return res
+}
+
+// seedTree writes a small directory tree with a .gitignore for the search tests.
+func seedTree(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	mustWrite := func(rel, content string) {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	mustWrite("main.go", "package main\nfunc main() { hello() }\n")
+	mustWrite("util.go", "package main\nfunc hello() {}\n")
+	mustWrite("README.md", "# project\nhello world\n")
+	mustWrite("sub/deep.go", "package sub\n// hello from sub\n")
+	mustWrite("build/generated.go", "package build\nfunc hello() {}\n")
+	mustWrite(".gitignore", "build/\n*.log\n")
+	mustWrite("debug.log", "hello log line\n")
+	return dir
+}
+
+func TestGrepBasic(t *testing.T) {
+	dir := seedTree(t)
+	tool := &GrepTool{Root: dir}
+	res := runSearch(t, tool, map[string]any{"pattern": "hello"})
+	txt := resultText(res)
+	// Matches in tracked files.
+	if !strings.Contains(txt, "main.go") || !strings.Contains(txt, "util.go") {
+		t.Errorf("expected go file matches, got %q", txt)
+	}
+	// .gitignore'd paths must be skipped.
+	if strings.Contains(txt, "build/generated.go") {
+		t.Errorf("ignored dir should be skipped: %q", txt)
+	}
+	if strings.Contains(txt, "debug.log") {
+		t.Errorf("ignored *.log should be skipped: %q", txt)
+	}
+}
+
+func TestGrepGlobFilter(t *testing.T) {
+	dir := seedTree(t)
+	tool := &GrepTool{Root: dir}
+	res := runSearch(t, tool, map[string]any{"pattern": "hello", "glob": "*.md"})
+	txt := resultText(res)
+	if !strings.Contains(txt, "README.md") {
+		t.Errorf("expected README match, got %q", txt)
+	}
+	if strings.Contains(txt, ".go") {
+		t.Errorf("glob *.md should exclude .go files: %q", txt)
+	}
+}
+
+func TestGrepInvalidPattern(t *testing.T) {
+	dir := seedTree(t)
+	tool := &GrepTool{Root: dir}
+	res := runSearch(t, tool, map[string]any{"pattern": "["})
+	if !strings.Contains(resultText(res), "invalid pattern") {
+		t.Errorf("expected invalid-pattern error, got %q", resultText(res))
+	}
+}
+
+func TestFindGlob(t *testing.T) {
+	dir := seedTree(t)
+	tool := &FindTool{Root: dir}
+	res := runSearch(t, tool, map[string]any{"glob": "*.go"})
+	txt := resultText(res)
+	if !strings.Contains(txt, "main.go") || !strings.Contains(txt, "sub/deep.go") {
+		t.Errorf("expected go files, got %q", txt)
+	}
+	if strings.Contains(txt, "build/generated.go") {
+		t.Errorf("ignored dir should be skipped: %q", txt)
+	}
+	if strings.Contains(txt, "README.md") {
+		t.Errorf("*.go should not match README.md: %q", txt)
+	}
+}
+
+func TestLsDistinguishesFilesAndDirs(t *testing.T) {
+	dir := seedTree(t)
+	tool := &LsTool{Root: dir}
+	res := runSearch(t, tool, map[string]any{})
+	txt := resultText(res)
+	// Directories carry a trailing slash.
+	if !strings.Contains(txt, "sub/") {
+		t.Errorf("expected sub/ dir marker, got %q", txt)
+	}
+	if !strings.Contains(txt, "main.go") {
+		t.Errorf("expected main.go file, got %q", txt)
+	}
+	details, ok := res.Details.(map[string]any)
+	if !ok {
+		t.Fatalf("details missing: %+v", res.Details)
+	}
+	if details["files"] == nil || details["dirs"] == nil {
+		t.Errorf("expected file/dir counts, got %+v", details)
+	}
+}
+
+func TestLsNotADirectory(t *testing.T) {
+	dir := seedTree(t)
+	tool := &LsTool{Root: dir}
+	res := runSearch(t, tool, map[string]any{"path": "main.go"})
+	if !strings.Contains(resultText(res), "not a directory") {
+		t.Errorf("expected not-a-directory error, got %q", resultText(res))
+	}
+}
+
+func TestLsMissing(t *testing.T) {
+	dir := seedTree(t)
+	tool := &LsTool{Root: dir}
+	res := runSearch(t, tool, map[string]any{"path": "nope"})
+	if !strings.Contains(resultText(res), "does not exist") {
+		t.Errorf("expected does-not-exist error, got %q", resultText(res))
+	}
+}
+
+func TestSearchPathTraversal(t *testing.T) {
+	dir := seedTree(t)
+	for _, tc := range []struct {
+		name string
+		tool AgentTool
+		args map[string]any
+	}{
+		{"grep", &GrepTool{Root: dir}, map[string]any{"pattern": "x", "path": "../"}},
+		{"find", &FindTool{Root: dir}, map[string]any{"glob": "*", "path": "../"}},
+		{"ls", &LsTool{Root: dir}, map[string]any{"path": "../"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := runSearch(t, tc.tool, tc.args)
+			if !strings.Contains(resultText(res), "outside the workspace root") {
+				t.Errorf("expected boundary error, got %q", resultText(res))
+			}
+		})
+	}
+}
+
+func TestSearchToolModes(t *testing.T) {
+	for _, tool := range []AgentTool{&GrepTool{}, &FindTool{}, &LsTool{}} {
+		if tool.ExecutionMode() != ToolExecutionParallel {
+			t.Errorf("%s should be parallel", tool.Name())
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(tool.Schema(), &schema); err != nil {
+			t.Errorf("%s schema not valid JSON: %v", tool.Name(), err)
+		}
+	}
+}
+
+func TestGitignoreNegation(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("*.txt\n!keep.txt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gi := loadGitignore(dir)
+	if !gi.ignored("drop.txt", false) {
+		t.Error("*.txt should be ignored")
+	}
+	if gi.ignored("keep.txt", false) {
+		t.Error("!keep.txt should be re-included")
+	}
+}


### PR DESCRIPTION
## Summary
- grep: search file contents by regexp with optional glob filter
- find: locate files by base-name glob
- ls: list a directory, marking directories with trailing slash
- Shared Root boundary guard + minimal .gitignore matcher; read-only (parallel); results capped at 1000

Closes #38

## Test plan
- [x] go build / vet clean
- [x] go test ./internal/agent/ pass (grep/find/ls, gitignore, traversal, modes)