### PR TITLE
Add action slash-commands (/model, /help) to the TUI

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -42,6 +43,7 @@ type interactiveOptions struct {
 	model        string
 	providerName string
 	provider     provider.Provider
+	baseURL      string
 	tools        []agentcore.AgentTool
 	sysPrompt    string
 
@@ -97,6 +99,17 @@ func runInteractive(opts interactiveOptions) error {
 		}
 	}
 
+	// live holds the run configuration that a control command (e.g. /model) may
+	// mutate mid-session. The run closure reads it on each prompt so a model
+	// switch takes effect on the next turn; header is updated so the switch is
+	// persisted with the session.
+	live := &liveRunConfig{
+		model:        opts.model,
+		providerName: opts.providerName,
+		provider:     opts.provider,
+		baseURL:      opts.baseURL,
+	}
+
 	// run appends the new prompt to the shared context, launches a loop run over
 	// the whole context, and returns its event stream. Steering is bridged into
 	// the loop's per-turn hook. The context grows in place as the loop appends
@@ -109,9 +122,9 @@ func runInteractive(opts interactiveOptions) error {
 		})
 		cfg := runtime.RunConfig{
 			LoopConfig: runtime.LoopConfig{
-				Model:     opts.model,
-				Provider:  opts.providerName,
-				Stream:    provider.StreamFnFromProvider(opts.provider),
+				Model:     live.model,
+				Provider:  live.providerName,
+				Stream:    provider.StreamFnFromProvider(live.provider),
 				GetAPIKey: creds.GetAPIKey,
 			},
 			Batch: agenttool.BatchConfig{
@@ -136,6 +149,8 @@ func runInteractive(opts interactiveOptions) error {
 		go func() {
 			_, _ = stream.Result(context.Background())
 			header.UpdatedAt = time.Now().UTC()
+			header.Model = live.model
+			header.Provider = live.providerName
 			if err := store.Save(header, agentCtx.Messages); err != nil {
 				fmt.Fprintf(os.Stderr, "pigo: session save failed: %v\n", err)
 			}
@@ -151,8 +166,9 @@ func runInteractive(opts interactiveOptions) error {
 	}
 	// Wire slash-commands: built-ins (compile-time) plus any user templates under
 	// ~/.pigo/commands (对标 the commands/*.md convention). A load error is
-	// non-fatal — the TUI still runs with the built-ins.
-	if slash, err := buildSlashRegistry(); err == nil {
+	// non-fatal — the TUI still runs with the built-ins. Instance built-ins that
+	// need live state (/model, /help) are registered against `live`.
+	if slash, err := buildSlashRegistry(live); err == nil {
 		m.SetSlashRegistry(slash)
 	} else {
 		fmt.Fprintf(os.Stderr, "pigo: slash-commands: %v\n", err)
@@ -213,12 +229,14 @@ func stdoutIsTerminal() bool {
 }
 
 // buildSlashRegistry assembles the TUI slash-command registry: compile-time
-// built-ins seeded by runtime.NewSlashRegistry plus user declarative templates
-// loaded from ~/.pigo/commands (or $PIGO_HOME/commands). A missing directory is
-// not an error. User commands that collide with a built-in are shadowed (the
-// built-in wins) and reported on stderr.
-func buildSlashRegistry() (*runtime.SlashRegistry, error) {
+// built-ins seeded by runtime.NewSlashRegistry, the live-state action commands
+// (/model, /help) bound to live, plus user declarative templates loaded from
+// ~/.pigo/commands (or $PIGO_HOME/commands). A missing directory is not an
+// error. User commands that collide with a built-in are shadowed (the built-in
+// wins) and reported on stderr.
+func buildSlashRegistry(live *liveRunConfig) (*runtime.SlashRegistry, error) {
 	reg := runtime.NewSlashRegistry()
+	registerLiveCommands(reg, live)
 	dir := os.Getenv("PIGO_HOME")
 	if dir == "" {
 		home, err := os.UserHomeDir()
@@ -238,4 +256,59 @@ func buildSlashRegistry() (*runtime.SlashRegistry, error) {
 		fmt.Fprintf(os.Stderr, "pigo: user commands shadowed by built-ins (rename to use): %v\n", shadowed)
 	}
 	return reg, nil
+}
+
+// liveRunConfig is the mutable run configuration a control command may change
+// mid-session. The run closure reads it on every prompt, so a /model switch
+// takes effect on the next turn. It carries no lock: it is read and written
+// only on bubbletea's single Update goroutine (slash actions run there, and the
+// run closure is invoked synchronously from that goroutine's startRun).
+type liveRunConfig struct {
+	model        string
+	providerName string
+	provider     provider.Provider
+	baseURL      string
+}
+
+// registerLiveCommands installs the built-in action commands that need live
+// runtime state. /model views or switches the active model; /help lists the
+// available commands. These are instance built-ins (AddBuiltin) because their
+// closures must capture live and the registry — state unreachable from an
+// init()-time global registration.
+func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
+	reg.AddBuiltin(runtime.SlashCommand{
+		Name:        "model",
+		Description: "view or switch the active model: /model [model-id]",
+		Action: func(args string) string {
+			id := strings.TrimSpace(args)
+			if id == "" {
+				return fmt.Sprintf("model: %s (provider: %s)", live.model, live.providerName)
+			}
+			prov, providerName, err := resolveProvider(id, live.baseURL)
+			if err != nil {
+				return fmt.Sprintf("model: cannot switch to %q: %v", id, err)
+			}
+			live.model = id
+			live.providerName = providerName
+			live.provider = prov
+			return fmt.Sprintf("model switched to %s (provider: %s)", id, providerName)
+		},
+	})
+	reg.AddBuiltin(runtime.SlashCommand{
+		Name:        "help",
+		Description: "list available slash commands",
+		Action: func(string) string {
+			var b strings.Builder
+			b.WriteString("available commands:")
+			for _, c := range reg.List() {
+				b.WriteString("\n  /")
+				b.WriteString(c.Name)
+				if c.Description != "" {
+					b.WriteString(" — ")
+					b.WriteString(c.Description)
+				}
+			}
+			return b.String()
+		},
+	})
 }

--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -98,6 +98,7 @@ func main() {
 			model:        model,
 			providerName: providerName,
 			provider:     provider,
+			baseURL:      baseURL,
 			tools:        tools,
 			sysPrompt:    sysPrompt,
 			resumeID:     resumeID,

--- a/docs/issue#slash-action-commands.html
+++ b/docs/issue#slash-action-commands.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Slash Action Commands (/model, /help)</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F2F0EC; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Feature: TUI 动作型斜杠命令（<code>/model</code>、<code>/help</code>）&mdash; 无对应 GitHub issue（源于「为啥 tui 下没有斜杠命令」的追问）&mdash; 2026-07-10</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 给 SlashCommand 增加 Action 通道，而非把副作用塞进 Expand</h3>
+      <p><strong>Ambiguity:</strong> 原设计 <code>Expand func(args string) string</code> 只产出 prompt 文本，结构上无法表达「切换模型」这类控制动作。需求（支持 /model）没规定如何扩展。</p>
+      <p><strong>Choice:</strong> 新增 <code>Action func(args string) string</code> 字段与 <code>ResolveOutcome</code>，返回结构化 <code>SlashOutcome{Handled, Kind, Prompt, Message}</code>。Action 命令执行副作用并返回状态行，不产出 prompt；Expand 命令保持原样。</p>
+      <p><strong>Rationale:</strong> 两类命令语义根本不同（一个生成 prompt 交给 agent 跑，一个改运行时状态后直接展示结果）。用独立字段区分比让 Expand 兼职副作用清晰得多，且 <code>Action</code> 闭包可捕获并修改 live 状态，这是纯函数 Expand 做不到的。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 新增实例级 AddBuiltin，而非只用全局 RegisterBuiltin</h3>
+      <p><strong>Ambiguity:</strong> 现有内置命令走 init() 期的全局 <code>RegisterBuiltin</code>；但 /model 的闭包必须捕获 main 里创建的 live 运行配置，init() 时该状态还不存在。</p>
+      <p><strong>Choice:</strong> 给 <code>*SlashRegistry</code> 加 <code>AddBuiltin</code>，把内置命令直接装到 registry 实例上，同样标 <code>SourceBuiltin</code>（对 user 命令仍胜出）。</p>
+      <p><strong>Rationale:</strong> 保留 init()-only 的全局路径（并发契约不变），又让需要 per-run 状态的动作命令有合法注册点，无需引入全局可变状态或锁。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> live 运行配置无锁，靠 Update goroutine 单线程约束</h3>
+      <p><strong>Ambiguity:</strong> /model 会 mid-session 改 model/provider，run 闭包每轮读它——是否需要同步？</p>
+      <p><strong>Choice:</strong> <code>liveRunConfig</code> 不加锁，注释声明「只在 bubbletea 单一 Update goroutine 上读写」（slash action 在该 goroutine 执行，startRun 也同步在其中调用 run 闭包）。</p>
+      <p><strong>Rationale:</strong> bubbletea 契约保证所有状态变更都在 Update goroutine，符合项目既有 uiState 的无锁设计，避免过度工程。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">None</span> 无 spec 可偏离</h3>
+      <p>本功能无正式 PRD/issue，是对用户「为啥没有 /model」追问的直接响应。实现目标（可注册内置命令 + 支持动作型命令 + /model 运行时切换 + /help 列表）均已达成，build/vet/gofmt/test 全绿。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 保留旧 Resolve 字符串 API 而非直接替换</h3>
+      <p><strong>Alternatives:</strong> (a) 破坏性地把 <code>Resolve</code> 改成返回 outcome；(b) 新增 <code>ResolveOutcome</code>，<code>Resolve</code> 委托它并保持旧签名。</p>
+      <p><strong>Chosen:</strong> (b)。</p>
+      <p><strong>Why it won:</strong> 现有测试与潜在只处理 prompt 命令的调用方仍可用旧 API；旧 <code>Resolve</code> 对 action 命令报「handled 但 prompt 空、动作不执行」，语义安全。代价是两个入口并存，但注释已标明 action 命令必须走 <code>ResolveOutcome</code>。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> /model 切换失败时返回状态行而非报错中断</h3>
+      <p><strong>Alternatives:</strong> (a) resolveProvider 失败即 abort/报致命错；(b) 返回「cannot switch」状态行，保持原模型不变。</p>
+      <p><strong>Chosen:</strong> (b)。</p>
+      <p><strong>Why it won:</strong> 交互式会话里误输入模型 id 很常见，静默保持当前模型并提示，比打断会话体验好。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> /model 是否应校验模型 id 真实可用</h3>
+      <p>当前 <code>resolveProvider</code> 只按前缀映射 provider（ollama/ 走 Ollama，其余走 OpenRouter），不校验模型是否真实存在——非法 id 要到下一轮真正请求时才失败。是否需要在切换时做一次轻量校验（如查模型列表）？留待确认。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 是否需要 /model 的补全或候选列表</h3>
+      <p>现在 /model 无参数只显示当前模型。是否要让它列出内置 provider 支持的常用模型 id 作为候选，方便用户切换？本次未做。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 动作命令的状态行样式</h3>
+      <p>动作结果与错误都走 <code>entrySystem</code>（· 前缀，system 主题色）。是否需要为「成功切换」与「错误」区分样式（如成功用 accent、失败用警告色）？当前统一 system 色，简单且够用。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/runtime/orchestration_test.go
+++ b/internal/runtime/orchestration_test.go
@@ -367,6 +367,78 @@ func TestSlashResolve(t *testing.T) {
 	}
 }
 
+// TestSlashActionCommand verifies an action command runs its side effect via
+// ResolveOutcome and reports SlashAction with its status message (no prompt),
+// while a prompt command reports SlashPrompt with expanded text.
+func TestSlashActionCommand(t *testing.T) {
+	r := NewSlashRegistry()
+	var ran string
+	r.AddBuiltin(SlashCommand{
+		Name:        "model",
+		Description: "switch model",
+		Action:      func(args string) string { ran = args; return "switched to " + args },
+	})
+	r.AddUser(SlashCommand{Name: "greet", Expand: func(args string) string { return "hello " + args }})
+
+	// Action command: runs the side effect and returns a status message.
+	out, err := r.ResolveOutcome("/model gpt-5")
+	if err != nil {
+		t.Fatalf("ResolveOutcome(/model) error: %v", err)
+	}
+	if !out.Handled || out.Kind != SlashAction {
+		t.Errorf("action command: got handled=%v kind=%v, want true/SlashAction", out.Handled, out.Kind)
+	}
+	if ran != "gpt-5" {
+		t.Errorf("action side effect not run with args: got %q", ran)
+	}
+	if out.Message != "switched to gpt-5" || out.Prompt != "" {
+		t.Errorf("action outcome = {msg:%q prompt:%q}, want status message and empty prompt", out.Message, out.Prompt)
+	}
+
+	// Prompt command: expands, no action.
+	out, err = r.ResolveOutcome("/greet world")
+	if err != nil {
+		t.Fatalf("ResolveOutcome(/greet) error: %v", err)
+	}
+	if !out.Handled || out.Kind != SlashPrompt || out.Prompt != "hello world" {
+		t.Errorf("prompt outcome = {kind:%v prompt:%q}, want SlashPrompt/hello world", out.Kind, out.Prompt)
+	}
+
+	// Non-command passthrough.
+	out, err = r.ResolveOutcome("plain text")
+	if err != nil || out.Handled || out.Prompt != "plain text" {
+		t.Errorf("passthrough = {%v %q %v}, want unhandled verbatim", out.Handled, out.Prompt, err)
+	}
+}
+
+// TestAddBuiltinDuplicatePanics verifies AddBuiltin rejects a duplicate
+// built-in name (a programming error), matching RegisterBuiltin semantics.
+func TestAddBuiltinDuplicatePanics(t *testing.T) {
+	r := NewSlashRegistry()
+	r.AddBuiltin(SlashCommand{Name: "dup", Action: func(string) string { return "" }})
+	defer func() {
+		if recover() == nil {
+			t.Error("duplicate AddBuiltin must panic")
+		}
+	}()
+	r.AddBuiltin(SlashCommand{Name: "dup", Action: func(string) string { return "" }})
+}
+
+// TestAddBuiltinWinsOverUser verifies an instance built-in (AddBuiltin) shadows
+// a same-named user command, just like a globally registered built-in.
+func TestAddBuiltinWinsOverUser(t *testing.T) {
+	r := NewSlashRegistry()
+	r.AddBuiltin(SlashCommand{Name: "x", Action: func(string) string { return "builtin" }})
+	r.AddUser(SlashCommand{Name: "x", Expand: func(string) string { return "user" }})
+	cmd, ok := r.Lookup("x")
+	if !ok || cmd.Source != SourceBuiltin {
+		t.Errorf("instance built-in must win, got ok=%v source=%v", ok, cmd.Source)
+	}
+	if len(r.Shadowed()) != 1 || r.Shadowed()[0] != "x" {
+		t.Errorf("shadowed = %v, want [x]", r.Shadowed())
+	}
+}
+
 // TestParseUserCommand verifies $ARGUMENTS substitution, frontmatter description,
 // and the append fallback when no placeholder is present.
 func TestParseUserCommand(t *testing.T) {

--- a/internal/runtime/slashcommand.go
+++ b/internal/runtime/slashcommand.go
@@ -46,16 +46,59 @@ func (s SlashCommandSource) String() string {
 }
 
 // SlashCommand is a resolved command: its name (without the leading "/"), a
-// short description for the command palette, its source, and an Expand function
-// that turns the invocation arguments into the prompt text fed to the agent.
+// short description for the command palette, and its source. A command is one
+// of two kinds, distinguished by which callback is set:
+//
+//   - A prompt command sets Expand: it turns the invocation arguments into the
+//     prompt text fed to the agent (the original slash-command behavior).
+//   - An action command sets Action instead: it performs a side effect (e.g.
+//     switching the runtime model) and returns a status line to show the user,
+//     rather than producing a prompt. No agent run is started.
+//
+// Exactly one of Expand/Action should be set. When both are set Action wins
+// (an action command never doubles as a prompt). This split is what lets a
+// control command like "/model" change runtime state — the old design could
+// only emit prompt text.
 type SlashCommand struct {
 	Name        string
 	Description string
 	Source      SlashCommandSource
 	// Expand maps the argument string (everything after "/name ") to the prompt
 	// text the command produces. For a built-in it may be arbitrary Go; for a
-	// user template it substitutes $ARGUMENTS into the markdown body.
+	// user template it substitutes $ARGUMENTS into the markdown body. Nil for an
+	// action command.
 	Expand func(args string) string
+	// Action performs a side effect for the invocation and returns a status
+	// message to display (may be empty). Set instead of Expand for a control
+	// command like "/model". Because it is an arbitrary Go closure it can capture
+	// and mutate live runtime state, which Expand (a pure prompt producer)
+	// cannot. Nil for a prompt command.
+	Action func(args string) string
+}
+
+// SlashKind classifies how a resolved invocation should be handled by the
+// caller: run its prompt through the agent, or treat it as a completed action.
+type SlashKind int
+
+const (
+	// SlashPrompt means the outcome carries prompt text to run (or, when not a
+	// command at all, the verbatim input).
+	SlashPrompt SlashKind = iota
+	// SlashAction means an action command already ran; the outcome carries only
+	// a status Message and no agent run should start.
+	SlashAction
+)
+
+// SlashOutcome is the structured result of resolving one input line. Handled is
+// false when the input was not a slash command (Prompt holds the verbatim input
+// to run). When Handled is true, Kind says whether Prompt should be run
+// (SlashPrompt) or an action already ran and Message should be shown without
+// starting a run (SlashAction).
+type SlashOutcome struct {
+	Handled bool
+	Kind    SlashKind
+	Prompt  string
+	Message string
 }
 
 // builtinCommands holds compile-time registered commands, keyed by name. It is
@@ -100,6 +143,24 @@ func NewSlashRegistry() *SlashRegistry {
 	return r
 }
 
+// AddBuiltin installs a built-in command directly on this registry instance,
+// bypassing the compile-time global. It exists for action commands whose
+// closure must capture live, per-run state (e.g. a model controller created in
+// main) — such state cannot be reached from an init()-time RegisterBuiltin. The
+// command is marked SourceBuiltin so it wins over a same-named user command,
+// exactly like a globally registered built-in. A duplicate name panics, since
+// two built-ins claiming one name is a programming error.
+func (r *SlashRegistry) AddBuiltin(cmd SlashCommand) {
+	if cmd.Name == "" {
+		panic("agent: AddBuiltin with empty name")
+	}
+	if existing, ok := r.commands[cmd.Name]; ok && existing.Source == SourceBuiltin {
+		panic(fmt.Sprintf("agent: duplicate built-in slash command %q", cmd.Name))
+	}
+	cmd.Source = SourceBuiltin
+	r.commands[cmd.Name] = cmd
+}
+
 // AddUser installs a user command unless a built-in already owns the name, in
 // which case the command is recorded as shadowed and the built-in is kept
 // (built-in-wins). A user command may override another user command of the same
@@ -135,13 +196,32 @@ func (r *SlashRegistry) List() []SlashCommand {
 
 // Resolve parses a raw input line and, if it is a slash-command invocation,
 // expands it to the prompt text the agent should run. It returns (prompt, true)
-// when input begins with "/" and names a known command; (input, false) when the
-// input is not a slash command (the caller runs it verbatim); and an error when
-// input is a "/name" for an unknown command.
+// when input begins with "/" and names a known PROMPT command; (input, false)
+// when the input is not a slash command (the caller runs it verbatim); and an
+// error when input is a "/name" for an unknown command.
+//
+// This is the legacy string API, kept for callers that only handle prompt
+// commands. It reports an action command as handled with an empty prompt (the
+// action does NOT run here) — callers that want action commands to execute must
+// use ResolveOutcome instead.
 func (r *SlashRegistry) Resolve(input string) (prompt string, handled bool, err error) {
+	out, err := r.ResolveOutcome(input)
+	if err != nil {
+		return "", false, err
+	}
+	return out.Prompt, out.Handled, nil
+}
+
+// ResolveOutcome parses a raw input line into a structured SlashOutcome. For a
+// non-command it returns {Handled:false, Prompt:input}. For a known prompt
+// command it returns {Handled:true, Kind:SlashPrompt, Prompt:<expanded>}. For a
+// known action command it RUNS the action and returns {Handled:true,
+// Kind:SlashAction, Message:<status>} — no prompt to run. An unknown "/name"
+// yields an error.
+func (r *SlashRegistry) ResolveOutcome(input string) (SlashOutcome, error) {
 	trimmed := strings.TrimLeft(input, " \t")
 	if !strings.HasPrefix(trimmed, "/") {
-		return input, false, nil
+		return SlashOutcome{Handled: false, Kind: SlashPrompt, Prompt: input}, nil
 	}
 	rest := trimmed[1:]
 	name := rest
@@ -152,9 +232,12 @@ func (r *SlashRegistry) Resolve(input string) (prompt string, handled bool, err 
 	}
 	cmd, ok := r.commands[name]
 	if !ok {
-		return "", false, fmt.Errorf("unknown command %q", "/"+name)
+		return SlashOutcome{}, fmt.Errorf("unknown command %q", "/"+name)
 	}
-	return cmd.Expand(args), true, nil
+	if cmd.Action != nil {
+		return SlashOutcome{Handled: true, Kind: SlashAction, Message: cmd.Action(args)}, nil
+	}
+	return SlashOutcome{Handled: true, Kind: SlashPrompt, Prompt: cmd.Expand(args)}, nil
 }
 
 // LoadUserCommandsDir loads declarative markdown command templates from dir

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -289,15 +289,27 @@ func (m *Model) handleKey(k tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if start {
 			// Expand a slash-command into its prompt text before running. An
 			// unknown "/name" is surfaced as a local system line and no run
-			// starts; a non-command prompt passes through unchanged.
+			// starts. An action command (e.g. /model) runs its side effect here
+			// and shows a status line without starting an agent run. A
+			// non-command prompt passes through unchanged.
 			if m.slash != nil {
-				expanded, handled, err := m.slash.Resolve(prompt)
+				out, err := m.slash.ResolveOutcome(prompt)
 				if err != nil {
 					m.state.abortStartedRun(err.Error())
+					m.follow = true
+					m.refreshViewport()
 					return m, nil
 				}
-				if handled {
-					prompt = expanded
+				if out.Handled && out.Kind == runtime.SlashAction {
+					// Action already ran; don't start a run. Undo the run submit()
+					// began and echo the action's status as a local system line.
+					m.state.abortStartedRun(out.Message)
+					m.follow = true
+					m.refreshViewport()
+					return m, nil
+				}
+				if out.Handled {
+					prompt = out.Prompt
 				}
 			}
 			return m, m.startRun(prompt)

--- a/internal/tui/slashaction_test.go
+++ b/internal/tui/slashaction_test.go
@@ -1,0 +1,90 @@
+package tui
+
+// Tests for slash-command dispatch in the TUI: a prompt command expands and
+// starts a run; an action command (e.g. /model) runs its side effect and shows
+// a status line WITHOUT starting a run; an unknown command surfaces an error
+// line and starts no run. These drive handleKey's Enter path with a wired
+// SlashRegistry — no live terminal.
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// TestSlashActionDoesNotStartRun is acceptance-critical: submitting an action
+// command must run its side effect and echo the status, but NOT hand any prompt
+// to the run func (no agent turn starts).
+func TestSlashActionDoesNotStartRun(t *testing.T) {
+	var started string
+	m := NewModel(nopRun(&started))
+	reg := runtime.NewSlashRegistry()
+	var ran bool
+	reg.AddBuiltin(runtime.SlashCommand{
+		Name:   "model",
+		Action: func(args string) string { ran = true; return "model: fake-model" },
+	})
+	m.SetSlashRegistry(reg)
+
+	typeRunes(m, "/model")
+	m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if !ran {
+		t.Error("action command side effect did not run")
+	}
+	if started != "" {
+		t.Errorf("action command must not start a run, but run got prompt %q", started)
+	}
+	if m.state.running {
+		t.Error("state must not be running after an action command")
+	}
+	last := m.state.transcript[len(m.state.transcript)-1]
+	if last.Kind != entrySystem || !strings.Contains(last.Text, "fake-model") {
+		t.Errorf("action status not echoed as system line, got %+v", last)
+	}
+}
+
+// TestSlashPromptCommandStartsRun verifies a prompt command still expands and
+// starts a run (regression guard for the outcome refactor).
+func TestSlashPromptCommandStartsRun(t *testing.T) {
+	var started string
+	m := NewModel(nopRun(&started))
+	reg := runtime.NewSlashRegistry()
+	reg.AddUser(runtime.SlashCommand{Name: "greet", Expand: func(args string) string { return "hello " + args }})
+	m.SetSlashRegistry(reg)
+
+	typeRunes(m, "/greet world")
+	m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if started != "hello world" {
+		t.Errorf("prompt command started run with %q, want 'hello world'", started)
+	}
+	if !m.state.running {
+		t.Error("state should be running after a prompt command starts a run")
+	}
+}
+
+// TestSlashUnknownCommandStartsNoRun verifies an unknown "/name" surfaces the
+// error as a local system line and starts no run.
+func TestSlashUnknownCommandStartsNoRun(t *testing.T) {
+	var started string
+	m := NewModel(nopRun(&started))
+	m.SetSlashRegistry(runtime.NewSlashRegistry())
+
+	typeRunes(m, "/definitely-not-a-command")
+	m.handleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if started != "" {
+		t.Errorf("unknown command must not start a run, got prompt %q", started)
+	}
+	if m.state.running {
+		t.Error("state must not be running after an unknown command")
+	}
+	last := m.state.transcript[len(m.state.transcript)-1]
+	if last.Kind != entrySystem || !strings.Contains(last.Text, "unknown command") {
+		t.Errorf("unknown command should surface an error system line, got %+v", last)
+	}
+}


### PR DESCRIPTION
## Summary
- 给 `SlashCommand` 增加 `Action` 通道：控制型命令可改运行时状态，而非只产出 prompt 文本
- 新增 `ResolveOutcome`（返回结构化 `SlashOutcome`，区分 prompt/action）与实例级 `AddBuiltin`（内置命令捕获 live per-run 状态）
- 在 `cmd/pigo` 注册 `/model`（会话中查看/切换模型）与 `/help`（列出命令）
- TUI 回车路径：动作命令执行副作用并以 system 行回显状态，不启动 agent run

回答了「为什么 TUI 里没有 /model 这类斜杠命令」——此前斜杠系统只能展开 prompt 文本，且无生产内置命令注册。

## Test plan
- [x] go build ./... 通过
- [x] go vet ./... 通过
- [x] gofmt -l 干净
- [x] go test ./... 全绿（新增 runtime 与 tui 动作命令单测）