### PR TITLE
TUI: viewport scrolling for long transcripts

### DIFF
--- a/docs/issue#0092.html
+++ b/docs/issue#0092.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0092</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F2F0EC; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/92">#92</a> &mdash; TUI: 视口滚动浏览长对话 &mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 用 bubbles/v2/viewport 承载 transcript，而非自建 chatScrollOffset</h3>
+      <p><strong>Ambiguity:</strong> AC 写「引入 <code>viewport</code>（或等价的 <code>chatScrollOffset</code> 滚动状态）」，二选一。</p>
+      <p><strong>Choice:</strong> 在 <code>Model</code> 里加 <code>viewport.Model</code> 字段，每次 transcript 变化调 <code>refreshViewport()</code> 把折行后的整段文本 <code>SetContent</code> 进视口，由视口负责裁剪与滚动。</p>
+      <p><strong>Rationale:</strong> viewport 已实现 PgUp/PgDn/方向键、<code>AtBottom</code>、<code>GotoBottom</code>、resize 等全部所需能力，自己维护 offset 等于重写它且更易出 off-by-one。与 #90 textinput 一样，widget 放在 Model 层，<code>uiState</code> 保持 framework-free（FR-14）。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> follow-tail 状态放在 Model，靠 <code>AtBottom()</code> 推导</h3>
+      <p><strong>Ambiguity:</strong> AC 要求「在底部则自动跟随，已上滚则不打断」，未规定如何判定"在底部"。</p>
+      <p><strong>Choice:</strong> Model 持一个 <code>follow bool</code>：新内容到达时若 <code>follow</code> 则 <code>GotoBottom()</code>；滚动键处理后用 <code>m.viewport.AtBottom()</code> 重算 <code>follow</code>。提交(steering)消息回显时强制 <code>follow=true</code> 以便用户看到自己的输入。</p>
+      <p><strong>Rationale:</strong> 把"是否在底部"交给视口的权威判断，避免自己累计行数判断底部的漂移；用户上滚 → <code>AtBottom()</code> 为假 → 停止跟随；滚回底部 → 为真 → 自动重新跟随，恰好满足 AC 的双向语义。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 视口高度 = 窗口高度 − 2 行 composer 预留</h3>
+      <p><strong>Ambiguity:</strong> AC 要求「resize 时视口尺寸更新，渲染不溢出」，未给出具体高度分配。</p>
+      <p><strong>Choice:</strong> 常量 <code>composerReservedRows = 2</code>（一空行 + "> " 输入行），视口高 = <code>height - 2</code>（下限 1）。<code>WindowSizeMsg</code> 里同步 <code>SetWidth</code>/<code>SetHeight</code>。</p>
+      <p><strong>Rationale:</strong> 固定预留保证输入行永不被高 transcript 挤出屏幕，且 resize 时随窗口重算，避免溢出。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">None</span> 实现遵循 spec</h3>
+      <p>AC 五项（引入 viewport、键盘上下滚动、底部自动跟随/上滚不打断、resize 更新视口、build+test 全绿）均按字面满足。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 首帧（WindowSizeMsg 未到）的降级渲染</h3>
+      <p><strong>Alternatives:</strong> (a) 视口未就绪时 <code>View</code> 回退为直接 dump 整段 transcript（#91 前行为）；(b) 用默认尺寸先建视口。</p>
+      <p><strong>Chosen:</strong> (a)，以 <code>vpReady</code> 标志切换。</p>
+      <p><strong>Why it won:</strong> 猜默认尺寸可能与真实终端不符，造成首帧错位；直接 dump 至少不破坏，首个 <code>WindowSizeMsg</code> 到达后自然进入视口模式。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 每次内容变化整体 SetContent 重渲</h3>
+      <p><strong>Alternatives:</strong> (a) 每次 transcript 变化重新拼接整段并 <code>SetContent</code>；(b) 增量只追加新行。</p>
+      <p><strong>Chosen:</strong> (a)。</p>
+      <p><strong>Why it won:</strong> 流式 assistant 消息是"就地增长"（<code>upsertStreamingAssistant</code> 覆盖末条），增量追加难以表达"改写最后一行"，整体重渲最简单且正确；transcript 规模对终端渲染而言开销可忽略。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 滚动键与 composer 编辑键的边界</h3>
+      <p>目前把 <code>up/down/pgup/pgdown/ctrl+u/ctrl+d</code> 全部划给视口滚动，因此这些键不再进入 textinput。若后续希望方向键在输入行内移动光标（多行输入场景），需要区分"输入为空/多行"来决定归属。当前单行 composer 下此取舍无碍。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 鼠标滚轮未启用</h3>
+      <p>viewport 支持 <code>MouseWheelEnabled</code>，但需在 bubbletea 程序层开启鼠标上报。本 issue 只做键盘滚动（AC 要求），鼠标滚轮留待后续按需接入。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -14,11 +14,18 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/textinput"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/runtime"
 )
