### PR TITLE
Extract agentcore leaf package from internal/agent

### DIFF
--- a/docs/issue#0074.html
+++ b/docs/issue#0074.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0074</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F2F0EC; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/74">#74</a> &mdash; (1/6) 建立 agentcore 叶子包 &mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Single alias shim file instead of scattered aliases</h3>
+      <p><strong>Ambiguity:</strong> The PRD's transition strategy said "旧 <code>internal/agent</code> 可临时用类型别名 <code>type X = agentcore.X</code> 保持编译" but didn't prescribe where the aliases live.</p>
+      <p><strong>Choice:</strong> One dedicated <code>internal/agent/agentcore_shim.go</code> collects every re-export — type aliases, const re-declarations, constructor <code>var</code> bindings — with a header comment marking it as transitional (removed in later steps).</p>
+      <p><strong>Rationale:</strong> Keeps the 4 unmoved files (providers/headless/stream_response/tool_executor) untouched except for the symbol cut-outs, and makes the shim trivially deletable in US-004/005 when call sites migrate to reference <code>agentcore</code> directly.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Export helpers as ContentToText / LastAssistantOf / EmitFunc</h3>
+      <p><strong>Ambiguity:</strong> The three hoisted symbols (<code>contentToText</code>, <code>lastAssistantOf</code>, <code>emitFunc</code>) are unexported, but once in <code>agentcore</code> they must be reachable across the package boundary.</p>
+      <p><strong>Choice:</strong> Capitalize them in agentcore (<code>ContentToText</code>, <code>LastAssistantOf</code>, <code>EmitFunc</code>) and alias the lowercase names back in the shim (<code>var contentToText = agentcore.ContentToText</code>, <code>type emitFunc = agentcore.EmitFunc</code>).</p>
+      <p><strong>Rationale:</strong> Cross-package visibility requires export; the lowercase aliases keep every existing call site in package <code>agent</code> compiling verbatim. Directly satisfies PRD 陷阱 2 (emitFunc hoist) and the shared-helper hoist.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Generic EventStream via alias + thin wrapper</h3>
+      <p><strong>Ambiguity:</strong> Go generic <em>functions</em> cannot be bound to a <code>var</code>, unlike ordinary functions.</p>
+      <p><strong>Choice:</strong> <code>type EventStream[T any, R any] = agentcore.EventStream[T, R]</code> (generic type alias, Go 1.24+) plus a hand-written wrapper <code>func NewEventStream[T any, R any](buffer int) *agentcore.EventStream[T, R]</code>.</p>
+      <p><strong>Rationale:</strong> Constructors like <code>NewTextContent</code> alias cleanly as <code>var</code>, but the generic <code>NewEventStream</code> needs an explicit wrapper — the only forwarder that isn't a one-liner var.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Hook types placed in helpers.go, not a hooks.go</h3>
+      <p><strong>Spec:</strong> US-001 lists <code>hooks.go</code> among the migrated files and says the hook func types should "统一收敛到 agentcore" without naming the target file.</p>
+      <p><strong>Implemented:</strong> <code>AfterToolCallResult</code> moved with <code>hooks.go</code> (it already lived there), but the func types cut from <code>tool_executor.go</code> (<code>PrepareArgumentsFunc</code>, <code>BeforeToolCallDecision</code>, <code>BeforeToolCallFunc</code>, <code>AfterToolCallFunc</code>) landed in a new <code>agentcore/helpers.go</code> alongside the relocated helpers.</p>
+      <p><strong>Why:</strong> These types originated in <code>tool_executor.go</code>, not <code>hooks.go</code>; grouping them with the other cross-layer relocations keeps hooks.go a verbatim <code>git mv</code> (clean diff) and co-locates all "hoisted from elsewhere" symbols in one reviewable file.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> git mv + rename vs copy-paste</h3>
+      <p><strong>Alternatives:</strong> (a) <code>git mv</code> each leaf file then flip the package clause; (b) create fresh files in agentcore and delete the originals.</p>
+      <p><strong>Chosen:</strong> (a). <strong>Pros:</strong> git tracks the move, so history/blame follow the code and the diff shows a 1-line package-clause change per file. <strong>Cons:</strong> none material.</p>
+      <p><strong>Why it won:</strong> Preserves authorship history across the split — valuable for a 64-file refactor where later archaeology on "why is this type shaped this way" should still resolve.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Keep shim in package agent vs migrate callers now</h3>
+      <p><strong>Alternatives:</strong> (a) alias shim so package agent compiles unchanged this step; (b) update every intra-agent call site to reference <code>agentcore.</code> immediately.</p>
+      <p><strong>Chosen:</strong> (a), per the PRD's bottom-up, one-layer-per-US plan.</p>
+      <p><strong>Why it won:</strong> Bounds each US to a compilable, testable checkpoint. Migrating callers is explicitly US-005's job; doing it now would balloon #74's blast radius and break the incremental verification guarantee.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> helpers.go will be split further in later steps?</h3>
+      <p><code>agentcore/helpers.go</code> currently bundles three unrelated concerns (text flattening, message scanning, hook func types). Confirm whether it should be split (e.g. <code>hooks.go</code> gains the func types, a <code>text.go</code> gains ContentToText) once the dust settles in US-006, or left as-is since it's small.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Shim lifetime</h3>
+      <p><code>agentcore_shim.go</code> is meant to be deleted once callers reference agentcore directly. Verify it is fully removed by the end of US-004/005 and that no external package accidentally starts depending on the <code>agent.*</code> aliases as a stable surface.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agent/agentcore_shim.go
+++ b/internal/agent/agentcore_shim.go
@@ -1,0 +1,147 @@
+// This file re-exports the symbols moved to internal/agentcore (US-001 of the
+// agent package split) via type aliases, const re-declarations, and thin
+// function wrappers, so the remaining files in package agent compile unchanged
+// during the transition. It will be removed as later steps migrate call sites
+// to reference agentcore directly.
+package agent
+
+import "github.com/smallnest/pigo/internal/agentcore"
+
+// --- message.go ---
+
+type (
+	Message           = agentcore.Message
+	AgentMessage      = agentcore.AgentMessage
+	Usage             = agentcore.Usage
+	UserMessage       = agentcore.UserMessage
+	AssistantMessage  = agentcore.AssistantMessage
+	ToolResultMessage = agentcore.ToolResultMessage
+	MessageList       = agentcore.MessageList
+)
+
+const (
+	RoleUser       = agentcore.RoleUser
+	RoleAssistant  = agentcore.RoleAssistant
+	RoleToolResult = agentcore.RoleToolResult
+
+	StopReasonEndTurn = agentcore.StopReasonEndTurn
+	StopReasonToolUse = agentcore.StopReasonToolUse
+	StopReasonLength  = agentcore.StopReasonLength
+	StopReasonError   = agentcore.StopReasonError
+	StopReasonAborted = agentcore.StopReasonAborted
+)
+
+// --- content.go ---
+
+type (
+	Content         = agentcore.Content
+	TextContent     = agentcore.TextContent
+	ThinkingContent = agentcore.ThinkingContent
+	ToolCallContent = agentcore.ToolCallContent
+	ImageContent    = agentcore.ImageContent
+	ContentList     = agentcore.ContentList
+)
+
+const (
+	ContentTypeText     = agentcore.ContentTypeText
+	ContentTypeThinking = agentcore.ContentTypeThinking
+	ContentTypeToolCall = agentcore.ContentTypeToolCall
+	ContentTypeImage    = agentcore.ContentTypeImage
+)
+
+var (
+	NewTextContent     = agentcore.NewTextContent
+	NewThinkingContent = agentcore.NewThinkingContent
+	NewToolCallContent = agentcore.NewToolCallContent
+	NewImageContent    = agentcore.NewImageContent
+)
+
+// --- event.go ---
+
+type (
+	AgentEvent               = agentcore.AgentEvent
+	AgentStartEvent          = agentcore.AgentStartEvent
+	AgentEndEvent            = agentcore.AgentEndEvent
+	TurnStartEvent           = agentcore.TurnStartEvent
+	TurnEndEvent             = agentcore.TurnEndEvent
+	MessageStartEvent        = agentcore.MessageStartEvent
+	MessageUpdateEvent       = agentcore.MessageUpdateEvent
+	MessageEndEvent          = agentcore.MessageEndEvent
+	ToolExecutionStartEvent  = agentcore.ToolExecutionStartEvent
+	ToolExecutionUpdateEvent = agentcore.ToolExecutionUpdateEvent
+	ToolExecutionEndEvent    = agentcore.ToolExecutionEndEvent
+)
+
+const (
+	EventAgentStart          = agentcore.EventAgentStart
+	EventAgentEnd            = agentcore.EventAgentEnd
+	EventTurnStart           = agentcore.EventTurnStart
+	EventTurnEnd             = agentcore.EventTurnEnd
+	EventMessageStart        = agentcore.EventMessageStart
+	EventMessageUpdate       = agentcore.EventMessageUpdate
+	EventMessageEnd          = agentcore.EventMessageEnd
+	EventToolExecutionStart  = agentcore.EventToolExecutionStart
+	EventToolExecutionUpdate = agentcore.EventToolExecutionUpdate
+	EventToolExecutionEnd    = agentcore.EventToolExecutionEnd
+)
+
+// --- event_stream.go ---
+
+type EventStream[T any, R any] = agentcore.EventStream[T, R]
+
+var ErrStreamIncomplete = agentcore.ErrStreamIncomplete
+
+// NewEventStream constructs an agentcore.EventStream with the given buffer size.
+// It is a thin wrapper because generic functions cannot be aliased with a var.
+func NewEventStream[T any, R any](buffer int) *agentcore.EventStream[T, R] {
+	return agentcore.NewEventStream[T, R](buffer)
+}
+
+// --- tool.go ---
+
+type (
+	AgentContext      = agentcore.AgentContext
+	ToolExecutionMode = agentcore.ToolExecutionMode
+	ToolUpdateFunc    = agentcore.ToolUpdateFunc
+	AgentTool         = agentcore.AgentTool
+	AgentToolCall     = agentcore.AgentToolCall
+	AgentToolResult   = agentcore.AgentToolResult
+)
+
+const (
+	ToolExecutionParallel   = agentcore.ToolExecutionParallel
+	ToolExecutionSequential = agentcore.ToolExecutionSequential
+)
+
+// --- hooks.go ---
+
+type (
+	ThinkingLevel       = agentcore.ThinkingLevel
+	ThinkingLevelMap    = agentcore.ThinkingLevelMap
+	AfterToolCallResult = agentcore.AfterToolCallResult
+	AgentLoopTurnUpdate = agentcore.AgentLoopTurnUpdate
+)
+
+const (
+	ThinkingOff     = agentcore.ThinkingOff
+	ThinkingMinimal = agentcore.ThinkingMinimal
+	ThinkingLow     = agentcore.ThinkingLow
+	ThinkingMedium  = agentcore.ThinkingMedium
+	ThinkingHigh    = agentcore.ThinkingHigh
+	ThinkingXHigh   = agentcore.ThinkingXHigh
+)
+
+// --- helpers.go (relocated symbols) ---
+
+type (
+	emitFunc               = agentcore.EmitFunc
+	PrepareArgumentsFunc   = agentcore.PrepareArgumentsFunc
+	BeforeToolCallDecision = agentcore.BeforeToolCallDecision
+	BeforeToolCallFunc     = agentcore.BeforeToolCallFunc
+	AfterToolCallFunc      = agentcore.AfterToolCallFunc
+)
+
+var (
+	contentToText   = agentcore.ContentToText
+	lastAssistantOf = agentcore.LastAssistantOf
+)

