### PR TITLE
Replace stdlib flag with spf13/pflag

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -12,10 +12,11 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"strings"
+
+	flag "github.com/spf13/pflag"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
@@ -34,8 +35,7 @@ func main() {
 		resumeID     string
 		continueLast bool
 	)
-	flag.StringVar(&prompt, "p", "", "prompt to run in headless print mode")
-	flag.StringVar(&prompt, "print", "", "prompt to run in headless print mode")
+	flag.StringVarP(&prompt, "print", "p", "", "prompt to run in headless print mode")
 	flag.StringVar(&model, "model", "openrouter/free", "model id to run against")
 	flag.StringVar(&baseURL, "base-url", "", "override provider base URL (e.g. local Ollama)")
 	flag.StringVar(&outputFmt, "output-format", "text", "output format: text | stream-json")

--- a/docs/issue#0087.html
+++ b/docs/issue#0087.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0087</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F2F0EC; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/87">#87</a> &mdash; 用 spf13/pflag 替换标准库 flag &mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Import pflag under the alias <code>flag</code></h3>
+      <p><strong>Ambiguity:</strong> The AC mandates the switch to pflag but doesn't say whether to import it as <code>pflag</code> and rewrite every call site, or alias it as <code>flag</code>.</p>
+      <p><strong>Choice:</strong> <code>flag "github.com/spf13/pflag"</code> — keep the local identifier <code>flag</code>, so every call site (<code>flag.StringVar</code>, <code>flag.Parse</code>, <code>flag.Args</code>) stays textually unchanged except the one <code>StringVarP</code> line.</p>
+      <p><strong>Rationale:</strong> pflag is intentionally a drop-in for the stdlib API; aliasing minimizes the diff to exactly the semantic changes (the <code>-p</code>/<code>--print</code> merge), making the migration reviewable at a glance and leaving no stray <code>pflag.</code> qualifiers to reconcile.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Collapse the two <code>-p</code>/<code>--print</code> bindings into one <code>StringVarP</code></h3>
+      <p><strong>Ambiguity:</strong> stdlib registered <code>-p</code> and <code>--print</code> as two independent flags both writing <code>&prompt</code>. pflag models short+long as a single flag, so the AC explicitly asked for <code>StringVarP</code>.</p>
+      <p><strong>Choice:</strong> <code>flag.StringVarP(&prompt, "print", "p", "", "...")</code> — <code>print</code> is the long name, <code>p</code> the short.</p>
+      <p><strong>Rationale:</strong> This is pflag's canonical idiom and yields the correct combined usage line <code>-p, --print string</code>. Two separate <code>StringVar</code> calls would either collide or produce a duplicate-flag panic under pflag.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">None</span> Implementation followed the spec as written</h3>
+      <p>Every AC item was met literally: pflag added and version-locked, all 9 flags migrated with names/defaults intact, <code>-p</code>/<code>--print</code> via <code>StringVarP</code>, <code>Parse</code>/<code>Args</code> switched, POSIX behavior accepted, build/vet/test/gofmt green, manual CLI checks confirmed.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Ran <code>go mod tidy</code> to promote pflag from indirect to direct</h3>
+      <p><strong>Alternatives:</strong> (a) leave <code>go get</code>'s initial <code>// indirect</code> marker on pflag; (b) run <code>go mod tidy</code> to reclassify it as a direct dependency.</p>
+      <p><strong>Chosen:</strong> (b).</p>
+      <p><strong>Why it won:</strong> pflag is now imported directly by <code>cmd/pigo/main.go</code>, so the <code>// indirect</code> comment <code>go get</code> left behind was factually wrong. <code>go mod tidy</code> moved it into the direct-require block, keeping <code>go.mod</code> honest and preventing a future <code>tidy</code> from producing a spurious diff.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Single-dash long options now rejected (accepted POSIX change)</h3>
+      <p>Per your confirmation, this is intentional: <code>pigo -model x</code> (single-dash long option, previously accepted by stdlib <code>flag</code>) no longer works — long options require <code>--model</code>. Verified the binary now prints usage instead of honoring <code>-model</code>. Confirm no shipped scripts, README examples, or CI invocations rely on single-dash long options; if any do, they need updating to <code>--</code>.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> pflag error-exit behavior differs subtly from stdlib</h3>
+      <p>pflag and stdlib <code>flag</code> both print usage on an unknown flag, but exit-code and error-message wording differ slightly. The command's own <code>os.Exit(1)</code> paths (no prompt in a pipe, etc.) are unaffected since they don't depend on the flag library. Worth a glance if any test or tooling asserts on exact CLI error text — none currently do (test suite green).</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.27rc1
 require (
 	charm.land/bubbletea/v2 v2.0.8
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+	github.com/spf13/pflag v1.0.10
 	golang.org/x/text v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 	mvdan.cc/sh/v3 v3.13.1

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=


### PR DESCRIPTION
## Summary
- Migrate `cmd/pigo/main.go` CLI parsing from stdlib `flag` to [`github.com/spf13/pflag`](https://github.com/spf13/pflag), imported under the `flag` alias to keep the diff minimal
- Collapse the two `-p` / `--print` stdlib bindings into a single pflag `StringVarP` (short `p`, long `print`)
- All 9 flag names and defaults preserved (`--model` default `openrouter/free`, `--output-format` default `text`, etc.)
- Accepts pflag's POSIX behavior: long options require `--`; single-dash long options (`-model`) are no longer honored (intentional, per issue)
- `go mod tidy` promotes pflag to a direct dependency

Closes #87

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` (all green)
- [x] `gofmt -l cmd/ internal/` (clean)
- [x] Manual: `-p "hi"`, `--model x`, `--list-sessions`, positional `hello world`, usage line shows `-p, --print`