+
+// composerReservedRows is the number of terminal rows reserved below the
+// scrolling transcript viewport for the composer: one blank spacer row plus the
+// "> " input row. The viewport gets the remaining height so a tall transcript
+// scrolls instead of pushing the input off-screen.
+const composerReservedRows = 2
 
 // RunFn starts an agent run for prompt and returns a stream of its events plus
 // a cancel func the TUI calls on Ctrl+C interrupt. Injected so the Model is
@@ -54,6 +61,21 @@ type Model struct {
 	// dropped. uiState stays framework-free; the model bridges the widget to it.
 	input textinput.Model
 
+	// viewport scrolls the transcript (#92). The transcript is rendered to a
+	// string, folded to width, and set as the viewport's content; the viewport
+	// clips it to its height and lets the user page/scroll through history. It is
+	// a pure display widget — uiState stays framework-free.
+	viewport viewport.Model
+	// vpReady is set once the first WindowSizeMsg has sized the viewport. Before
+	// that the terminal dimensions are unknown, so View falls back to dumping the
+	// whole transcript (pre-#92 behavior).
+	vpReady bool
+	// follow tracks whether the viewport should auto-scroll to the bottom on new
+	// content. It starts true (follow the latest output) and is cleared when the
+	// user scrolls up to read history, so streaming updates don't yank them back
+	// down; re-armed once they scroll back to the bottom.
+	follow bool
+
 	// cancel interrupts the in-flight run's context (set while running).
 	cancel context.CancelFunc
 	// program is set by SetProgram so the event-drain goroutine can Send events
@@ -83,7 +105,7 @@ func newComposer() textinput.Model {
 
 // NewModel builds a Model driven by run.
 func NewModel(run RunFn) *Model {
-	return &Model{state: newUIState(), run: run, input: newComposer()}
+	return &Model{state: newUIState(), run: run, input: newComposer(), viewport: viewport.New(), follow: true}
 }
 
 // NewModelWithHistory builds a Model whose transcript is pre-seeded from a
@@ -91,7 +113,7 @@ func NewModel(run RunFn) *Model {
 // prior conversation before any new input; the model starts idle so the next
 // submit continues the session via the injected run func.
 func NewModelWithHistory(run RunFn, history []agentcore.AgentMessage) *Model {
-	m := &Model{state: newUIState(), run: run, input: newComposer()}
+	m := &Model{state: newUIState(), run: run, input: newComposer(), viewport: viewport.New(), follow: true}
 	m.state.replay(history)
 	return m
 }
@@ -110,6 +132,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
+		// Size the transcript viewport to the window minus the composer rows.
+		vh := m.height - composerReservedRows
+		if vh < 1 {
+			vh = 1
+		}
+		m.viewport.SetWidth(m.width)
+		m.viewport.SetHeight(vh)
+		m.vpReady = true
+		m.refreshViewport()
 		return m, nil
 
 	case tea.KeyPressMsg:
@@ -117,14 +148,39 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case agentEventMsg:
 		m.state.applyEvent(msg.runID, msg.event)
+		m.refreshViewport()
 		return m, nil
 
 	case runDoneMsg:
 		m.state.finishRun(msg.runID, msg.err)
 		m.cancel = nil
+		m.refreshViewport()
 		return m, nil
 	}
 	return m, nil
+}
+
+// refreshViewport re-renders the transcript into the viewport, folding each
+// entry to the viewport width on rune boundaries (#91) so CJK/wide characters
+// wrap without being split. If the user is following the tail (follow), the
+// viewport is pinned to the bottom so streaming output stays visible; if they
+// have scrolled up to read history, their position is preserved. A no-op until
+// the first WindowSizeMsg sizes the viewport.
+func (m *Model) refreshViewport() {
+	if !m.vpReady {
+		return
+	}
+	var b strings.Builder
+	for i, e := range m.state.transcript {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(wrapWidth(renderEntry(e, m.viewport.Width()), m.viewport.Width()))
+	}
+	m.viewport.SetContent(b.String())
+	if m.follow {
+		m.viewport.GotoBottom()
+	}
 }
 
 // handleKey processes a key press. Ctrl+C and Enter are handled explicitly
@@ -168,7 +224,21 @@ func (m *Model) handleKey(k tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, m.startRun(prompt)
 		}
+		// A submitted (steering) message appended to the transcript should snap
+		// the view back to the bottom so the user sees their echoed input.
+		m.follow = true
+		m.refreshViewport()
 		return m, nil
+
+	case "up", "down", "pgup", "pgdown", "ctrl+u", "ctrl+d":
+		// Transcript scrolling (#92). Delegate to the viewport, then recompute
+		// follow: if the user scrolled up off the bottom, stop auto-following so
+		// streaming output doesn't yank them back; re-arm once they return to the
+		// bottom. Scroll keys don't disarm the two-phase Ctrl+C (they aren't edits).
+		var cmd tea.Cmd
+		m.viewport, cmd = m.viewport.Update(k)
+		m.follow = m.viewport.AtBottom()
+		return m, cmd
 
 	default:
 		// Any other key edits the composer. Delegating to textinput gives
@@ -209,18 +279,26 @@ func (m *Model) drain(runID int, stream *runtime.LoopEventStream) {
 	}
 }
 
