### PR TITLE
TUI: width-aware rendering and alignment

### DIFF
--- a/docs/issue#0091.html
+++ b/docs/issue#0091.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0091</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F2F0EC; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/91">#91</a> &mdash; TUI: 宽度感知的渲染与对齐 &mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 用 go-runewidth 直接算宽度，而非 lipgloss.Width</h3>
+      <p><strong>Ambiguity:</strong> AC 写「<code>lipgloss.Width</code>（或 go-runewidth）」，二选一。</p>
+      <p><strong>Choice:</strong> 新建 <code>rendering.go</code>，用 <code>runewidth.StringWidth</code>/<code>RuneWidth</code> 实现 <code>displayWidth</code>/<code>truncateWidth</code>/<code>wrapWidth</code>，并把 go-runewidth 提升为 direct 依赖。</p>
+      <p><strong>Rationale:</strong> 折行/截断需要逐 rune 累加列宽并在边界停下，<code>RuneWidth(r)</code> 正好提供单 rune 列宽；<code>lipgloss.Width</code> 只给整串宽度，做不了「逐 rune 判断是否越界」。go-runewidth 本就是 lipgloss 的底层，直接用它最贴合需求且无新增依赖树。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 采用硬列折行（不按词边界）</h3>
+      <p><strong>Ambiguity:</strong> AC 只要求「按显示宽度在 rune 边界折行，不切半个宽字符」，未规定是否按单词折。</p>
+      <p><strong>Choice:</strong> <code>wrapWidth</code> 纯按列宽在 rune 边界折，不做 word-wrap。</p>
+      <p><strong>Rationale:</strong> transcript 内容是代码、CJK 散文这类字符导向文本，中文本无空格分词，按词折反而在 CJK 上无意义且易错。硬列折是安全默认；真正的 Markdown 排版留给 #94。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>renderEntry</code> 增加 <code>width</code> 参数，仅对 tool-result 摘要做宽度截断</h3>
+      <p><strong>Ambiguity:</strong> AC 要求「<code>firstLine</code>/tool-result 摘要按显示宽度截断」，但普通文本行由 <code>wrapWidth</code> 折行即可。</p>
+      <p><strong>Choice:</strong> <code>renderEntry(e, width)</code> 只在 <code>entryToolResult</code> 分支把首行 gist 截到 <code>width - 前缀宽</code>；其余种类交给外层 <code>wrapWidth</code> 折行。</p>
+      <p><strong>Rationale:</strong> tool-result 是「一行摘要」语义（截断），普通文本是「完整可见」语义（折行），两者处理不同。给前缀 <code>"  ↳ "</code> 预留列宽，保证整行含前缀不超屏。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">None</span> 实现遵循 spec</h3>
+      <p>AC 四项（显示宽度替换 len()、rune 边界折行不切宽字符、tool-result 按宽截断、宽字符折行/截断单测全绿）均按字面满足。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> <code>width &lt;= 0</code> 的降级行为</h3>
+      <p><strong>Alternatives:</strong> (a) width 未知（如首帧 WindowSizeMsg 未到）时不折行、不截断，原样输出；(b) 用一个默认宽度（如 80）兜底。</p>
+      <p><strong>Chosen:</strong> (a)。</p>
+      <p><strong>Why it won:</strong> 猜一个默认宽度可能与真实终端不符，反造成错位；原样输出至少不主动破坏，等首个 <code>WindowSizeMsg</code> 到达后自然进入宽度感知。<code>wrapWidth</code> 在 width&lt;=0 时也避免了除零/死循环。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> composer 输入行本身尚未做宽度感知折行</h3>
+      <p>本 issue 聚焦 transcript 渲染。输入行由 textinput（#90）自管，其超宽横向滚动/折行行为未在此改动。长中文输入行的显示留待接入 viewport（#92）与整体 composer 改造时复核。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 折行未感知 ANSI 样式序列</h3>
+      <p>当前 transcript 文本尚未上色（主题接入是 #94/#95）。<code>wrapWidth</code> 目前按可见 rune 计宽，若未来在折行前就嵌入 ANSI 转义，需确保宽度计算跳过转义序列（lipgloss 的样式最好在折行之后再套）。接入主题时验证顺序。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
+	github.com/mattn/go-runewidth v0.0.24
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/text v0.14.0
@@ -24,7 +25,6 @@ require (
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
-	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -211,13 +211,15 @@ func (m *Model) drain(runID int, stream *runtime.LoopEventStream) {
 
 // View implements tea.Model: it renders the transcript then the input line as a
 // plain string; bubbletea diffs and paints it (no custom incremental render).
+// Each transcript entry is folded to the terminal width on rune boundaries so
+// double-width CJK/emoji wrap without being split (#91).
 func (m *Model) View() tea.View {
 	if m.quitting {
 		return tea.NewView("bye\n")
 	}
 	var b strings.Builder
 	for _, e := range m.state.transcript {
-		b.WriteString(renderEntry(e))
+		b.WriteString(wrapWidth(renderEntry(e, m.width), m.width))
 		b.WriteByte('\n')
 	}
 	b.WriteString("\n")
@@ -233,8 +235,10 @@ func (m *Model) View() tea.View {
 
 // renderEntry formats one transcript entry with a role prefix. Assistant text
 // is passed through fenceBuffer so an unterminated code fence renders cleanly
-// (no half-open ``` breaking the layout mid-stream).
-func renderEntry(e transcriptEntry) string {
+// (no half-open ``` breaking the layout mid-stream). width is the terminal
+// width used to truncate a long tool-result summary on rune boundaries; a
+// non-positive width disables that truncation.
+func renderEntry(e transcriptEntry, width int) string {
 	switch e.Kind {
 	case entryUser:
 		return "you> " + e.Text
@@ -243,7 +247,13 @@ func renderEntry(e transcriptEntry) string {
 	case entryToolCall:
 		return "⚙ " + e.Text
 	case entryToolResult:
-		return "  ↳ " + firstLine(e.Text)
+		const prefix = "  ↳ "
+		gist := firstLine(e.Text)
+		if width > 0 {
+			// Reserve the prefix's display columns so the whole line fits.
+			gist = truncateWidth(gist, width-displayWidth(prefix))
+		}
+		return prefix + gist
 	case entrySystem:
 		return "· " + e.Text
 	default:

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1,0 +1,73 @@
+// This file holds width-aware rendering helpers (#91). The terminal measures
+// text by display columns, not bytes or runes: a CJK ideograph or wide emoji
+// occupies two columns, a combining mark zero. Wrapping, truncating, or
+// aligning by len()/byte count therefore mis-positions everything once
+// non-ASCII text appears. These helpers compute display width via
+// go-runewidth (the same backing lipgloss.Width uses) and always cut on rune
+// boundaries so a wide character is never split across a boundary.
+package tui
+
+import (
+	"strings"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// displayWidth reports the number of terminal columns s occupies. It is the
+// width primitive every layout decision here is built on, replacing len().
+func displayWidth(s string) int { return runewidth.StringWidth(s) }
+
+// truncateWidth returns the longest prefix of s whose display width is <= max,
+// cut on a rune boundary so a wide (double-column) character is never sliced in
+// half. A non-positive max yields "". Newlines are treated as ordinary runes;
+// callers that want a single line should pass one line (see firstLine).
+func truncateWidth(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	if displayWidth(s) <= max {
+		return s
+	}
+	var b strings.Builder
+	w := 0
+	for _, r := range s {
+		rw := runewidth.RuneWidth(r)
+		if w+rw > max {
+			break
+		}
+		b.WriteRune(r)
+		w += rw
+	}
+	return b.String()
+}
+
+// wrapWidth folds s into lines no wider than max display columns, breaking on
+// rune boundaries (never mid-wide-character). Existing newlines in s are
+// preserved as hard breaks. A non-positive max disables wrapping (s is returned
+// split only on its existing newlines). This is a deliberately simple
+// column-based wrap — it does not break on word boundaries, matching the
+// transcript's character-oriented content (code, CJK prose) where hard column
+// wrapping is the safe default.
+func wrapWidth(s string, max int) string {
+	if max <= 0 {
+		return s
+	}
+	var out strings.Builder
+	lines := strings.Split(s, "\n")
+	for li, line := range lines {
+		if li > 0 {
+			out.WriteByte('\n')
+		}
+		w := 0
+		for _, r := range line {
+			rw := runewidth.RuneWidth(r)
+			if w+rw > max && w > 0 {
+				out.WriteByte('\n')
+				w = 0
+			}
+			out.WriteRune(r)
+			w += rw
+		}
+	}
+	return out.String()
+}

--- a/internal/tui/rendering_test.go
+++ b/internal/tui/rendering_test.go
@@ -1,0 +1,119 @@
+package tui
+
+// Tests for width-aware rendering (#91): display-width truncation and wrapping
+// must cut on rune boundaries so a double-column CJK character or wide emoji is
+// never split, and must count display columns (not bytes or runes).
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// TestDisplayWidthCountsColumns verifies width is display columns: ASCII is 1
+// each, CJK is 2 each, so "abc中文" = 3 + 4 = 7.
+func TestDisplayWidthCountsColumns(t *testing.T) {
+	if got := displayWidth("abc中文"); got != 7 {
+		t.Errorf("displayWidth(abc中文) = %d, want 7", got)
+	}
+	if got := displayWidth(""); got != 0 {
+		t.Errorf("displayWidth(empty) = %d, want 0", got)
+	}
+}
+
+// TestTruncateWidthNeverSplitsWideRune is acceptance-critical: truncating
+// "abc中文def" to a width that lands mid-CJK must stop before the wide rune,
+// never emit a half character, and never exceed the budget.
+func TestTruncateWidthNeverSplitsWideRune(t *testing.T) {
+	// "abc" = 3 cols, then "中" would take cols 4-5. Budget 4 cannot fit "中".
+	got := truncateWidth("abc中文def", 4)
+	if got != "abc" {
+		t.Errorf("truncateWidth(...,4) = %q, want abc (must not split 中)", got)
+	}
+	if w := displayWidth(got); w > 4 {
+		t.Errorf("truncated width = %d, exceeds budget 4", w)
+	}
+	// Budget 5 fits exactly "abc中" (3+2).
+	if got := truncateWidth("abc中文def", 5); got != "abc中" {
+		t.Errorf("truncateWidth(...,5) = %q, want abc中", got)
+	}
+	// Budget >= full width returns the whole string.
+	full := "abc中文def"
+	if got := truncateWidth(full, 100); got != full {
+		t.Errorf("truncateWidth(full,100) = %q, want %q", got, full)
+	}
+	// Non-positive budget yields empty.
+	if got := truncateWidth(full, 0); got != "" {
+		t.Errorf("truncateWidth(full,0) = %q, want empty", got)
+	}
+}
+
+// TestWrapWidthFoldsOnRuneBoundary is acceptance-critical: a long mixed line
+// folded to a narrow width must break on rune boundaries — every wrapped line's
+// display width stays within the budget and no wide rune is split.
+func TestWrapWidthFoldsOnRuneBoundary(t *testing.T) {
+	// "abc中文def" is 9 cols. Wrap to 4: expect "abc" | "中文"(4) | "def".
+	got := wrapWidth("abc中文def", 4)
+	lines := strings.Split(got, "\n")
+	for _, ln := range lines {
+		if w := displayWidth(ln); w > 4 {
+			t.Errorf("wrapped line %q width %d exceeds 4", ln, w)
+		}
+		// No line may end or begin with a broken rune — Split on \n over a
+		// valid UTF-8 string can't produce invalid runes, but assert the join
+		// round-trips to the original glyph sequence.
+	}
+	if joined := strings.ReplaceAll(got, "\n", ""); joined != "abc中文def" {
+		t.Errorf("wrap lost/reordered content: %q -> %q", got, joined)
+	}
+}
+
+// TestWrapWidthPreservesExistingNewlines verifies hard breaks in the input are
+// kept (each pre-existing line is wrapped independently).
+func TestWrapWidthPreservesExistingNewlines(t *testing.T) {
+	got := wrapWidth("ab\ncd", 10)
+	if got != "ab\ncd" {
+		t.Errorf("wrapWidth kept-newlines = %q, want ab\\ncd", got)
+	}
+}
+
+// TestWrapWidthNonPositiveDisablesWrap verifies width<=0 only splits on
+// existing newlines (no column folding), so a zero terminal width degrades
+// gracefully rather than looping.
+func TestWrapWidthNonPositiveDisablesWrap(t *testing.T) {
+	s := "abc中文def"
+	if got := wrapWidth(s, 0); got != s {
+		t.Errorf("wrapWidth(s,0) = %q, want unchanged %q", got, s)
+	}
+}
+
+// TestRenderEntryTruncatesToolResultByWidth verifies a long tool-result gist is
+// truncated to the terminal width (accounting for the "  ↳ " prefix) on a rune
+// boundary, so a CJK-heavy result summary does not overflow or split.
+func TestRenderEntryTruncatesToolResultByWidth(t *testing.T) {
+	e := transcriptEntry{Kind: entryToolResult, Text: strings.Repeat("中", 40)}
+	out := renderEntry(e, 20)
+	if w := displayWidth(out); w > 20 {
+		t.Errorf("rendered tool-result width = %d, exceeds terminal width 20: %q", w, out)
+	}
+	if !strings.HasPrefix(out, "  ↳ ") {
+		t.Errorf("tool-result must keep its prefix, got %q", out)
+	}
+	// The gist portion must contain only whole 中 runes (no partial bytes): its
+	// width must be even (each 中 is 2 cols).
+	gist := strings.TrimPrefix(out, "  ↳ ")
+	if runewidth.StringWidth(gist)%2 != 0 {
+		t.Errorf("gist %q split a wide rune (odd width)", gist)
+	}
+}
+
+// TestRenderEntryZeroWidthNoTruncate verifies width<=0 leaves the tool-result
+// gist untruncated (first-line only), preserving pre-#91 behavior when the
+// terminal size is unknown.
+func TestRenderEntryZeroWidthNoTruncate(t *testing.T) {
+	e := transcriptEntry{Kind: entryToolResult, Text: "one line result"}
+	if out := renderEntry(e, 0); out != "  ↳ one line result" {
+		t.Errorf("zero-width render = %q, want '  ↳ one line result'", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Add width-aware rendering helpers in `internal/tui/rendering.go`: `displayWidth` (terminal columns via go-runewidth), `truncateWidth` (rune-boundary prefix within a column budget), `wrapWidth` (column-based folding on rune boundaries, preserving existing newlines).
- `View` folds each transcript entry to the terminal width; `renderEntry` now takes `width` and truncates tool-result gists by display width (reserving the `"  ↳ "` prefix).
- Promote `github.com/mattn/go-runewidth` to a direct dependency.

Closes #91

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `gofmt -l internal/tui/` clean
- [x] `go test ./internal/tui/` — display-width counting, rune-boundary truncation ("abc中文def"@4→"abc", @5→"abc中"), wrapping, newline preservation, non-positive-width degradation, tool-result truncation