### PR TITLE
Implement two-layer agent loop runLoop (US-006)

### DIFF
--- a/docs/issue#0023.html
+++ b/docs/issue#0023.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0023</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/23">#23</a> &mdash; 双层主循环 runLoop（US-006）&mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>RunConfig</code> 内嵌 <code>LoopConfig</code>，聚合四个循环级钩子</h3>
+      <p><strong>Ambiguity:</strong> 验收列出六个钩子，但 <code>getSteeringMessages</code>/<code>getFollowUpMessages</code>/<code>prepareNextTurn</code>/<code>shouldStopAfterTurn</code> 是循环级、<code>beforeToolCall</code>/<code>afterToolCall</code> 是工具级，配置如何分层未规定。</p>
+      <p><strong>Choice:</strong> 新增 <code>RunConfig</code>：内嵌已有的 <code>LoopConfig</code>（每轮流式配置）+ <code>BatchConfig</code>（含 before/after 工具钩子）+ 四个循环级钩子字段 + <code>EventBuffer</code>。工具级两钩子复用既有 <code>ToolExecutorConfig</code>，不重复声明。</p>
+      <p><strong>Rationale:</strong> 各层配置各归其位，<code>runLoop</code> 只消费 <code>RunConfig</code>，流式与批量执行的既有契约零改动。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>afterTurn</code> 统一承载每个 turn_end 后的三段钩子</h3>
+      <p><strong>Ambiguity:</strong> steering 注入、prepareNextTurn、shouldStopAfterTurn 的相对顺序与触发条件在验收里分列，未给单一调用点。</p>
+      <p><strong>Choice:</strong> 抽出 <code>afterTurn(ctx, agentCtx, cfg, hadToolExecution)</code>：先按 pi per-turn 语义拉 <code>getSteeringMessages</code> 并注入（仅当本轮有工具执行）、再 <code>prepareNextTurn</code> 应用 <code>TurnUpdate</code>、最后 <code>shouldStopAfterTurn</code> 决定是否退出。自然 turn end 与工具回灌 turn end 都经此点。</p>
+      <p><strong>Rationale:</strong> 单一函数保证三个钩子的顺序与时机全局一致，避免在内层循环两处 turn_end 分支各写一遍导致漂移。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>TurnUpdate</code> 用指针字段表达"仅替换已设置项"</h3>
+      <p><strong>Ambiguity:</strong> prepareNextTurn "可替换 context/model/thinkingLevel" 未说明部分替换语义。</p>
+      <p><strong>Choice:</strong> <code>TurnUpdate</code> 全部字段为指针（<code>*MessageList</code>/<code>*string</code>/<code>*[]AgentTool</code>/<code>*ThinkingLevel</code>），<code>applyTurnUpdate</code> 只对非 nil 字段赋值；model/thinkingLevel 写回 <code>cfg</code>，context 三项写回 <code>agentCtx</code>。</p>
+      <p><strong>Rationale:</strong> 沿用 pigo 既定的"三态用指针"映射，调用方可只换 model 而不动 context。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 全部工具 terminate 时立即结束整个 run</h3>
+      <p><strong>Spec:</strong> 验收未显式描述 tool <code>terminate</code> 在双层循环中的传播。</p>
+      <p><strong>Implemented:</strong> <code>executeToolCalls</code> 返回 <code>allTerminate</code>（批内每个结果都 terminate 才为真）后，<code>runLoop</code> 直接 <code>finish()</code>，不再进入 follow-up。</p>
+      <p><strong>Why:</strong> 复刻 pi 语义——工具请求终止即终止整个 agent run；这是既有 batch_executor 契约的自然延伸，非偏离。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 生产者 goroutine + EventStream vs 同步回调</h3>
+      <p><strong>Alternatives:</strong> (A) 入口返回 <code>LoopEventStream</code>，<code>runLoop</code> 在 goroutine 中驱动、经 <code>Emit</code> 推事件、<code>SetResult</code> 交付新消息；(B) 入口接收一个 emit 回调同步跑完。</p>
+      <p><strong>Pros/Cons:</strong> A 与 pi 的 async generator 语义一致、消费者可 <code>range Events()</code> 且能单独取 <code>Result</code>，天然背压；B 更简单但把并发/取消责任推给调用方，且与 US-003 流式层的 EventStream 风格不统一。</p>
+      <p><strong>Winner:</strong> A——项目已确立 async generator→EventStream 映射，两入口 <code>agentLoop</code>/<code>agentLoopContinue</code> 均返回 <code>*LoopEventStream</code>。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> run 结果 = 本次新增消息的快照拷贝</h3>
+      <p><strong>Alternatives:</strong> (A) 记录 <code>startIdx</code>，结束时 <code>copy</code> 出 <code>agentCtx.Messages[startIdx:]</code> 作为 <code>AgentEndEvent.Messages</code> 与 stream result；(B) 返回整个 <code>agentCtx.Messages</code>。</p>
+      <p><strong>Pros/Cons:</strong> A 精确交付"本次 run 产出"、拷贝隔离后续变更；B 省一次拷贝但混入 run 前的历史消息，续跑场景语义错。</p>
+      <p><strong>Winner:</strong> A——<code>agentLoopContinue</code> 从已有 context 续跑时，结果只应含本次新增。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> emit 被取消（ctx cancel）时的收尾是否需要区分 aborted</h3>
+      <p><strong>Assumption:</strong> 当 <code>Emit</code> 因 ctx 取消返回错误，当前一律走 <code>finish()</code> 发 <code>agent_end</code> 并以已产出消息收尾。</p>
+      <p><strong>Verify:</strong> 后续接入真实取消（US-013 中断）时，是否需要在结果里附带一个 aborted 标记或专门的终止消息，供会话恢复判断？当前留给上层。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> steering 仅在"有工具执行"的 turn 后注入</h3>
+      <p><strong>Assumption:</strong> 依验收"每轮工具执行后拉取"，自然 turn end（无 tool call）不拉 steering。</p>
+      <p><strong>Verify:</strong> 若产品希望用户在纯文本回复后也能插入 steering，需要放宽该条件——是否符合 pi per-turn 原意待确认。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1,0 +1,299 @@
+// This file implements pi's two-layer agent loop (US-006, FR-1). It strings
+// together streaming assistant responses, batch tool execution, and the loop's
+// six hooks with control flow kept faithful to pi's runLoop:
+//
+//   - Inner loop: one turn = stream an assistant response → execute its tool
+//     calls → feed the results back, repeating until an assistant message has no
+//     tool calls (a natural turn end).
+//   - Outer loop: after the inner loop settles, pull getFollowUpMessages; if any
+//     are returned they become the next pending input and the inner loop runs
+//     again, otherwise the run ends.
+//
+// Per-turn hooks after each turn_end: getSteeringMessages (pulled after tool
+// execution and injected before the next turn), prepareNextTurn (may swap
+// context / model / thinkingLevel), shouldStopAfterTurn (true ⇒ agent_end +
+// exit). Two stop reasons are handled specially: length (the response was
+// truncated by the token cap) fails every tool call so the model resends
+// (failToolCallsFromTruncatedMessage); error / aborted end the run immediately.
+//
+// agentLoop starts a fresh run from a prompt already appended to the context;
+// agentLoopContinue resumes an existing context and validates that the last
+// message is not an assistant message (nothing to continue from otherwise).
+package agent
+
+import (
+	"context"
+	"errors"
+)
+
+// TurnUpdate is the optional result of PrepareNextTurn: any non-nil field
+// replaces the corresponding piece of loop state before the next turn. It lets
+// a caller swap the trimmed context, system prompt, tool set, model, or
+// thinking level between turns (FR-6).
+type TurnUpdate struct {
+	Messages      *MessageList
+	SystemPrompt  *string
+	Tools         *[]AgentTool
+	Model         *string
+	ThinkingLevel *ThinkingLevel
+}
+
+// RunConfig is the full configuration for a loop run: the per-turn streaming
+// config (embedded LoopConfig), the batch tool-execution config, and the four
+// loop-level hooks. Every hook is optional (nil = default behavior).
+type RunConfig struct {
+	LoopConfig
+	// Batch holds the tool registry and the prepare/before/after hooks used to
+	// execute each assistant message's tool calls.
+	Batch BatchConfig
+
+	// GetFollowUpMessages is consulted after the inner loop settles (an assistant
+	// message with no tool calls). Returning messages continues the outer loop
+	// with them as the next input; returning none ends the run (FR-9).
+	GetFollowUpMessages func(ctx context.Context, agentCtx *AgentContext) []AgentMessage
+	// GetSteeringMessages is pulled after each turn's tool execution and injected
+	// before the next turn (pi per-turn semantics, FR-8).
+	GetSteeringMessages func(ctx context.Context) []AgentMessage
+	// PrepareNextTurn runs after each turn_end and may swap context / model /
+	// thinkingLevel for the next turn (FR-6).
+	PrepareNextTurn func(ctx context.Context, agentCtx *AgentContext) *TurnUpdate
+	// ShouldStopAfterTurn runs after each turn_end; true ends the run with an
+	// agent_end event (FR-7).
+	ShouldStopAfterTurn func(ctx context.Context, agentCtx *AgentContext) bool
+
+	// EventBuffer is the buffer size of the emitted EventStream. 0 gives fully
+	// synchronous back-pressure (matching pi's awaited emit).
+	EventBuffer int
+}
+
+// LoopEventStream is the stream returned by the loop entry points: it carries
+// AgentEvents and yields the messages newly produced during the run.
+type LoopEventStream = EventStream[AgentEvent, []AgentMessage]
+
+// ErrContinueLastAssistant is the result error when agentLoopContinue is called
+// on a context whose last message is an assistant message (nothing to respond
+// to — the loop would immediately stream another assistant turn against a stale
+// context).
+var ErrContinueLastAssistant = errors.New("agent: cannot continue loop, last message is an assistant message")
+
+// agentLoop starts a fresh run. The caller has already appended the initiating
+// user message(s) to agentCtx.Messages. It returns immediately with an
+// EventStream; a producer goroutine drives the loop and closes the stream when
+// the run ends.
+func agentLoop(ctx context.Context, agentCtx *AgentContext, cfg RunConfig) *LoopEventStream {
+	stream := NewEventStream[AgentEvent, []AgentMessage](cfg.EventBuffer)
+	go runLoop(ctx, agentCtx, cfg, stream)
+	return stream
+}
+
+// agentLoopContinue resumes an existing context. It validates that the last
+// message is not an assistant message before running; on violation it returns a
+// stream that yields ErrContinueLastAssistant with no events.
+func agentLoopContinue(ctx context.Context, agentCtx *AgentContext, cfg RunConfig) *LoopEventStream {
+	stream := NewEventStream[AgentEvent, []AgentMessage](cfg.EventBuffer)
+	if n := len(agentCtx.Messages); n > 0 {
+		if _, isAssistant := agentCtx.Messages[n-1].(AssistantMessage); isAssistant {
+			stream.SetError(ErrContinueLastAssistant)
+			stream.Close()
+			return stream
+		}
+	}
+	go runLoop(ctx, agentCtx, cfg, stream)
+	return stream
+}
+
+// runLoop is the producer: it drives the two-layer loop, emitting events onto
+// stream and setting the stream result to the messages produced during the run.
+func runLoop(ctx context.Context, agentCtx *AgentContext, cfg RunConfig, stream *LoopEventStream) {
+	startIdx := len(agentCtx.Messages)
+	// newMessages returns the messages appended since the run began.
+	newMessages := func() []AgentMessage {
+		if len(agentCtx.Messages) <= startIdx {
+			return nil
+		}
+		out := make([]AgentMessage, len(agentCtx.Messages)-startIdx)
+		copy(out, agentCtx.Messages[startIdx:])
+		return out
+	}
+	emit := func(ev AgentEvent) error { return stream.Emit(ctx, ev) }
+
+	// finish emits agent_end (unless suppressed by a prior emit error), records
+	// the run result, and closes the stream exactly once.
+	finish := func() {
+		msgs := newMessages()
+		_ = emit(AgentEndEvent{Messages: msgs})
+		stream.SetResult(msgs)
+		stream.Close()
+	}
+
+	if err := emit(AgentStartEvent{}); err != nil {
+		finish()
+		return
+	}
+
+	for { // outer loop: pending / follow-up messages
+		for { // inner loop: turns until no tool calls
+			if err := emit(TurnStartEvent{}); err != nil {
+				finish()
+				return
+			}
+
+			assistant, err := streamAssistantResponse(ctx, agentCtx, cfg.LoopConfig, func(c context.Context, ev AgentEvent) error {
+				return stream.Emit(c, ev)
+			})
+			if err != nil {
+				// emit was cancelled mid-stream; end the run.
+				finish()
+				return
+			}
+
+			switch assistant.StopReason {
+			case StopReasonLength:
+				// Truncated by the token cap: fail every tool call so the model
+				// resends, then continue feeding back.
+				toolResults := failToolCallsFromTruncatedMessage(agentCtx, assistant)
+				if err := emit(TurnEndEvent{Message: assistant, ToolResults: toolResults}); err != nil {
+					finish()
+					return
+				}
+				if afterTurn(ctx, agentCtx, &cfg, true) {
+					finish()
+					return
+				}
+				continue
+			case StopReasonError, StopReasonAborted:
+				// Terminal failure: emit the turn end and stop.
+				_ = emit(TurnEndEvent{Message: assistant})
+				finish()
+				return
+			}
+
+			calls := toAgentToolCalls(assistant.ToolCalls())
+			if len(calls) == 0 {
+				// Natural turn end: no tools to run.
+				if err := emit(TurnEndEvent{Message: assistant}); err != nil {
+					finish()
+					return
+				}
+				if afterTurn(ctx, agentCtx, &cfg, false) {
+					finish()
+					return
+				}
+				break // exit inner loop → consult follow-up messages
+			}
+
+			toolResults, allTerminate := executeToolCalls(ctx, cfg.Batch, calls, func(c context.Context, ev AgentEvent) error {
+				return stream.Emit(c, ev)
+			})
+			for _, tr := range toolResults {
+				agentCtx.Messages = append(agentCtx.Messages, tr)
+			}
+			if err := emit(TurnEndEvent{Message: assistant, ToolResults: toolResults}); err != nil {
+				finish()
+				return
+			}
+			if allTerminate {
+				// Every tool asked to terminate the run.
+				finish()
+				return
+			}
+			if afterTurn(ctx, agentCtx, &cfg, true) {
+				finish()
+				return
+			}
+			// Feed the tool results back into the next turn.
+		}
+
+		// Inner loop settled: consult follow-up messages.
+		if cfg.GetFollowUpMessages != nil {
+			if follow := cfg.GetFollowUpMessages(ctx, agentCtx); len(follow) > 0 {
+				agentCtx.Messages = append(agentCtx.Messages, follow...)
+				continue // outer loop with the follow-ups as new input
+			}
+		}
+		break
+	}
+
+	finish()
+}
+
+// afterTurn runs the per-turn hooks after a turn_end. When hadToolExecution is
+// true it first pulls getSteeringMessages and injects them before the next turn
+// (pi per-turn semantics). It then applies prepareNextTurn and finally consults
+// shouldStopAfterTurn, returning true when the run should end.
+func afterTurn(ctx context.Context, agentCtx *AgentContext, cfg *RunConfig, hadToolExecution bool) (stop bool) {
+	if hadToolExecution && cfg.GetSteeringMessages != nil {
+		if steer := cfg.GetSteeringMessages(ctx); len(steer) > 0 {
+			agentCtx.Messages = append(agentCtx.Messages, steer...)
+		}
+	}
+	if cfg.PrepareNextTurn != nil {
+		if upd := cfg.PrepareNextTurn(ctx, agentCtx); upd != nil {
+			applyTurnUpdate(agentCtx, cfg, upd)
+		}
+	}
+	if cfg.ShouldStopAfterTurn != nil {
+		return cfg.ShouldStopAfterTurn(ctx, agentCtx)
+	}
+	return false
+}
+
+// applyTurnUpdate applies a non-nil TurnUpdate to the mutable loop state: any
+// set field replaces the current context / config value for the next turn.
+func applyTurnUpdate(agentCtx *AgentContext, cfg *RunConfig, upd *TurnUpdate) {
+	if upd.Messages != nil {
+		agentCtx.Messages = *upd.Messages
+	}
+	if upd.SystemPrompt != nil {
+		agentCtx.SystemPrompt = *upd.SystemPrompt
+	}
+	if upd.Tools != nil {
+		agentCtx.Tools = *upd.Tools
+	}
+	if upd.Model != nil {
+		cfg.Model = *upd.Model
+	}
+	if upd.ThinkingLevel != nil {
+		cfg.ThinkingLevel = *upd.ThinkingLevel
+	}
+}
+
+// failToolCallsFromTruncatedMessage produces an error tool-result message for
+// every tool call in a truncated (stopReason=length) assistant message, telling
+// the model the response was cut off and to resend. The results are appended to
+// the context and returned. Mirrors pi's failToolCallsFromTruncatedMessage.
+func failToolCallsFromTruncatedMessage(agentCtx *AgentContext, assistant AssistantMessage) []ToolResultMessage {
+	calls := assistant.ToolCalls()
+	if len(calls) == 0 {
+		return nil
+	}
+	results := make([]ToolResultMessage, 0, len(calls))
+	for _, c := range calls {
+		results = append(results, ToolResultMessage{
+			RoleField:  RoleToolResult,
+			ToolCallID: c.ID,
+			ToolName:   c.Name,
+			Content: ContentList{NewTextContent(
+				"The previous response was truncated because it hit the output token limit, " +
+					"so this tool call was not executed. Please send a shorter response and retry.")},
+			IsError: true,
+		})
+	}
+	for _, r := range results {
+		agentCtx.Messages = append(agentCtx.Messages, r)
+	}
+	return results
+}
+
+// toAgentToolCalls converts the assistant message's ToolCallContent blocks into
+// the loop-level AgentToolCall view executeToolCalls consumes.
+func toAgentToolCalls(blocks []ToolCallContent) []AgentToolCall {
+	if len(blocks) == 0 {
+		return nil
+	}
+	calls := make([]AgentToolCall, len(blocks))
+	for i, b := range blocks {
+		calls[i] = AgentToolCall{ID: b.ID, Name: b.Name, Arguments: b.Arguments}
+	}
+	return calls
+}

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1,0 +1,307 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// collectStream drains a LoopEventStream, returning the event types in order
+// and the run result messages.
+func collectStream(t *testing.T, s *LoopEventStream) ([]string, []AgentMessage) {
+	t.Helper()
+	var kinds []string
+	for ev := range s.Events() {
+		kinds = append(kinds, ev.EventType())
+	}
+	msgs, err := s.Result(context.Background())
+	if err != nil {
+		t.Fatalf("stream result: %v", err)
+	}
+	return kinds, msgs
+}
+
+// oneToolAssistant builds an assistant message with a single tool call.
+func oneToolAssistant(id, name string) AssistantMessage {
+	return AssistantMessage{
+		RoleField:  RoleAssistant,
+		StopReason: StopReasonToolUse,
+		Content:    ContentList{NewToolCallContent(id, name, json.RawMessage(`{}`))},
+	}
+}
+
+// scriptedStream returns a StreamFn that emits one StreamDoneEvent per call,
+// consuming msgs in order. Extra calls beyond msgs emit a plain end_turn.
+func scriptedStream(msgs []AssistantMessage) StreamFn {
+	i := 0
+	return func(ctx context.Context, model string, llm LlmContext, cfg StreamConfig) (*AssistantMessageEventStream, error) {
+		var msg AssistantMessage
+		if i < len(msgs) {
+			msg = msgs[i]
+		} else {
+			msg = AssistantMessage{RoleField: RoleAssistant, StopReason: StopReasonEndTurn}
+		}
+		i++
+		s := NewAssistantMessageEventStream(0)
+		go func() {
+			_ = s.Emit(ctx, StreamDoneEvent{Message: msg})
+			s.Close()
+		}()
+		return s, nil
+	}
+}
+
+func newRunCfg(stream StreamFn, tools ...AgentTool) RunConfig {
+	reg := NewToolRegistry()
+	for _, tl := range tools {
+		_ = reg.Register(tl)
+	}
+	return RunConfig{
+		LoopConfig: LoopConfig{Model: "fake", Stream: stream},
+		Batch:      BatchConfig{ToolExecutorConfig: ToolExecutorConfig{Registry: reg}},
+	}
+}
+
+func TestAgentLoopNoToolCallsSingleTurn(t *testing.T) {
+	cfg := newRunCfg(scriptedStream([]AssistantMessage{
+		{RoleField: RoleAssistant, StopReason: StopReasonEndTurn, Content: ContentList{NewTextContent("hi")}},
+	}))
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+
+	kinds, msgs := collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+
+	want := []string{EventAgentStart, EventTurnStart, EventMessageEnd, EventTurnEnd, EventAgentEnd}
+	assertEventKinds(t, kinds, want)
+	if len(msgs) != 1 {
+		t.Fatalf("run produced %d messages, want 1: %+v", len(msgs), msgs)
+	}
+}
+
+func TestAgentLoopInnerLoopFeedsToolResults(t *testing.T) {
+	// Turn 1: tool call. Turn 2: no tool call → inner loop ends.
+	cfg := newRunCfg(scriptedStream([]AssistantMessage{
+		oneToolAssistant("c1", "echo"),
+		{RoleField: RoleAssistant, StopReason: StopReasonEndTurn, Content: ContentList{NewTextContent("done")}},
+	}), echoTool("echo", ToolExecutionParallel, false))
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+
+	kinds, msgs := collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+
+	// Two turns; a tool executed in the first.
+	if countKind(kinds, EventTurnStart) != 2 {
+		t.Errorf("expected 2 turns, got kinds %v", kinds)
+	}
+	if countKind(kinds, EventToolExecutionEnd) != 1 {
+		t.Errorf("expected 1 tool execution, got kinds %v", kinds)
+	}
+	// Messages produced: assistant(tool) + toolResult + assistant(done) = 3.
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 new messages, got %d: %+v", len(msgs), msgs)
+	}
+	if _, ok := msgs[1].(ToolResultMessage); !ok {
+		t.Errorf("expected message[1] to be a tool result, got %T", msgs[1])
+	}
+}
+
+func TestAgentLoopFollowUpMessagesContinue(t *testing.T) {
+	served := false
+	cfg := newRunCfg(scriptedStream([]AssistantMessage{
+		{RoleField: RoleAssistant, StopReason: StopReasonEndTurn, Content: ContentList{NewTextContent("first")}},
+		{RoleField: RoleAssistant, StopReason: StopReasonEndTurn, Content: ContentList{NewTextContent("second")}},
+	}))
+	cfg.GetFollowUpMessages = func(ctx context.Context, agentCtx *AgentContext) []AgentMessage {
+		if served {
+			return nil
+		}
+		served = true
+		return []AgentMessage{UserMessage{RoleField: RoleUser, Content: ContentList{NewTextContent("more")}}}
+	}
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+
+	kinds, _ := collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+	if countKind(kinds, EventTurnStart) != 2 {
+		t.Errorf("follow-up should drive a second turn, got kinds %v", kinds)
+	}
+}
+
+func TestAgentLoopShouldStopAfterTurn(t *testing.T) {
+	cfg := newRunCfg(scriptedStream([]AssistantMessage{
+		oneToolAssistant("c1", "echo"),
+		{RoleField: RoleAssistant, StopReason: StopReasonEndTurn},
+	}), echoTool("echo", ToolExecutionParallel, false))
+	cfg.ShouldStopAfterTurn = func(ctx context.Context, agentCtx *AgentContext) bool { return true }
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+
+	kinds, _ := collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+	// Stops after the first turn_end, so only one turn.
+	if countKind(kinds, EventTurnStart) != 1 {
+		t.Errorf("shouldStopAfterTurn=true must stop after one turn, got %v", kinds)
+	}
+	if kinds[len(kinds)-1] != EventAgentEnd {
+		t.Errorf("run must end with agent_end, got %v", kinds)
+	}
+}
+
+func TestAgentLoopSteeringInjected(t *testing.T) {
+	var injectedSeen bool
+	steer := UserMessage{RoleField: RoleUser, Content: ContentList{NewTextContent("steer")}}
+	cfg := newRunCfg(scriptedStream([]AssistantMessage{
+		oneToolAssistant("c1", "echo"),
+		{RoleField: RoleAssistant, StopReason: StopReasonEndTurn},
+	}), echoTool("echo", ToolExecutionParallel, false))
+	pulled := false
+	cfg.GetSteeringMessages = func(ctx context.Context) []AgentMessage {
+		if pulled {
+			return nil
+		}
+		pulled = true
+		return []AgentMessage{steer}
+	}
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+	collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+	for _, m := range agentCtx.Messages {
+		if um, ok := m.(UserMessage); ok && len(um.Content) == 1 {
+			if tc, ok := um.Content[0].(TextContent); ok && tc.Text == "steer" {
+				injectedSeen = true
+			}
+		}
+	}
+	if !injectedSeen {
+		t.Errorf("steering message was not injected into the context")
+	}
+}
+
+func TestAgentLoopPrepareNextTurnSwapsModel(t *testing.T) {
+	var seenModels []string
+	streamFn := func(ctx context.Context, model string, llm LlmContext, cfg StreamConfig) (*AssistantMessageEventStream, error) {
+		seenModels = append(seenModels, model)
+		var msg AssistantMessage
+		if len(seenModels) == 1 {
+			msg = oneToolAssistant("c1", "echo")
+		} else {
+			msg = AssistantMessage{RoleField: RoleAssistant, StopReason: StopReasonEndTurn}
+		}
+		s := NewAssistantMessageEventStream(0)
+		go func() { _ = s.Emit(ctx, StreamDoneEvent{Message: msg}); s.Close() }()
+		return s, nil
+	}
+	cfg := newRunCfg(streamFn, echoTool("echo", ToolExecutionParallel, false))
+	newModel := "swapped-model"
+	cfg.PrepareNextTurn = func(ctx context.Context, agentCtx *AgentContext) *TurnUpdate {
+		return &TurnUpdate{Model: &newModel}
+	}
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+	collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+	if len(seenModels) != 2 || seenModels[1] != newModel {
+		t.Errorf("prepareNextTurn should swap model to %q, saw %v", newModel, seenModels)
+	}
+}
+
+func TestAgentLoopLengthFailsToolCalls(t *testing.T) {
+	// Turn 1: tool call but truncated (length). Turn 2: end.
+	truncated := oneToolAssistant("c1", "echo")
+	truncated.StopReason = StopReasonLength
+	cfg := newRunCfg(scriptedStream([]AssistantMessage{
+		truncated,
+		{RoleField: RoleAssistant, StopReason: StopReasonEndTurn},
+	}), echoTool("echo", ToolExecutionParallel, false))
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+
+	kinds, msgs := collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+	// The tool must NOT have executed (truncated → failed instead).
+	if countKind(kinds, EventToolExecutionEnd) != 0 {
+		t.Errorf("truncated message must not execute tools, got %v", kinds)
+	}
+	// A failed tool result must have been synthesized.
+	var foundFail bool
+	for _, m := range msgs {
+		if tr, ok := m.(ToolResultMessage); ok && tr.IsError && tr.ToolCallID == "c1" {
+			foundFail = true
+		}
+	}
+	if !foundFail {
+		t.Errorf("expected a synthesized failed tool result for the truncated call")
+	}
+}
+
+func TestAgentLoopErrorStopEndsRun(t *testing.T) {
+	cfg := newRunCfg(scriptedStream([]AssistantMessage{
+		{RoleField: RoleAssistant, StopReason: StopReasonError, ErrorMessage: "boom"},
+	}))
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+
+	kinds, _ := collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+	if countKind(kinds, EventTurnStart) != 1 {
+		t.Errorf("error stop must end after one turn, got %v", kinds)
+	}
+	if kinds[len(kinds)-1] != EventAgentEnd {
+		t.Errorf("run must end with agent_end, got %v", kinds)
+	}
+}
+
+func TestAgentLoopAllTerminateStopsRun(t *testing.T) {
+	term := true
+	termTool := execTool{
+		name: "quit",
+		run: func(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+			return AgentToolResult{Content: ContentList{NewTextContent("bye")}, Terminate: &term}, nil
+		},
+	}
+	cfg := newRunCfg(scriptedStream([]AssistantMessage{
+		oneToolAssistant("c1", "quit"),
+		{RoleField: RoleAssistant, StopReason: StopReasonEndTurn}, // should never be reached
+	}), termTool)
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+
+	kinds, _ := collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+	if countKind(kinds, EventTurnStart) != 1 {
+		t.Errorf("terminate must end the run after one turn, got %v", kinds)
+	}
+}
+
+func TestAgentLoopContinueRejectsAssistantLast(t *testing.T) {
+	cfg := newRunCfg(scriptedStream(nil))
+	agentCtx := &AgentContext{Messages: MessageList{AssistantMessage{RoleField: RoleAssistant}}}
+	s := agentLoopContinue(context.Background(), agentCtx, cfg)
+	for range s.Events() { // should be empty
+	}
+	if _, err := s.Result(context.Background()); err != ErrContinueLastAssistant {
+		t.Errorf("expected ErrContinueLastAssistant, got %v", err)
+	}
+}
+
+func TestAgentLoopContinueRunsWhenLastNonAssistant(t *testing.T) {
+	cfg := newRunCfg(scriptedStream([]AssistantMessage{
+		{RoleField: RoleAssistant, StopReason: StopReasonEndTurn, Content: ContentList{NewTextContent("resumed")}},
+	}))
+	agentCtx := &AgentContext{Messages: MessageList{
+		AssistantMessage{RoleField: RoleAssistant},
+		ToolResultMessage{RoleField: RoleToolResult, ToolCallID: "c1"},
+	}}
+	kinds, _ := collectStream(t, agentLoopContinue(context.Background(), agentCtx, cfg))
+	if countKind(kinds, EventTurnStart) != 1 {
+		t.Errorf("continue should run one turn, got %v", kinds)
+	}
+}
+
+func assertEventKinds(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("event kinds = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("event[%d] = %q, want %q (full %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func countKind(kinds []string, want string) int {
+	n := 0
+	for _, k := range kinds {
+		if k == want {
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION
## Summary
- Add `internal/agent/loop.go` implementing pi's two-layer agent loop
- Inner loop: stream response → execute tool calls → feed back until no tool calls
- Outer loop: pull `getFollowUpMessages` to decide whether to continue
- Per-turn hooks: `getSteeringMessages`, `prepareNextTurn` (TurnUpdate), `shouldStopAfterTurn`
- `stopReason=length` fails all tool calls (`failToolCallsFromTruncatedMessage`); `error`/`aborted` end the run
- `agentLoop` + `agentLoopContinue` entry points (continue rejects assistant-last context)

Closes #23

## Test plan
- [x] go build ./... / go vet ./... clean
- [x] go test ./... passes (11 new loop tests: single-turn, tool feedback, follow-up, steering, prepareNextTurn model swap, length-fail, error-stop, all-terminate, continue guard)