### PR TITLE
会话持久化（JSONL）与恢复续跑 (US-024)

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -1,46 +1,119 @@
-// This file wires the interactive TUI (US-022) into the pigo command. When the
-// command is invoked without a prompt and stdout is a terminal, pigo starts the
-// bubbletea interactive loop instead of the headless print path.
+// This file wires the interactive TUI (US-022) and session persistence
+// (US-024, #43) into the pigo command. When invoked without a prompt on a
+// terminal, pigo starts the bubbletea interactive loop; each run's messages are
+// persisted to a local JSONL session so the conversation can be listed, resumed
+// and replayed later.
 package main
 
 import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/smallnest/pigo/internal/agent"
+	"github.com/smallnest/pigo/internal/session"
 	"github.com/smallnest/pigo/internal/tui"
 )
 
-// runInteractive starts the bubbletea TUI. Each submitted prompt launches an
-// agent run whose events are streamed into the UI; queued steering text is
-// injected between turns via the loop's GetSteeringMessages hook.
-func runInteractive(model, providerName string, provider agent.Provider, tools []agent.AgentTool, sysPrompt string) error {
-	creds := agent.NewCredentialStore(nil)
-	reg := toolRegistry(tools)
+// sessionStore returns the session store rooted at ~/.pigo/sessions (or under
+// PIGO_HOME when set), creating the directory on first use.
+func sessionStore() (*session.Store, error) {
+	dir := os.Getenv("PIGO_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve home dir: %w", err)
+		}
+		dir = filepath.Join(home, ".pigo")
+	}
+	return session.NewStore(filepath.Join(dir, "sessions"))
+}
 
