### PR TITLE
Add Gemini provider decoder (US-010)

### DIFF
--- a/docs/issue#0030.html
+++ b/docs/issue#0030.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0030</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/30">#30</a> &mdash; Gemini provider decoder（US-010）&mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> functionCall 无 id，分配稳定合成 id <code>call_&lt;序号&gt;</code></h3>
+      <p><strong>Ambiguity:</strong> 验收要求"解析 functionCall"，但 Gemini 的 functionCall part 不携带调用 id，而 pigo 的 <code>ToolCallContent</code> 及后续 tool-result 关联依赖非空 id。</p>
+      <p><strong>Choice:</strong> 按到达顺序为每个 functionCall 分配 <code>call_0</code>、<code>call_1</code>… 的合成 id。</p>
+      <p><strong>Rationale:</strong> 下游 <code>executeToolCalls</code> 用 id 关联 tool-result；合成 id 稳定、唯一、可预期，且 Gemini 回传 tool-result 时按 name/顺序匹配而非 id，故合成 id 不影响与 Gemini 的往返。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> functionCall 的 args 作为完整 JSON 对象一次性承载，非增量拼接</h3>
+      <p><strong>Ambiguity:</strong> 其它 provider（OpenAI/Anthropic）的工具参数是跨分片累积的字符串，验收未说明 Gemini 是否相同。</p>
+      <p><strong>Choice:</strong> Gemini 在单个 part 里给出完整的 <code>args</code> 对象（<code>json.RawMessage</code>），直接透传，不做增量 builder 累积。</p>
+      <p><strong>Rationale:</strong> Gemini wire 格式本就单片交付完整 args；强行套用累积模型反而引入无谓状态。终态仍做 <code>{}</code> 兜底以防空 args。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>thought=true</code> 的 part 归为 thinking 内容</h3>
+      <p><strong>Ambiguity:</strong> Gemini 2.x 的 thinking 以带 <code>thought:true</code> 标记的 text part 表达，验收只提"解析文本与 functionCall"未明确 thinking。</p>
+      <p><strong>Choice:</strong> part 若 <code>thought=true</code> 则累积进 thinking builder 并发 <code>StreamThinkingEvent</code>；否则普通 text。terminal 消息中 thinking 块在 text 块之前。</p>
+      <p><strong>Rationale:</strong> 与 Anthropic decoder 的 thinking 处理对齐；提前正确归类避免把推理内容混入正文。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> finishReason=STOP 在存在 functionCall 时映射为 tool_use 而非 end_turn</h3>
+      <p><strong>Spec:</strong> 验收要求"stopReason 映射正确（length/tool_use/end_turn）"。</p>
+      <p><strong>Implemented:</strong> Gemini 即便产生 functionCall 也报 <code>finishReason=STOP</code>（不像 OpenAI 有专门的 <code>tool_calls</code>）。因此 <code>mapGeminiFinishReason</code> 与 <code>finishDone</code> 均优先判断"是否出现过 functionCall"：出现即映射 <code>tool_use</code>，与 loop 的工具执行分支对齐。</p>
+      <p><strong>Why:</strong> 若照字面把 STOP 映射为 end_turn，loop 会误判为自然终止而不执行工具调用，导致 Gemini 的工具能力失效。以"是否有 tool call"为准更贴近语义与 pi 行为。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> usageMetadata 覆盖式记录 vs 累加</h3>
+      <p><strong>Alternatives:</strong> (A) 每次出现 <code>usageMetadata</code> 覆盖式写入 input/output tokens；(B) 累加各 chunk 的增量。</p>
+      <p><strong>Pros/Cons:</strong> A 简单，符合 Gemini "usageMetadata 携累积总量、通常仅在末尾 chunk 出现"的行为；B 在 Gemini 报增量时才需要，但 Gemini 实际报累积值，累加会翻倍。</p>
+      <p><strong>Winner:</strong> A——与 Anthropic decoder 的 usage 处理一致；Gemini 的 usageMetadata 是累积快照，覆盖即正确。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 复用 <code>feedSSE</code>/<code>sseServer</code> 录制 fixture vs 独立测试骨架</h3>
+      <p><strong>Alternatives:</strong> (A) 复用共享的 <code>feedSSE</code>/<code>eventKinds</code>/<code>sseServer</code>/<code>newReqFn</code>，一份 Gemini fixture 同时跑纯 decoder 单测与 transport 全链路；(B) 为 Gemini 单建骨架。</p>
+      <p><strong>Pros/Cons:</strong> A 与 Anthropic/OpenAI 测试范式统一、零重复；B 隔离性略好但重复。</p>
+      <p><strong>Winner:</strong> A——三个 provider decoder 共享 transport 契约与测试骨架，保证行为一致。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 合成 tool-call id 是否影响 Gemini 多轮 tool-result 回传</h3>
+      <p><strong>Assumption:</strong> 假设 Gemini 的 functionResponse 按函数 name 匹配，不依赖调用方回传 id，故合成 <code>call_N</code> 安全。</p>
+      <p><strong>Verify:</strong> 接入真实多轮工具调用后核对：向 Gemini 回传 tool-result 时是否需要原样带回某个 id；若需要，则合成方案需改为透传 Gemini 侧标识。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 并行 functionCall 与 thinking 的顺序假设</h3>
+      <p><strong>Assumption:</strong> 当前按 part 到达顺序处理，terminal 内容块顺序为 thinking→text→functionCall。</p>
+      <p><strong>Verify:</strong> 若 Gemini 在单响应内交错多个 functionCall 与 text，需确认展示顺序是否仍符合预期；必要时保留严格的 part 到达序。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -1,0 +1,227 @@
+// This file implements the Gemini streaming decoder (US-010): a stateful
+// Decoder (see transport.go) for the Google Gemini streamGenerateContent SSE
+// stream (alt=sse). Like the other provider decoders it is base-URL agnostic —
+// selecting the endpoint is a transport concern (NewRequest builds the
+// *http.Request).
+//
+// Gemini streams a sequence of GenerateContentResponse snapshots, each carrying
+// incremental candidate parts:
+//
+//	{"candidates":[{"content":{"parts":[{"text":"Hel"}],"role":"model"}}]}   → text delta
+//	{"candidates":[{"content":{"parts":[{"functionCall":{"name":"f",
+//	    "args":{"a":1}}}]}}]}                                                → function call
+//	{"candidates":[{"content":{"parts":[{"thought":true,
+//	    "text":"reasoning"}]}}]}                                             → thinking delta
+//	{"candidates":[{"finishReason":"STOP"}]}                                → stop reason
+//	{"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5}}      → usage
+//
+// Unlike OpenAI, Gemini function calls arrive as one complete part (args is a
+// full JSON object, not an accumulated string) and carry no call id, so a
+// stable synthetic id is assigned. Gemini reports STOP even when a functionCall
+// is present, so the presence of any function call maps the stop reason to
+// tool_use.
+//
+// Per the dual failure model (FR-13) the decoder never panics: malformed
+// payloads and Gemini `error` payloads surface as a returned error which the
+// transport turns into a terminal StreamErrorEvent.
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// geminiFunctionCall accumulates one Gemini function call. Gemini delivers the
+// whole call in a single part (name + complete args object), so nothing is
+// streamed incrementally; the synthetic id keeps tool-result correlation stable.
+type geminiFunctionCall struct {
+	id   string
+	name string
+	args json.RawMessage
+}
+
+// GeminiDecoder is the stateful SSE decoder for the Gemini
+// streamGenerateContent API. It implements the transport Decoder interface and
+// is not safe for concurrent use — the transport drives it from one goroutine.
+type GeminiDecoder struct {
+	text     strings.Builder
+	thinking strings.Builder
+	calls    []geminiFunctionCall
+
+	responseID    string
+	responseModel string
+	inputTokens   int
+	outputTokens  int
+	stopReason    string // mapped pigo stop reason (empty until finishReason)
+	hasToolCall   bool
+	done          bool
+}
+
+// NewGeminiDecoder builds a fresh decoder for one streamed response.
+func NewGeminiDecoder() *GeminiDecoder {
+	return &GeminiDecoder{}
+}
+
+// geminiResponse is the streamed GenerateContentResponse envelope.
+type geminiResponse struct {
+	ResponseID   string `json:"responseId"`
+	ModelVersion string `json:"modelVersion"`
+	Candidates   []struct {
+		Content struct {
+			Parts []geminiPart `json:"parts"`
+			Role  string       `json:"role"`
+		} `json:"content"`
+		FinishReason string `json:"finishReason"`
+	} `json:"candidates"`
+	UsageMetadata *struct {
+		PromptTokenCount     int `json:"promptTokenCount"`
+		CandidatesTokenCount int `json:"candidatesTokenCount"`
+	} `json:"usageMetadata"`
+	// Gemini surfaces failures as a top-level error object.
+	Error *struct {
+		Code    int    `json:"code"`
+		Status  string `json:"status"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// geminiPart is one content part: text, thinking text (thought=true), or a
+// functionCall. Exactly one shape is populated per part.
+type geminiPart struct {
+	Text         string `json:"text"`
+	Thought      bool   `json:"thought"`
+	FunctionCall *struct {
+		Name string          `json:"name"`
+		Args json.RawMessage `json:"args"`
+	} `json:"functionCall"`
+}
+
+// Decode turns one Gemini SSE data payload into zero or more StreamEvents.
+func (d *GeminiDecoder) Decode(payload []byte) ([]StreamEvent, error) {
+	var resp geminiResponse
+	if err := json.Unmarshal(payload, &resp); err != nil {
+		return nil, fmt.Errorf("gemini: parse response: %w", err)
+	}
+	if resp.Error != nil {
+		msg := "gemini stream error"
+		if resp.Error.Status != "" {
+			msg = "gemini " + resp.Error.Status
+		}
+		if resp.Error.Message != "" {
+			msg += ": " + resp.Error.Message
+		}
+		return nil, fmt.Errorf("%s", msg)
+	}
+
+	if resp.ResponseID != "" {
+		d.responseID = resp.ResponseID
+	}
+	if resp.ModelVersion != "" {
+		d.responseModel = resp.ModelVersion
+	}
+	if resp.UsageMetadata != nil {
+		d.inputTokens = resp.UsageMetadata.PromptTokenCount
+		d.outputTokens = resp.UsageMetadata.CandidatesTokenCount
+	}
+
+	var events []StreamEvent
+	for _, cand := range resp.Candidates {
+		for _, part := range cand.Content.Parts {
+			switch {
+			case part.FunctionCall != nil:
+				d.calls = append(d.calls, geminiFunctionCall{
+					id:   "call_" + strconv.Itoa(len(d.calls)),
+					name: part.FunctionCall.Name,
+					args: part.FunctionCall.Args,
+				})
+				d.hasToolCall = true
+				events = append(events, StreamToolCallEvent{Partial: d.partial()})
+			case part.Thought:
+				d.thinking.WriteString(part.Text)
+				events = append(events, StreamThinkingEvent{Partial: d.partial()})
+			case part.Text != "":
+				d.text.WriteString(part.Text)
+				events = append(events, StreamTextEvent{Partial: d.partial()})
+			}
+		}
+		if cand.FinishReason != "" {
+			d.stopReason = mapGeminiFinishReason(cand.FinishReason, d.hasToolCall)
+		}
+	}
+	return events, nil
+}
+
+// Finish flushes a terminal done event if the stream ended without an explicit
+// terminator, so a partial response is still delivered rather than lost.
+func (d *GeminiDecoder) Finish() ([]StreamEvent, error) {
+	if d.done {
+		return nil, nil
+	}
+	return d.finishDone(), nil
+}
+
+// finishDone builds the terminal assistant message and marks the decoder done.
+func (d *GeminiDecoder) finishDone() []StreamEvent {
+	if d.done {
+		return nil
+	}
+	d.done = true
+	msg := d.partial()
+	if msg.StopReason == "" {
+		if d.hasToolCall {
+			msg.StopReason = StopReasonToolUse
+		} else {
+			msg.StopReason = StopReasonEndTurn
+		}
+	}
+	return []StreamEvent{StreamDoneEvent{Message: msg}}
+}
+
+// partial materializes the accumulated state into an AssistantMessage: thinking
+// block first (if any), then text, then function-call blocks in arrival order.
+func (d *GeminiDecoder) partial() AssistantMessage {
+	msg := AssistantMessage{
+		RoleField:     RoleAssistant,
+		API:           "gemini",
+		Provider:      "google",
+		StopReason:    d.stopReason,
+		ResponseID:    d.responseID,
+		ResponseModel: d.responseModel,
+	}
+	if d.inputTokens != 0 || d.outputTokens != 0 {
+		msg.Usage = &Usage{InputTokens: d.inputTokens, OutputTokens: d.outputTokens}
+	}
+	if d.thinking.Len() > 0 {
+		msg.Content = append(msg.Content, NewThinkingContent(d.thinking.String()))
+	}
+	if d.text.Len() > 0 {
+		msg.Content = append(msg.Content, NewTextContent(d.text.String()))
+	}
+	for _, c := range d.calls {
+		args := json.RawMessage(strings.TrimSpace(string(c.args)))
+		if len(args) == 0 {
+			args = json.RawMessage("{}")
+		}
+		msg.Content = append(msg.Content, NewToolCallContent(c.id, c.name, args))
+	}
+	return msg
+}
+
+// mapGeminiFinishReason maps a Gemini finishReason to the pigo StopReason set.
+// Gemini reports STOP even alongside a functionCall, so a present tool call
+// takes precedence and maps to tool_use. Unknown reasons default to end_turn.
+func mapGeminiFinishReason(reason string, hasToolCall bool) string {
+	if hasToolCall {
+		return StopReasonToolUse
+	}
+	switch reason {
+	case "MAX_TOKENS":
+		return StopReasonLength
+	case "STOP":
+		return StopReasonEndTurn
+	default:
+		return StopReasonEndTurn
+	}
+}

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -1,0 +1,176 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A recorded Gemini streamGenerateContent SSE stream (alt=sse) covering a
+// thinking part (thought=true), a text part, and a functionCall part, ending
+// with finishReason=STOP and usageMetadata. Structurally faithful to the real
+// wire format.
+const geminiToolCallSSE = `data: {"responseId":"resp-1","modelVersion":"gemini-2.0-flash","candidates":[{"content":{"parts":[{"thought":true,"text":"Let me think."}],"role":"model"}}]}
+
+data: {"responseId":"resp-1","modelVersion":"gemini-2.0-flash","candidates":[{"content":{"parts":[{"text":"I'll check "}],"role":"model"}}]}
+
+data: {"responseId":"resp-1","modelVersion":"gemini-2.0-flash","candidates":[{"content":{"parts":[{"text":"the weather."}],"role":"model"}}]}
+
+data: {"responseId":"resp-1","modelVersion":"gemini-2.0-flash","candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","args":{"city":"SF"}}}],"role":"model"}}]}
+
+data: {"responseId":"resp-1","modelVersion":"gemini-2.0-flash","candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":21,"candidatesTokenCount":14}}
+
+`
+
+func TestGeminiDecoderToolCallStream(t *testing.T) {
+	dec := NewGeminiDecoder()
+	events, final := feedSSE(t, dec, geminiToolCallSSE)
+
+	if len(events) == 0 || events[len(events)-1].EventKind() != StreamEventDone {
+		t.Fatalf("expected a done event last, got %v", eventKinds(events))
+	}
+	// A functionCall present → tool_use even though Gemini reports STOP.
+	if final.StopReason != StopReasonToolUse {
+		t.Errorf("stop reason = %q, want tool_use", final.StopReason)
+	}
+	// Usage: prompt→input, candidates→output.
+	if final.Usage == nil || final.Usage.InputTokens != 21 || final.Usage.OutputTokens != 14 {
+		t.Errorf("usage = %+v, want input=21 output=14", final.Usage)
+	}
+	if final.ResponseID != "resp-1" || final.ResponseModel != "gemini-2.0-flash" {
+		t.Errorf("response id/model = %q/%q", final.ResponseID, final.ResponseModel)
+	}
+
+	// Content blocks: thinking, text, function-call.
+	if len(final.Content) != 3 {
+		t.Fatalf("expected 3 content blocks, got %d: %+v", len(final.Content), final.Content)
+	}
+	th, ok := final.Content[0].(ThinkingContent)
+	if !ok || th.Thinking != "Let me think." {
+		t.Errorf("thinking block = %+v", final.Content[0])
+	}
+	txt, ok := final.Content[1].(TextContent)
+	if !ok || txt.Text != "I'll check the weather." {
+		t.Errorf("text block = %+v", final.Content[1])
+	}
+	tool, ok := final.Content[2].(ToolCallContent)
+	if !ok || tool.Name != "get_weather" || tool.ID == "" {
+		t.Fatalf("tool block = %+v", final.Content[2])
+	}
+	var args map[string]string
+	if err := json.Unmarshal(tool.Arguments, &args); err != nil {
+		t.Fatalf("tool arguments not valid JSON %q: %v", tool.Arguments, err)
+	}
+	if args["city"] != "SF" {
+		t.Errorf("tool arguments = %v, want city=SF", args)
+	}
+}
+
+func TestGeminiDecoderTextOnlyStop(t *testing.T) {
+	body := `data: {"responseId":"r","modelVersion":"m","candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"}}]}
+
+data: {"responseId":"r","modelVersion":"m","candidates":[{"content":{"parts":[{"text":" world"}],"role":"model"}}]}
+
+data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2}}
+
+`
+	dec := NewGeminiDecoder()
+	_, final := feedSSE(t, dec, body)
+	if final.StopReason != StopReasonEndTurn {
+		t.Errorf("stop reason = %q, want end_turn", final.StopReason)
+	}
+	if len(final.Content) != 1 {
+		t.Fatalf("expected 1 content block, got %d", len(final.Content))
+	}
+	txt, ok := final.Content[0].(TextContent)
+	if !ok || txt.Text != "Hello world" {
+		t.Errorf("text = %+v", final.Content[0])
+	}
+}
+
+func TestGeminiDecoderMaxTokensMapsToLength(t *testing.T) {
+	body := `data: {"candidates":[{"content":{"parts":[{"text":"truncated"}],"role":"model"}}]}
+
+data: {"candidates":[{"finishReason":"MAX_TOKENS"}]}
+
+`
+	dec := NewGeminiDecoder()
+	_, final := feedSSE(t, dec, body)
+	if final.StopReason != StopReasonLength {
+		t.Errorf("MAX_TOKENS must map to length, got %q", final.StopReason)
+	}
+}
+
+// TestGeminiDecoderErrorPayload verifies a Gemini error object becomes a decode
+// error (which the transport turns into a terminal error event), never a panic.
+func TestGeminiDecoderErrorPayload(t *testing.T) {
+	dec := NewGeminiDecoder()
+	_, err := dec.Decode([]byte(`{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"quota"}}`))
+	if err == nil {
+		t.Fatal("error payload must return a decode error")
+	}
+	if !strings.Contains(err.Error(), "RESOURCE_EXHAUSTED") {
+		t.Errorf("error should name the status, got %v", err)
+	}
+}
+
+// TestGeminiDecoderMalformedPayload verifies invalid JSON is a returned error,
+// not a panic.
+func TestGeminiDecoderMalformedPayload(t *testing.T) {
+	dec := NewGeminiDecoder()
+	if _, err := dec.Decode([]byte(`{not json`)); err == nil {
+		t.Fatal("malformed payload must return an error")
+	}
+}
+
+// TestGeminiDecoderFinishFlushesPartial verifies a stream cut short (no
+// finishReason) still yields a done event on Finish, defaulting to end_turn.
+func TestGeminiDecoderFinishFlushesPartial(t *testing.T) {
+	body := `data: {"candidates":[{"content":{"parts":[{"text":"partial"}],"role":"model"}}]}
+
+`
+	dec := NewGeminiDecoder()
+	events, final := feedSSE(t, dec, body)
+	if events[len(events)-1].EventKind() != StreamEventDone {
+		t.Fatalf("Finish must emit a terminal done event, got %v", eventKinds(events))
+	}
+	if final.StopReason != StopReasonEndTurn {
+		t.Errorf("cut-short stream should default to end_turn, got %q", final.StopReason)
+	}
+	if len(final.Content) != 1 {
+		t.Fatalf("expected the partial text block, got %+v", final.Content)
+	}
+}
+
+// TestGeminiDecoderThroughTransport wires the decoder through the real transport
+// pump against a recorded SSE server, exercising the full path.
+func TestGeminiDecoderThroughTransport(t *testing.T) {
+	srv := sseServer(t, geminiToolCallSSE)
+	defer srv.Close()
+
+	stream, err := StreamRequest(context.Background(), TransportConfig{
+		NewRequest: newReqFn(srv.URL),
+		Decoder:    NewGeminiDecoder(),
+	})
+	if err != nil {
+		t.Fatalf("StreamRequest: %v", err)
+	}
+	var kinds []string
+	for ev := range stream.Events() {
+		kinds = append(kinds, ev.EventKind())
+	}
+	final, resErr := stream.Result(context.Background())
+	if resErr != nil {
+		t.Fatalf("result: %v", resErr)
+	}
+	if final.StopReason != StopReasonToolUse {
+		t.Errorf("stop reason via transport = %q, want tool_use", final.StopReason)
+	}
+	if len(final.Content) != 3 {
+		t.Errorf("expected 3 content blocks via transport, got %d", len(final.Content))
+	}
+	if kinds[len(kinds)-1] != StreamEventDone {
+		t.Errorf("stream must end with done, got %v", kinds)
+	}
+}


### PR DESCRIPTION
## Summary
- Implement `GeminiDecoder`, a stateful `Decoder` for the Gemini streamGenerateContent SSE stream
- Parse text parts, `thought=true` thinking parts, and `functionCall` parts (whole args object in one part; stable synthetic id assigned since Gemini carries none)
- Map `finishReason` (MAX_TOKENS→length, STOP→end_turn) and `usageMetadata` (prompt→input, candidates→output)
- A present function call takes precedence to `tool_use` even when Gemini reports STOP (Gemini has no dedicated tool stop reason)
- Error payloads and malformed JSON ride the stream as a terminal error per the dual failure model — never panic

Closes #30

## Test plan
- [x] Recorded-fixture SSE tests: thinking+text+functionCall stream, text-only stop, MAX_TOKENS mapping, error payload, malformed payload, cut-short Finish
- [x] Transport integration test through real StreamRequest/sseServer
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./...` passes