-// View implements tea.Model: it renders the transcript then the input line as a
-// plain string; bubbletea diffs and paints it (no custom incremental render).
-// Each transcript entry is folded to the terminal width on rune boundaries so
-// double-width CJK/emoji wrap without being split (#91).
+// View implements tea.Model: it renders the scrolling transcript viewport then
+// the input line as a plain string; bubbletea diffs and paints it (no custom
+// incremental render). The transcript is held in a viewport (#92) that clips a
+// tall history to the window and lets the user page/scroll through it; each
+// entry inside is folded to width on rune boundaries so double-width CJK/emoji
+// wrap without being split (#91). Before the first WindowSizeMsg sizes the
+// viewport, View falls back to dumping the whole transcript (pre-#92 behavior).
 func (m *Model) View() tea.View {
 	if m.quitting {
 		return tea.NewView("bye\n")
 	}
 	var b strings.Builder
-	for _, e := range m.state.transcript {
-		b.WriteString(wrapWidth(renderEntry(e, m.width), m.width))
+	if m.vpReady {
+		b.WriteString(m.viewport.View())
 		b.WriteByte('\n')
+	} else {
+		for _, e := range m.state.transcript {
+			b.WriteString(wrapWidth(renderEntry(e, m.width), m.width))
+			b.WriteByte('\n')
+		}
 	}
 	b.WriteString("\n")
 	b.WriteString("> ")

--- a/internal/tui/viewport_test.go
+++ b/internal/tui/viewport_test.go
@@ -1,0 +1,135 @@
+package tui
+
+// Tests for viewport scrolling of the transcript (#92): a tall transcript must
+// be clipped to the window and scrollable, new output must auto-follow the
+// bottom only while the user is at the bottom, and a window resize must resize
+// the viewport without overflowing. These drive Update/handleKey with synthetic
+// messages — no live terminal.
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// sizeModel feeds a WindowSizeMsg so the viewport is initialized to w x h.
+func sizeModel(m *Model, w, h int) {
+	m.Update(tea.WindowSizeMsg{Width: w, Height: h})
+}
+
+// fillTranscript appends n plain assistant lines so the transcript exceeds a
+// small viewport height, forcing scrolling.
+func fillTranscript(m *Model, n int) {
+	for i := 0; i < n; i++ {
+		m.state.transcript = append(m.state.transcript, transcriptEntry{Kind: entryAssistant, Text: "line"})
+	}
+	m.refreshViewport()
+}
+
+// TestViewportSizesToWindowMinusComposer verifies the transcript viewport takes
+// the window height minus the rows reserved for the composer, so the input line
+// is never pushed off-screen.
+func TestViewportSizesToWindowMinusComposer(t *testing.T) {
+	m := NewModel(nopRun(new(string)))
+	sizeModel(m, 40, 20)
+	if !m.vpReady {
+		t.Fatal("viewport should be ready after WindowSizeMsg")
+	}
+	if got, want := m.viewport.Height(), 20-composerReservedRows; got != want {
+		t.Errorf("viewport height = %d, want %d", got, want)
+	}
+	if got := m.viewport.Width(); got != 40 {
+		t.Errorf("viewport width = %d, want 40", got)
+	}
+}
+
+// TestViewportResizeUpdatesDimensions verifies a second WindowSizeMsg (terminal
+// resize) re-sizes the viewport rather than leaving it stale.
+func TestViewportResizeUpdatesDimensions(t *testing.T) {
+	m := NewModel(nopRun(new(string)))
+	sizeModel(m, 40, 20)
+	sizeModel(m, 100, 50)
+	if got, want := m.viewport.Height(), 50-composerReservedRows; got != want {
+		t.Errorf("resized viewport height = %d, want %d", got, want)
+	}
+	if got := m.viewport.Width(); got != 100 {
+		t.Errorf("resized viewport width = %d, want 100", got)
+	}
+}
+
+// TestViewportAutoFollowsBottomOnNewContent is acceptance-critical: while the
+// user is at the bottom, new transcript content must keep the view pinned to the
+// bottom (the latest output stays visible).
+func TestViewportAutoFollowsBottomOnNewContent(t *testing.T) {
+	m := NewModel(nopRun(new(string)))
+	sizeModel(m, 40, 6) // small: 4 visible transcript rows
+	fillTranscript(m, 50)
+	if !m.follow {
+		t.Fatal("should still be following after content grows while at bottom")
+	}
+	if !m.viewport.AtBottom() {
+		t.Error("viewport should be pinned to bottom while following")
+	}
+}
+
+// TestScrollUpStopsAutoFollow is acceptance-critical: once the user scrolls up
+// to read history, streaming/new content must NOT yank them back to the bottom.
+func TestScrollUpStopsAutoFollow(t *testing.T) {
+	m := NewModel(nopRun(new(string)))
+	sizeModel(m, 40, 6)
+	fillTranscript(m, 50)
+
+	// Scroll up: follow must clear.
+	m.handleKey(tea.KeyPressMsg{Code: tea.KeyPgUp})
+	if m.follow {
+		t.Fatal("scrolling up must stop auto-follow")
+	}
+	offBefore := m.viewport.YOffset()
+
+	// New content arrives; the user's scroll position must be preserved (not
+	// jumped to the bottom).
+	fillTranscript(m, 10)
+	if m.viewport.AtBottom() {
+		t.Error("new content must not force the scrolled-up user back to bottom")
+	}
+	if m.viewport.YOffset() != offBefore {
+		t.Errorf("scroll position moved from %d to %d on new content", offBefore, m.viewport.YOffset())
+	}
+}
+
+// TestScrollBackToBottomReArmsFollow verifies that scrolling back down to the
+// bottom re-arms auto-follow, so subsequent output tracks the tail again.
+func TestScrollBackToBottomReArmsFollow(t *testing.T) {
+	m := NewModel(nopRun(new(string)))
+	sizeModel(m, 40, 6)
+	fillTranscript(m, 50)
+
+	m.handleKey(tea.KeyPressMsg{Code: tea.KeyPgUp})
+	if m.follow {
+		t.Fatal("scrolling up must stop auto-follow")
+	}
+	// Page down repeatedly until back at the bottom.
+	for i := 0; i < 50 && !m.viewport.AtBottom(); i++ {
+		m.handleKey(tea.KeyPressMsg{Code: tea.KeyPgDown})
+	}
+	if !m.follow {
+		t.Error("returning to the bottom must re-arm auto-follow")
+	}
+}
+
+// TestViewShowsViewportOnceReady verifies View renders the viewport (clipped)
+// once sized, and still ends with the composer prompt.
+func TestViewShowsViewportOnceReady(t *testing.T) {
+	m := NewModel(nopRun(new(string)))
+	sizeModel(m, 40, 6)
+	fillTranscript(m, 50)
+	out := m.View().Content
+	if !strings.Contains(out, "> ") {
+		t.Error("View must still render the composer prompt")
+	}
+	// The viewport clips to 4 transcript rows, so far fewer than 50 "line"s show.
+	if strings.Count(out, "line") >= 50 {
+		t.Error("viewport should clip a tall transcript, not render all 50 lines")
+	}
+}


### PR DESCRIPTION
## Summary
- Hold the transcript in a `charm.land/bubbles/v2/viewport`, sized to the window height minus reserved composer rows, so a tall history is clipped and scrollable rather than stacked all at once.
- Keyboard scrolling via PgUp/PgDn/↑/↓/Ctrl+U/Ctrl+D delegated to the viewport.
- Auto-follow the tail while at the bottom; scrolling up to read history stops auto-follow (streaming output won't yank the user down); returning to the bottom re-arms it.
- Re-size the viewport on `WindowSizeMsg`. Falls back to dumping the transcript before the first size message. `uiState` stays framework-free.

Closes #92

## Test plan
- [x] `go build ./...` / `go vet ./...` clean, `gofmt -l` clean
- [x] `go test ./internal/tui/` — viewport sizing, resize, auto-follow at bottom, scroll-up stops follow, scroll-back re-arms, View clips a tall transcript