### PR TITLE
Add first concrete providers: Bedrock/OpenRouter/Ollama

### DIFF
--- a/docs/issue#0033.html
+++ b/docs/issue#0033.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0033</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/33">#33</a> &mdash; Bedrock/OpenRouter/Ollama provider（US-013）&mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 两个共享 driver 覆盖三个 provider，而非各写一份</h3>
+      <p><strong>Ambiguity:</strong> 验收要求"复用共享 driver / OpenRouter 作为通用 OpenAI 兼容层样例"，但未规定 driver 的边界如何切分。</p>
+      <p><strong>Choice:</strong> 抽出 <code>openAICompatDriver</code>（POST <code>{baseURL}/chat/completions</code> + <code>OpenAIDecoder</code>）与 <code>anthropicCompatDriver</code>（POST Messages wire + <code>AnthropicDecoder</code>）。OpenRouter/Ollama 是前者的两个实例（仅 baseURL/auth 不同），Bedrock 走后者。</p>
+      <p><strong>Rationale:</strong> Chat Completions 与 Messages 是两种 wire 契约；按 wire 而非按厂商切分，让"新增一个 OpenAI 兼容网关"退化为一次构造调用（Groq/together/本地 server 皆可），真正兑现"通用兼容层"。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 这是仓库中第一批具体 Provider——此前只有 Decoder 和测试 fakeProvider</h3>
+      <p><strong>Ambiguity:</strong> 验收写"各实现 Decoder"，但 anthropic/openai/gemini 的 Decoder 早已存在（#28/#29/#30），从未有 Provider 把 Decoder 经 <code>StreamRequest</code> 串起来。</p>
+      <p><strong>Choice:</strong> 把验收理解为"实现首批 <em>Provider</em>"：<code>StreamCompletion</code> 构建 <code>*http.Request</code>（base URL + auth + JSON body）后交给 <code>StreamRequest(TransportConfig{NewRequest, Decoder})</code>，复用既有 Decoder 而非重写。</p>
+      <p><strong>Rationale:</strong> Decoder 已完备且测试充分；#33 的真正缺口是"把 Decoder 接到真实 HTTP/SSE 上的 Provider"。复用 Decoder 即满足"各实现 Decoder"的意图。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 缺 API key 是唯一的早返回错误，其余失败一律走流内终态</h3>
+      <p><strong>Ambiguity:</strong> 验收未提失败模型，但 FR-13 双失败模型是全局约束。</p>
+      <p><strong>Choice:</strong> <code>requiresAuth</code> 的 provider（OpenRouter/Bedrock）在 key 为空时早返回 <code>"&lt;provider&gt;: missing API key"</code>；Ollama 本地无需 key。请求构建后所有运行时失败由 <code>StreamRequest</code> 落到终态 <code>StreamErrorEvent</code>。</p>
+      <p><strong>Rationale:</strong> 与 transport/provider_interface 的双失败模型对齐；错误仅按 provider 名引用，绝不泄漏 key 值（US-012/US-026）。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Bedrock 走标准 Anthropic Messages 端点，未实现 AWS SigV4 / invoke-with-response-stream</h3>
+      <p><strong>Spec:</strong> 验收要求"Bedrock 实现 Decoder，复用共享 driver"与"每个 provider 最小流式单测"。</p>
+      <p><strong>Implemented:</strong> Bedrock 复用 <code>AnthropicDecoder</code>，以 <code>Authorization: Bearer</code>（Bedrock API key）POST Messages wire。真实 Bedrock 的 <code>/model/{id}/invoke-with-response-stream</code> 路径与 SigV4 签名以 <code>pathFor</code> 钩子和"由调用方 HTTP client 分层签名"的方式预留，未在本 issue 内落地。</p>
+      <p><strong>Why:</strong> 验收明确是"最小流式单测 + 复用共享 driver"，Anthropic-on-Bedrock 本就说 Messages 协议，Decoder 可原样复用；SigV4 与区域端点属部署/凭证细节，超出本 issue 范围，留待接入真实 Bedrock 流量时补齐。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 内容降维为纯文本 vs 保留完整多模态块</h3>
+      <p><strong>Alternatives:</strong> (A) <code>contentToText</code> 把 content list 压平为文本（tool_call/thinking 走各自字段）；(B) 完整映射 image/thinking 等所有块到各 wire。</p>
+      <p><strong>Pros/Cons:</strong> A 是所有 OpenAI 兼容网关都接受的最小公分母、实现简单；B 更完备但各网关对多模态支持参差，易在边缘网关上出错。Anthropic 侧已保留 text/tool_use/tool_result 结构化块。</p>
+      <p><strong>Winner:</strong> A（OpenAI 侧）——先保证跨网关可用；多模态透传待具体 provider 需要时按需扩展。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> captureServer 断言 wire 形状 vs 仅断言事件流</h3>
+      <p><strong>Alternatives:</strong> (A) 新增 <code>captureServer</code> 记录 path/headers/body，断言 driver 真正 POST 出的报文形状；(B) 仅复用 <code>sseServer</code> 断言解码后的事件。</p>
+      <p><strong>Pros/Cons:</strong> A 能验证 auth header、system 顶层字段、stream flag、max_tokens 等 driver 独有职责；B 只覆盖 Decoder（已被 #29/#30 测过），对 Provider 层几乎零增量。</p>
+      <p><strong>Winner:</strong> A——#33 的新增职责是"构建请求"，测试必须落在请求形状上才有意义。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Bedrock 真实端点与 SigV4 签名如何接入</h3>
+      <p><strong>Assumption:</strong> 假设可通过 Bedrock API key（Bearer）+ 标准 Messages 端点直连；<code>pathFor</code> 钩子预留了 <code>/model/{id}/invoke-with-response-stream</code> 的定制点。</p>
+      <p><strong>Verify:</strong> 接入真实 Bedrock 时确认：是否必须 SigV4（则由自定义 <code>*http.Client</code> 的 RoundTripper 分层签名）、响应是否为 AWS event-stream 二进制帧而非纯 SSE（若是则需 Bedrock 专用 Decoder，而非复用 AnthropicDecoder）。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> OpenRouter 归因 header 是否应可配置</h3>
+      <p><strong>Assumption:</strong> 当前硬编码 <code>HTTP-Referer</code>/<code>X-Title</code> 为 pigo 仓库信息。</p>
+      <p><strong>Verify:</strong> 若下游希望按部署自定义归因，需把 <code>extraHeaders</code> 提升为构造参数或配置项。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/providers.go
+++ b/internal/agent/providers.go
@@ -1,0 +1,397 @@
+// This file implements the first concrete Providers (US-013): Bedrock,
+// OpenRouter, and Ollama. Each satisfies the Provider interface by building an
+// *http.Request and delegating to the shared transport (StreamRequest) with a
+// provider-appropriate Decoder — no bespoke HTTP/SSE handling per provider.
+//
+// Two backing driver shapes cover all three:
+//
+//   - openAICompatDriver — POSTs to {baseURL}/chat/completions in the OpenAI
+//     Chat Completions wire format, decoded by OpenAIDecoder. OpenRouter and
+//     Ollama are instances of it; it is the generic OpenAI-compatible layer,
+//     reusable for any gateway (Groq, together, local servers, …).
+//   - anthropicCompatDriver — POSTs the Anthropic Messages wire format, decoded
+//     by AnthropicDecoder. Bedrock rides this: Anthropic-on-Bedrock speaks the
+//     Messages API, so the decoder is reused wholesale.
+//
+// Failures follow the dual failure model (FR-13): only the earliest "cannot
+// build the stream" case (missing key, bad request construction) is a returned
+// error; every runtime failure rides the stream as a terminal error event,
+// which StreamRequest already guarantees.
+//
+// Security (US-012 / US-026): API keys are referenced by provider name in any
+// error; secret values are never logged or embedded in error text.
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// providerBaseURLs holds the default endpoint per built-in provider. A base URL
+// is a transport concern (the decoders are URL-agnostic), so overriding it —
+// e.g. pointing Ollama at a remote host — needs no decoder change.
+const (
+	openRouterBaseURL = "https://openrouter.ai/api/v1"
+	ollamaBaseURL     = "http://localhost:11434/v1"
+	// bedrockBaseURL is a placeholder default; real Bedrock endpoints are
+	// region-specific (bedrock-runtime.<region>.amazonaws.com) and supplied at
+	// construction. It is exported as a field so callers set the resolved URL.
+	bedrockBaseURL = "https://bedrock-runtime.us-east-1.amazonaws.com"
+)
+
+// ---------------------------------------------------------------------------
+// OpenAI-compatible driver (OpenRouter, Ollama, and any OpenAI-compatible API).
+// ---------------------------------------------------------------------------
+
+// openAICompatDriver is the shared backing for every OpenAI-compatible
+// provider. It holds the provider identity, endpoint, model catalog, and the
+// auth scheme; StreamCompletion builds the chat-completions request and hands
+// it to the transport with a fresh OpenAIDecoder.
+type openAICompatDriver struct {
+	name    string
+	baseURL string
+	models  []Model
+	// requiresAuth reports whether an Authorization: Bearer header is sent.
+	// Ollama (local) needs none; OpenRouter does.
+	requiresAuth bool
+	// extraHeaders are attached to every request (e.g. OpenRouter attribution).
+	extraHeaders map[string]string
+}
+
+func (d *openAICompatDriver) Name() string    { return d.name }
+func (d *openAICompatDriver) Models() []Model { return d.models }
+
+// StreamCompletion builds the OpenAI Chat Completions request and streams it.
+func (d *openAICompatDriver) StreamCompletion(ctx context.Context, req CompletionRequest) (*AssistantMessageEventStream, error) {
+	if d.requiresAuth && strings.TrimSpace(req.Config.APIKey) == "" {
+		// Early "cannot build the stream": reference the provider, never a value.
+		return nil, fmt.Errorf("%s: missing API key", d.name)
+	}
+	body, err := encodeOpenAIRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s: build request body: %w", d.name, err)
+	}
+	newReq := func(ctx context.Context) (*http.Request, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+"/chat/completions", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Accept", "text/event-stream")
+		if d.requiresAuth {
+			httpReq.Header.Set("Authorization", "Bearer "+req.Config.APIKey)
+		}
+		for k, v := range d.extraHeaders {
+			httpReq.Header.Set(k, v)
+		}
+		return httpReq, nil
+	}
+	return StreamRequest(ctx, TransportConfig{NewRequest: newReq, Decoder: NewOpenAIDecoder()})
+}
+
+// encodeOpenAIRequest serializes a CompletionRequest into an OpenAI Chat
+// Completions JSON body with streaming enabled and usage requested.
+func encodeOpenAIRequest(req CompletionRequest) ([]byte, error) {
+	msgs := make([]map[string]any, 0, len(req.Context.Messages)+1)
+	if sp := req.Context.SystemPrompt; sp != "" {
+		msgs = append(msgs, map[string]any{"role": "system", "content": sp})
+	}
+	for _, m := range req.Context.Messages {
+		msgs = append(msgs, encodeOpenAIMessage(m)...)
+	}
+	body := map[string]any{
+		"model":          req.Model,
+		"messages":       msgs,
+		"stream":         true,
+		"stream_options": map[string]any{"include_usage": true},
+	}
+	if tools := encodeOpenAITools(req.Context.Tools); len(tools) > 0 {
+		body["tools"] = tools
+	}
+	return json.Marshal(body)
+}
+
+// encodeOpenAIMessage maps one pigo message onto the OpenAI wire shape. An
+// assistant message may expand to content + tool_calls in a single entry; a
+// tool result becomes a role:"tool" entry keyed by tool_call_id.
+func encodeOpenAIMessage(m Message) []map[string]any {
+	switch msg := m.(type) {
+	case UserMessage:
+		return []map[string]any{{"role": "user", "content": contentToText(msg.Content)}}
+	case AssistantMessage:
+		entry := map[string]any{"role": "assistant"}
+		entry["content"] = contentToText(msg.Content)
+		var toolCalls []map[string]any
+		for _, c := range msg.Content {
+			if tc, ok := c.(ToolCallContent); ok {
+				toolCalls = append(toolCalls, map[string]any{
+					"id":   tc.ID,
+					"type": "function",
+					"function": map[string]any{
+						"name":      tc.Name,
+						"arguments": string(tc.Arguments),
+					},
+				})
+			}
+		}
+		if len(toolCalls) > 0 {
+			entry["tool_calls"] = toolCalls
+		}
+		return []map[string]any{entry}
+	case ToolResultMessage:
+		return []map[string]any{{
+			"role":         "tool",
+			"tool_call_id": msg.ToolCallID,
+			"content":      contentToText(msg.Content),
+		}}
+	default:
+		return nil
+	}
+}
+
+// encodeOpenAITools maps AgentTools onto the OpenAI function-tool schema.
+func encodeOpenAITools(tools []AgentTool) []map[string]any {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(tools))
+	for _, t := range tools {
+		params := json.RawMessage(t.Schema())
+		if len(params) == 0 {
+			params = json.RawMessage("{}")
+		}
+		out = append(out, map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        t.Name(),
+				"description": t.Description(),
+				"parameters":  params,
+			},
+		})
+	}
+	return out
+}
+
+// contentToText flattens text blocks of a content list into a single string,
+// the lowest-common-denominator representation accepted by every OpenAI-
+// compatible gateway. Non-text blocks (thinking, tool calls) are surfaced
+// through their own fields, so they are skipped here.
+func contentToText(list ContentList) string {
+	var b strings.Builder
+	for _, c := range list {
+		if tc, ok := c.(TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic-compatible driver (Bedrock).
+// ---------------------------------------------------------------------------
+
+// anthropicCompatDriver backs Anthropic-wire providers that are not the direct
+// Anthropic API — Bedrock being the case here. It POSTs the Messages wire
+// format and decodes with AnthropicDecoder.
+type anthropicCompatDriver struct {
+	name    string
+	baseURL string
+	models  []Model
+	// path is the endpoint path appended to baseURL (Bedrock's invoke path
+	// embeds the model id, so it is derived per request).
+	pathFor func(model string) string
+	// authHeader sets provider auth on the request (never logs the value).
+	authHeader func(req *http.Request, apiKey string)
+}
+
+func (d *anthropicCompatDriver) Name() string    { return d.name }
+func (d *anthropicCompatDriver) Models() []Model { return d.models }
+
+// StreamCompletion builds the Anthropic Messages request and streams it,
+// decoding with AnthropicDecoder.
+func (d *anthropicCompatDriver) StreamCompletion(ctx context.Context, req CompletionRequest) (*AssistantMessageEventStream, error) {
+	if strings.TrimSpace(req.Config.APIKey) == "" {
+		return nil, fmt.Errorf("%s: missing API key", d.name)
+	}
+	body, err := encodeAnthropicRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s: build request body: %w", d.name, err)
+	}
+	path := "/messages"
+	if d.pathFor != nil {
+		path = d.pathFor(req.Model)
+	}
+	newReq := func(ctx context.Context) (*http.Request, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, d.baseURL+path, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Accept", "text/event-stream")
+		if d.authHeader != nil {
+			d.authHeader(httpReq, req.Config.APIKey)
+		}
+		return httpReq, nil
+	}
+	return StreamRequest(ctx, TransportConfig{NewRequest: newReq, Decoder: NewAnthropicDecoder()})
+}
+
+// encodeAnthropicRequest serializes a CompletionRequest into an Anthropic
+// Messages JSON body with streaming enabled. The system prompt is a top-level
+// field; tool results and tool calls follow the Messages content-block shape.
+func encodeAnthropicRequest(req CompletionRequest) ([]byte, error) {
+	msgs := make([]map[string]any, 0, len(req.Context.Messages))
+	for _, m := range req.Context.Messages {
+		if enc := encodeAnthropicMessage(m); enc != nil {
+			msgs = append(msgs, enc)
+		}
+	}
+	body := map[string]any{
+		"messages": msgs,
+		"stream":   true,
+	}
+	if sp := req.Context.SystemPrompt; sp != "" {
+		body["system"] = sp
+	}
+	if maxTok := maxOutputTokensFor(req); maxTok > 0 {
+		body["max_tokens"] = maxTok
+	} else {
+		// Anthropic requires max_tokens; supply a safe default when unknown.
+		body["max_tokens"] = 4096
+	}
+	if tools := encodeAnthropicTools(req.Context.Tools); len(tools) > 0 {
+		body["tools"] = tools
+	}
+	return json.Marshal(body)
+}
+
+// encodeAnthropicMessage maps one pigo message onto the Anthropic Messages
+// wire shape. Assistant tool calls become tool_use blocks; tool results become
+// a user message carrying a tool_result block (Anthropic's convention).
+func encodeAnthropicMessage(m Message) map[string]any {
+	switch msg := m.(type) {
+	case UserMessage:
+		return map[string]any{"role": "user", "content": contentToText(msg.Content)}
+	case AssistantMessage:
+		var blocks []map[string]any
+		for _, c := range msg.Content {
+			switch b := c.(type) {
+			case TextContent:
+				blocks = append(blocks, map[string]any{"type": "text", "text": b.Text})
+			case ToolCallContent:
+				var input any
+				_ = json.Unmarshal(b.Arguments, &input)
+				blocks = append(blocks, map[string]any{
+					"type": "tool_use", "id": b.ID, "name": b.Name, "input": input,
+				})
+			}
+		}
+		if len(blocks) == 0 {
+			blocks = []map[string]any{{"type": "text", "text": ""}}
+		}
+		return map[string]any{"role": "assistant", "content": blocks}
+	case ToolResultMessage:
+		return map[string]any{"role": "user", "content": []map[string]any{{
+			"type":        "tool_result",
+			"tool_use_id": msg.ToolCallID,
+			"content":     contentToText(msg.Content),
+		}}}
+	default:
+		return nil
+	}
+}
+
+// encodeAnthropicTools maps AgentTools onto the Anthropic tool schema.
+func encodeAnthropicTools(tools []AgentTool) []map[string]any {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(tools))
+	for _, t := range tools {
+		schema := json.RawMessage(t.Schema())
+		if len(schema) == 0 {
+			schema = json.RawMessage("{}")
+		}
+		out = append(out, map[string]any{
+			"name":         t.Name(),
+			"description":  t.Description(),
+			"input_schema": schema,
+		})
+	}
+	return out
+}
+
+// maxOutputTokensFor pulls a max-output hint from the request Extra map, if any,
+// so callers can bound Anthropic responses without a registry lookup here.
+func maxOutputTokensFor(req CompletionRequest) int {
+	if req.Config.Extra == nil {
+		return 0
+	}
+	switch v := req.Config.Extra["max_tokens"].(type) {
+	case int:
+		return v
+	case float64:
+		return int(v)
+	}
+	return 0
+}
+
+// ---------------------------------------------------------------------------
+// Constructors.
+// ---------------------------------------------------------------------------
+
+// NewOpenRouterProvider builds the OpenRouter provider — the reference
+// OpenAI-compatible gateway. baseURL defaults to the public endpoint when empty.
+func NewOpenRouterProvider(baseURL string, models []Model) Provider {
+	if baseURL == "" {
+		baseURL = openRouterBaseURL
+	}
+	return &openAICompatDriver{
+		name:         "openrouter",
+		baseURL:      baseURL,
+		models:       models,
+		requiresAuth: true,
+		extraHeaders: map[string]string{
+			// OpenRouter attribution headers (optional but recommended).
+			"HTTP-Referer": "https://github.com/smallnest/pigo",
+			"X-Title":      "pigo",
+		},
+	}
+}
+
+// NewOllamaProvider builds the Ollama provider (local, OpenAI-compatible, no
+// auth). baseURL defaults to the local daemon when empty.
+func NewOllamaProvider(baseURL string, models []Model) Provider {
+	if baseURL == "" {
+		baseURL = ollamaBaseURL
+	}
+	return &openAICompatDriver{
+		name:         "ollama",
+		baseURL:      baseURL,
+		models:       models,
+		requiresAuth: false,
+	}
+}
+
+// NewBedrockProvider builds the Bedrock provider, reusing the Anthropic Messages
+// decoder (Anthropic-on-Bedrock speaks the Messages wire format). baseURL
+// defaults to a us-east-1 runtime endpoint when empty; real deployments pass
+// the region-specific URL. Auth is a Bearer token (Bedrock API keys); SigV4
+// signing, when required, is layered by the caller's HTTP client.
+func NewBedrockProvider(baseURL string, models []Model) Provider {
+	if baseURL == "" {
+		baseURL = bedrockBaseURL
+	}
+	return &anthropicCompatDriver{
+		name:    "bedrock",
+		baseURL: baseURL,
+		models:  models,
+		authHeader: func(req *http.Request, apiKey string) {
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+		},
+	}
+}

--- a/internal/agent/providers_test.go
+++ b/internal/agent/providers_test.go
@@ -1,0 +1,202 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// captureServer records the last request path, headers, and decoded JSON body,
+// then replays a canned SSE stream. It lets the provider tests assert the wire
+// shape a driver produced without a live upstream.
+type captureServer struct {
+	srv     *httptest.Server
+	path    string
+	headers http.Header
+	body    map[string]any
+}
+
+func newCaptureServer(t *testing.T, sseBody string) *captureServer {
+	t.Helper()
+	cs := &captureServer{}
+	cs.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cs.path = r.URL.Path
+		cs.headers = r.Header.Clone()
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &cs.body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseBody))
+	}))
+	t.Cleanup(cs.srv.Close)
+	return cs
+}
+
+// drainStream collects event kinds and the final message from a provider stream.
+func drainStream(t *testing.T, stream *AssistantMessageEventStream) ([]string, AssistantMessage) {
+	t.Helper()
+	var kinds []string
+	for ev := range stream.Events() {
+		kinds = append(kinds, ev.EventKind())
+	}
+	final, err := stream.Result(context.Background())
+	if err != nil {
+		t.Fatalf("stream result: %v", err)
+	}
+	return kinds, final
+}
+
+// TestOpenRouterProviderStreamsChatCompletions drives OpenRouter (the reference
+// OpenAI-compatible provider) end to end: the driver must POST to
+// /chat/completions with a Bearer token and stream through OpenAIDecoder.
+func TestOpenRouterProviderStreamsChatCompletions(t *testing.T) {
+	cs := newCaptureServer(t, openaiToolCallSSE)
+	p := NewOpenRouterProvider(cs.srv.URL, []Model{{Provider: "openrouter", ID: "openai/gpt-4o"}})
+
+	if p.Name() != "openrouter" {
+		t.Errorf("name = %q, want openrouter", p.Name())
+	}
+	stream, err := p.StreamCompletion(context.Background(), CompletionRequest{
+		Model:   "openai/gpt-4o",
+		Context: LlmContext{SystemPrompt: "be brief", Messages: MessageList{UserMessage{RoleField: RoleUser, Content: ContentList{NewTextContent("hi")}}}},
+		Config:  StreamConfig{APIKey: "sk-test"},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	kinds, final := drainStream(t, stream)
+	if kinds[len(kinds)-1] != StreamEventDone {
+		t.Errorf("last event = %q, want done", kinds[len(kinds)-1])
+	}
+	if final.StopReason != StopReasonToolUse {
+		t.Errorf("stop reason = %q, want tool_use", final.StopReason)
+	}
+
+	// Wire assertions: path, auth header, and request body shape.
+	if cs.path != "/chat/completions" {
+		t.Errorf("path = %q, want /chat/completions", cs.path)
+	}
+	if got := cs.headers.Get("Authorization"); got != "Bearer sk-test" {
+		t.Errorf("auth header = %q, want Bearer sk-test", got)
+	}
+	if cs.body["stream"] != true {
+		t.Errorf("stream flag = %v, want true", cs.body["stream"])
+	}
+	if cs.body["model"] != "openai/gpt-4o" {
+		t.Errorf("model = %v, want openai/gpt-4o", cs.body["model"])
+	}
+	msgs, _ := cs.body["messages"].([]any)
+	if len(msgs) != 2 {
+		t.Fatalf("messages len = %d, want 2 (system+user)", len(msgs))
+	}
+	first, _ := msgs[0].(map[string]any)
+	if first["role"] != "system" || first["content"] != "be brief" {
+		t.Errorf("system message = %v", first)
+	}
+}
+
+// TestOpenRouterMissingKeyIsEarlyError verifies a missing API key is the early
+// "cannot build the stream" returned error, and the provider name is named
+// without leaking any value.
+func TestOpenRouterMissingKeyIsEarlyError(t *testing.T) {
+	p := NewOpenRouterProvider("", nil)
+	_, err := p.StreamCompletion(context.Background(), CompletionRequest{Model: "m"})
+	if err == nil {
+		t.Fatal("missing API key must return an early error")
+	}
+	if !strings.Contains(err.Error(), "openrouter") {
+		t.Errorf("error should name the provider, got %v", err)
+	}
+}
+
+// TestOllamaProviderNoAuth verifies the local Ollama provider sends no
+// Authorization header and still streams through OpenAIDecoder.
+func TestOllamaProviderNoAuth(t *testing.T) {
+	cs := newCaptureServer(t, openaiToolCallSSE)
+	p := NewOllamaProvider(cs.srv.URL, []Model{{Provider: "ollama", ID: "llama3"}})
+	if p.Name() != "ollama" {
+		t.Errorf("name = %q, want ollama", p.Name())
+	}
+	// No API key configured — Ollama must not require one.
+	stream, err := p.StreamCompletion(context.Background(), CompletionRequest{
+		Model:   "llama3",
+		Context: LlmContext{Messages: MessageList{UserMessage{RoleField: RoleUser, Content: ContentList{NewTextContent("hi")}}}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion (no auth): %v", err)
+	}
+	_, final := drainStream(t, stream)
+	if final.StopReason != StopReasonToolUse {
+		t.Errorf("stop reason = %q, want tool_use", final.StopReason)
+	}
+	if got := cs.headers.Get("Authorization"); got != "" {
+		t.Errorf("Ollama must send no auth header, got %q", got)
+	}
+}
+
+// TestBedrockProviderStreamsAnthropicWire verifies the Bedrock provider POSTs
+// the Anthropic Messages wire format (system top-level, max_tokens present) and
+// streams through AnthropicDecoder.
+func TestBedrockProviderStreamsAnthropicWire(t *testing.T) {
+	cs := newCaptureServer(t, anthropicToolUseSSE)
+	p := NewBedrockProvider(cs.srv.URL, []Model{{Provider: "bedrock", ID: "anthropic.claude-3"}})
+	if p.Name() != "bedrock" {
+		t.Errorf("name = %q, want bedrock", p.Name())
+	}
+	stream, err := p.StreamCompletion(context.Background(), CompletionRequest{
+		Model:   "anthropic.claude-3",
+		Context: LlmContext{SystemPrompt: "sys", Messages: MessageList{UserMessage{RoleField: RoleUser, Content: ContentList{NewTextContent("hi")}}}},
+		Config:  StreamConfig{APIKey: "bedrock-key"},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	kinds, _ := drainStream(t, stream)
+	if kinds[len(kinds)-1] != StreamEventDone {
+		t.Errorf("last event = %q, want done", kinds[len(kinds)-1])
+	}
+	if cs.body["system"] != "sys" {
+		t.Errorf("system = %v, want top-level 'sys'", cs.body["system"])
+	}
+	if cs.body["max_tokens"] == nil {
+		t.Error("Anthropic wire requires max_tokens")
+	}
+	if cs.body["stream"] != true {
+		t.Errorf("stream flag = %v, want true", cs.body["stream"])
+	}
+}
+
+// TestBedrockMissingKeyIsEarlyError mirrors the OpenRouter early-error check.
+func TestBedrockMissingKeyIsEarlyError(t *testing.T) {
+	p := NewBedrockProvider("", nil)
+	_, err := p.StreamCompletion(context.Background(), CompletionRequest{Model: "m"})
+	if err == nil {
+		t.Fatal("missing API key must return an early error")
+	}
+	if !strings.Contains(err.Error(), "bedrock") {
+		t.Errorf("error should name the provider, got %v", err)
+	}
+}
+
+// TestProvidersRegisterInModelRegistry verifies the shared driver providers plug
+// into the model registry (US-011) and resolve their models.
+func TestProvidersRegisterInModelRegistry(t *testing.T) {
+	reg := NewModelRegistry()
+	if err := reg.RegisterProvider(NewOpenRouterProvider("", []Model{{Provider: "openrouter", ID: "or-model"}})); err != nil {
+		t.Fatalf("register openrouter: %v", err)
+	}
+	if err := reg.RegisterProvider(NewOllamaProvider("", []Model{{Provider: "ollama", ID: "ol-model"}})); err != nil {
+		t.Fatalf("register ollama: %v", err)
+	}
+	m, prov, err := reg.Resolve("or-model")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if m.ID != "or-model" || prov.Name() != "openrouter" {
+		t.Errorf("resolved %+v via %q", m, prov.Name())
+	}
+}


### PR DESCRIPTION
## Summary
- 实现仓库首批具体 Provider，把既有 decoder 经 `StreamRequest` 接到真实 HTTP/SSE
- 两个共享 driver 覆盖三者：`openAICompatDriver`（chat/completions + OpenAIDecoder，OpenRouter/Ollama 复用）与 `anthropicCompatDriver`（Messages wire + AnthropicDecoder，Bedrock 复用）
- OpenRouter 作为通用 OpenAI 兼容层样例；Ollama 本地无 auth；缺 key 是唯一早返回错误，其余失败走流内终态
- 每个 provider 最小流式单测（capture-server 断言 path/auth/body 形状）

Closes #33

## Test plan
- [x] gofmt / go build / go vet clean
- [x] go test ./... 通过