--- a/internal/agent/headless.go
+++ b/internal/agent/headless.go
@@ -129,16 +129,6 @@ func RunHeadless(ctx context.Context, agentCtx *AgentContext, cfg HeadlessConfig
 	return nil
 }
 
-// lastAssistantOf returns a pointer to the last AssistantMessage in msgs, or nil.
-func lastAssistantOf(msgs []AgentMessage) *AssistantMessage {
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if a, ok := msgs[i].(AssistantMessage); ok {
-			return &a
-		}
-	}
-	return nil
-}
-
 // writeEventJSON serializes one AgentEvent as a single line of JSON, terminated
 // by a newline, onto w. The envelope always carries a "type" discriminant so a
 // consumer can dispatch without positional knowledge.

--- a/internal/agent/providers.go
+++ b/internal/agent/providers.go
@@ -176,20 +176,6 @@ func encodeOpenAITools(tools []AgentTool) []map[string]any {
 	return out
 }
 
-// contentToText flattens text blocks of a content list into a single string,
-// the lowest-common-denominator representation accepted by every OpenAI-
-// compatible gateway. Non-text blocks (thinking, tool calls) are surfaced
-// through their own fields, so they are skipped here.
-func contentToText(list ContentList) string {
-	var b strings.Builder
-	for _, c := range list {
-		if tc, ok := c.(TextContent); ok {
-			b.WriteString(tc.Text)
-		}
-	}
-	return b.String()
-}
-
 // ---------------------------------------------------------------------------
 // Anthropic-compatible driver (Bedrock).
 // ---------------------------------------------------------------------------

