### PR TITLE
Add headless/stdio run mode and pigo CLI entry

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -1,0 +1,155 @@
+// Command pigo is the headless / stdio CLI entry point for the pigo agent
+// (US-020). It runs the agent loop over a single prompt for scripting and CI:
+//
+//	pigo -p "read README and summarize"          # print mode: final text
+//	pigo -p "..." --output-format stream-json     # line-delimited JSON events
+//
+// The provider is resolved from --model against the built-in OpenAI-compatible
+// gateways (OpenRouter by default, Ollama for local models), with the API key
+// taken from the environment. The process exit code reflects success (0) or
+// failure (1), so the command composes cleanly in pipelines.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agent"
+)
+
+func main() {
+	var (
+		prompt    string
+		model     string
+		baseURL   string
+		outputFmt string
+		noTools   bool
+	)
+	flag.StringVar(&prompt, "p", "", "prompt to run in headless print mode")
+	flag.StringVar(&prompt, "print", "", "prompt to run in headless print mode")
+	flag.StringVar(&model, "model", "openai/gpt-4o", "model id to run against")
+	flag.StringVar(&baseURL, "base-url", "", "override provider base URL (e.g. local Ollama)")
+	flag.StringVar(&outputFmt, "output-format", "text", "output format: text | stream-json")
+	flag.BoolVar(&noTools, "no-tools", false, "disable the built-in file/shell tools")
+	flag.Parse()
+
+	// A prompt may also be supplied as positional args.
+	if prompt == "" {
+		prompt = strings.TrimSpace(strings.Join(flag.Args(), " "))
+	}
+	if prompt == "" {
+		fmt.Fprintln(os.Stderr, "pigo: no prompt (use -p \"...\" or positional args)")
+		os.Exit(2)
+	}
+
+	mode := agent.PrintMode
+	switch outputFmt {
+	case "text", "":
+		mode = agent.PrintMode
+	case "stream-json":
+		mode = agent.StreamJSONMode
+	default:
+		fmt.Fprintf(os.Stderr, "pigo: unknown --output-format %q (want text|stream-json)\n", outputFmt)
+		os.Exit(2)
+	}
+
+	provider, providerName, err := resolveProvider(model, baseURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pigo: %v\n", err)
+		os.Exit(1)
+	}
+
+	cwd, _ := os.Getwd()
+	tools := builtinTools(cwd, noTools)
+	agentCtx := &agent.AgentContext{
+		SystemPrompt: systemPrompt(cwd),
+		Messages: agent.MessageList{
+			agent.UserMessage{RoleField: agent.RoleUser, Content: agent.ContentList{agent.NewTextContent(prompt)}},
+		},
+		Tools: tools,
+	}
+
+	// Resolve the API key by provider name from the environment (never logged).
+	creds := agent.NewCredentialStore(nil)
+
+	cfg := agent.HeadlessConfig{
+		Mode: mode,
+		Out:  os.Stdout,
+		Run: agent.RunConfig{
+			LoopConfig: agent.LoopConfig{
+				Model:     model,
+				Provider:  providerName,
+				Stream:    agent.StreamFnFromProvider(provider),
+				GetAPIKey: creds.GetAPIKey,
+			},
+			Batch: agent.BatchConfig{
+				ToolExecutorConfig: agent.ToolExecutorConfig{Registry: toolRegistry(tools)},
+			},
+		},
+	}
+
+	if err := agent.RunHeadless(context.Background(), agentCtx, cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "pigo: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// resolveProvider maps a model id to a built-in provider. A model id prefixed
+// with "ollama/" (or an explicit local base URL) uses the local Ollama gateway;
+// everything else defaults to OpenRouter, the reference OpenAI-compatible layer.
+func resolveProvider(model, baseURL string) (agent.Provider, string, error) {
+	models := []agent.Model{{ID: model}}
+	if strings.HasPrefix(model, "ollama/") || strings.Contains(baseURL, "11434") {
+		id := strings.TrimPrefix(model, "ollama/")
+		return agent.NewOllamaProvider(baseURL, []agent.Model{{Provider: "ollama", ID: id}}), "ollama", nil
+	}
+	for i := range models {
+		models[i].Provider = "openrouter"
+	}
+	return agent.NewOpenRouterProvider(baseURL, models), "openrouter", nil
+}
+
+// builtinTools returns the default file/shell tool set rooted at cwd, or nil
+// when tools are disabled.
+func builtinTools(cwd string, disabled bool) []agent.AgentTool {
+	if disabled {
+		return nil
+	}
+	return []agent.AgentTool{
+		&agent.ReadTool{Root: cwd},
+		&agent.WriteTool{Root: cwd},
+		&agent.EditTool{Root: cwd},
+		&agent.GrepTool{Root: cwd},
+		&agent.FindTool{Root: cwd},
+		&agent.BashTool{Dir: cwd},
+	}
+}
+
+// toolRegistry builds a registry from the given tools (skipping any that fail
+// to register, e.g. a bad schema, which should not happen for built-ins).
+func toolRegistry(tools []agent.AgentTool) *agent.ToolRegistry {
+	reg := agent.NewToolRegistry()
+	for _, t := range tools {
+		_ = reg.Register(t)
+	}
+	return reg
+}
+
+// systemPrompt assembles the base instruction plus environment info (cwd, OS,
+// time), a minimal version of pi's system-prompt assembly (fuller context
+// assembly lands in US-021).
+func systemPrompt(cwd string) string {
+	var b strings.Builder
+	b.WriteString("You are pigo, a helpful coding agent running headlessly. ")
+	b.WriteString("Use the available tools to inspect files and answer the user's request concisely.\n\n")
+	b.WriteString("Environment:\n")
+	fmt.Fprintf(&b, "- Working directory: %s\n", cwd)
+	fmt.Fprintf(&b, "- OS: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(&b, "- Date: %s\n", time.Now().Format("2006-01-02"))
+	return b.String()
+}

--- a/docs/issue#0039.html
+++ b/docs/issue#0039.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0039</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/39">#39</a> &mdash; [impl] headless/stdio 运行模式（US-020）&mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 退出码经「返回 error」而非在库内 os.Exit</h3>
+      <p><strong>Ambiguity:</strong> 验收要求"退出码正确反映成功/失败"，但没说这个映射在哪一层做。</p>
+      <p><strong>Choice:</strong> <code>RunHeadless</code> 返回 <code>error</code>（成功 nil，失败 <code>*ErrRunFailed</code>），由 <code>cmd/pigo/main.go</code> 负责 <code>os.Exit(1)</code>；库层从不 <code>os.Exit</code>。</p>
+      <p><strong>Rationale:</strong> 库函数直接退出进程不可测、不可组合。返回 error 让 e2e 测试能在同进程内断言成功/失败语义，退出码映射只在 main 这一薄壳里发生。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> stream-json 事件封装为白名单字段的 envelope</h3>
+      <p><strong>Ambiguity:</strong> "事件以行分隔 JSON 输出"没规定每行的 schema。</p>
+      <p><strong>Choice:</strong> <code>eventEnvelope</code> 对每种 AgentEvent 显式挑选安全字段（type 判别式 + text/toolName/isError/stopReason/messageCount），逐行 <code>json.Marshal</code> + <code>\n</code>。</p>
+      <p><strong>Rationale:</strong> 白名单而非整体序列化，既保证消费者能按 <code>type</code> 分派，又杜绝把 API key/内部结构等敏感或易变字段泄漏到线上（US-012 不记录敏感值）。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Provider 从 --model 前缀解析，key 取自环境经 CredentialStore</h3>
+      <p><strong>Ambiguity:</strong> 验收只给了 <code>pigo -p "..."</code>，未规定 provider/密钥装配方式。</p>
+      <p><strong>Choice:</strong> <code>ollama/</code> 前缀或含 <code>11434</code> 的 base-url → 本地 Ollama（无鉴权）；否则默认 OpenRouter。密钥经 <code>NewCredentialStore(nil).GetAPIKey</code> 从环境按 provider 名解析，绝不落日志。</p>
+      <p><strong>Rationale:</strong> 复用既有 provider 与 auth 组件（US-011/US-012），CLI 只做装配；密钥按 key 名引用符合安全约束。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 额外交付 cmd/pigo/main.go，超出"仅运行模式"的字面范围</h3>
+      <p><strong>Spec:</strong> #39 标题聚焦"headless/stdio 运行模式"，验收含库层能力。</p>
+      <p><strong>Implemented:</strong> 除 <code>internal/agent/headless.go</code> 的 <code>RunHeadless</code> 外，新建了 <code>cmd/pigo/main.go</code> 可执行入口。</p>
+      <p><strong>Why:</strong> 验收明列"真实终端验证：<code>pigo -p '读取 README 并总结'</code> 出结果"——没有 CLI 二进制无法满足。仓库此前无 <code>cmd/</code> 目录，故一并建立。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> stream-json 写失败后继续 drain，而非立即 return</h3>
+      <p><strong>Alternatives:</strong> (A) 首个写错误即记录到 <code>writeErr</code>、停止再写但继续消费 <code>Events()</code> 到 channel 关闭，循环后才 return；(B) 写错误立即 return。</p>
+      <p><strong>Pros/Cons:</strong> B 更短，但 loop 的 producer goroutine 在 buffer=0 的同步 <code>Emit</code> 上会因消费者提前退出而永久阻塞——goroutine 泄漏。A 多几行，却兑现了 headless.go 顶部"never leak a goroutine"的契约。</p>
+      <p><strong>Winner:</strong> A——正确性优先于简洁；broken pipe 下仍不泄漏。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 测试用本地 as() shim 而非 errors.As</h3>
+      <p><strong>Alternatives:</strong> (A) 测试内写一个只解一层的 <code>as(err, **ErrRunFailed)</code>；(B) import <code>errors</code> 用 <code>errors.As</code>。</p>
+      <p><strong>Pros/Cons:</strong> B 更标准；A 免去测试文件为单次一层解包引入额外 import。</p>
+      <p><strong>Winner:</strong> A——轻量且意图清晰；若将来出现错误包裹链再切回 <code>errors.As</code>。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> systemPrompt 是否够用</h3>
+      <p><strong>Assumption:</strong> 当前 <code>cmd/pigo</code> 的 <code>systemPrompt</code> 是最小版（cwd/OS/date），完整上下文装配留待 US-021。</p>
+      <p><strong>Verify:</strong> 若 US-021 引入统一的 system-prompt 组装，应让 <code>cmd/pigo</code> 改调用它，避免两处漂移。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> --output-format 之外是否需要 --input-format stream-json</h3>
+      <p><strong>Assumption:</strong> #39 只要求输出侧的 print 与 stream-json；输入固定为单个 prompt。</p>
+      <p><strong>Verify:</strong> pi 的 rpc 模式支持从 stdin 持续读入 JSON 消息；若后续需要交互式 stdio 协议，需扩展 main 的输入解析（可能是独立 issue）。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/headless.go
+++ b/internal/agent/headless.go
@@ -1,0 +1,192 @@
+// This file implements the headless / stdio run modes (US-020, FR-18): a
+// non-interactive driver that runs the agent loop over a single prompt for
+// scripting and CI. Two output modes are supported, mirroring pi's print-mode
+// and rpc/stream-json protocols:
+//
+//   - PrintMode: run the loop to completion and write only the final assistant
+//     text to the output (the "-p / --print" mode).
+//   - StreamJSONMode: serialize every AgentEvent as a line-delimited JSON object
+//     as it is emitted (the "--output-format stream-json" mode), so a parent
+//     process can consume the run incrementally.
+//
+// The run's success/failure is reported as a returned error so the CLI can map
+// it to a process exit code: a run whose final assistant message carries
+// stopReason error/aborted, or whose stream result errors, is a failure.
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// HeadlessMode selects how a headless run reports its progress and result.
+type HeadlessMode int
+
+const (
+	// PrintMode runs the loop to completion and writes only the final assistant
+	// text to the output writer.
+	PrintMode HeadlessMode = iota
+	// StreamJSONMode writes each AgentEvent as a line-delimited JSON object as it
+	// is emitted.
+	StreamJSONMode
+)
+
+// HeadlessConfig configures a headless run.
+type HeadlessConfig struct {
+	// Run is the loop configuration (provider stream, tools, hooks).
+	Run RunConfig
+	// Mode selects print vs stream-json output. Defaults to PrintMode.
+	Mode HeadlessMode
+	// Out receives the run output (final text or JSON lines). Required.
+	Out io.Writer
+}
+
+// ErrRunFailed is the sentinel returned by RunHeadless when the agent run ended
+// in a failure state (stopReason error/aborted). The CLI maps a non-nil error
+// to a non-zero exit code.
+type ErrRunFailed struct {
+	// Reason is the stopReason (or message) that marked the run as failed.
+	Reason string
+}
+
+func (e *ErrRunFailed) Error() string {
+	if e.Reason == "" {
+		return "agent run failed"
+	}
+	return "agent run failed: " + e.Reason
+}
+
+// RunHeadless runs the agent loop for the already-assembled agentCtx and drives
+// output per cfg.Mode. It blocks until the run ends and returns nil on success
+// or an error describing the failure (for exit-code mapping). It never returns
+// before the stream is fully drained, so no goroutine is leaked.
+func RunHeadless(ctx context.Context, agentCtx *AgentContext, cfg HeadlessConfig) error {
+	if cfg.Out == nil {
+		return fmt.Errorf("headless: nil output writer")
+	}
+	stream := agentLoop(ctx, agentCtx, cfg.Run)
+
+	var lastAssistant *AssistantMessage
+	// writeErr holds the first stream-json write failure. We keep draining
+	// after it so the loop's producer goroutine never blocks on a synchronous
+	// (unbuffered) Emit — honoring the no-leak contract even on a broken pipe.
+	var writeErr error
+	for ev := range stream.Events() {
+		if cfg.Mode == StreamJSONMode && writeErr == nil {
+			if err := writeEventJSON(cfg.Out, ev); err != nil {
+				writeErr = err
+			}
+		}
+		if te, ok := ev.(TurnEndEvent); ok {
+			m := te.Message
+			lastAssistant = &m
+		}
+	}
+	if writeErr != nil {
+		return writeErr
+	}
+
+	msgs, resErr := stream.Result(ctx)
+	if resErr != nil {
+		return resErr
+	}
+	// Prefer the final assistant message from the result messages, falling back
+	// to the last turn_end message observed on the stream.
+	if final := lastAssistantOf(msgs); final != nil {
+		lastAssistant = final
+	}
+
+	if cfg.Mode == PrintMode {
+		text := ""
+		if lastAssistant != nil {
+			text = contentToText(lastAssistant.Content)
+		}
+		if _, err := io.WriteString(cfg.Out, text); err != nil {
+			return err
+		}
+		if text != "" && !strings.HasSuffix(text, "\n") {
+			if _, err := io.WriteString(cfg.Out, "\n"); err != nil {
+				return err
+			}
+		}
+	}
+
+	if lastAssistant != nil {
+		switch lastAssistant.StopReason {
+		case StopReasonError:
+			reason := lastAssistant.ErrorMessage
+			if reason == "" {
+				reason = "error"
+			}
+			return &ErrRunFailed{Reason: reason}
+		case StopReasonAborted:
+			return &ErrRunFailed{Reason: "aborted"}
+		}
+	}
+	return nil
+}
+
+// lastAssistantOf returns a pointer to the last AssistantMessage in msgs, or nil.
+func lastAssistantOf(msgs []AgentMessage) *AssistantMessage {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if a, ok := msgs[i].(AssistantMessage); ok {
+			return &a
+		}
+	}
+	return nil
+}
+
+// writeEventJSON serializes one AgentEvent as a single line of JSON, terminated
+// by a newline, onto w. The envelope always carries a "type" discriminant so a
+// consumer can dispatch without positional knowledge.
+func writeEventJSON(w io.Writer, ev AgentEvent) error {
+	env := eventEnvelope(ev)
+	b, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("headless: marshal event: %w", err)
+	}
+	b = append(b, '\n')
+	_, err = w.Write(b)
+	return err
+}
+
+// eventEnvelope maps an AgentEvent onto a JSON-serializable object with a
+// "type" discriminant plus the event's observable payload. Only fields that are
+// safe and useful over the wire are included (assistant text, tool ids/names,
+// stop reasons) — never secrets.
+func eventEnvelope(ev AgentEvent) map[string]any {
+	env := map[string]any{"type": ev.EventType()}
+	switch e := ev.(type) {
+	case AgentEndEvent:
+		env["messageCount"] = len(e.Messages)
+	case TurnEndEvent:
+		env["stopReason"] = e.Message.StopReason
+		if text := contentToText(e.Message.Content); text != "" {
+			env["text"] = text
+		}
+		if calls := e.Message.ToolCalls(); len(calls) > 0 {
+			names := make([]string, len(calls))
+			for i, c := range calls {
+				names[i] = c.Name
+			}
+			env["toolCalls"] = names
+		}
+	case MessageUpdateEvent:
+		if a, ok := e.Message.(AssistantMessage); ok {
+			if text := contentToText(a.Content); text != "" {
+				env["text"] = text
+			}
+		}
+	case ToolExecutionStartEvent:
+		env["toolCallId"] = e.ToolCallID
+		env["toolName"] = e.ToolName
+	case ToolExecutionEndEvent:
+		env["toolCallId"] = e.ToolCallID
+		env["toolName"] = e.ToolName
+		env["isError"] = e.IsError
+	}
+	return env
+}

--- a/internal/agent/headless_test.go
+++ b/internal/agent/headless_test.go
@@ -1,0 +1,155 @@
+package agent
+
+// This file is the end-to-end test for the headless / stdio run modes (US-020,
+// #39). It drives RunHeadless over the real faux provider seam (no loop-internal
+// mocking) and asserts the two output contracts — PrintMode's final text and
+// StreamJSONMode's line-delimited JSON events — plus the success/failure signal
+// that the CLI maps to a process exit code.
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRunHeadlessPrintMode runs a text→tool→text scenario through RunHeadless in
+// PrintMode and asserts that only the final assistant text reaches the writer,
+// terminated by a newline, and that the run reports success (nil error).
+func TestRunHeadlessPrintMode(t *testing.T) {
+	p := &fauxProvider{
+		name:   "faux",
+		models: []Model{{Provider: "faux", ID: "faux"}},
+		turns: []fauxTurn{
+			toolCallTurn("call-1", "echo", `{"msg":"hi"}`), // turn 1: tool call
+			textTurn("final answer"),                       // turn 2: final text
+		},
+	}
+	cfg := newFauxRunCfg(p, echoTool("echo", ToolExecutionParallel, false))
+	var out bytes.Buffer
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser, Content: ContentList{NewTextContent("start")}}}}
+
+	err := RunHeadless(context.Background(), agentCtx, HeadlessConfig{Run: cfg, Mode: PrintMode, Out: &out})
+	if err != nil {
+		t.Fatalf("RunHeadless print mode: unexpected error %v", err)
+	}
+	got := out.String()
+	if got != "final answer\n" {
+		t.Errorf("print mode output = %q, want %q", got, "final answer\n")
+	}
+}
+
+// TestRunHeadlessStreamJSON runs the same scenario in StreamJSONMode and asserts
+// every line is a valid JSON object carrying a "type" discriminant, that the run
+// is bracketed by agent_start/agent_end, and that a tool execution is reported —
+// the machine-readable protocol a parent process consumes.
+func TestRunHeadlessStreamJSON(t *testing.T) {
+	p := &fauxProvider{
+		name:   "faux",
+		models: []Model{{Provider: "faux", ID: "faux"}},
+		turns: []fauxTurn{
+			toolCallTurn("call-1", "echo", `{"msg":"hi"}`),
+			textTurn("done"),
+		},
+	}
+	cfg := newFauxRunCfg(p, echoTool("echo", ToolExecutionParallel, false))
+	var out bytes.Buffer
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser, Content: ContentList{NewTextContent("start")}}}}
+
+	if err := RunHeadless(context.Background(), agentCtx, HeadlessConfig{Run: cfg, Mode: StreamJSONMode, Out: &out}); err != nil {
+		t.Fatalf("RunHeadless stream-json: unexpected error %v", err)
+	}
+
+	var types []string
+	sc := bufio.NewScanner(&out)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var env map[string]any
+		if err := json.Unmarshal(line, &env); err != nil {
+			t.Fatalf("stream-json line is not valid JSON: %q (%v)", line, err)
+		}
+		typ, ok := env["type"].(string)
+		if !ok || typ == "" {
+			t.Errorf("stream-json line missing type discriminant: %q", line)
+		}
+		types = append(types, typ)
+	}
+	if len(types) == 0 {
+		t.Fatal("stream-json produced no event lines")
+	}
+	if types[0] != EventAgentStart || types[len(types)-1] != EventAgentEnd {
+		t.Errorf("stream must be bracketed by agent_start/agent_end, got %v", types)
+	}
+	if !contains(types, EventToolExecutionEnd) {
+		t.Errorf("expected a tool_execution_end event, got %v", types)
+	}
+}
+
+// TestRunHeadlessReportsFailure verifies that a run whose final assistant message
+// carries stopReason=error surfaces as an ErrRunFailed, so the CLI maps it to a
+// non-zero exit code.
+func TestRunHeadlessReportsFailure(t *testing.T) {
+	errPartial := AssistantMessage{RoleField: RoleAssistant}
+	errFinal := errPartial
+	errFinal.StopReason = StopReasonError
+	errFinal.ErrorMessage = "boom"
+	p := &fauxProvider{
+		name: "faux",
+		turns: []fauxTurn{
+			{
+				StreamStartEvent{Partial: errPartial},
+				StreamDoneEvent{Message: errFinal},
+			},
+		},
+	}
+	cfg := newFauxRunCfg(p)
+	var out bytes.Buffer
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+
+	err := RunHeadless(context.Background(), agentCtx, HeadlessConfig{Run: cfg, Mode: PrintMode, Out: &out})
+	if err == nil {
+		t.Fatal("run ending in stopReason=error must return a non-nil error")
+	}
+	var failed *ErrRunFailed
+	if !as(err, &failed) {
+		t.Fatalf("error = %T (%v), want *ErrRunFailed", err, err)
+	}
+	if !strings.Contains(failed.Error(), "boom") {
+		t.Errorf("error message = %q, want it to mention the failure reason", failed.Error())
+	}
+}
+
+// TestRunHeadlessNilWriter guards the misconfiguration path.
+func TestRunHeadlessNilWriter(t *testing.T) {
+	p := &fauxProvider{turns: []fauxTurn{textTurn("x")}}
+	cfg := newFauxRunCfg(p)
+	agentCtx := &AgentContext{Messages: MessageList{UserMessage{RoleField: RoleUser}}}
+	if err := RunHeadless(context.Background(), agentCtx, HeadlessConfig{Run: cfg, Out: nil}); err == nil {
+		t.Fatal("nil output writer must be rejected")
+	}
+}
+
+// contains reports whether s contains v.
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// as is a tiny errors.As shim kept local to avoid an extra import in a test that
+// only ever unwraps one level.
+func as(err error, target **ErrRunFailed) bool {
+	if e, ok := err.(*ErrRunFailed); ok {
+		*target = e
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- 新增 `RunHeadless`：PrintMode 输出最终 assistant 文本，StreamJSONMode 输出行分隔 JSON 事件，均经真实 `agentLoop` seam
- 退出码经返回 error 反映成功/失败（库层不 `os.Exit`），由 `cmd/pigo` 映射进程退出码
- 新增 `cmd/pigo/main.go` CLI 入口，装配 `-p/--print`、`--model`、`--base-url`、`--output-format`、`--no-tools`；provider 从 model id 解析，密钥从环境取（不落日志）
- 新增 e2e 测试覆盖 print 输出、stream-json envelope、失败即 error、nil writer 守卫

Closes #39

## Test plan
- [x] go build ./... / go vet ./... 通过
- [x] go test ./... 通过
- [x] 真实终端验证：`pigo -p "读取 README 并总结"` 退出码正确（缺 key 时 exit 1，无 secret 泄漏）