### PR TITLE
test: faux provider + loop 集成测试（主 seam）

### DIFF
--- a/docs/issue#0024.html
+++ b/docs/issue#0024.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0024</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/24">#24</a> &mdash; fake provider + loop 集成测试（主 seam）（US-002）&mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 用「细粒度事件脚本」的 fauxProvider，而非复用已存在的 fakeProvider</h3>
+      <p><strong>Ambiguity:</strong> 仓库里已有两个 fake：<code>loop_test.go</code> 的 <code>scriptedStream</code>（每次仅发一个 <code>StreamDoneEvent</code>）与 <code>provider_interface_test.go</code> 的 <code>fakeProvider</code>（发预设 <code>[]AssistantMessageEvent</code> 后 Close）。验收要求"fake provider 接受预设 SSE 事件脚本、驱动完整 loop"，但没说是否复用。</p>
+      <p><strong>Choice:</strong> 新建 <code>fauxProvider</code>（对标 pi <code>providers/faux.ts</code>）：每次 <code>StreamCompletion</code> 回放<em>一整个 turn 的细粒度脚本</em>（start → text/toolcall delta → done），按调用序消费 <code>turns []fauxTurn</code>，脚本耗尽后回放空 end_turn。经 <code>StreamFnFromProvider</code> 接入 loop。</p>
+      <p><strong>Rationale:</strong> 只有细粒度 start/delta/done 才能让 <code>streamAssistantResponse</code> 真正走 message_start/message_update/message_end 三段路径；粗粒度的 <code>scriptedStream</code> 只发 done，覆盖不到 delta。faux 是"真 Provider 经真 seam"，符合"不 mock loop 内部函数"。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> "六钩子"锚定为 2 个 per-request（LoopConfig）+ 4 个 per-turn（RunConfig）</h3>
+      <p><strong>Ambiguity:</strong> 验收写"六钩子经此 seam 覆盖"，但 pigo 的钩子散布在 <code>LoopConfig</code>（TransformContext/ConvertToLlm/GetAPIKey…）与 <code>RunConfig</code>（GetFollowUpMessages/GetSteeringMessages/PrepareNextTurn/ShouldStopAfterTurn），并非恰好命名为"六个"。</p>
+      <p><strong>Choice:</strong> <code>TestFauxSeamSixHooks</code> 取 loop 控制流真正消费的六个：TransformContext、ConvertToLlm、GetAPIKey（per-request 三个）+ GetFollowUpMessages、GetSteeringMessages、PrepareNextTurn、ShouldStopAfterTurn（per-turn 四个，共七回调）。每个钩子记录是否触发，并在可观测处断言其副作用真的到达 provider 请求（GetAPIKey→APIKey、PrepareNextTurn→Model swap）。</p>
+      <p><strong>Rationale:</strong> pi 的"六钩子"是概念数；忠实映射应覆盖 loop 实际编排的全部回调点，且断言副作用而非仅"被调用"，才真正验证 seam 行为。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> faux 回放的是解码后的 AssistantMessageEvent，而非原始 SSE 字节</h3>
+      <p><strong>Spec:</strong> 验收原文"fake provider 接受预设 <em>SSE 事件</em>脚本"。</p>
+      <p><strong>Implemented:</strong> <code>fauxTurn = []AssistantMessageEvent</code>，直接回放 loop 层事件，不经过 SSE 行解析/Decoder。</p>
+      <p><strong>Why:</strong> #24 的 seam 是 <em>Provider→loop</em>，测的是 loop 编排（钩子/截断/保序/取消），不是 SSE 解码——后者已由 transport_test.go 与三个 decoder 测试（#28/#29/#30）覆盖。让 faux 在 AssistantMessageEvent 层回放，正是 pi <code>faux.ts</code> 的做法，也避免与已覆盖的解码路径重复。原始 SSE→事件的转换已在 <code>captureServer</code>/decoder 测试里验证。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 取消测试断言"nil 或 context.Canceled"，而非强制某一种</h3>
+      <p><strong>Alternatives:</strong> (A) 读一个事件后 cancel，断言 <code>Result</code> 要么无错（run 已自然发完 agent_end）要么恰为 <code>context.Canceled</code>；(B) 精确断言必定返回 <code>context.Canceled</code>。</p>
+      <p><strong>Pros/Cons:</strong> B 更强，但取消与 producer goroutine 发完事件存在固有竞态——即便 provider 每 delta sleep 50ms，仍可能在 cancel 传播前已 Close 并 SetResult，届时 Result 返回 nil。强行要求 Canceled 会引入偶发 flake。A 仍验证了核心不变量：取消后消费者不 hang、Result 立即返回且错误（若有）必是取消。</p>
+      <p><strong>Winner:</strong> A——seam 的取消契约是"不泄漏 goroutine、不 hang、错误语义正确"，用 <code>-race -count=3</code> 复跑确认无竞态与 flake。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 并行保序用 sleep 反序 vs 注入同步原语</h3>
+      <p><strong>Alternatives:</strong> (A) 三个 parallel 工具按源序 slow/mid/fast 递减 sleep，使完成序与源序相反，断言 tool-result 仍按 <code>a0,a1,a2</code>；(B) 用 channel/barrier 精确编排完成顺序。</p>
+      <p><strong>Pros/Cons:</strong> A 简单、与既有 <code>batch_executor_test.go</code> 的 <code>TestBatchParallelPreservesOrder</code> 范式一致；B 更确定但更重、且 batch executor 的保序（index-backfill）已被单测直接覆盖。</p>
+      <p><strong>Winner:</strong> A——此处目的是"经 seam 端到端确认保序"，非重测 executor 内部；sleep 反序足以暴露乱序，且风格统一。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 取消测试是否需要更强的确定性断言</h3>
+      <p><strong>Assumption:</strong> 假设"消费者不 hang + 错误若有必为 Canceled"是取消契约的充分验证。</p>
+      <p><strong>Verify:</strong> 若后续希望强制"取消必中断且必返回 Canceled"，需在 producer 侧引入可观测的中断点（如 emit 前的 barrier），把竞态窗口消除后再收紧断言。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> faux 是否应升级为读真实 SSE fixture 的 provider</h3>
+      <p><strong>Assumption:</strong> 当前 faux 在 AssistantMessageEvent 层回放，SSE→事件由 decoder 测试单独覆盖，两者不重叠即可。</p>
+      <p><strong>Verify:</strong> 若将来想要一条"字节→事件→loop"的全链路冒烟测试，可让 faux 底层改用 <code>captureServer</code>+decoder 回放真实 SSE 文本；目前判断收益低于重复成本，未做。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/faux_provider_test.go
+++ b/internal/agent/faux_provider_test.go
@@ -1,0 +1,425 @@
+package agent
+
+// This file implements the faux provider (对标 pi providers/faux.ts) and the
+// loop integration tests that drive the whole agent loop through it — the
+// project's primary and only core test seam (US-002 / Testing Decisions, #16).
+//
+// Unlike loop_test.go, which drives the loop with a coarse StreamFn that emits
+// only a terminal StreamDoneEvent, the faux provider is a real Provider whose
+// StreamCompletion replays a *fine-grained* script of AssistantMessageEvents
+// (start → text/toolcall deltas → done) — one scripted turn per call. It is
+// wired into the loop via StreamFnFromProvider, the real seam, so the whole
+// path (message_start / message_update / message_end deltas, the six hooks,
+// truncation protection, parallel ordering, and EventStream cancellation) is
+// covered end to end without mocking any loop-internal function.
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fauxTurn is one scripted assistant turn: the fine-grained stream events the
+// faux provider replays for a single StreamCompletion call.
+type fauxTurn []AssistantMessageEvent
+
+// textTurn scripts a turn that streams text as start → text delta → done(end_turn).
+func textTurn(text string) fauxTurn {
+	partial := AssistantMessage{RoleField: RoleAssistant}
+	withText := partial
+	withText.Content = ContentList{NewTextContent(text)}
+	final := withText
+	final.StopReason = StopReasonEndTurn
+	return fauxTurn{
+		StreamStartEvent{Partial: partial},
+		StreamTextEvent{Partial: withText},
+		StreamDoneEvent{Message: final},
+	}
+}
+
+// toolCallTurn scripts a turn that streams one tool call as
+// start → toolcall delta → done(tool_use).
+func toolCallTurn(id, name, args string) fauxTurn {
+	partial := AssistantMessage{RoleField: RoleAssistant}
+	withCall := partial
+	withCall.Content = ContentList{NewToolCallContent(id, name, json.RawMessage(args))}
+	final := withCall
+	final.StopReason = StopReasonToolUse
+	return fauxTurn{
+		StreamStartEvent{Partial: partial},
+		StreamToolCallEvent{Partial: withCall},
+		StreamDoneEvent{Message: final},
+	}
+}
+
+// fauxProvider is a real Provider that replays one scripted turn per
+// StreamCompletion call, in order. It records every request it received so
+// tests can assert what the loop actually sent (model, context, config). Once
+// the script is exhausted it replays a plain end_turn turn.
+type fauxProvider struct {
+	name   string
+	models []Model
+	turns  []fauxTurn
+
+	mu       sync.Mutex
+	calls    int
+	requests []CompletionRequest
+	// delay optionally slows each delta emit, used by the cancellation test to
+	// keep the stream open long enough to cancel mid-flight.
+	delay time.Duration
+}
+
+func (p *fauxProvider) Name() string    { return p.name }
+func (p *fauxProvider) Models() []Model { return p.models }
+
+func (p *fauxProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+func (p *fauxProvider) requestAt(i int) CompletionRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.requests[i]
+}
+
+func (p *fauxProvider) StreamCompletion(ctx context.Context, req CompletionRequest) (*AssistantMessageEventStream, error) {
+	p.mu.Lock()
+	idx := p.calls
+	p.calls++
+	p.requests = append(p.requests, req)
+	var turn fauxTurn
+	if idx < len(p.turns) {
+		turn = p.turns[idx]
+	} else {
+		turn = textTurn("")
+	}
+	delay := p.delay
+	p.mu.Unlock()
+
+	s := NewAssistantMessageEventStream(0)
+	go func() {
+		for _, ev := range turn {
+			if delay > 0 {
+				select {
+				case <-time.After(delay):
+				case <-ctx.Done():
+					s.SetError(ctx.Err())
+					s.Close()
+					return
+				}
+			}
+			if err := s.Emit(ctx, ev); err != nil {
+				s.SetError(err)
+				s.Close()
+				return
+			}
+		}
+		s.Close()
+	}()
+	return s, nil
+}
+
+// newFauxRunCfg wires a faux provider into the loop via StreamFnFromProvider
+// (the real seam) and registers the given tools. No loop-internal function is
+// mocked — only the provider boundary.
+func newFauxRunCfg(p *fauxProvider, tools ...AgentTool) RunConfig {
+	reg := NewToolRegistry()
+	for _, tl := range tools {
+		_ = reg.Register(tl)
+	}
+	return RunConfig{
+		LoopConfig: LoopConfig{Model: "faux", Stream: StreamFnFromProvider(p)},
+		Batch:      BatchConfig{ToolExecutorConfig: ToolExecutorConfig{Registry: reg}},
+	}
+}
+
+// TestFauxProviderTextToolText drives the flagship seam scenario end to end:
+// text → tool call → text over the real loop, asserting both the AgentEvent
+// stream shape and the final []AgentMessage. Nothing loop-internal is mocked.
+func TestFauxProviderTextToolText(t *testing.T) {
+	p := &fauxProvider{
+		name:   "faux",
+		models: []Model{{Provider: "faux", ID: "faux"}},
+		turns: []fauxTurn{
+			textTurn("thinking about it"),                     // turn 1: plain text, no tool
+			toolCallTurn("call-1", "echo", `{"msg":"hello"}`), // turn 2: tool call
+			textTurn("all done"),                              // turn 3: final text
+		},
+	}
+	// GetFollowUpMessages injects a follow-up once so the loop advances past the
+	// first natural (text-only) turn end into the tool-call turn.
+	served := false
+	cfg := newFauxRunCfg(p, echoTool("echo", ToolExecutionParallel, false))
+	cfg.GetFollowUpMessages = func(ctx context.Context, agentCtx *AgentContext) []AgentMessage {
+		if served {
+			return nil
+		}
+		served = true
+		return []AgentMessage{UserMessage{RoleField: RoleUser, Content: ContentList{NewTextContent("go on")}}}
+	}
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser, Content: ContentList{NewTextContent("start")}}}}
+
+	kinds, msgs := collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+
+	// Event shape: message deltas must appear (start/update/end), a tool
+	// executed exactly once, and the run bookended by agent_start/agent_end.
+	if kinds[0] != EventAgentStart || kinds[len(kinds)-1] != EventAgentEnd {
+		t.Fatalf("run must be bracketed by agent_start/agent_end, got %v", kinds)
+	}
+	if countKind(kinds, EventMessageStart) < 3 || countKind(kinds, EventMessageEnd) < 3 {
+		t.Errorf("expected fine-grained message deltas for each turn, got %v", kinds)
+	}
+	if countKind(kinds, EventMessageUpdate) < 3 {
+		t.Errorf("expected message_update deltas (text/toolcall), got %v", kinds)
+	}
+	if got := countKind(kinds, EventToolExecutionStart); got != 1 {
+		t.Errorf("expected 1 tool_execution_start, got %d in %v", got, kinds)
+	}
+	if got := countKind(kinds, EventToolExecutionEnd); got != 1 {
+		t.Errorf("expected 1 tool_execution_end, got %d in %v", got, kinds)
+	}
+	if got := countKind(kinds, EventTurnStart); got != 3 {
+		t.Errorf("expected 3 turns (text→tool→text), got %d in %v", got, kinds)
+	}
+
+	// Final messages: assistant(text) + user(follow-up) + assistant(tool) +
+	// toolResult + assistant(text) = 5, in order.
+	if len(msgs) != 5 {
+		t.Fatalf("expected 5 new messages, got %d: %+v", len(msgs), msgs)
+	}
+	if a, ok := msgs[0].(AssistantMessage); !ok || textContentOf(a.Content) != "thinking about it" {
+		t.Errorf("msg[0] should be the first text assistant message, got %T %+v", msgs[0], msgs[0])
+	}
+	if _, ok := msgs[1].(UserMessage); !ok {
+		t.Errorf("msg[1] should be the injected follow-up user message, got %T", msgs[1])
+	}
+	if a, ok := msgs[2].(AssistantMessage); !ok || len(a.ToolCalls()) != 1 {
+		t.Errorf("msg[2] should be the tool-call assistant message, got %T %+v", msgs[2], msgs[2])
+	}
+	tr, ok := msgs[3].(ToolResultMessage)
+	if !ok || tr.ToolCallID != "call-1" || tr.IsError {
+		t.Errorf("msg[3] should be the successful echo tool result, got %T %+v", msgs[3], msgs[3])
+	}
+	if a, ok := msgs[4].(AssistantMessage); !ok || textContentOf(a.Content) != "all done" {
+		t.Errorf("msg[4] should be the final text assistant message, got %T %+v", msgs[4], msgs[4])
+	}
+
+	// The loop must have driven the provider exactly three times, each carrying
+	// the growing context and the configured model.
+	if p.callCount() != 3 {
+		t.Fatalf("provider called %d times, want 3", p.callCount())
+	}
+	if req := p.requestAt(0); req.Model != "faux" {
+		t.Errorf("provider request model = %q, want faux", req.Model)
+	}
+}
+
+// textContentOf returns the concatenated text of a content list.
+func textContentOf(list ContentList) string {
+	var s string
+	for _, c := range list {
+		if tc, ok := c.(TextContent); ok {
+			s += tc.Text
+		}
+	}
+	return s
+}
+
+// TestFauxSeamSixHooks exercises all six loop hooks through the real seam in a
+// single run: the two per-request LoopConfig hooks (TransformContext,
+// ConvertToLlm resolved via GetAPIKey) and the four RunConfig hooks
+// (GetFollowUpMessages, GetSteeringMessages, PrepareNextTurn,
+// ShouldStopAfterTurn). Each hook records that it fired and, where observable,
+// that its effect reached the provider request.
+func TestFauxSeamSixHooks(t *testing.T) {
+	p := &fauxProvider{
+		name:   "faux",
+		models: []Model{{Provider: "faux", ID: "faux"}},
+		turns: []fauxTurn{
+			toolCallTurn("call-1", "echo", `{}`), // turn 1: tool → afterTurn hooks fire
+			textTurn("second"),                   // turn 2: end (after model swap)
+		},
+	}
+	var fired struct {
+		transform, convert, apiKey, followUp, steering, prepare, shouldStop bool
+	}
+	swapped := "swapped-model"
+	cfg := newFauxRunCfg(p, echoTool("echo", ToolExecutionParallel, false))
+	cfg.Provider = "faux"
+	cfg.TransformContext = func(ctx context.Context, msgs MessageList) MessageList {
+		fired.transform = true
+		return msgs
+	}
+	cfg.ConvertToLlm = func(msgs MessageList) MessageList {
+		fired.convert = true
+		return msgs
+	}
+	cfg.GetAPIKey = func(ctx context.Context, provider string) string {
+		fired.apiKey = true
+		return "dyn-key"
+	}
+	cfg.GetSteeringMessages = func(ctx context.Context) []AgentMessage {
+		fired.steering = true
+		return nil
+	}
+	cfg.PrepareNextTurn = func(ctx context.Context, agentCtx *AgentContext) *TurnUpdate {
+		fired.prepare = true
+		return &TurnUpdate{Model: &swapped}
+	}
+	stopCalls := 0
+	cfg.ShouldStopAfterTurn = func(ctx context.Context, agentCtx *AgentContext) bool {
+		fired.shouldStop = true
+		stopCalls++
+		return false // never stop early; let the run end naturally
+	}
+	cfg.GetFollowUpMessages = func(ctx context.Context, agentCtx *AgentContext) []AgentMessage {
+		fired.followUp = true
+		// No follow-up: the tool-call turn already drives turn 2, so the run
+		// ends naturally after the second turn.
+		return nil
+	}
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser, Content: ContentList{NewTextContent("hi")}}}}
+
+	collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+
+	if !fired.transform || !fired.convert || !fired.apiKey {
+		t.Errorf("per-request hooks not all fired: %+v", fired)
+	}
+	if !fired.followUp || !fired.steering || !fired.prepare || !fired.shouldStop {
+		t.Errorf("per-turn hooks not all fired: %+v", fired)
+	}
+	if stopCalls == 0 {
+		t.Error("ShouldStopAfterTurn was never consulted")
+	}
+	// GetAPIKey's dynamic key must have reached the provider request config.
+	if got := p.requestAt(0).Config.APIKey; got != "dyn-key" {
+		t.Errorf("GetAPIKey result not threaded to provider, APIKey = %q", got)
+	}
+	// PrepareNextTurn swapped the model before turn 2.
+	if p.callCount() >= 2 {
+		if got := p.requestAt(1).Config.APIKey; got != "dyn-key" {
+			t.Errorf("turn 2 APIKey = %q, want dyn-key", got)
+		}
+		if got := p.requestAt(1).Model; got != swapped {
+			t.Errorf("PrepareNextTurn model swap not applied, turn 2 model = %q, want %q", got, swapped)
+		}
+	}
+}
+
+// TestFauxSeamTruncationProtection verifies that a truncated (stopReason=length)
+// tool-call turn is protected: the tool is NOT executed and a synthesized failed
+// tool result is fed back, all through the seam.
+func TestFauxSeamTruncationProtection(t *testing.T) {
+	// Turn 1: a tool call that arrives truncated. Turn 2: end.
+	truncPartial := AssistantMessage{RoleField: RoleAssistant, Content: ContentList{NewToolCallContent("t1", "echo", json.RawMessage(`{}`))}}
+	truncFinal := truncPartial
+	truncFinal.StopReason = StopReasonLength
+	p := &fauxProvider{
+		name: "faux",
+		turns: []fauxTurn{
+			{
+				StreamStartEvent{Partial: AssistantMessage{RoleField: RoleAssistant}},
+				StreamToolCallEvent{Partial: truncPartial},
+				StreamDoneEvent{Message: truncFinal},
+			},
+			textTurn("recovered"),
+		},
+	}
+	cfg := newFauxRunCfg(p, echoTool("echo", ToolExecutionParallel, false))
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+
+	kinds, msgs := collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+
+	if countKind(kinds, EventToolExecutionEnd) != 0 {
+		t.Errorf("truncated tool call must not execute, got %v", kinds)
+	}
+	var foundFail bool
+	for _, m := range msgs {
+		if tr, ok := m.(ToolResultMessage); ok && tr.IsError && tr.ToolCallID == "t1" {
+			foundFail = true
+		}
+	}
+	if !foundFail {
+		t.Errorf("expected a synthesized failed tool result for the truncated call, got %+v", msgs)
+	}
+}
+
+// TestFauxSeamParallelOrderingPreserved verifies that a turn with multiple
+// parallel tool calls yields tool results in source order regardless of which
+// tool finishes first, driven through the seam.
+func TestFauxSeamParallelOrderingPreserved(t *testing.T) {
+	// One assistant turn with three tool calls in a fixed order; the tools sleep
+	// in reverse so completion order differs from source order.
+	partial := AssistantMessage{RoleField: RoleAssistant, Content: ContentList{
+		NewToolCallContent("a0", "slow", json.RawMessage(`{}`)),
+		NewToolCallContent("a1", "mid", json.RawMessage(`{}`)),
+		NewToolCallContent("a2", "fast", json.RawMessage(`{}`)),
+	}}
+	final := partial
+	final.StopReason = StopReasonToolUse
+	p := &fauxProvider{
+		turns: []fauxTurn{
+			{StreamStartEvent{Partial: AssistantMessage{RoleField: RoleAssistant}}, StreamToolCallEvent{Partial: partial}, StreamDoneEvent{Message: final}},
+			textTurn("done"),
+		},
+	}
+	mk := func(name string, delay time.Duration) execTool {
+		return execTool{
+			name: name,
+			mode: ToolExecutionParallel,
+			run: func(ctx context.Context, id string, args json.RawMessage, onUpdate ToolUpdateFunc) (AgentToolResult, error) {
+				time.Sleep(delay)
+				return AgentToolResult{Content: ContentList{NewTextContent(name)}}, nil
+			},
+		}
+	}
+	cfg := newFauxRunCfg(p, mk("slow", 25*time.Millisecond), mk("mid", 12*time.Millisecond), mk("fast", 1*time.Millisecond))
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+
+	_, msgs := collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+
+	var order []string
+	for _, m := range msgs {
+		if tr, ok := m.(ToolResultMessage); ok {
+			order = append(order, tr.ToolCallID)
+		}
+	}
+	want := []string{"a0", "a1", "a2"}
+	if len(order) != 3 || order[0] != want[0] || order[1] != want[1] || order[2] != want[2] {
+		t.Errorf("parallel tool results out of source order: got %v, want %v", order, want)
+	}
+}
+
+// TestFauxSeamStreamCancellation verifies that cancelling the context stops the
+// run: the consumer stops receiving events and Result reports the cancellation,
+// exercised through the seam with a provider that streams slowly.
+func TestFauxSeamStreamCancellation(t *testing.T) {
+	p := &fauxProvider{
+		turns: []fauxTurn{textTurn("never fully delivered")},
+		delay: 50 * time.Millisecond, // slow enough to cancel mid-stream
+	}
+	cfg := newFauxRunCfg(p)
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s := agentLoop(ctx, agentCtx, cfg)
+
+	// Read the first event, then cancel while the provider is still streaming.
+	<-s.Events()
+	cancel()
+	// Drain remaining events (must terminate, not hang).
+	for range s.Events() {
+	}
+	if _, err := s.Result(context.Background()); err != nil {
+		// A set result is also acceptable (the run may have finished emitting
+		// agent_end before cancellation propagated); but if an error is set it
+		// must be the cancellation.
+		if err != context.Canceled {
+			t.Errorf("cancelled run result error = %v, want context.Canceled or nil", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- 新建 `fauxProvider`（对标 pi `providers/faux.ts`）：真 Provider 回放细粒度 start→delta→done 脚本，经 `StreamFnFromProvider` 接入 loop（唯一 seam，不 mock loop 内部函数）
- `TestFauxProviderTextToolText`：文本→工具调用→文本 多轮，断言 AgentEvent 流 + 最终 []AgentMessage
- `TestFauxSeamSixHooks`：六钩子全触发并断言副作用（GetAPIKey→APIKey、PrepareNextTurn→Model swap）
- `TestFauxSeamTruncationProtection` / `TestFauxSeamParallelOrderingPreserved` / `TestFauxSeamStreamCancellation`

Closes #24

## Test plan
- [x] gofmt / go build / go vet clean
- [x] go test ./... 通过
- [x] -race -count=3 无竞态与 flake