+// interactiveOptions carries the resolved run configuration plus optional
+// resume state into runInteractive.
+type interactiveOptions struct {
+	model        string
+	providerName string
+	provider     agent.Provider
+	tools        []agent.AgentTool
+	sysPrompt    string
+
+	// resumeID, when non-empty, resumes an existing session: its messages seed
+	// the context and TUI transcript. Otherwise a fresh session is created.
+	resumeID string
+}
+
+// runInteractive starts the bubbletea TUI over a persisted session. It keeps a
+// single growing AgentContext across prompts (so turns share history) and saves
+// the session's messages after each run completes.
+func runInteractive(opts interactiveOptions) error {
+	creds := agent.NewCredentialStore(nil)
+	reg := toolRegistry(opts.tools)
+
+	store, err := sessionStore()
+	if err != nil {
+		return err
+	}
+
+	// Establish the session: resume an existing one or create a fresh header.
+	now := time.Now().UTC()
+	var (
+		agentCtx *agent.AgentContext
+		header   session.SessionHeader
+		history  []agent.AgentMessage
+	)
+	if opts.resumeID != "" {
+		// Interactive resume differs from headless continue: the user re-prompts,
+		// so a new user message is always appended before the loop runs. A session
+		// that ended normally (trailing assistant reply) is therefore resumable
+		// here, unlike store.Resume (which guards agentLoopContinue). So load the
+		// raw session and rebuild the context directly.
+		h, msgs, err := store.Load(opts.resumeID)
+		if err != nil {
+			return err
+		}
+		header = h
+		agentCtx = &agent.AgentContext{SystemPrompt: h.SystemPrompt, Messages: msgs, Tools: opts.tools}
+		history = msgs
+		if agentCtx.SystemPrompt == "" {
+			agentCtx.SystemPrompt = opts.sysPrompt
+		}
+	} else {
+		agentCtx = &agent.AgentContext{SystemPrompt: opts.sysPrompt, Tools: opts.tools}
+		header = session.SessionHeader{
+			ID:           session.NewID(now),
+			CreatedAt:    now,
+			UpdatedAt:    now,
+			Model:        opts.model,
+			Provider:     opts.providerName,
+			SystemPrompt: opts.sysPrompt,
+		}
+	}
+
+	// run appends the new prompt to the shared context, launches a loop run over
+	// the whole context, and returns its event stream. Steering is bridged into
+	// the loop's per-turn hook. The context grows in place as the loop appends
+	// assistant/tool messages, so the next prompt continues the conversation.
 	run := func(ctx context.Context, prompt string, steering func() []string) (*agent.LoopEventStream, context.CancelFunc) {
 		runCtx, cancel := context.WithCancel(ctx)
-		agentCtx := &agent.AgentContext{
-			SystemPrompt: sysPrompt,
-			Messages: agent.MessageList{
-				agent.UserMessage{RoleField: agent.RoleUser, Content: agent.ContentList{agent.NewTextContent(prompt)}},
-			},
-			Tools: tools,
-		}
+		agentCtx.Messages = append(agentCtx.Messages, agent.UserMessage{
+			RoleField: agent.RoleUser,
+			Content:   agent.ContentList{agent.NewTextContent(prompt)},
+		})
 		cfg := agent.RunConfig{
 			LoopConfig: agent.LoopConfig{
-				Model:     model,
-				Provider:  providerName,
-				Stream:    agent.StreamFnFromProvider(provider),
+				Model:     opts.model,
+				Provider:  opts.providerName,
+				Stream:    agent.StreamFnFromProvider(opts.provider),
 				GetAPIKey: creds.GetAPIKey,
 			},
 			Batch: agent.BatchConfig{
 				ToolExecutorConfig: agent.ToolExecutorConfig{Registry: reg},
 			},
-			// Bridge the TUI's steering queue into the loop's per-turn hook.
 			GetSteeringMessages: func(context.Context) []agent.AgentMessage {
 				texts := steering()
 				if len(texts) == 0 {
@@ -53,16 +126,69 @@ func runInteractive(model, providerName string, provider agent.Provider, tools [
 				return msgs
 			},
 		}
-		return agent.StartRun(runCtx, agentCtx, cfg), cancel
+		stream := agent.StartRun(runCtx, agentCtx, cfg)
+		// Persist the session once this run settles. Result blocks until the loop
+		// ends; calling it here (in addition to the TUI's drain) is safe — Result
+		// resolves once and can be read by multiple goroutines.
+		go func() {
+			_, _ = stream.Result(context.Background())
+			header.UpdatedAt = time.Now().UTC()
+			if err := store.Save(header, agentCtx.Messages); err != nil {
+				fmt.Fprintf(os.Stderr, "pigo: session save failed: %v\n", err)
+			}
+		}()
+		return stream, cancel
 	}
 
-	m := tui.NewModel(run)
+	var m *tui.Model
+	if len(history) > 0 {
+		m = tui.NewModelWithHistory(run, history)
+	} else {
+		m = tui.NewModel(run)
+	}
 	p := tea.NewProgram(m)
 	m.SetProgram(p)
 	if _, err := p.Run(); err != nil {
 		return fmt.Errorf("tui: %w", err)
 	}
 	return nil
+}
+
+// printSessions prints the stored sessions, most-recent first, to stdout.
+func printSessions() error {
+	store, err := sessionStore()
+	if err != nil {
+		return err
+	}
+	headers, err := store.List()
+	if err != nil {
+		return err
+	}
+	if len(headers) == 0 {
+		fmt.Println("no sessions")
+		return nil
+	}
+	for _, h := range headers {
+		fmt.Printf("%s\t%s\t%s\n", h.ID, h.UpdatedAt.Local().Format("2006-01-02 15:04"), h.Model)
+	}
+	return nil
+}
+
+// mostRecentSessionID returns the id of the most recently updated session, or
+// "" if there are none.
+func mostRecentSessionID() (string, error) {
+	store, err := sessionStore()
+	if err != nil {
+		return "", err
+	}
+	headers, err := store.List()
+	if err != nil {
+		return "", err
+	}
+	if len(headers) == 0 {
+		return "", nil
+	}
+	return headers[0].ID, nil
 }
 
 // stdoutIsTerminal reports whether stdout is an interactive terminal (not a

--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -22,11 +22,14 @@ import (
 
 func main() {
 	var (
-		prompt    string
-		model     string
-		baseURL   string
-		outputFmt string
-		noTools   bool
+		prompt       string
+		model        string
+		baseURL      string
+		outputFmt    string
+		noTools      bool
+		listSessions bool
+		resumeID     string
+		continueLast bool
 	)
 	flag.StringVar(&prompt, "p", "", "prompt to run in headless print mode")
 	flag.StringVar(&prompt, "print", "", "prompt to run in headless print mode")
@@ -34,18 +37,45 @@ func main() {
 	flag.StringVar(&baseURL, "base-url", "", "override provider base URL (e.g. local Ollama)")
 	flag.StringVar(&outputFmt, "output-format", "text", "output format: text | stream-json")
 	flag.BoolVar(&noTools, "no-tools", false, "disable the built-in file/shell tools")
+	flag.BoolVar(&listSessions, "list-sessions", false, "list stored interactive sessions and exit")
+	flag.StringVar(&resumeID, "resume", "", "resume the interactive session with this id")
+	flag.BoolVar(&continueLast, "continue", false, "resume the most recent interactive session")
 	flag.Parse()
+
+	// --list-sessions is a standalone action: print and exit.
+	if listSessions {
+		if err := printSessions(); err != nil {
+			fmt.Fprintf(os.Stderr, "pigo: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	// --continue resolves to the most recently updated session id.
+	if continueLast && resumeID == "" {
+		id, err := mostRecentSessionID()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "pigo: %v\n", err)
+			os.Exit(1)
+		}
+		if id == "" {
+			fmt.Fprintln(os.Stderr, "pigo: no sessions to continue")
+			os.Exit(1)
+		}
+		resumeID = id
+	}
 
 	// A prompt may also be supplied as positional args.
 	if prompt == "" {
 		prompt = strings.TrimSpace(strings.Join(flag.Args(), " "))
 	}
 
-	// No prompt + an interactive terminal → start the TUI (US-022). No prompt
-	// with a non-terminal stdout (pipe/CI) is an error, since there is nothing
-	// to run and nothing to interact with.
+	// No prompt + an interactive terminal → start the TUI (US-022). A --resume id
+	// also enters the TUI to continue an existing session. No prompt with a
+	// non-terminal stdout (pipe/CI) and no resume is an error, since there is
+	// nothing to run and nothing to interact with.
 	if prompt == "" {
-		if !stdoutIsTerminal() {
+		if resumeID == "" && !stdoutIsTerminal() {
 			fmt.Fprintln(os.Stderr, "pigo: no prompt (use -p \"...\" or positional args)")
 			os.Exit(2)
 		}
@@ -61,7 +91,14 @@ func main() {
 			fmt.Fprintf(os.Stderr, "pigo: %v\n", err)
 			os.Exit(1)
 		}
-		if err := runInteractive(model, providerName, provider, tools, sysPrompt); err != nil {
+		if err := runInteractive(interactiveOptions{
+			model:        model,
+			providerName: providerName,
+			provider:     provider,
+			tools:        tools,
+			sysPrompt:    sysPrompt,
+			resumeID:     resumeID,
+		}); err != nil {
 			fmt.Fprintf(os.Stderr, "pigo: %v\n", err)
 			os.Exit(1)
 		}

--- a/docs/issue#0043.html
+++ b/docs/issue#0043.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0043</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/43">#43</a> &mdash; [impl] 会话持久化（JSONL）（US-024） &mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> JSONL layout: header line + one message per line</h3>
+      <p><strong>Ambiguity:</strong> The spec (issue #16, 会话格式 #5) fixes only "本地 JSONL，内部自洽，不与 pi 互读" — it does not prescribe the on-disk record layout.</p>
+      <p><strong>Choice:</strong> Line 1 is a <code>SessionHeader</code> (version + metadata); every subsequent line is one message, encoded with the same <code>"role"</code>-discriminated shape as <code>agent.MessageList</code>.</p>
+      <p><strong>Rationale:</strong> Listing reads only line 1 (cheap), and message decoding reuses the existing discriminated <code>MessageList.UnmarshalJSON</code> by wrapping each line in a one-element array <code>[…]</code> — no second, drift-prone codec.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Schema versioning with a hard forward-incompatibility guard</h3>
+      <p><strong>Ambiguity:</strong> The spec mentions a migration-chain design space but leaves the guard behavior unspecified.</p>
+      <p><strong>Choice:</strong> <code>SchemaVersion = 1</code> is written into every header; <code>version == 0</code> (missing) and <code>version &gt; SchemaVersion</code> (newer than the binary) are both rejected on read.</p>
+      <p><strong>Rationale:</strong> A newer file must never be silently misread by an older binary; failing loudly preserves the migration hook for later versions.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Atomic writes via temp file + rename</h3>
+      <p><strong>Ambiguity:</strong> Durability semantics were not specified.</p>
+      <p><strong>Choice:</strong> <code>Save</code> writes to <code>&lt;id&gt;.jsonl.tmp</code> then <code>os.Rename</code>s over the target.</p>
+      <p><strong>Rationale:</strong> A concurrent or crashing reader never observes a half-written session; rename is atomic on the same filesystem.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Time-ordered session IDs</h3>
+      <p><strong>Ambiguity:</strong> ID scheme unspecified.</p>
+      <p><strong>Choice:</strong> <code>NewID</code> = UTC <code>20060102-150405</code> + a 6-digit microsecond suffix, so IDs sort lexicographically by creation time and disambiguate within a second.</p>
+      <p><strong>Rationale:</strong> Human-readable, collision-resistant for interactive use, and naturally ordered without a separate index.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Whole-session <code>Save</code> after each run rather than incremental <code>Append</code> in the CLI</h3>
+      <p><strong>Ambiguity:</strong> The spec requires persistence but not the write cadence.</p>
+      <p><strong>Choice:</strong> The interactive driver keeps one growing <code>AgentContext</code> and calls <code>Save</code> with the full message slice when each run settles. <code>Append</code> exists and is unit-tested for callers that want incremental writes.</p>
+      <p><strong>Rationale:</strong> The context grows in place across turns, so a single <code>Save</code> of the whole slice is simplest and always consistent; interactive session sizes make the rewrite cost negligible.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> CLI resume path bypasses <code>Store.Resume</code>'s trailing-assistant guard</h3>
+      <p><strong>Spec:</strong> Resume "对接 agentLoopContinue", whose precondition rejects a context whose last message is an assistant message.</p>
+      <p><strong>Implemented:</strong> <code>Store.Resume</code> still enforces that guard (for the headless/continue path and its tests). But the interactive CLI resume uses <code>Store.Load</code> directly and rebuilds the context, because the user always types a fresh prompt first — a new user message is appended before the loop runs.</p>
+      <p><strong>Why:</strong> A normally-ended session (trailing assistant reply) is the common case a user wants to resume in the TUI; refusing it would make resume nearly useless interactively. The <code>agentLoopContinue</code> invariant is still upheld because the appended user prompt makes the last message a user message before any loop step.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> <code>Append</code> does load-modify-save instead of true file append</h3>
+      <p><strong>Alternatives:</strong> (A) genuine <code>O_APPEND</code> of new message lines; (B) load whole session, append in memory, rewrite atomically.</p>
+      <p><strong>Pros/cons:</strong> (A) is O(new) I/O but cannot update the header's <code>UpdatedAt</code> in place (the header is line 1), and risks a torn file on crash. (B) is O(total) I/O but keeps the header authoritative and reuses the atomic <code>Save</code> path.</p>
+      <p><strong>Chosen:</strong> (B) — correctness and header freshness matter more than I/O at interactive session sizes.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Scanner buffer capped at 16&nbsp;MB per line</h3>
+      <p><strong>Alternatives:</strong> default 64&nbsp;KB <code>bufio.Scanner</code> cap; a streaming <code>json.Decoder</code>; a large fixed cap.</p>
+      <p><strong>Pros/cons:</strong> 64&nbsp;KB truncates long tool-result lines; a full streaming decoder complicates the line-oriented format; a fixed 16&nbsp;MB cap is simple and covers realistic tool outputs.</p>
+      <p><strong>Chosen:</strong> 16&nbsp;MB cap — pragmatic headroom without unbounded memory.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Interactive resume + real provider not manually verified</h3>
+      <p>Unit tests cover write/read/resume/replay and the CLI builds with <code>--resume</code>/<code>--continue</code>/<code>--list-sessions</code>, but a live end-to-end resume against a real model in a terminal has not been exercised. Worth a manual smoke test before relying on it.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Sessions never expire or get pruned</h3>
+      <p><code>~/.pigo/sessions</code> grows unbounded. Should there be a retention policy or a <code>--rm</code>/prune command? Not required by the acceptance criteria — confirm whether it's wanted as follow-up.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Concurrent writers to the same session id</h3>
+      <p>Two pigo processes resuming the same id would last-writer-win via rename. Interactive use is single-writer, so this is assumed acceptable — confirm no multi-process resume scenario is expected.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,0 +1,287 @@
+// Package session implements local JSONL session persistence and resume
+// (US-024, #43). A session is stored as a single append-only JSONL file: the
+// first line is a SessionHeader (schema version + metadata), and every
+// subsequent line is one persisted message (user / assistant / toolResult),
+// using the same "role"-discriminated encoding as agent.MessageList.
+//
+// The format is internally self-consistent and deliberately NOT wire-compatible
+// with pi's session files (spec #16, 会话格式 decision #5): pigo owns the schema
+// and versions it via SessionHeader.Version so future migrations have a hook.
+//
+// A persisted session round-trips into an agent.AgentContext, so a run can be
+// resumed by feeding the reconstructed context to agent.ContinueRun and the
+// transcript replays correctly in the TUI.
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agent"
+)
+
+// SchemaVersion is the current session file schema version. It is written into
+// every SessionHeader and checked on read; an unknown (higher) version is a
+// hard error so a newer file is never silently misread by an older binary.
+const SchemaVersion = 1
+
+// SessionHeader is the first line of a session file: schema version plus the
+// metadata needed to list and resume a session without reading its messages.
+type SessionHeader struct {
+	// Version is the schema version (SchemaVersion at write time).
+	Version int `json:"version"`
+	// ID is the session identifier, also the file stem (see FileName).
+	ID string `json:"id"`
+	// CreatedAt is when the session file was created (RFC 3339, UTC).
+	CreatedAt time.Time `json:"createdAt"`
+	// UpdatedAt is when the session was last appended to.
+	UpdatedAt time.Time `json:"updatedAt"`
+	// Model / Provider record what the session ran against, for display and to
+	// re-establish the run configuration on resume. Optional.
+	Model    string `json:"model,omitempty"`
+	Provider string `json:"provider,omitempty"`
+	// SystemPrompt is the system prompt the session ran under. Persisted so the
+	// resumed context is faithful. Optional.
+	SystemPrompt string `json:"systemPrompt,omitempty"`
+}
+
+// FileName returns the on-disk file name for a session id (id + ".jsonl").
+func FileName(id string) string { return id + ".jsonl" }
+
+// NewID returns a time-ordered session id: a UTC timestamp stem that sorts
+// lexicographically by creation time (e.g. "20260710-142530-uniq"). The suffix
+// disambiguates sessions created within the same second.
+func NewID(now time.Time) string {
+	return fmt.Sprintf("%s-%06d", now.UTC().Format("20060102-150405"), now.UTC().Nanosecond()/1000%1_000_000)
+}
+
+// Store persists sessions as JSONL files under a directory (typically
+// ~/.pigo/sessions). The zero value is unusable; construct with NewStore.
+type Store struct {
+	dir string
+}
+
+// NewStore returns a Store rooted at dir, creating the directory if needed.
+func NewStore(dir string) (*Store, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("session: store dir must not be empty")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("session: create store dir: %w", err)
+	}
+	return &Store{dir: dir}, nil
+}
+
+// Dir returns the store's root directory.
+func (s *Store) Dir() string { return s.dir }
+
+// path returns the on-disk path for a session id.
+func (s *Store) path(id string) string { return filepath.Join(s.dir, FileName(id)) }
+
+// Save writes header and messages to a fresh session file, overwriting any
+// existing file for the same id. The header's Version is forced to
+// SchemaVersion; CreatedAt/UpdatedAt are left as the caller set them. Save is
+// the whole-session write; Append adds messages to an existing file.
+func (s *Store) Save(header SessionHeader, messages agent.MessageList) error {
+	header.Version = SchemaVersion
+	if header.ID == "" {
+		return fmt.Errorf("session: header ID must not be empty")
+	}
+	tmp := s.path(header.ID) + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("session: create %s: %w", tmp, err)
+	}
+	w := bufio.NewWriter(f)
+	if err := writeSession(w, header, messages); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := w.Flush(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("session: flush %s: %w", tmp, err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("session: close %s: %w", tmp, err)
+	}
+	// Atomic replace so a reader never sees a half-written file.
+	if err := os.Rename(tmp, s.path(header.ID)); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("session: commit %s: %w", header.ID, err)
+	}
+	return nil
+}
+
+// writeSession emits the header line followed by one line per message.
+func writeSession(w io.Writer, header SessionHeader, messages agent.MessageList) error {
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(header); err != nil {
+		return fmt.Errorf("session: encode header: %w", err)
+	}
+	for i, m := range messages {
+		if err := enc.Encode(m); err != nil {
+			return fmt.Errorf("session: encode message[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// Load reads a session file and returns its header and messages. It validates
+// the schema version (an unknown version is rejected) and decodes each message
+// line using the same role-discriminated logic as agent.MessageList.
+func (s *Store) Load(id string) (SessionHeader, agent.MessageList, error) {
+	f, err := os.Open(s.path(id))
+	if err != nil {
+		return SessionHeader{}, nil, fmt.Errorf("session: open %s: %w", id, err)
+	}
+	defer f.Close()
+	return readSession(f)
+}
+
+// readSession decodes a session stream: header line first, then messages.
+func readSession(r io.Reader) (SessionHeader, agent.MessageList, error) {
+	sc := bufio.NewScanner(r)
+	// Session lines can be large (long tool results); grow the buffer well past
+	// the default 64KB token cap.
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+
+	if !sc.Scan() {
+		if err := sc.Err(); err != nil {
+			return SessionHeader{}, nil, fmt.Errorf("session: read header: %w", err)
+		}
+		return SessionHeader{}, nil, fmt.Errorf("session: empty file (no header)")
+	}
+	var header SessionHeader
+	if err := json.Unmarshal(sc.Bytes(), &header); err != nil {
+		return SessionHeader{}, nil, fmt.Errorf("session: parse header: %w", err)
+	}
+	if header.Version == 0 {
+		return SessionHeader{}, nil, fmt.Errorf("session: header missing version")
+	}
+	if header.Version > SchemaVersion {
+		return SessionHeader{}, nil, fmt.Errorf("session: file schema version %d newer than supported %d", header.Version, SchemaVersion)
+	}
+
+	var messages agent.MessageList
+	for line := 2; sc.Scan(); line++ {
+		raw := sc.Bytes()
+		if len(strings.TrimSpace(string(raw))) == 0 {
+			continue // tolerate blank lines
+		}
+		// Reuse MessageList's discriminated decoding by wrapping the single object
+		// in a one-element array.
+		var one agent.MessageList
+		if err := json.Unmarshal([]byte("["+string(raw)+"]"), &one); err != nil {
+			return SessionHeader{}, nil, fmt.Errorf("session: parse message line %d: %w", line, err)
+		}
+		messages = append(messages, one...)
+	}
+	if err := sc.Err(); err != nil {
+		return SessionHeader{}, nil, fmt.Errorf("session: scan: %w", err)
+	}
+	return header, messages, nil
+}
+
+// List returns the headers of all sessions in the store, sorted by UpdatedAt
+// descending (most recently used first). Files that fail to parse are skipped
+// rather than failing the whole listing, so one corrupt session does not hide
+// the rest.
+func (s *Store) List() ([]SessionHeader, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return nil, fmt.Errorf("session: read store dir: %w", err)
+	}
+	var headers []SessionHeader
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".jsonl")
+		h, err := s.loadHeader(id)
+		if err != nil {
+			continue // skip unreadable/corrupt session
+		}
+		headers = append(headers, h)
+	}
+	sort.Slice(headers, func(i, j int) bool {
+		return headers[i].UpdatedAt.After(headers[j].UpdatedAt)
+	})
+	return headers, nil
+}
+
+// loadHeader reads only the header line of a session file (cheap for listing).
+func (s *Store) loadHeader(id string) (SessionHeader, error) {
+	f, err := os.Open(s.path(id))
+	if err != nil {
+		return SessionHeader{}, err
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	if !sc.Scan() {
+		return SessionHeader{}, fmt.Errorf("session: empty file")
+	}
+	var header SessionHeader
+	if err := json.Unmarshal(sc.Bytes(), &header); err != nil {
+		return SessionHeader{}, err
+	}
+	if header.Version == 0 {
+		return SessionHeader{}, fmt.Errorf("session: missing version")
+	}
+	return header, nil
+}
+
+// Resume loads a session and reconstructs an agent.AgentContext from it, ready
+// to hand to agent.ContinueRun. The system prompt is taken from the header. The
+// returned header lets the caller re-establish model/provider. It errors if the
+// session has no messages or its last message is an assistant message (nothing
+// to continue from — mirrors agentLoopContinue's precondition).
+func (s *Store) Resume(id string) (*agent.AgentContext, SessionHeader, error) {
+	header, messages, err := s.Load(id)
+	if err != nil {
+		return nil, SessionHeader{}, err
+	}
+	if len(messages) == 0 {
+		return nil, SessionHeader{}, fmt.Errorf("session %s: no messages to resume", id)
+	}
+	if _, isAssistant := messages[len(messages)-1].(agent.AssistantMessage); isAssistant {
+		return nil, SessionHeader{}, fmt.Errorf("session %s: last message is an assistant message, nothing to continue", id)
+	}
+	ctx := &agent.AgentContext{
+		SystemPrompt: header.SystemPrompt,
+		Messages:     messages,
+	}
+	return ctx, header, nil
+}
+
+// Append adds messages to an existing session file and bumps its UpdatedAt to
+// updatedAt. It is the incremental-persistence path: after each turn the driver
+// appends only the newly produced messages rather than rewriting the whole
+// file. The header's UpdatedAt is rewritten in place (line 0), then the new
+// messages are appended. If the session does not exist it is an error — use
+// Save to create one first.
+//
+// Because the header lives on the first line and JSONL is otherwise
+// append-only, updating UpdatedAt requires rewriting the file; Append does a
+// load-modify-save under the hood, which is simple and correct for the session
+// sizes pigo produces. Callers that never need UpdatedAt precision can batch
+// with Save at session end instead.
+func (s *Store) Append(id string, updatedAt time.Time, messages agent.MessageList) error {
+	header, existing, err := s.Load(id)
+	if err != nil {
+		return err
+	}
+	header.UpdatedAt = updatedAt
+	existing = append(existing, messages...)
+	return s.Save(header, existing)
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1,0 +1,243 @@
+package session
+
+// Tests for local JSONL session persistence and resume (US-024, #43). They
+// cover the write→read round-trip, listing order, resume into an AgentContext,
+// schema-version guarding, and append — driving the real filesystem via
+// t.TempDir(), the standard Go pattern for behavior tests.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agent"
+)
+
+// writeFile writes content to path (test helper for hand-crafted fixtures).
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// sampleMessages returns a small multi-turn transcript: user prompt, assistant
+// with a tool call, tool result, then a final assistant reply.
+func sampleMessages() agent.MessageList {
+	return agent.MessageList{
+		agent.UserMessage{RoleField: agent.RoleUser, Content: agent.ContentList{agent.NewTextContent("read main.go")}},
+		agent.AssistantMessage{
+			RoleField:  agent.RoleAssistant,
+			Content:    agent.ContentList{agent.NewTextContent("Reading it."), agent.NewToolCallContent("call-1", "read", []byte(`{"path":"main.go"}`))},
+			StopReason: agent.StopReasonToolUse,
+		},
+		agent.ToolResultMessage{
+			RoleField:  agent.RoleToolResult,
+			ToolCallID: "call-1",
+			ToolName:   "read",
+			Content:    agent.ContentList{agent.NewTextContent("package main")},
+		},
+		agent.AssistantMessage{
+			RoleField:  agent.RoleAssistant,
+			Content:    agent.ContentList{agent.NewTextContent("It is package main.")},
+			StopReason: agent.StopReasonEndTurn,
+		},
+	}
+}
+
+func newStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+// TestSaveLoadRoundTrip is the core acceptance check: a saved session loads
+// back with an identical header and message sequence.
+func TestSaveLoadRoundTrip(t *testing.T) {
+	s := newStore(t)
+	now := time.Date(2026, 7, 10, 14, 25, 30, 0, time.UTC)
+	header := SessionHeader{
+		ID:           NewID(now),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		Model:        "anthropic/claude-opus-4",
+		Provider:     "anthropic",
+		SystemPrompt: "You are pigo.",
+	}
+	msgs := sampleMessages()
+	if err := s.Save(header, msgs); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	gotHeader, gotMsgs, err := s.Load(header.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if gotHeader.Version != SchemaVersion {
+		t.Errorf("version = %d, want %d", gotHeader.Version, SchemaVersion)
+	}
+	if gotHeader.Model != header.Model || gotHeader.SystemPrompt != header.SystemPrompt {
+		t.Errorf("header mismatch: %+v", gotHeader)
+	}
+	if len(gotMsgs) != len(msgs) {
+		t.Fatalf("message count = %d, want %d", len(gotMsgs), len(msgs))
+	}
+	// Roles must round-trip in order.
+	wantRoles := []string{agent.RoleUser, agent.RoleAssistant, agent.RoleToolResult, agent.RoleAssistant}
+	for i, m := range gotMsgs {
+		if m.Role() != wantRoles[i] {
+			t.Errorf("message[%d] role = %q, want %q", i, m.Role(), wantRoles[i])
+		}
+	}
+	// The assistant tool call must survive the round-trip.
+	a, ok := gotMsgs[1].(agent.AssistantMessage)
+	if !ok {
+		t.Fatalf("message[1] is not AssistantMessage: %T", gotMsgs[1])
+	}
+	calls := a.ToolCalls()
+	if len(calls) != 1 || calls[0].Name != "read" {
+		t.Errorf("tool calls = %+v, want one 'read'", calls)
+	}
+}
+
+// TestSaveOverwrites verifies Save replaces an existing session file (same id)
+// atomically rather than appending.
+func TestSaveOverwrites(t *testing.T) {
+	s := newStore(t)
+	now := time.Now().UTC()
+	h := SessionHeader{ID: "fixed", CreatedAt: now, UpdatedAt: now}
+	if err := s.Save(h, sampleMessages()); err != nil {
+		t.Fatalf("first Save: %v", err)
+	}
+	shorter := agent.MessageList{agent.UserMessage{RoleField: agent.RoleUser, Content: agent.ContentList{agent.NewTextContent("hi")}}}
+	if err := s.Save(h, shorter); err != nil {
+		t.Fatalf("second Save: %v", err)
+	}
+	_, msgs, err := s.Load("fixed")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Errorf("after overwrite, message count = %d, want 1", len(msgs))
+	}
+}
+
+// TestListSortedByUpdatedDesc verifies List returns sessions most-recent-first.
+func TestListSortedByUpdatedDesc(t *testing.T) {
+	s := newStore(t)
+	base := time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)
+	for i, id := range []string{"old", "mid", "new"} {
+		h := SessionHeader{
+			ID:        id,
+			CreatedAt: base,
+			UpdatedAt: base.Add(time.Duration(i) * time.Hour),
+		}
+		if err := s.Save(h, sampleMessages()); err != nil {
+			t.Fatalf("Save %s: %v", id, err)
+		}
+	}
+	headers, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(headers) != 3 {
+		t.Fatalf("List count = %d, want 3", len(headers))
+	}
+	wantOrder := []string{"new", "mid", "old"}
+	for i, h := range headers {
+		if h.ID != wantOrder[i] {
+			t.Errorf("List[%d].ID = %q, want %q", i, h.ID, wantOrder[i])
+		}
+	}
+}
+
+// TestResumeReconstructsContext verifies Resume rebuilds an AgentContext whose
+// system prompt and messages match the persisted session — the data the TUI
+// replays on resume.
+func TestResumeReconstructsContext(t *testing.T) {
+	s := newStore(t)
+	now := time.Now().UTC()
+	// A session whose last message is a tool result (not assistant), so it is
+	// resumable per agentLoopContinue's precondition.
+	msgs := agent.MessageList{
+		agent.UserMessage{RoleField: agent.RoleUser, Content: agent.ContentList{agent.NewTextContent("go")}},
+		agent.AssistantMessage{RoleField: agent.RoleAssistant, Content: agent.ContentList{agent.NewToolCallContent("c1", "read", []byte(`{}`))}, StopReason: agent.StopReasonToolUse},
+		agent.ToolResultMessage{RoleField: agent.RoleToolResult, ToolCallID: "c1", ToolName: "read", Content: agent.ContentList{agent.NewTextContent("data")}},
+	}
+	h := SessionHeader{ID: "resumable", CreatedAt: now, UpdatedAt: now, SystemPrompt: "sys"}
+	if err := s.Save(h, msgs); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	ctx, header, err := s.Resume("resumable")
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if ctx.SystemPrompt != "sys" {
+		t.Errorf("resumed system prompt = %q, want sys", ctx.SystemPrompt)
+	}
+	if len(ctx.Messages) != 3 {
+		t.Errorf("resumed message count = %d, want 3", len(ctx.Messages))
+	}
+	if header.ID != "resumable" {
+		t.Errorf("resumed header ID = %q", header.ID)
+	}
+}
+
+// TestResumeRejectsTrailingAssistant verifies Resume errors when the last
+// message is an assistant message (nothing to continue from).
+func TestResumeRejectsTrailingAssistant(t *testing.T) {
+	s := newStore(t)
+	now := time.Now().UTC()
+	msgs := agent.MessageList{
+		agent.UserMessage{RoleField: agent.RoleUser, Content: agent.ContentList{agent.NewTextContent("q")}},
+		agent.AssistantMessage{RoleField: agent.RoleAssistant, Content: agent.ContentList{agent.NewTextContent("a")}, StopReason: agent.StopReasonEndTurn},
+	}
+	if err := s.Save(SessionHeader{ID: "done", CreatedAt: now, UpdatedAt: now}, msgs); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, _, err := s.Resume("done"); err == nil {
+		t.Error("Resume must reject a session whose last message is an assistant message")
+	}
+}
+
+// TestLoadRejectsNewerSchema verifies a file whose version is newer than the
+// binary supports is rejected rather than silently misread.
+func TestLoadRejectsNewerSchema(t *testing.T) {
+	s := newStore(t)
+	// Hand-write a session file with a future version.
+	future := `{"version":9999,"id":"future","createdAt":"2026-07-10T00:00:00Z","updatedAt":"2026-07-10T00:00:00Z"}` + "\n"
+	path := filepath.Join(s.Dir(), FileName("future"))
+	if err := writeFile(path, future); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if _, _, err := s.Load("future"); err == nil {
+		t.Error("Load must reject a newer schema version")
+	}
+}
+
+// TestAppendGrowsSession verifies Append adds messages and bumps UpdatedAt.
+func TestAppendGrowsSession(t *testing.T) {
+	s := newStore(t)
+	created := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	h := SessionHeader{ID: "grow", CreatedAt: created, UpdatedAt: created}
+	initial := agent.MessageList{agent.UserMessage{RoleField: agent.RoleUser, Content: agent.ContentList{agent.NewTextContent("first")}}}
+	if err := s.Save(h, initial); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	later := created.Add(time.Hour)
+	more := agent.MessageList{agent.AssistantMessage{RoleField: agent.RoleAssistant, Content: agent.ContentList{agent.NewTextContent("reply")}, StopReason: agent.StopReasonEndTurn}}
+	if err := s.Append("grow", later, more); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	gotHeader, gotMsgs, err := s.Load("grow")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(gotMsgs) != 2 {
+		t.Errorf("after append, message count = %d, want 2", len(gotMsgs))
+	}
+	if !gotHeader.UpdatedAt.Equal(later) {
+		t.Errorf("UpdatedAt = %v, want %v", gotHeader.UpdatedAt, later)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -60,6 +60,16 @@ func NewModel(run RunFn) *Model {
 	return &Model{state: newUIState(), run: run}
 }
 
+// NewModelWithHistory builds a Model whose transcript is pre-seeded from a
+// resumed session's messages (US-024). The replayed transcript renders the
+// prior conversation before any new input; the model starts idle so the next
+// submit continues the session via the injected run func.
+func NewModelWithHistory(run RunFn, history []agent.AgentMessage) *Model {
+	m := &Model{state: newUIState(), run: run}
+	m.state.replay(history)
+	return m
+}
+
 // SetProgram wires the running Program so the bridge goroutine can Send events.
 // Must be called before Run (the cmd/pigo entry point does this).
 func (m *Model) SetProgram(p *tea.Program) { m.program = p }

--- a/internal/tui/state.go
+++ b/internal/tui/state.go
@@ -69,6 +69,32 @@ func newUIState() *uiState {
 	return &uiState{runID: 0}
 }
 
+// replay seeds the transcript from a persisted session's messages so a resumed
+// session renders its prior conversation before any new input. It maps each
+// message role to the matching transcript entries: user text, assistant text,
+// assistant tool calls, and tool results — the same shapes applyEvent produces
+// for a live run, so a replayed transcript is indistinguishable from one built
+// turn-by-turn. It does not touch runID/running (a resumed session starts idle).
+func (s *uiState) replay(messages []agent.AgentMessage) {
+	for _, m := range messages {
+		switch msg := m.(type) {
+		case agent.UserMessage:
+			if text := userText(msg); text != "" {
+				s.transcript = append(s.transcript, transcriptEntry{Kind: entryUser, Text: text})
+			}
+		case agent.AssistantMessage:
+			if text := assistantText(msg); text != "" {
+				s.transcript = append(s.transcript, transcriptEntry{Kind: entryAssistant, Text: text})
+			}
+			for _, c := range msg.ToolCalls() {
+				s.transcript = append(s.transcript, transcriptEntry{Kind: entryToolCall, Text: c.Name})
+			}
+		case agent.ToolResultMessage:
+			s.transcript = append(s.transcript, transcriptEntry{Kind: entryToolResult, Text: toolResultText(msg)})
+		}
+	}
+}
+
 // submit handles the user pressing Enter. When idle it starts a new run and
 // returns (prompt, true): the caller launches the agent loop under the new
 // runID. When a run is in flight it queues the text as steering and returns
@@ -199,6 +225,18 @@ func (s *uiState) finalizeStreaming() {
 func assistantText(a agent.AssistantMessage) string {
 	var b strings.Builder
 	for _, c := range a.Content {
+		if tc, ok := c.(agent.TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}
+
+// userText extracts the plain text of a user message (used when replaying a
+// persisted session into the transcript).
+func userText(u agent.UserMessage) string {
+	var b strings.Builder
+	for _, c := range u.Content {
 		if tc, ok := c.(agent.TextContent); ok {
 			b.WriteString(tc.Text)
 		}

--- a/internal/tui/state_test.go
+++ b/internal/tui/state_test.go
@@ -238,3 +238,45 @@ func TestFenceBufferClosesDanglingFence(t *testing.T) {
 		t.Error("balanced fences must be left unchanged")
 	}
 }
+
+// TestReplaySeedsTranscript verifies replay reconstructs the transcript from a
+// persisted session's messages (US-024): user text, assistant text, tool
+// calls, and tool results appear in order, so a resumed session renders its
+// prior conversation. A resumed session starts idle (running=false, runID=0).
+func TestReplaySeedsTranscript(t *testing.T) {
+	s := newUIState()
+	history := []agent.AgentMessage{
+		agent.UserMessage{RoleField: agent.RoleUser, Content: agent.ContentList{agent.NewTextContent("read main.go")}},
+		agent.AssistantMessage{
+			RoleField: agent.RoleAssistant,
+			Content:   agent.ContentList{agent.NewTextContent("Reading."), agent.NewToolCallContent("c1", "read", json.RawMessage(`{}`))},
+		},
+		agent.ToolResultMessage{RoleField: agent.RoleToolResult, ToolCallID: "c1", ToolName: "read", Content: agent.ContentList{agent.NewTextContent("package main")}},
+		agent.AssistantMessage{RoleField: agent.RoleAssistant, Content: agent.ContentList{agent.NewTextContent("It is package main.")}},
+	}
+	s.replay(history)
+
+	if s.running || s.runID != 0 {
+		t.Errorf("resumed session must start idle: running=%v runID=%d", s.running, s.runID)
+	}
+	kinds := []entryKind{entryUser, entryAssistant, entryToolCall, entryToolResult, entryAssistant}
+	if len(s.transcript) != len(kinds) {
+		t.Fatalf("transcript len = %d, want %d: %+v", len(s.transcript), len(kinds), s.transcript)
+	}
+	for i, want := range kinds {
+		if s.transcript[i].Kind != want {
+			t.Errorf("transcript[%d].Kind = %d, want %d", i, s.transcript[i].Kind, want)
+		}
+	}
+	if s.transcript[0].Text != "read main.go" {
+		t.Errorf("first entry text = %q", s.transcript[0].Text)
+	}
+	if s.transcript[2].Text != "read" {
+		t.Errorf("tool call entry text = %q, want read", s.transcript[2].Text)
+	}
+	// After replay, a submit starts a fresh run at runID 1 (continues session).
+	s.input = "and now?"
+	if _, start := s.submit(); !start || s.runID != 1 {
+		t.Errorf("submit after replay should start run 1, got runID=%d", s.runID)
+	}
+}


### PR DESCRIPTION
## Summary
- 新增 `internal/session`：JSONL 持久化（首行 header + 每行一条消息），复用 `agent.MessageList` 的 role 判别解码
- 原子写入（tmp + rename）、schema 版本守卫（拒绝更高版本）、时间有序 session id
- `Store` 提供 Save/Load/List/Resume/Append
- CLI 接入 `--list-sessions` / `--resume <id>` / `--continue`，交互式运行结束后持久化会话
- TUI 经 `NewModelWithHistory` 从持久化消息重放 transcript，恢复后正确渲染历史对话

Closes #43

## Test plan
- [x] `go test ./...` 通过（session 7 项 + TUI replay 测试）
- [x] `go build ./...` / `go vet ./...` clean
- [x] 二进制 `--list-sessions` / `--help` 冒烟通过