### PR TITLE
TUI: streaming status spinner and tool-call cards

### DIFF
--- a/docs/issue#0093.html
+++ b/docs/issue#0093.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0093</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F2F0EC; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/93">#93</a> &mdash; TUI: 流式状态指示与工具调用卡片 &mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> spinner tick 只在 running 时自续，靠 tea.Batch 与 drain 一起启动</h3>
+      <p><strong>Ambiguity:</strong> AC 要求「tick 命令驱动、不阻塞 Update、run 结束后停止动画」，未规定如何停。</p>
+      <p><strong>Choice:</strong> <code>startRun</code> 返回 <code>tea.Batch(drain, m.spinner.Tick)</code>；<code>Update</code> 收到 <code>spinner.TickMsg</code> 时若 <code>!running</code> 直接返回 nil（不再续 tick），否则 <code>m.spinner.Update</code> 返回下一个 tick。</p>
+      <p><strong>Rationale:</strong> spinner 的自续机制是"处理 tick → 返回下一个 tick"，只要在 idle 时掐断续命，动画自然在 run 结束后一帧内停下，无需显式 Stop；tick 走 bubbletea 命令队列，不阻塞 Update。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 工具卡片 = 复用 #89 主题样式 + #91 折行后再上色</h3>
+      <p><strong>Ambiguity:</strong> AC 要求 tool-call/tool-result「以带样式的卡片呈现，区别于普通文本」，未规定卡片具体形态。</p>
+      <p><strong>Choice:</strong> 新增 <code>styleEntry(kind, text)</code>，按 entry 种类套用 <code>theme.toolCall</code>/<code>theme.toolResult</code> 等样式；在 <code>wrapWidth</code> 折行「之后」再上色。tool-call 用 magenta 头 + ⚙ 前缀，tool-result 用 grey 体 + ↳ 前缀，与 assistant/user 配色区分。</p>
+      <p><strong>Rationale:</strong> 主题层（#89）已备好每类样式，直接复用避免重复定义配色；先折行后上色保证 #91 的显示宽度计算落在裸 rune 上而非 ANSI 转义（否则宽度算错）——正是 #91 open question 预警的顺序。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> spinner 选用 MiniDot，样式取主题 accent 色</h3>
+      <p><strong>Ambiguity:</strong> AC 未指定 spinner 具体样式。</p>
+      <p><strong>Choice:</strong> <code>spinner.New(WithSpinner(MiniDot), WithStyle(theme.accent))</code>，运行提示语整体也套 accent。</p>
+      <p><strong>Rationale:</strong> MiniDot 单宽 braille 帧稳定不抖动、对中文终端友好；accent 色与主题统一。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">None</span> 实现遵循 spec</h3>
+      <p>AC 五项（spinner 运行动画 + 提示、工具卡片区别于普通文本、保留 steering/Ctrl+C 提示语义、tick 驱动不阻塞且结束停止、build+test 全绿）均按字面满足。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 卡片=着色行，而非带边框的多行 box</h3>
+      <p><strong>Alternatives:</strong> (a) 用 lipgloss 边框/padding 画真正的多行卡片框；(b) 仅用配色 + 前缀 glyph 区分的"轻卡片"。</p>
+      <p><strong>Chosen:</strong> (b)。</p>
+      <p><strong>Why it won:</strong> 多行边框框在 viewport 折行、CJK 宽字符对齐下极易错位，且会与 #91 的宽度计算、#94 的 markdown 排版打架；配色+glyph 已满足"视觉区别于普通文本"的 AC，且 NO_COLOR 下退化为 glyph 仍可区分。真正的边框 box 留待样式体系稳定后（#94/#95 之后）再考虑。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> theme 固定为 dark，未接入运行时切换</h3>
+      <p><strong>Alternatives:</strong> (a) Model 固定 <code>buildTheme(themeDark)</code>；(b) 本 issue 就加 light/dark 切换入口。</p>
+      <p><strong>Chosen:</strong> (a)。</p>
+      <p><strong>Why it won:</strong> 主题切换是 #89 的范畴，本 issue 只消费主题样式；NO_COLOR 已由 buildTheme 处理。切换 UI 留给后续。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> spinner 帧宽与 viewport 底部行</h3>
+      <p>运行提示当前渲染在 viewport 之外的固定底部区（composer 上方）。若后续把运行状态并入可滚动区域，需复核 spinner 动态帧宽对 #91 宽度对齐的影响（MiniDot 单宽已规避）。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 是否需要区分「工具执行中」与「工具已完成」的卡片态</h3>
+      <p>当前 tool-call 与 tool-result 是两条独立 transcript entry。zero 的 tool card 会把 call→result 合并为一张带状态的卡片。是否需要该合并（含 pending/done 图标切换）留待确认；本 issue 先按 PRD 的两态着色实现。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"strings"
 
