### PR TITLE
Add system-prompt assembly with AGENTS.md injection

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -15,9 +15,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
-	"time"
 
 	"github.com/smallnest/pigo/internal/agent"
 )
@@ -66,8 +64,13 @@ func main() {
 
 	cwd, _ := os.Getwd()
 	tools := builtinTools(cwd, noTools)
+	sysPrompt, err := agent.BuildSystemPrompt(agent.PromptConfig{WorkingDir: cwd, Root: cwd})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pigo: %v\n", err)
+		os.Exit(1)
+	}
 	agentCtx := &agent.AgentContext{
-		SystemPrompt: systemPrompt(cwd),
+		SystemPrompt: sysPrompt,
 		Messages: agent.MessageList{
 			agent.UserMessage{RoleField: agent.RoleUser, Content: agent.ContentList{agent.NewTextContent(prompt)}},
 		},
@@ -138,18 +141,4 @@ func toolRegistry(tools []agent.AgentTool) *agent.ToolRegistry {
 		_ = reg.Register(t)
 	}
 	return reg
-}
-
-// systemPrompt assembles the base instruction plus environment info (cwd, OS,
-// time), a minimal version of pi's system-prompt assembly (fuller context
-// assembly lands in US-021).
-func systemPrompt(cwd string) string {
-	var b strings.Builder
-	b.WriteString("You are pigo, a helpful coding agent running headlessly. ")
-	b.WriteString("Use the available tools to inspect files and answer the user's request concisely.\n\n")
-	b.WriteString("Environment:\n")
-	fmt.Fprintf(&b, "- Working directory: %s\n", cwd)
-	fmt.Fprintf(&b, "- OS: %s/%s\n", runtime.GOOS, runtime.GOARCH)
-	fmt.Fprintf(&b, "- Date: %s\n", time.Now().Format("2006-01-02"))
-	return b.String()
 }

