### PR TITLE
Add Anthropic Messages API streaming decoder

### DIFF
--- a/docs/issue#0028.html
+++ b/docs/issue#0028.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0028</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/28">#28</a> &mdash; Anthropic provider decoder（US-008）&mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>AnthropicDecoder</code> 作为有状态 <code>Decoder</code>，按 content-block index 累积 partial</h3>
+      <p><strong>Ambiguity:</strong> 验收只要求"正确解析 text/thinking/tool_use 增量"，未规定 decoder 如何组织跨多个 SSE 事件的累积状态。</p>
+      <p><strong>Choice:</strong> 用 <code>map[int]*anthropicBlock</code> 按 Anthropic 的 content-block <code>index</code> 归集每个块的增量（text/thinking 各自 <code>strings.Builder</code>，tool_use 累积 partial JSON 字符串），并单独记录 <code>order</code> 保证首见顺序；每次 delta 后 <code>partial()</code> 物化出完整 <code>AssistantMessage</code> 随事件外发。</p>
+      <p><strong>Rationale:</strong> 复刻既有 transport <code>Decoder</code> 契约（<code>Decode</code>+<code>Finish</code>），与 <code>jsonDecoder</code> 测试范式一致；index 归集天然处理 Anthropic 交错到达的 block 事件，partial 物化让消费方每步都拿到可用快照。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>message_delta</code> 不产出独立事件，仅累积 stop_reason 与 usage</h3>
+      <p><strong>Ambiguity:</strong> AssistantMessageEvent 集合里没有"usage/stop 更新"这种 kind，验收也没要求为其单独发事件。</p>
+      <p><strong>Choice:</strong> <code>onMessageDelta</code> 只把 <code>stop_reason</code>（经 <code>mapAnthropicStopReason</code> 映射）与 output/input token 写入 decoder 状态，返回 <code>nil</code>（零事件）；这些值在终态 <code>StreamDoneEvent.Message</code> 里一并交付。</p>
+      <p><strong>Rationale:</strong> 事件集合是固定的 6 种（start/text/thinking/toolcall/done/error），不为 Anthropic 特有的中间态硬造事件；终态消息已携带 Usage 与 StopReason，消费方无需中途感知。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>stop_reason</code> 映射表：<code>max_tokens→length</code>、<code>tool_use→tool_use</code>、其余→<code>end_turn</code></h3>
+      <p><strong>Ambiguity:</strong> 验收要求"正确映射 stopReason（length/tool_use/end_turn）"，但 Anthropic 还有 <code>stop_sequence</code> 等值未列出。</p>
+      <p><strong>Choice:</strong> <code>max_tokens→StopReasonLength</code>、<code>tool_use→StopReasonToolUse</code>、<code>end_turn</code>/<code>stop_sequence→StopReasonEndTurn</code>，未知值兜底 <code>end_turn</code>。</p>
+      <p><strong>Rationale:</strong> <code>stop_sequence</code> 语义上是自然停止，归入 <code>end_turn</code> 最贴近 pi；未知值兜底为非 error 的自然停止，避免把新出现的 wire 值误判为失败。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Anthropic <code>error</code> 事件表达为 <code>Decode</code> 返回 error，而非自行发 <code>StreamErrorEvent</code></h3>
+      <p><strong>Spec:</strong> 验收要求"网络/限流/鉴权失败以流内终态 error 消息表达不 panic"。</p>
+      <p><strong>Implemented:</strong> decoder 遇到 <code>error</code> 事件或畸形 JSON 时返回 Go error；由 transport 的 <code>flush()</code> 统一转成终态 <code>StreamErrorEvent</code>（stopReason=error）。decoder 自身从不构造终态 error 事件、从不 panic。</p>
+      <p><strong>Why:</strong> transport 已拥有 dual failure model 的唯一落点（<code>fail()</code>），decoder 只需把失败上报为 error，职责单一；网络/限流/鉴权失败本就发生在 transport 层（连接/读循环），decoder 层的 error 事件与之走同一条终态路径，语义统一。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> tool_use 参数在 partial 中透传原始累积串，终态兜底 <code>{}</code></h3>
+      <p><strong>Alternatives:</strong> (A) partial 阶段直接透传 <code>toolJSON</code> 累积串（可能是不完整 JSON），终态若为空则兜底 <code>{}</code>；(B) 每次 delta 都尝试解析完整 JSON，未闭合则丢弃。</p>
+      <p><strong>Pros/Cons:</strong> A 简单、零解析开销、流式 partial 可展示"正在输入的参数"，代价是 partial 期 Arguments 可能非法 JSON（消费方本就应只在 done 后解析）；B 保证每个 partial 的 Arguments 恒合法，但要反复试解析、且丢弃中间态失去流式可见性。</p>
+      <p><strong>Winner:</strong> A——input_json_delta 是逐段拼接设计，闭合只在最后一段发生；下游（loop/executeToolCalls）只消费终态 done 的 Arguments，partial 的合法性非必需。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 录制 fixture SSE 单测 vs mock decoder 单元测试</h3>
+      <p><strong>Alternatives:</strong> (A) 内联一段结构忠实的录制 Anthropic SSE 常量，既做纯 decoder 单测（<code>feedSSE</code> 手工切分）又串 transport（<code>sseServer</code>）跑全链路；(B) 只测 <code>Decode</code> 逐事件返回。</p>
+      <p><strong>Pros/Cons:</strong> A 覆盖真实事件序列（message_start→block×3→message_delta→message_stop）与 transport 集成，贴合验收"录制 fixture 的 SSE 解析单测"；B 更细粒度但漏掉 transport 拼装/flush 路径。</p>
+      <p><strong>Winner:</strong> A——复用 <code>transport_test.go</code> 已有的 <code>sseServer</code>/<code>newReqFn</code> 范式，一份 fixture 同时验证 decoder 与端到端。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> <code>message_delta</code> 的 usage 是累积值还是增量值</h3>
+      <p><strong>Assumption:</strong> 假设 Anthropic 的 <code>message_delta.usage.output_tokens</code> 为累积总量，故直接覆盖（而非累加）decoder 的 <code>outputTokens</code>。</p>
+      <p><strong>Verify:</strong> 若某些 Anthropic API 版本按增量报 usage，需改为累加；接入真实流量后核对最终 token 数是否与账单一致。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> <code>redacted_thinking</code> 是否需要保留其密文载荷</h3>
+      <p><strong>Assumption:</strong> 当前只置 <code>Redacted=true</code> 标记，不保留 Anthropic 返回的加密 thinking 数据块内容。</p>
+      <p><strong>Verify:</strong> 若后续多轮对话需回传 redacted thinking 的原始 <code>data</code> 以维持推理连续性，需扩展 <code>anthropicBlock</code> 与 <code>ThinkingContent</code> 承载该密文。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/anthropic.go
+++ b/internal/agent/anthropic.go
@@ -1,0 +1,332 @@
+// This file implements the Anthropic Messages API streaming decoder (US-008).
+// It is a stateful Decoder (see transport.go) that translates Anthropic SSE
+// event payloads into the provider-agnostic AssistantMessageEvent set,
+// accumulating a partial AssistantMessage as deltas arrive.
+//
+// Anthropic streams a fixed event sequence:
+//
+//	message_start        → seeds id/model and initial usage (input tokens)
+//	content_block_start  → opens a text / thinking / tool_use block at an index
+//	content_block_delta  → text_delta / thinking_delta / signature_delta /
+//	                       input_json_delta append to the open block
+//	content_block_stop   → closes the block (tool_use JSON is parsed here)
+//	message_delta        → carries the final stop_reason and output-token usage
+//	message_stop         → terminal; the accumulated message is emitted as done
+//	error                → a runtime error payload → terminal error event
+//
+// Per the dual failure model (FR-13) the decoder never panics: malformed
+// payloads and Anthropic `error` events are surfaced as a returned error (which
+// the transport turns into a terminal StreamErrorEvent) rather than crashing.
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// anthropicBlock accumulates one content block's streaming state, keyed by its
+// Anthropic content-block index. text/thinking append their deltas; tool_use
+// accumulates a partial JSON string parsed lazily when the block is realized.
+type anthropicBlock struct {
+	kind        string // "text" | "thinking" | "tool_use" | "redacted_thinking"
+	text        strings.Builder
+	thinking    strings.Builder
+	thinkingSig string
+	textSig     string
+	toolID      string
+	toolName    string
+	toolJSON    strings.Builder
+	redacted    bool
+}
+
+// AnthropicDecoder is the stateful SSE decoder for the Anthropic Messages API.
+// It implements the transport Decoder interface. It is not safe for concurrent
+// use — the transport drives it from a single goroutine.
+type AnthropicDecoder struct {
+	blocks map[int]*anthropicBlock
+	order  []int // content-block indices in first-seen order
+
+	responseID    string
+	responseModel string
+	inputTokens   int
+	outputTokens  int
+	stopReason    string // mapped pigo stop reason (empty until message_delta)
+	done          bool   // message_stop / done already emitted
+}
+
+// NewAnthropicDecoder builds a fresh decoder for one streamed response.
+func NewAnthropicDecoder() *AnthropicDecoder {
+	return &AnthropicDecoder{blocks: make(map[int]*anthropicBlock)}
+}
+
+// anthropicEvent is the discriminated envelope shared by every Anthropic SSE
+// data payload; fields are populated selectively by event type.
+type anthropicEvent struct {
+	Type  string `json:"type"`
+	Index int    `json:"index"`
+
+	Message *struct {
+		ID    string          `json:"id"`
+		Model string          `json:"model"`
+		Usage *anthropicUsage `json:"usage"`
+	} `json:"message"`
+
+	ContentBlock *struct {
+		Type string `json:"type"`
+		// text
+		Text string `json:"text"`
+		// thinking
+		Thinking string `json:"thinking"`
+		// tool_use
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"content_block"`
+
+	Delta *struct {
+		Type string `json:"type"`
+		// text_delta
+		Text string `json:"text"`
+		// thinking_delta
+		Thinking string `json:"thinking"`
+		// signature_delta
+		Signature string `json:"signature"`
+		// input_json_delta
+		PartialJSON string `json:"partial_json"`
+		// message_delta
+		StopReason string `json:"stop_reason"`
+	} `json:"delta"`
+
+	Usage *anthropicUsage `json:"usage"`
+
+	Error *struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type anthropicUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// Decode turns one Anthropic SSE data payload into zero or more StreamEvents.
+func (d *AnthropicDecoder) Decode(payload []byte) ([]StreamEvent, error) {
+	var ev anthropicEvent
+	if err := json.Unmarshal(payload, &ev); err != nil {
+		return nil, fmt.Errorf("anthropic: parse event: %w", err)
+	}
+
+	switch ev.Type {
+	case "message_start":
+		return d.onMessageStart(ev), nil
+	case "content_block_start":
+		return d.onBlockStart(ev), nil
+	case "content_block_delta":
+		return d.onBlockDelta(ev), nil
+	case "content_block_stop":
+		// Nothing to emit on stop; the block is already reflected in the partial.
+		return nil, nil
+	case "message_delta":
+		return d.onMessageDelta(ev), nil
+	case "message_stop":
+		return d.finishDone(), nil
+	case "ping":
+		return nil, nil
+	case "error":
+		msg := "anthropic stream error"
+		if ev.Error != nil {
+			if ev.Error.Type != "" {
+				msg = "anthropic " + ev.Error.Type
+			}
+			if ev.Error.Message != "" {
+				msg += ": " + ev.Error.Message
+			}
+		}
+		return nil, fmt.Errorf("%s", msg)
+	default:
+		// Unknown event types are ignored (forward-compatible).
+		return nil, nil
+	}
+}
+
+// Finish flushes a terminal done event if the stream ended without an explicit
+// message_stop (e.g. a clean EOF mid-stream), so a partial response is still
+// delivered rather than lost.
+func (d *AnthropicDecoder) Finish() ([]StreamEvent, error) {
+	if d.done {
+		return nil, nil
+	}
+	return d.finishDone(), nil
+}
+
+func (d *AnthropicDecoder) onMessageStart(ev anthropicEvent) []StreamEvent {
+	if ev.Message != nil {
+		d.responseID = ev.Message.ID
+		d.responseModel = ev.Message.Model
+		if ev.Message.Usage != nil {
+			d.inputTokens = ev.Message.Usage.InputTokens
+			d.outputTokens = ev.Message.Usage.OutputTokens
+		}
+	}
+	return []StreamEvent{StreamStartEvent{Partial: d.partial()}}
+}
+
+func (d *AnthropicDecoder) onBlockStart(ev anthropicEvent) []StreamEvent {
+	if ev.ContentBlock == nil {
+		return nil
+	}
+	b := &anthropicBlock{kind: ev.ContentBlock.Type}
+	switch ev.ContentBlock.Type {
+	case "text":
+		b.text.WriteString(ev.ContentBlock.Text)
+	case "thinking":
+		b.thinking.WriteString(ev.ContentBlock.Thinking)
+	case "redacted_thinking":
+		b.redacted = true
+	case "tool_use":
+		b.toolID = ev.ContentBlock.ID
+		b.toolName = ev.ContentBlock.Name
+	}
+	d.putBlock(ev.Index, b)
+
+	switch ev.ContentBlock.Type {
+	case "thinking", "redacted_thinking":
+		return []StreamEvent{StreamThinkingEvent{Partial: d.partial()}}
+	case "tool_use":
+		return []StreamEvent{StreamToolCallEvent{Partial: d.partial()}}
+	default:
+		return []StreamEvent{StreamTextEvent{Partial: d.partial()}}
+	}
+}
+
+func (d *AnthropicDecoder) onBlockDelta(ev anthropicEvent) []StreamEvent {
+	if ev.Delta == nil {
+		return nil
+	}
+	b := d.blocks[ev.Index]
+	if b == nil {
+		// A delta for an unseen index: open a bare block so we don't drop data.
+		b = &anthropicBlock{}
+		d.putBlock(ev.Index, b)
+	}
+	switch ev.Delta.Type {
+	case "text_delta":
+		b.text.WriteString(ev.Delta.Text)
+		return []StreamEvent{StreamTextEvent{Partial: d.partial()}}
+	case "thinking_delta":
+		b.thinking.WriteString(ev.Delta.Thinking)
+		return []StreamEvent{StreamThinkingEvent{Partial: d.partial()}}
+	case "signature_delta":
+		// Signature belongs to the thinking block it rides on.
+		b.thinkingSig += ev.Delta.Signature
+		return []StreamEvent{StreamThinkingEvent{Partial: d.partial()}}
+	case "input_json_delta":
+		b.toolJSON.WriteString(ev.Delta.PartialJSON)
+		return []StreamEvent{StreamToolCallEvent{Partial: d.partial()}}
+	default:
+		return nil
+	}
+}
+
+func (d *AnthropicDecoder) onMessageDelta(ev anthropicEvent) []StreamEvent {
+	if ev.Delta != nil && ev.Delta.StopReason != "" {
+		d.stopReason = mapAnthropicStopReason(ev.Delta.StopReason)
+	}
+	if ev.Usage != nil {
+		// message_delta reports cumulative output tokens (and sometimes input).
+		if ev.Usage.OutputTokens != 0 {
+			d.outputTokens = ev.Usage.OutputTokens
+		}
+		if ev.Usage.InputTokens != 0 {
+			d.inputTokens = ev.Usage.InputTokens
+		}
+	}
+	// No standalone event kind for usage/stop-reason accumulation; the values
+	// surface in the terminal done message.
+	return nil
+}
+
+// finishDone builds the terminal assistant message and marks the decoder done.
+func (d *AnthropicDecoder) finishDone() []StreamEvent {
+	if d.done {
+		return nil
+	}
+	d.done = true
+	msg := d.partial()
+	if msg.StopReason == "" {
+		msg.StopReason = StopReasonEndTurn
+	}
+	return []StreamEvent{StreamDoneEvent{Message: msg}}
+}
+
+// putBlock records a block at index, tracking first-seen order.
+func (d *AnthropicDecoder) putBlock(index int, b *anthropicBlock) {
+	if _, seen := d.blocks[index]; !seen {
+		d.order = append(d.order, index)
+	}
+	d.blocks[index] = b
+}
+
+// partial materializes the accumulated state into an AssistantMessage. Content
+// blocks are emitted in content-block index order. Tool-use JSON that has not
+// yet parsed cleanly is passed through as-is (raw partial), which is valid for
+// a still-streaming partial and finalized once the block completes.
+func (d *AnthropicDecoder) partial() AssistantMessage {
+	msg := AssistantMessage{
+		RoleField:     RoleAssistant,
+		API:           "anthropic",
+		Provider:      "anthropic",
+		StopReason:    d.stopReason,
+		ResponseID:    d.responseID,
+		ResponseModel: d.responseModel,
+	}
+	if d.inputTokens != 0 || d.outputTokens != 0 {
+		msg.Usage = &Usage{InputTokens: d.inputTokens, OutputTokens: d.outputTokens}
+	}
+
+	idx := make([]int, len(d.order))
+	copy(idx, d.order)
+	sort.Ints(idx)
+
+	for _, i := range idx {
+		b := d.blocks[i]
+		if b == nil {
+			continue
+		}
+		switch b.kind {
+		case "thinking", "redacted_thinking":
+			tc := NewThinkingContent(b.thinking.String())
+			tc.ThinkingSignature = b.thinkingSig
+			tc.Redacted = b.redacted
+			msg.Content = append(msg.Content, tc)
+		case "tool_use":
+			args := json.RawMessage(strings.TrimSpace(b.toolJSON.String()))
+			if len(args) == 0 {
+				args = json.RawMessage("{}")
+			}
+			msg.Content = append(msg.Content, NewToolCallContent(b.toolID, b.toolName, args))
+		default: // text
+			tc := NewTextContent(b.text.String())
+			tc.TextSignature = b.textSig
+			msg.Content = append(msg.Content, tc)
+		}
+	}
+	return msg
+}
+
+// mapAnthropicStopReason maps an Anthropic stop_reason to the pigo StopReason
+// set. Unknown reasons default to end_turn (a natural, non-error stop).
+func mapAnthropicStopReason(reason string) string {
+	switch reason {
+	case "max_tokens":
+		return StopReasonLength
+	case "tool_use":
+		return StopReasonToolUse
+	case "end_turn", "stop_sequence":
+		return StopReasonEndTurn
+	default:
+		return StopReasonEndTurn
+	}
+}

--- a/internal/agent/anthropic_test.go
+++ b/internal/agent/anthropic_test.go
@@ -1,0 +1,293 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A recorded Anthropic Messages API SSE stream covering a text block, a
+// thinking block (with signature), and a tool_use block, ending with a
+// tool_use stop reason and output-token usage. Trimmed but structurally
+// faithful to the real wire format.
+const anthropicToolUseSSE = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_01ABC","model":"claude-opus-4-8","usage":{"input_tokens":42,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think. "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Use the tool."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sigABC"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"I'll check "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"the weather."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: content_block_start
+data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_01","name":"get_weather"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"city\":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":" \"SF\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":2}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":57}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+
+// feedSSE splits a recorded SSE body into events (blank-line separated),
+// extracts each `data:` payload, and drives the decoder exactly as the
+// transport pump would, returning all emitted events plus the final message.
+func feedSSE(t *testing.T, dec Decoder, body string) ([]StreamEvent, AssistantMessage) {
+	t.Helper()
+	var events []StreamEvent
+	for _, block := range strings.Split(body, "\n\n") {
+		var payload strings.Builder
+		for _, line := range strings.Split(block, "\n") {
+			line = strings.TrimRight(line, "\r")
+			if strings.HasPrefix(line, "data:") {
+				payload.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			}
+		}
+		if payload.Len() == 0 {
+			continue
+		}
+		evs, err := dec.Decode([]byte(payload.String()))
+		if err != nil {
+			t.Fatalf("decode %q: %v", payload.String(), err)
+		}
+		events = append(events, evs...)
+	}
+	finalEvents, err := dec.Finish()
+	if err != nil {
+		t.Fatalf("finish: %v", err)
+	}
+	events = append(events, finalEvents...)
+
+	var final AssistantMessage
+	for _, ev := range events {
+		if d, ok := ev.(StreamDoneEvent); ok {
+			final = d.Message
+		}
+	}
+	return events, final
+}
+
+func TestAnthropicDecoderToolUseStream(t *testing.T) {
+	dec := NewAnthropicDecoder()
+	events, final := feedSSE(t, dec, anthropicToolUseSSE)
+
+	// The first emitted event must be a start event.
+	if len(events) == 0 || events[0].EventKind() != StreamEventStart {
+		t.Fatalf("expected a start event first, got %v", eventKinds(events))
+	}
+	// The last emitted event must be the terminal done event.
+	if events[len(events)-1].EventKind() != StreamEventDone {
+		t.Fatalf("expected a done event last, got %v", eventKinds(events))
+	}
+
+	// Stop reason: tool_use.
+	if final.StopReason != StopReasonToolUse {
+		t.Errorf("stop reason = %q, want tool_use", final.StopReason)
+	}
+	// Usage: input from message_start, output from message_delta.
+	if final.Usage == nil || final.Usage.InputTokens != 42 || final.Usage.OutputTokens != 57 {
+		t.Errorf("usage = %+v, want input=42 output=57", final.Usage)
+	}
+	// Response identity from message_start.
+	if final.ResponseID != "msg_01ABC" || final.ResponseModel != "claude-opus-4-8" {
+		t.Errorf("response id/model = %q/%q", final.ResponseID, final.ResponseModel)
+	}
+
+	// Content blocks in index order: thinking, text, tool_use.
+	if len(final.Content) != 3 {
+		t.Fatalf("expected 3 content blocks, got %d: %+v", len(final.Content), final.Content)
+	}
+	th, ok := final.Content[0].(ThinkingContent)
+	if !ok || th.Thinking != "Let me think. Use the tool." {
+		t.Errorf("thinking block = %+v", final.Content[0])
+	}
+	if th.ThinkingSignature != "sigABC" {
+		t.Errorf("thinking signature = %q, want sigABC", th.ThinkingSignature)
+	}
+	txt, ok := final.Content[1].(TextContent)
+	if !ok || txt.Text != "I'll check the weather." {
+		t.Errorf("text block = %+v", final.Content[1])
+	}
+	tool, ok := final.Content[2].(ToolCallContent)
+	if !ok || tool.Name != "get_weather" || tool.ID != "toolu_01" {
+		t.Fatalf("tool block = %+v", final.Content[2])
+	}
+	// tool_use JSON must have accumulated into valid arguments.
+	var args map[string]string
+	if err := json.Unmarshal(tool.Arguments, &args); err != nil {
+		t.Fatalf("tool arguments not valid JSON %q: %v", tool.Arguments, err)
+	}
+	if args["city"] != "SF" {
+		t.Errorf("tool arguments = %v, want city=SF", args)
+	}
+}
+
+func TestAnthropicDecoderTextOnlyEndTurn(t *testing.T) {
+	body := `data: {"type":"message_start","message":{"id":"msg_1","model":"claude-x","usage":{"input_tokens":10,"output_tokens":0}}}
+
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}
+
+data: {"type":"content_block_stop","index":0}
+
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}
+
+data: {"type":"message_stop"}
+
+`
+	dec := NewAnthropicDecoder()
+	_, final := feedSSE(t, dec, body)
+	if final.StopReason != StopReasonEndTurn {
+		t.Errorf("stop reason = %q, want end_turn", final.StopReason)
+	}
+	if len(final.Content) != 1 {
+		t.Fatalf("expected 1 content block, got %d", len(final.Content))
+	}
+	txt, ok := final.Content[0].(TextContent)
+	if !ok || txt.Text != "Hello world" {
+		t.Errorf("text = %+v", final.Content[0])
+	}
+}
+
+func TestAnthropicDecoderMaxTokensMapsToLength(t *testing.T) {
+	body := `data: {"type":"message_start","message":{"id":"m","model":"c","usage":{"input_tokens":5,"output_tokens":0}}}
+
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"truncated"}}
+
+data: {"type":"content_block_stop","index":0}
+
+data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":100}}
+
+data: {"type":"message_stop"}
+
+`
+	dec := NewAnthropicDecoder()
+	_, final := feedSSE(t, dec, body)
+	if final.StopReason != StopReasonLength {
+		t.Errorf("max_tokens must map to length, got %q", final.StopReason)
+	}
+}
+
+// TestAnthropicDecoderErrorEvent verifies an Anthropic `error` event becomes a
+// decode error (which the transport turns into a terminal error event), never
+// a panic.
+func TestAnthropicDecoderErrorEvent(t *testing.T) {
+	dec := NewAnthropicDecoder()
+	_, err := dec.Decode([]byte(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`))
+	if err == nil {
+		t.Fatal("error event must return a decode error")
+	}
+	if !strings.Contains(err.Error(), "overloaded_error") {
+		t.Errorf("error should name the type, got %v", err)
+	}
+}
+
+// TestAnthropicDecoderMalformedPayload verifies invalid JSON is a returned
+// error (rides the stream as terminal error), not a panic.
+func TestAnthropicDecoderMalformedPayload(t *testing.T) {
+	dec := NewAnthropicDecoder()
+	if _, err := dec.Decode([]byte(`{not json`)); err == nil {
+		t.Fatal("malformed payload must return an error")
+	}
+}
+
+// TestAnthropicDecoderFinishFlushesPartial verifies a stream cut short (no
+// message_stop) still yields a done event on Finish so the partial isn't lost.
+func TestAnthropicDecoderFinishFlushesPartial(t *testing.T) {
+	body := `data: {"type":"message_start","message":{"id":"m","model":"c","usage":{"input_tokens":5,"output_tokens":0}}}
+
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}
+
+`
+	dec := NewAnthropicDecoder()
+	events, final := feedSSE(t, dec, body)
+	if events[len(events)-1].EventKind() != StreamEventDone {
+		t.Fatalf("Finish must emit a terminal done event, got %v", eventKinds(events))
+	}
+	// No message_delta arrived → default end_turn.
+	if final.StopReason != StopReasonEndTurn {
+		t.Errorf("cut-short stream should default to end_turn, got %q", final.StopReason)
+	}
+	if len(final.Content) != 1 {
+		t.Fatalf("expected the partial text block, got %+v", final.Content)
+	}
+}
+
+// TestAnthropicDecoderThroughTransport wires the decoder through the real
+// transport pump against a recorded SSE server, exercising the full path.
+func TestAnthropicDecoderThroughTransport(t *testing.T) {
+	srv := sseServer(t, anthropicToolUseSSE)
+	defer srv.Close()
+
+	stream, err := StreamRequest(context.Background(), TransportConfig{
+		NewRequest: newReqFn(srv.URL),
+		Decoder:    NewAnthropicDecoder(),
+	})
+	if err != nil {
+		t.Fatalf("StreamRequest: %v", err)
+	}
+	var kinds []string
+	for ev := range stream.Events() {
+		kinds = append(kinds, ev.EventKind())
+	}
+	final, resErr := stream.Result(context.Background())
+	if resErr != nil {
+		t.Fatalf("result: %v", resErr)
+	}
+	if final.StopReason != StopReasonToolUse {
+		t.Errorf("stop reason via transport = %q, want tool_use", final.StopReason)
+	}
+	if len(final.Content) != 3 {
+		t.Errorf("expected 3 content blocks via transport, got %d", len(final.Content))
+	}
+	if kinds[len(kinds)-1] != StreamEventDone {
+		t.Errorf("stream must end with done, got %v", kinds)
+	}
+}
+
+func eventKinds(events []StreamEvent) []string {
+	out := make([]string, len(events))
+	for i, ev := range events {
+		out[i] = ev.EventKind()
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- Add `AnthropicDecoder`: a stateful transport `Decoder` for the Anthropic Messages API SSE stream
- Parse text/thinking/tool_use content-block deltas, accumulating a partial `AssistantMessage`
- Report usage (input tokens from `message_start`, output tokens from `message_delta`)
- Map `stop_reason`: `max_tokens→length`, `tool_use`, `end_turn`/`stop_sequence→end_turn`
- Anthropic `error` events + malformed payloads surface as decode errors → terminal `StreamErrorEvent` via transport (never panics)
- Recorded-fixture SSE parse tests + full transport integration test

Closes #28

## Test plan
- [x] gofmt / go build / go vet clean
- [x] go test ./... passes