### PR TITLE
Change default model to openrouter/free

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -36,7 +36,7 @@ func main() {
 	)
 	flag.StringVar(&prompt, "p", "", "prompt to run in headless print mode")
 	flag.StringVar(&prompt, "print", "", "prompt to run in headless print mode")
-	flag.StringVar(&model, "model", "openai/gpt-4o", "model id to run against")
+	flag.StringVar(&model, "model", "openrouter/free", "model id to run against")
 	flag.StringVar(&baseURL, "base-url", "", "override provider base URL (e.g. local Ollama)")
 	flag.StringVar(&outputFmt, "output-format", "text", "output format: text | stream-json")
 	flag.BoolVar(&noTools, "no-tools", false, "disable the built-in file/shell tools")

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -51,7 +51,7 @@ type ConfigLayer struct {
 // DefaultConfigLayer is the base layer applied before all others. It gives a
 // usable configuration out of the box.
 func DefaultConfigLayer() ConfigLayer {
-	model := "openai/gpt-4o"
+	model := "openrouter/free"
 	provider := "openrouter"
 	mode := string(agentcore.ToolExecutionParallel)
 	level := string(agentcore.ThinkingMedium)


### PR DESCRIPTION
## Summary
- Switch the built-in default model id from `openai/gpt-4o` to `openrouter/free`
- Applied in both the CLI flag default (`cmd/pigo/main.go`) and the base config layer (`internal/runtime/config.go`)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`