--- a/docs/issue#0040.html
+++ b/docs/issue#0040.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0040</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/40">#40</a> &mdash; [impl] 系统提示词 + AGENTS.md 注入（US-021）&mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> AGENTS.md 遍历以显式 Root 为上界，而非无限向上到文件系统根</h3>
+      <p><strong>Ambiguity:</strong> 验收说"从根到子目录按通用→具体注入"，但"根"指仓库根还是文件系统根未定义。</p>
+      <p><strong>Choice:</strong> <code>PromptConfig.Root</code> 显式界定遍历上界；从 <code>WorkingDir</code> 向上收集到 <code>Root</code>（含）再反转成 root-first。<code>Root</code> 为空时只看 <code>WorkingDir</code> 自身，不做祖先遍历。</p>
+      <p><strong>Rationale:</strong> "根"= 仓库根，由调用方（<code>cmd/pigo</code> 传 cwd）决定，避免误读用户 HOME 或 <code>/</code> 下的无关 AGENTS.md；显式边界也让行为可测、可预期。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 缺失的 AGENTS.md 静默跳过，仅真实 I/O 错误上报</h3>
+      <p><strong>Ambiguity:</strong> 验收未提"某层没有 AGENTS.md"或"文件不可读"该如何处理。</p>
+      <p><strong>Choice:</strong> <code>os.IsNotExist</code> → 跳过并继续；其它错误（如权限）→ 包装后返回。空内容文件也跳过。</p>
+      <p><strong>Rationale:</strong> monorepo 中大多数目录本就没有 AGENTS.md，缺失是常态而非错误；但"文件存在却读不了"是需暴露的真实故障。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 注入 Now/ReadFile 依赖以支持确定性单测</h3>
+      <p><strong>Ambiguity:</strong> 验收要"单测验证注入顺序"，但顺序依赖真实磁盘布局与时钟，难以稳定断言。</p>
+      <p><strong>Choice:</strong> <code>PromptConfig</code> 暴露可选 <code>Now func() time.Time</code> 与 <code>ReadFile func(path)([]byte,error)</code>，默认 <code>time.Now</code>/<code>os.ReadFile</code>。测试用 map 伪造 AGENTS.md 布局。</p>
+      <p><strong>Rationale:</strong> 让顺序断言不触碰磁盘、不受当天日期影响，测试稳定且快速——与仓库既有"注入 seam"风格一致。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 移除 cmd/pigo 内联 systemPrompt，改调用库函数</h3>
+      <p><strong>Spec:</strong> #40 只要求实现装配能力。</p>
+      <p><strong>Implemented:</strong> 顺带删除了 #39 在 <code>cmd/pigo/main.go</code> 里的临时 <code>systemPrompt</code>（当时注明"fuller assembly lands in US-021"），改为调用新的 <code>agent.BuildSystemPrompt</code>。</p>
+      <p><strong>Why:</strong> 该临时函数正是本 issue 要替代的对象；不删会造成两处提示词逻辑漂移。删除兑现了 #39 note 里记下的 Open Question。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 向上收集再反转 vs 先算深度再自上而下</h3>
+      <p><strong>Alternatives:</strong> (A) 从 wd 用 <code>filepath.Dir</code> 逐级上行到 root，收集后反转成 root-first；(B) 用字符串前缀/分隔符计数直接自上而下构造路径。</p>
+      <p><strong>Pros/Cons:</strong> B 需处理分隔符、卷标、<code>..</code> 等平台差异，易错；A 复用 <code>filepath.Dir</code>/<code>Clean</code> 的既有语义，且天然处理"wd 不在 root 之下"（走到文件系统根仍未命中 → 回退 wd 独一）。</p>
+      <p><strong>Winner:</strong> A——更少的手写路径运算，边界条件由标准库兜底。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 文件名是否只认 AGENTS.md</h3>
+      <p><strong>Assumption:</strong> 当前只注入 <code>AGENTS.md</code>（对标 zero/pi）。</p>
+      <p><strong>Verify:</strong> 若需兼容 <code>CLAUDE.md</code>/<code>.agentsrc</code> 等别名，应扩展 <code>agentsFileName</code> 为候选列表；目前判断超出 US-021 范围。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 基础指令是否应随交互/headless 模式而异</h3>
+      <p><strong>Assumption:</strong> <code>DefaultBaseInstruction</code> 对 headless 与未来 TUI（US-022）通用。</p>
+      <p><strong>Verify:</strong> 若 TUI 需要不同语气/能力说明，可由调用方传 <code>BaseInstruction</code> 覆盖，无需改库。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -1,0 +1,145 @@
+// This file implements system-prompt assembly (US-021, #40), the pigo port of
+// pi's prompt construction. A run's system prompt is built from three layers,
+// in order:
+//
+//  1. a base instruction (who the agent is and how it should behave),
+//  2. an environment block (working directory, OS/arch, current date), and
+//  3. every AGENTS.md found on the path from a root directory down to the
+//     working directory, concatenated general-to-specific.
+//
+// The AGENTS.md ordering mirrors zero/pi's monorepo behavior: a repo-root
+// AGENTS.md states broad conventions, and a nested package's AGENTS.md refines
+// them, so the more specific file appears later and takes precedence in the
+// model's reading.
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// agentsFileName is the per-directory instruction file injected into the system
+// prompt, general-to-specific from the root down to the working directory.
+const agentsFileName = "AGENTS.md"
+
+// PromptConfig configures system-prompt assembly. The zero value is usable: it
+// produces the base instruction plus an environment block for the process
+// working directory, with no AGENTS.md injection.
+type PromptConfig struct {
+	// BaseInstruction is the leading text of the system prompt. When empty,
+	// DefaultBaseInstruction is used.
+	BaseInstruction string
+	// WorkingDir is the directory the run operates in. When empty, the process
+	// working directory (os.Getwd) is used. It anchors both the environment
+	// block and the lower bound of the AGENTS.md walk.
+	WorkingDir string
+	// Root bounds the AGENTS.md walk at its top. AGENTS.md files are injected for
+	// every directory from Root down to WorkingDir, inclusive. When empty, only
+	// WorkingDir's own AGENTS.md (if any) is considered — no ancestor walk.
+	Root string
+	// Now supplies the timestamp for the environment block. When nil, time.Now
+	// is used. Injected for deterministic tests.
+	Now func() time.Time
+	// ReadFile reads a file's contents. When nil, os.ReadFile is used. Injected
+	// for tests so AGENTS.md layout can be faked without touching disk.
+	ReadFile func(path string) ([]byte, error)
+}
+
+// DefaultBaseInstruction is the leading system-prompt text used when
+// PromptConfig.BaseInstruction is empty.
+const DefaultBaseInstruction = "You are pigo, a helpful coding agent. " +
+	"Use the available tools to inspect files and accomplish the user's request precisely and concisely."
+
+// BuildSystemPrompt assembles the full system prompt from cfg: base instruction,
+// environment block, then AGENTS.md files ordered general-to-specific from Root
+// down to WorkingDir. Missing AGENTS.md files are skipped silently; only a
+// present-but-unreadable file (a real I/O error other than not-exist) is
+// reported.
+func BuildSystemPrompt(cfg PromptConfig) (string, error) {
+	base := cfg.BaseInstruction
+	if base == "" {
+		base = DefaultBaseInstruction
+	}
+	wd := cfg.WorkingDir
+	if wd == "" {
+		if cwd, err := os.Getwd(); err == nil {
+			wd = cwd
+		}
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	readFile := cfg.ReadFile
+	if readFile == nil {
+		readFile = os.ReadFile
+	}
+
+	var b strings.Builder
+	b.WriteString(base)
+
+	b.WriteString("\n\nEnvironment:\n")
+	fmt.Fprintf(&b, "- Working directory: %s\n", wd)
+	fmt.Fprintf(&b, "- OS: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(&b, "- Date: %s", now().Format("2006-01-02"))
+
+	dirs := agentsDirChain(cfg.Root, wd)
+	for _, dir := range dirs {
+		path := filepath.Join(dir, agentsFileName)
+		data, err := readFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", fmt.Errorf("read %s: %w", path, err)
+		}
+		content := strings.TrimSpace(string(data))
+		if content == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "\n\n# Project instructions (%s)\n%s", path, content)
+	}
+
+	return b.String(), nil
+}
+
+// agentsDirChain returns the directories whose AGENTS.md should be injected, in
+// general-to-specific order (root first, working directory last). When root is
+// empty or is not an ancestor of wd, only wd is returned. When wd is empty, the
+// chain is empty.
+func agentsDirChain(root, wd string) []string {
+	if wd == "" {
+		return nil
+	}
+	wd = filepath.Clean(wd)
+	if root == "" {
+		return []string{wd}
+	}
+	root = filepath.Clean(root)
+
+	// Walk up from wd to root, collecting each directory, then reverse so the
+	// root comes first (general → specific). If root is never reached, wd is not
+	// under root, so fall back to wd alone.
+	var up []string
+	cur := wd
+	for {
+		up = append(up, cur)
+		if cur == root {
+			// Reverse in place: root-first.
+			for i, j := 0, len(up)-1; i < j; i, j = i+1, j-1 {
+				up[i], up[j] = up[j], up[i]
+			}
+			return up
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Reached filesystem root without hitting `root`: wd not under root.
+			return []string{wd}
+		}
+		cur = parent
+	}
+}

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -1,0 +1,155 @@
+package agent
+
+// Tests for system-prompt assembly (US-021, #40): the base instruction, the
+// environment block, and — the acceptance-critical part — the general-to-
+// specific ordering of AGENTS.md injection from a root directory down to the
+// working directory. AGENTS.md layout is faked via PromptConfig.ReadFile so the
+// ordering is asserted without touching disk.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixedTime is a deterministic clock for the environment block.
+func fixedTime() time.Time { return time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC) }
+
+// TestBuildSystemPromptBaseAndEnv verifies the base instruction and environment
+// block (cwd, OS, date) are present, with no AGENTS.md when none exist.
+func TestBuildSystemPromptBaseAndEnv(t *testing.T) {
+	got, err := BuildSystemPrompt(PromptConfig{
+		WorkingDir: "/work/proj",
+		Now:        fixedTime,
+		ReadFile:   func(string) ([]byte, error) { return nil, os.ErrNotExist },
+	})
+	if err != nil {
+		t.Fatalf("BuildSystemPrompt: %v", err)
+	}
+	if !strings.HasPrefix(got, DefaultBaseInstruction) {
+		t.Errorf("prompt should start with the default base instruction, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Working directory: /work/proj") {
+		t.Errorf("environment block missing working directory:\n%s", got)
+	}
+	if !strings.Contains(got, "Date: 2026-07-10") {
+		t.Errorf("environment block missing date:\n%s", got)
+	}
+	if strings.Contains(got, "Project instructions") {
+		t.Errorf("no AGENTS.md exists, but prompt injected one:\n%s", got)
+	}
+}
+
+// TestBuildSystemPromptAGENTSOrdering is the acceptance-critical test: with an
+// AGENTS.md at the root and at a nested working directory, the root's content
+// must appear BEFORE the nested one (general → specific).
+func TestBuildSystemPromptAGENTSOrdering(t *testing.T) {
+	root := filepath.Clean("/repo")
+	mid := filepath.Join(root, "services")
+	wd := filepath.Join(mid, "api")
+
+	files := map[string]string{
+		filepath.Join(root, agentsFileName): "ROOT CONVENTIONS",
+		filepath.Join(mid, agentsFileName):  "SERVICES CONVENTIONS",
+		filepath.Join(wd, agentsFileName):   "API CONVENTIONS",
+	}
+	got, err := BuildSystemPrompt(PromptConfig{
+		WorkingDir: wd,
+		Root:       root,
+		Now:        fixedTime,
+		ReadFile: func(path string) ([]byte, error) {
+			if c, ok := files[path]; ok {
+				return []byte(c), nil
+			}
+			return nil, os.ErrNotExist
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSystemPrompt: %v", err)
+	}
+
+	iRoot := strings.Index(got, "ROOT CONVENTIONS")
+	iMid := strings.Index(got, "SERVICES CONVENTIONS")
+	iAPI := strings.Index(got, "API CONVENTIONS")
+	if iRoot < 0 || iMid < 0 || iAPI < 0 {
+		t.Fatalf("all three AGENTS.md must be injected, got:\n%s", got)
+	}
+	if !(iRoot < iMid && iMid < iAPI) {
+		t.Errorf("AGENTS.md must be ordered general→specific (root<mid<api), got positions root=%d mid=%d api=%d", iRoot, iMid, iAPI)
+	}
+}
+
+// TestBuildSystemPromptSkipsMissingIntermediate verifies a missing intermediate
+// AGENTS.md is skipped without breaking the ordering of the present ones.
+func TestBuildSystemPromptSkipsMissingIntermediate(t *testing.T) {
+	root := filepath.Clean("/repo")
+	mid := filepath.Join(root, "services")
+	wd := filepath.Join(mid, "api")
+	files := map[string]string{
+		filepath.Join(root, agentsFileName): "ROOT ONLY",
+		filepath.Join(wd, agentsFileName):   "API ONLY",
+		// no AGENTS.md at mid
+	}
+	got, err := BuildSystemPrompt(PromptConfig{
+		WorkingDir: wd, Root: root, Now: fixedTime,
+		ReadFile: func(path string) ([]byte, error) {
+			if c, ok := files[path]; ok {
+				return []byte(c), nil
+			}
+			return nil, os.ErrNotExist
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSystemPrompt: %v", err)
+	}
+	iRoot := strings.Index(got, "ROOT ONLY")
+	iAPI := strings.Index(got, "API ONLY")
+	if iRoot < 0 || iAPI < 0 || iRoot >= iAPI {
+		t.Errorf("present AGENTS.md must stay ordered root<api, got root=%d api=%d in:\n%s", iRoot, iAPI, got)
+	}
+}
+
+// TestBuildSystemPromptNoRootOnlyWorkingDir verifies that with no Root, only the
+// working directory's own AGENTS.md is considered (no ancestor walk).
+func TestBuildSystemPromptNoRootOnlyWorkingDir(t *testing.T) {
+	wd := filepath.Clean("/repo/services/api")
+	ancestor := filepath.Join(filepath.Dir(wd), agentsFileName)
+	files := map[string]string{
+		filepath.Join(wd, agentsFileName): "WD ONLY",
+		ancestor:                          "ANCESTOR (should NOT appear)",
+	}
+	got, err := BuildSystemPrompt(PromptConfig{
+		WorkingDir: wd, Now: fixedTime,
+		ReadFile: func(path string) ([]byte, error) {
+			if c, ok := files[path]; ok {
+				return []byte(c), nil
+			}
+			return nil, os.ErrNotExist
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSystemPrompt: %v", err)
+	}
+	if !strings.Contains(got, "WD ONLY") {
+		t.Errorf("working-dir AGENTS.md must be injected:\n%s", got)
+	}
+	if strings.Contains(got, "ANCESTOR") {
+		t.Errorf("with no Root, ancestor AGENTS.md must not be walked:\n%s", got)
+	}
+}
+
+// TestBuildSystemPromptReadErrorSurfaces verifies a present-but-unreadable
+// AGENTS.md (a non-not-exist I/O error) is reported rather than silently
+// dropped.
+func TestBuildSystemPromptReadErrorSurfaces(t *testing.T) {
+	wd := filepath.Clean("/repo")
+	_, err := BuildSystemPrompt(PromptConfig{
+		WorkingDir: wd, Now: fixedTime,
+		ReadFile: func(string) ([]byte, error) { return nil, os.ErrPermission },
+	})
+	if err == nil {
+		t.Fatal("an unreadable AGENTS.md must surface an error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- 新增 `BuildSystemPrompt`：基础指令 + 环境块（cwd/OS/日期）+ 从 Root 到 WorkingDir 的 AGENTS.md，按通用→具体（root 在前）拼接
- 缺失 AGENTS.md 静默跳过；存在但不可读则上报错误；`Now`/`ReadFile` 可注入以支持确定性单测
- `cmd/pigo` 改调 `BuildSystemPrompt`，替换 #39 的临时内联 systemPrompt

Closes #40

## Test plan
- [x] 单测验证 AGENTS.md root→mid→api 注入顺序、缺失跳过、无 Root 仅取 WorkingDir、不可读上报
- [x] go build ./... / go vet ./... / go test ./... 通过