+	"charm.land/bubbles/v2/spinner"
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
@@ -76,6 +77,15 @@ type Model struct {
 	// down; re-armed once they scroll back to the bottom.
 	follow bool
 
+	// spinner animates while a run is in flight (#93). It is driven by its own
+	// tick command (started when a run begins, ignored once idle) so the running
+	// indicator animates without blocking Update. Its style comes from the theme's
+	// accent color.
+	spinner spinner.Model
+	// theme holds the resolved lipgloss styles (#89) applied to transcript
+	// entries, tool cards, and the spinner/running status.
+	theme tuiTheme
+
 	// cancel interrupts the in-flight run's context (set while running).
 	cancel context.CancelFunc
 	// program is set by SetProgram so the event-drain goroutine can Send events
@@ -103,9 +113,16 @@ func newComposer() textinput.Model {
 	return ti
 }
 
+// newSpinner builds the running-indicator spinner (#93), styled with the
+// theme's accent color so it matches the rest of the palette.
+func newSpinner(th tuiTheme) spinner.Model {
+	return spinner.New(spinner.WithSpinner(spinner.MiniDot), spinner.WithStyle(th.accent))
+}
+
 // NewModel builds a Model driven by run.
 func NewModel(run RunFn) *Model {
-	return &Model{state: newUIState(), run: run, input: newComposer(), viewport: viewport.New(), follow: true}
+	th := buildTheme(themeDark)
+	return &Model{state: newUIState(), run: run, input: newComposer(), viewport: viewport.New(), follow: true, spinner: newSpinner(th), theme: th}
 }
 
 // NewModelWithHistory builds a Model whose transcript is pre-seeded from a
@@ -113,7 +130,8 @@ func NewModel(run RunFn) *Model {
 // prior conversation before any new input; the model starts idle so the next
 // submit continues the session via the injected run func.
 func NewModelWithHistory(run RunFn, history []agentcore.AgentMessage) *Model {
-	m := &Model{state: newUIState(), run: run, input: newComposer(), viewport: viewport.New(), follow: true}
+	th := buildTheme(themeDark)
+	m := &Model{state: newUIState(), run: run, input: newComposer(), viewport: viewport.New(), follow: true, spinner: newSpinner(th), theme: th}
 	m.state.replay(history)
 	return m
 }
@@ -146,6 +164,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		return m.handleKey(msg)
 
+	case spinner.TickMsg:
+		// Advance the spinner only while a run is in flight; once idle we stop
+		// re-issuing the tick so the animation halts (AC: stop after run ends).
+		if !m.state.running {
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
 	case agentEventMsg:
 		m.state.applyEvent(msg.runID, msg.event)
 		m.refreshViewport()
@@ -175,11 +203,36 @@ func (m *Model) refreshViewport() {
 		if i > 0 {
 			b.WriteByte('\n')
 		}
-		b.WriteString(wrapWidth(renderEntry(e, m.viewport.Width()), m.viewport.Width()))
+		line := wrapWidth(renderEntry(e, m.viewport.Width()), m.viewport.Width())
+		b.WriteString(m.styleEntry(e.Kind, line))
 	}
 	m.viewport.SetContent(b.String())
 	if m.follow {
 		m.viewport.GotoBottom()
+	}
+}
+
+// styleEntry applies the theme style for an entry kind to its already-rendered,
+// width-folded text (#89/#93). Tool calls and tool results are colorized as
+// visually distinct "cards" (a colored header glyph line and a greyed result
+// body), separating them from plain assistant/user text. Styling is applied
+// after wrapping so display-width math (#91) stays on the raw runes, not ANSI
+// escapes. Under NO_COLOR every theme style is a no-op, so this returns text
+// unchanged and meaning rides on the prefix glyphs instead.
+func (m *Model) styleEntry(kind entryKind, text string) string {
+	switch kind {
+	case entryUser:
+		return m.theme.user.Render(text)
+	case entryAssistant:
+		return m.theme.assistant.Render(text)
+	case entryToolCall:
+		return m.theme.toolCall.Render(text)
+	case entryToolResult:
+		return m.theme.toolResult.Render(text)
+	case entrySystem:
+		return m.theme.system.Render(text)
+	default:
+		return text
 	}
 }
 
@@ -253,15 +306,20 @@ func (m *Model) handleKey(k tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 // startRun launches the agent run for prompt and returns a command that drains
 // its event stream into Update. The drain runs in a goroutine spawned by the
-// command; each event is Sent back tagged with the current runID.
+// command; each event is Sent back tagged with the current runID. The spinner's
+// tick is started alongside so the running indicator animates (#93); it halts
+// itself once the run ends (Update ignores ticks while idle).
 func (m *Model) startRun(prompt string) tea.Cmd {
 	runID := m.state.runID
 	stream, cancel := m.run(context.Background(), prompt, m.state.drainSteering)
 	m.cancel = cancel
-	return func() tea.Msg {
-		go m.drain(runID, stream)
-		return nil
-	}
+	return tea.Batch(
+		func() tea.Msg {
+			go m.drain(runID, stream)
+			return nil
+		},
+		m.spinner.Tick,
+	)
 }
 
 // drain forwards every event from stream into Update via Program.Send, then
@@ -296,7 +354,7 @@ func (m *Model) View() tea.View {
 		b.WriteByte('\n')
 	} else {
 		for _, e := range m.state.transcript {
-			b.WriteString(wrapWidth(renderEntry(e, m.width), m.width))
+			b.WriteString(m.styleEntry(e.Kind, wrapWidth(renderEntry(e, m.width), m.width)))
 			b.WriteByte('\n')
 		}
 	}
@@ -304,9 +362,12 @@ func (m *Model) View() tea.View {
 	b.WriteString("> ")
 	b.WriteString(m.input.View())
 	if m.state.running {
-		b.WriteString("  … (running; type to steer, Ctrl+C to interrupt)")
+		// Animated spinner + running status (#93), styled with the theme accent.
+		b.WriteString("  ")
+		b.WriteString(m.spinner.View())
+		b.WriteString(m.theme.accent.Render(" (running; type to steer, Ctrl+C to interrupt)"))
 	} else if m.state.ctrlCArmed {
-		b.WriteString("  (press Ctrl+C again to quit)")
+		b.WriteString(m.theme.system.Render("  (press Ctrl+C again to quit)"))
 	}
 	return tea.NewView(b.String())
 }

--- a/internal/tui/spinner_test.go
+++ b/internal/tui/spinner_test.go
@@ -1,0 +1,144 @@
+package tui
+
+// Tests for the streaming status indicator and tool-call cards (#93): a spinner
+// animates while a run is in flight and stops when idle, and tool-call/result
+// entries render as styled cards distinct from plain text. These drive
+// Update/View with synthetic messages — no live terminal.
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestSpinnerTickAdvancesWhileRunning verifies a spinner.TickMsg advances the
+// animation while a run is in flight and returns a follow-up tick command (so
+// the animation keeps going without blocking Update).
+func TestSpinnerTickAdvancesWhileRunning(t *testing.T) {
+	m := NewModel(nopRun(new(string)))
+	m.state.running = true
+	_, cmd := m.Update(m.spinner.Tick())
+	if cmd == nil {
+		t.Error("spinner tick while running should schedule the next tick")
+	}
+}
+
+// TestSpinnerTickHaltsWhenIdle is acceptance-critical: once the run ends
+// (running == false), a stray tick must NOT re-schedule itself, so the
+// animation stops rather than spinning forever.
+func TestSpinnerTickHaltsWhenIdle(t *testing.T) {
+	m := NewModel(nopRun(new(string)))
+	m.state.running = false
+	_, cmd := m.Update(spinner.TickMsg{})
+	if cmd != nil {
+		t.Error("spinner tick while idle must not schedule another tick")
+	}
+}
+
+// TestRunningStatusShowsSpinnerAndHint verifies View shows the animated spinner
+// plus the preserved running hint (steering + Ctrl+C interrupt semantics) while
+// a run is in flight.
+func TestRunningStatusShowsSpinnerAndHint(t *testing.T) {
+	withNoColor(t, true) // strip ANSI so we can assert on plain text
+	m := NewModel(nopRun(new(string)))
+	m.state.running = true
+	out := m.View().Content
+	if !strings.Contains(out, "running") || !strings.Contains(out, "Ctrl+C") {
+		t.Errorf("running status must preserve steer/interrupt hint, got %q", out)
+	}
+	// The MiniDot spinner's first frame is a braille dot; assert some spinner
+	// glyph is present alongside the hint.
+	frame := spinner.MiniDot.Frames[0]
+	if !strings.Contains(out, frame) {
+		t.Errorf("running view must include spinner frame %q, got %q", frame, out)
+	}
+}
+
+// TestIdleStatusNoSpinner verifies that when idle, no running hint/spinner is
+// shown (the composer stands alone).
+func TestIdleStatusNoSpinner(t *testing.T) {
+	withNoColor(t, true)
+	m := NewModel(nopRun(new(string)))
+	m.state.running = false
+	out := m.View().Content
+	if strings.Contains(out, "running") {
+		t.Errorf("idle view must not show the running hint, got %q", out)
+	}
+}
+
+// TestToolCardsAreStyledDistinctly is acceptance-critical: tool-call and
+// tool-result entries must be visually distinct from plain assistant text. With
+// color enabled, the styled tool lines carry ANSI escapes (their card styling),
+// whereas the raw rendered text does not.
+func TestToolCardsAreStyledDistinctly(t *testing.T) {
+	withNoColor(t, false) // ensure colors are active
+	m := NewModel(nopRun(new(string)))
+
+	callStyled := m.styleEntry(entryToolCall, "⚙ read_file")
+	resultStyled := m.styleEntry(entryToolResult, "  ↳ ok")
+	if !strings.Contains(callStyled, "\x1b[") {
+		t.Errorf("tool-call card must be styled (ANSI), got %q", callStyled)
+	}
+	if !strings.Contains(resultStyled, "\x1b[") {
+		t.Errorf("tool-result card must be styled (ANSI), got %q", resultStyled)
+	}
+	// Tool call and tool result use different palette colors, so their styled
+	// output must differ even for the same inner text.
+	if a, b := m.styleEntry(entryToolCall, "x"), m.styleEntry(entryToolResult, "x"); a == b {
+		t.Errorf("tool-call and tool-result should style differently, both = %q", a)
+	}
+}
+
+// TestStyledEntryPreservesGlyphUnderNoColor verifies that under NO_COLOR the
+// tool cards fall back to plain text (no ANSI) but keep their distinguishing
+// prefix glyph, so meaning never relies on color alone.
+func TestStyledEntryPreservesGlyphUnderNoColor(t *testing.T) {
+	withNoColor(t, true)
+	m := NewModel(nopRun(new(string)))
+	got := m.styleEntry(entryToolCall, "⚙ read_file")
+	if strings.Contains(got, "\x1b[") {
+		t.Errorf("NO_COLOR tool card must be plain, got %q", got)
+	}
+	if !strings.Contains(got, "⚙") {
+		t.Errorf("tool card must keep its glyph under NO_COLOR, got %q", got)
+	}
+}
+
+// TestSpinnerStartsOnRunAndBatchesTick verifies startRun returns a command batch
+// that includes the spinner tick, so the animation begins when a run starts.
+func TestSpinnerStartsOnRunAndBatchesTick(t *testing.T) {
+	m := NewModel(nopRun(new(string)))
+	typeRunes(m, "hi")
+	_, cmd := m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("submitting a prompt should return a command (drain + spinner tick)")
+	}
+	// Executing the batched command should eventually surface a spinner.TickMsg
+	// among the produced messages.
+	if !producesSpinnerTick(cmd) {
+		t.Error("startRun batch should include the spinner tick command")
+	}
+}
+
+// producesSpinnerTick runs a (possibly batched) command and reports whether any
+// resulting message is a spinner.TickMsg. It handles tea.BatchMsg by executing
+// each sub-command.
+func producesSpinnerTick(cmd tea.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+	msg := cmd()
+	switch mm := msg.(type) {
+	case spinner.TickMsg:
+		return true
+	case tea.BatchMsg:
+		for _, c := range mm {
+			if producesSpinnerTick(c) {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Animated MiniDot spinner (theme accent) runs while an agent run is in flight, halts when idle — driven by a batched `spinner.Tick`; the `spinner.TickMsg` case only re-issues a tick while `running`, so the animation stops one frame after the run ends without an explicit Stop.
- Tool-call/tool-result transcript entries render as color-distinct cards via `styleEntry`, applied after width-wrapping (#91) so display-width math stays on raw runes; under NO_COLOR meaning rides on prefix glyphs (⚙ / ↳).
- Running status preserves the steer + Ctrl+C interrupt hint.

Closes #93

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/tui/` green (spinner_test.go: tick advance/halt, styled tool cards, NO_COLOR glyph fallback, batched-tick-on-run)