--- a/internal/agent/stream_response.go
+++ b/internal/agent/stream_response.go
@@ -39,9 +39,6 @@ type LoopConfig struct {
 	Extra map[string]any
 }
 
-// emitFunc emits a loop-level AgentEvent honoring cancellation.
-type emitFunc func(ctx context.Context, ev AgentEvent) error
-
 // streamAssistantResponse runs one assistant turn: it builds the request from
 // agentCtx, streams the provider response, back-fills the partial into
 // agentCtx.Messages, and returns the final assistant message. The sequence

--- a/internal/agent/tool_executor.go
+++ b/internal/agent/tool_executor.go
@@ -16,28 +16,6 @@ import (
 	"fmt"
 )
 
-// PrepareArgumentsFunc optionally rewrites a tool's raw arguments before schema
-// validation (e.g. injecting defaults). An error aborts the call with an error
-// result. Optional (nil = identity).
-type PrepareArgumentsFunc func(ctx context.Context, toolName string, args json.RawMessage) (json.RawMessage, error)
-
-// BeforeToolCallDecision is the optional result of the beforeToolCall hook. When
-// Block is true the tool is not executed and an error result is produced;
-// Content/Details override the default block message when set.
-type BeforeToolCallDecision struct {
-	Block   bool
-	Content *ContentList
-	Details *any
-}
-
-// BeforeToolCallFunc runs after validation and may block the call (permission /
-// sandbox checks, FR-4/FR-26). Returning nil allows the call. Optional.
-type BeforeToolCallFunc func(ctx context.Context, call AgentToolCall) *BeforeToolCallDecision
-
-// AfterToolCallFunc runs after execution and may override the result
-// field-by-field via AfterToolCallResult (FR-5, no deep merge). Optional.
-type AfterToolCallFunc func(ctx context.Context, call AgentToolCall, result AgentToolResult, isError bool) *AfterToolCallResult
-
 // ToolExecutorConfig holds the registry and the optional per-phase hooks. Every
 // hook is optional (nil = default behavior).
 type ToolExecutorConfig struct {

--- a/internal/agentcore/content.go
+++ b/internal/agentcore/content.go
@@ -1,5 +1,7 @@
-// Package agent defines the core data types and control flow for the pigo
-// agent harness, a Go reimplementation of the pi agent loop.
+// Package agentcore defines the core "leaf" data types and control flow for the
+// pigo agent harness, a Go reimplementation of the pi agent loop. It is the
+// foundation package that every other agent sub-package depends on and imports
+// nothing from them.
 //
 // This file defines the Content model: a sealed interface implemented by the
 // four content block kinds (text, thinking, toolCall, image). Because Go's
@@ -7,7 +9,7 @@
 // containers holding []Content implement custom UnmarshalJSON that peeks at the
 // "type" field and decodes into the concrete struct. Mirrors pi's discriminated
 // union (packages/ai/src/types.ts) as interface + type switch.
-package agent
+package agentcore
 
 import (
 	"encoding/json"

--- a/internal/agentcore/event.go
+++ b/internal/agentcore/event.go
@@ -1,4 +1,4 @@
-package agent
+package agentcore
 
 // AgentEvent is the sealed interface implemented by every event the loop emits.
 // Consumers dispatch with a type switch, consistent with Content. pigo covers

--- a/internal/agentcore/event_stream.go
+++ b/internal/agentcore/event_stream.go
@@ -1,4 +1,4 @@
-package agent
+package agentcore
 
 import (
 	"context"

--- a/internal/agentcore/event_stream_test.go
+++ b/internal/agentcore/event_stream_test.go
@@ -1,4 +1,4 @@
-package agent
+package agentcore
 
 import (
 	"context"

--- a/internal/agentcore/helpers.go
+++ b/internal/agentcore/helpers.go
@@ -1,0 +1,56 @@
+package agentcore
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+)
+
+// ContentToText flattens text blocks of a content list into a single string,
+// the lowest-common-denominator representation accepted by every OpenAI-
+// compatible gateway. Non-text blocks (thinking, tool calls) are surfaced
+// through their own fields, so they are skipped here.
+func ContentToText(list ContentList) string {
+	var b strings.Builder
+	for _, c := range list {
+		if tc, ok := c.(TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}
+
+// LastAssistantOf returns a pointer to the last AssistantMessage in msgs, or nil.
+func LastAssistantOf(msgs []AgentMessage) *AssistantMessage {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if a, ok := msgs[i].(AssistantMessage); ok {
+			return &a
+		}
+	}
+	return nil
+}
+
+// EmitFunc emits a loop-level AgentEvent honoring cancellation.
+type EmitFunc func(ctx context.Context, ev AgentEvent) error
+
+// PrepareArgumentsFunc optionally rewrites a tool's raw arguments before schema
+// validation (e.g. injecting defaults). An error aborts the call with an error
+// result. Optional (nil = identity).
+type PrepareArgumentsFunc func(ctx context.Context, toolName string, args json.RawMessage) (json.RawMessage, error)
+
+// BeforeToolCallDecision is the optional result of the beforeToolCall hook. When
+// Block is true the tool is not executed and an error result is produced;
+// Content/Details override the default block message when set.
+type BeforeToolCallDecision struct {
+	Block   bool
+	Content *ContentList
+	Details *any
+}
+
+// BeforeToolCallFunc runs after validation and may block the call (permission /
+// sandbox checks, FR-4/FR-26). Returning nil allows the call. Optional.
+type BeforeToolCallFunc func(ctx context.Context, call AgentToolCall) *BeforeToolCallDecision
+
+// AfterToolCallFunc runs after execution and may override the result
+// field-by-field via AfterToolCallResult (FR-5, no deep merge). Optional.
+type AfterToolCallFunc func(ctx context.Context, call AgentToolCall, result AgentToolResult, isError bool) *AfterToolCallResult

--- a/internal/agentcore/hooks.go
+++ b/internal/agentcore/hooks.go
@@ -1,4 +1,4 @@
-package agent
+package agentcore
 
 // ThinkingLevel is the unified reasoning-effort enum (agent layer). It keeps
 // pi's full 6 levels; providers map it to their own wire format via a

--- a/internal/agentcore/message.go
+++ b/internal/agentcore/message.go
@@ -1,4 +1,4 @@
-package agent
+package agentcore
 
 import (
 	"encoding/json"

--- a/internal/agentcore/tool.go
+++ b/internal/agentcore/tool.go
@@ -1,4 +1,4 @@
-package agent
+package agentcore
 
 import (
 	"context"

--- a/internal/agentcore/types_test.go
+++ b/internal/agentcore/types_test.go
@@ -1,4 +1,4 @@
-package agent
+package agentcore
 
 import (
 	"encoding/json"


### PR DESCRIPTION
## Summary
- Move leaf types (message/content/event/event_stream/tool/hooks + their tests) into a new `internal/agentcore` package
- Hoist cross-layer helpers `ContentToText`, `LastAssistantOf`, `EmitFunc` and hook func types (`PrepareArgumentsFunc`/`BeforeToolCallDecision`/`BeforeToolCallFunc`/`AfterToolCallFunc`) into agentcore (PRD 陷阱 2 & 3)
- Keep the old `internal/agent` package compiling unchanged via an alias shim (`agentcore_shim.go`), to be removed in later steps
- `agentcore` is a clean leaf: zero internal pigo dependencies

Closes #74

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` (agent/agentcore/session/tui all pass)
- [x] `gofmt -l` clean
- [x] `go list -deps ./internal/agentcore` confirms no internal deps