### PR TITLE
Add preset provider/model catalog with NVIDIA support

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -278,11 +278,11 @@ type liveRunConfig struct {
 func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 	reg.AddBuiltin(runtime.SlashCommand{
 		Name:        "model",
-		Description: "view or switch the active model: /model [model-id]",
+		Description: "view or switch the active model: /model [model-id] (see /models for presets)",
 		Action: func(args string) string {
 			id := strings.TrimSpace(args)
 			if id == "" {
-				return fmt.Sprintf("model: %s (provider: %s)", live.model, live.providerName)
+				return fmt.Sprintf("model: %s (provider: %s)\nrun /models to see presets, or /model <id> to switch", live.model, live.providerName)
 			}
 			prov, providerName, err := resolveProvider(id, live.baseURL)
 			if err != nil {
@@ -293,6 +293,11 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 			live.provider = prov
 			return fmt.Sprintf("model switched to %s (provider: %s)", id, providerName)
 		},
+	})
+	reg.AddBuiltin(runtime.SlashCommand{
+		Name:        "models",
+		Description: "list preset providers and models you can switch to",
+		Action:      func(args string) string { return presetListing(strings.TrimSpace(args)) },
 	})
 	reg.AddBuiltin(runtime.SlashCommand{
 		Name:        "help",
@@ -311,4 +316,48 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 			return b.String()
 		},
 	})
+}
+
+// presetListing renders the preset provider/model catalog for /models. With an
+// argument it filters to a single provider (e.g. "/models nvidia"). Providers
+// are grouped and shown with the env var their API key is read from (referenced
+// by name only, never a value). The output guides the user to `/model <id>`.
+func presetListing(filter string) string {
+	var b strings.Builder
+	b.WriteString("preset providers & models (switch with /model <id>):")
+	shown := 0
+	for _, pv := range provider.PresetProviders {
+		if filter != "" && !strings.EqualFold(filter, pv.Name) {
+			continue
+		}
+		models := provider.PresetsByProvider(pv.Name)
+		if len(models) == 0 {
+			continue
+		}
+		shown++
+		b.WriteString("\n\n")
+		b.WriteString(pv.Name)
+		if pv.EnvVar != "" {
+			b.WriteString(" (API key: $")
+			b.WriteString(pv.EnvVar)
+			b.WriteString(")")
+		} else {
+			b.WriteString(" (local, no API key)")
+		}
+		for _, m := range models {
+			b.WriteString("\n  ")
+			b.WriteString(m.ID)
+			if m.DisplayName != "" {
+				b.WriteString("  — ")
+				b.WriteString(m.DisplayName)
+			}
+		}
+	}
+	if shown == 0 {
+		if filter != "" {
+			return fmt.Sprintf("no preset provider named %q (try openrouter, nvidia, or ollama)", filter)
+		}
+		return "no presets configured"
+	}
+	return b.String()
 }

--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -166,19 +166,39 @@ func main() {
 	}
 }
 
-// resolveProvider maps a model id to a built-in provider. A model id prefixed
-// with "ollama/" (or an explicit local base URL) uses the local Ollama gateway;
-// everything else defaults to OpenRouter, the reference OpenAI-compatible layer.
+// resolveProvider maps a model id to a built-in provider. Resolution order:
+//
+//  1. If the id is in the preset catalog, use its declared provider (this is how
+//     OpenRouter/NVIDIA/Ollama presets pick the right gateway).
+//  2. An "ollama/" prefix (or a base URL on the Ollama port) → local Ollama.
+//  3. An "nvidia/" prefix → NVIDIA NIM (strips the prefix for the wire id).
+//  4. Everything else → OpenRouter, the reference OpenAI-compatible gateway.
 func resolveProvider(model, baseURL string) (provider.Provider, string, error) {
-	models := []provider.Model{{ID: model}}
+	// 1. Preset catalog wins: a curated id knows its own provider.
+	if p, ok := provider.LookupPreset(model); ok {
+		switch p.Provider {
+		case "nvidia":
+			return provider.NewNvidiaProvider(baseURL, []provider.Model{{Provider: "nvidia", ID: model}}), "nvidia", nil
+		case "ollama":
+			id := strings.TrimPrefix(model, "ollama/")
+			return provider.NewOllamaProvider(baseURL, []provider.Model{{Provider: "ollama", ID: id}}), "ollama", nil
+		default: // openrouter and any OpenAI-compatible upstream
+			return provider.NewOpenRouterProvider(baseURL, []provider.Model{{Provider: "openrouter", ID: model}}), "openrouter", nil
+		}
+	}
+
+	// 2. Local Ollama by prefix or port.
 	if strings.HasPrefix(model, "ollama/") || strings.Contains(baseURL, "11434") {
 		id := strings.TrimPrefix(model, "ollama/")
 		return provider.NewOllamaProvider(baseURL, []provider.Model{{Provider: "ollama", ID: id}}), "ollama", nil
 	}
-	for i := range models {
-		models[i].Provider = "openrouter"
+	// 3. NVIDIA NIM by prefix.
+	if strings.HasPrefix(model, "nvidia/") {
+		id := strings.TrimPrefix(model, "nvidia/")
+		return provider.NewNvidiaProvider(baseURL, []provider.Model{{Provider: "nvidia", ID: id}}), "nvidia", nil
 	}
-	return provider.NewOpenRouterProvider(baseURL, models), "openrouter", nil
+	// 4. Default: OpenRouter.
+	return provider.NewOpenRouterProvider(baseURL, []provider.Model{{Provider: "openrouter", ID: model}}), "openrouter", nil
 }
 
 // builtinTools returns the default file/shell tool set rooted at cwd, or nil

--- a/cmd/pigo/presets_test.go
+++ b/cmd/pigo/presets_test.go
@@ -1,0 +1,83 @@
+package main
+
+// Tests for provider resolution and the /models preset listing. resolveProvider
+// maps a model id to the right gateway (preset catalog first, then prefix rules,
+// then OpenRouter default); presetListing renders the curated catalog for the
+// TUI /models command.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestResolveProviderPresetCatalog verifies a preset id resolves to its declared
+// provider (NVIDIA and Ollama presets do not fall through to OpenRouter).
+func TestResolveProviderPresetCatalog(t *testing.T) {
+	cases := []struct {
+		model    string
+		wantName string
+	}{
+		{"meta/llama-3.3-70b-instruct", "nvidia"},     // NVIDIA preset
+		{"ollama/llama3.3", "ollama"},                 // Ollama preset
+		{"openai/gpt-4o", "openrouter"},               // OpenRouter preset
+		{"anthropic/claude-3.5-sonnet", "openrouter"}, // OpenRouter preset
+	}
+	for _, c := range cases {
+		_, name, err := resolveProvider(c.model, "")
+		if err != nil {
+			t.Errorf("resolveProvider(%q) error: %v", c.model, err)
+			continue
+		}
+		if name != c.wantName {
+			t.Errorf("resolveProvider(%q) = %q, want %q", c.model, name, c.wantName)
+		}
+	}
+}
+
+// TestResolveProviderPrefixAndDefault verifies the prefix rules and the
+// OpenRouter default for ids not in the catalog.
+func TestResolveProviderPrefixAndDefault(t *testing.T) {
+	cases := []struct {
+		model    string
+		baseURL  string
+		wantName string
+	}{
+		{"ollama/some-local-model", "", "ollama"}, // ollama/ prefix
+		{"nvidia/some-nim-model", "", "nvidia"},   // nvidia/ prefix
+		{"some-unknown-model", "", "openrouter"},  // default
+		{"m", "http://host:11434/v1", "ollama"},   // ollama port
+	}
+	for _, c := range cases {
+		_, name, err := resolveProvider(c.model, c.baseURL)
+		if err != nil {
+			t.Errorf("resolveProvider(%q) error: %v", c.model, err)
+			continue
+		}
+		if name != c.wantName {
+			t.Errorf("resolveProvider(%q, %q) = %q, want %q", c.model, c.baseURL, name, c.wantName)
+		}
+	}
+}
+
+// TestPresetListingGroupsAndFilters verifies /models lists all providers by
+// default and filters to one provider when given an argument.
+func TestPresetListingGroupsAndFilters(t *testing.T) {
+	all := presetListing("")
+	for _, want := range []string{"openrouter", "nvidia", "ollama"} {
+		if !strings.Contains(all, want) {
+			t.Errorf("full listing missing provider %q:\n%s", want, all)
+		}
+	}
+	// Filter to nvidia only: openrouter must not appear.
+	nv := presetListing("nvidia")
+	if !strings.Contains(nv, "nvidia") {
+		t.Errorf("filtered listing missing nvidia:\n%s", nv)
+	}
+	if strings.Contains(nv, "openrouter") {
+		t.Errorf("nvidia filter must not include openrouter:\n%s", nv)
+	}
+	// Unknown filter yields a helpful message, not a crash.
+	if got := presetListing("bogus"); !strings.Contains(got, "no preset provider") {
+		t.Errorf("unknown filter = %q, want a not-found message", got)
+	}
+}

--- a/internal/provider/auth.go
+++ b/internal/provider/auth.go
@@ -29,6 +29,7 @@ var providerEnvVars = map[string][]string{
 	"xai":        {"XAI_API_KEY"},
 	"groq":       {"GROQ_API_KEY"},
 	"openrouter": {"OPENROUTER_API_KEY"},
+	"nvidia":     {"NVIDIA_API_KEY", "NVIDIA_NIM_API_KEY"},
 	"mistral":    {"MISTRAL_API_KEY"},
 }
 

--- a/internal/provider/presets.go
+++ b/internal/provider/presets.go
@@ -1,0 +1,101 @@
+// This file defines the built-in preset catalog: a curated set of ready-to-use
+// (provider, model) pairs a user can pick from without knowing each gateway's
+// wire details (对标 pi agent's preset provider/model picker). It covers the
+// OpenAI-compatible gateways pigo ships — OpenRouter and NVIDIA NIM — plus a few
+// local Ollama defaults.
+//
+// A preset binds a model id to the provider that serves it and that provider's
+// default endpoint, so selecting a preset is enough to build a working Provider.
+// The naive prefix-based mapping (ollama/…) still works for arbitrary ids; the
+// preset catalog is the "menu" of vetted choices surfaced to the user.
+//
+// Security: presets carry no secrets. Each provider resolves its API key by name
+// from the environment at request time (see auth.go); keys are never embedded
+// here or logged.
+package provider
+
+// PresetModel is one entry in the preset catalog: a model the user can select by
+// id, the provider that serves it, and a short human label for the picker.
+type PresetModel struct {
+	// Provider is the owning provider name (e.g. "openrouter", "nvidia").
+	Provider string
+	// ID is the model id passed to the provider (e.g. "openai/gpt-4o").
+	ID string
+	// DisplayName is a friendly label shown in the picker; falls back to ID.
+	DisplayName string
+}
+
+// Label returns the display label for a preset, falling back to the id.
+func (p PresetModel) Label() string {
+	if p.DisplayName != "" {
+		return p.DisplayName
+	}
+	return p.ID
+}
+
+// PresetProviders lists the providers the preset catalog draws from, with the
+// environment variable each expects its API key in (referenced by name only,
+// never a value). Order is the display order in the picker.
+var PresetProviders = []struct {
+	Name   string
+	EnvVar string
+}{
+	{Name: "openrouter", EnvVar: "OPENROUTER_API_KEY"},
+	{Name: "nvidia", EnvVar: "NVIDIA_API_KEY"},
+	{Name: "ollama", EnvVar: ""}, // local, no key
+}
+
+// PresetCatalog is the built-in curated list of selectable models, grouped by
+// provider in the order PresetProviders declares. These ids are the ones a user
+// can `/model <id>` into or pick from `/models`; the list is representative, not
+// exhaustive — any valid id for a known provider still works.
+var PresetCatalog = []PresetModel{
+	// --- OpenRouter (routes to many upstreams via one OpenAI-compatible API) ---
+	{Provider: "openrouter", ID: "openai/gpt-4o", DisplayName: "GPT-4o (OpenRouter)"},
+	{Provider: "openrouter", ID: "openai/gpt-4o-mini", DisplayName: "GPT-4o mini (OpenRouter)"},
+	{Provider: "openrouter", ID: "anthropic/claude-3.5-sonnet", DisplayName: "Claude 3.5 Sonnet (OpenRouter)"},
+	{Provider: "openrouter", ID: "anthropic/claude-3.7-sonnet", DisplayName: "Claude 3.7 Sonnet (OpenRouter)"},
+	{Provider: "openrouter", ID: "google/gemini-2.0-flash-001", DisplayName: "Gemini 2.0 Flash (OpenRouter)"},
+	{Provider: "openrouter", ID: "google/gemini-2.5-pro", DisplayName: "Gemini 2.5 Pro (OpenRouter)"},
+	{Provider: "openrouter", ID: "meta-llama/llama-3.3-70b-instruct", DisplayName: "Llama 3.3 70B (OpenRouter)"},
+	{Provider: "openrouter", ID: "deepseek/deepseek-chat", DisplayName: "DeepSeek V3 (OpenRouter)"},
+	{Provider: "openrouter", ID: "deepseek/deepseek-r1", DisplayName: "DeepSeek R1 (OpenRouter)"},
+	{Provider: "openrouter", ID: "qwen/qwen-2.5-72b-instruct", DisplayName: "Qwen 2.5 72B (OpenRouter)"},
+	{Provider: "openrouter", ID: "mistralai/mistral-large", DisplayName: "Mistral Large (OpenRouter)"},
+	{Provider: "openrouter", ID: "x-ai/grok-2-1212", DisplayName: "Grok 2 (OpenRouter)"},
+
+	// --- NVIDIA NIM (hosted, OpenAI-compatible) ---
+	{Provider: "nvidia", ID: "meta/llama-3.3-70b-instruct", DisplayName: "Llama 3.3 70B (NVIDIA)"},
+	{Provider: "nvidia", ID: "meta/llama-3.1-405b-instruct", DisplayName: "Llama 3.1 405B (NVIDIA)"},
+	{Provider: "nvidia", ID: "deepseek-ai/deepseek-r1", DisplayName: "DeepSeek R1 (NVIDIA)"},
+	{Provider: "nvidia", ID: "qwen/qwen2.5-coder-32b-instruct", DisplayName: "Qwen 2.5 Coder 32B (NVIDIA)"},
+	{Provider: "nvidia", ID: "nvidia/llama-3.1-nemotron-70b-instruct", DisplayName: "Nemotron 70B (NVIDIA)"},
+	{Provider: "nvidia", ID: "mistralai/mixtral-8x22b-instruct-v0.1", DisplayName: "Mixtral 8x22B (NVIDIA)"},
+
+	// --- Ollama (local, no API key) ---
+	{Provider: "ollama", ID: "ollama/llama3.3", DisplayName: "Llama 3.3 (local Ollama)"},
+	{Provider: "ollama", ID: "ollama/qwen2.5-coder", DisplayName: "Qwen 2.5 Coder (local Ollama)"},
+}
+
+// LookupPreset returns the preset entry for a model id, if the id is in the
+// catalog. Used to resolve a selected id to its owning provider.
+func LookupPreset(id string) (PresetModel, bool) {
+	for _, p := range PresetCatalog {
+		if p.ID == id {
+			return p, true
+		}
+	}
+	return PresetModel{}, false
+}
+
+// PresetsByProvider returns the presets served by a given provider name, in
+// catalog order.
+func PresetsByProvider(providerName string) []PresetModel {
+	var out []PresetModel
+	for _, p := range PresetCatalog {
+		if p.Provider == providerName {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/provider/presets_test.go
+++ b/internal/provider/presets_test.go
@@ -1,0 +1,64 @@
+package provider
+
+// Tests for the preset provider/model catalog (对标 pi agent's preset picker):
+// LookupPreset resolves a catalog id to its owning provider, PresetsByProvider
+// groups by provider, and every preset must name a provider that has a known
+// credential env var (or be the local, keyless Ollama).
+
+import "testing"
+
+// TestLookupPresetResolvesProvider verifies a catalog id resolves to its
+// declared provider, and an unknown id does not.
+func TestLookupPresetResolvesProvider(t *testing.T) {
+	p, ok := LookupPreset("meta/llama-3.3-70b-instruct")
+	if !ok {
+		t.Fatal("expected NVIDIA llama preset to be in the catalog")
+	}
+	if p.Provider != "nvidia" {
+		t.Errorf("provider = %q, want nvidia", p.Provider)
+	}
+	if _, ok := LookupPreset("definitely/not-a-preset"); ok {
+		t.Error("unknown id must not resolve to a preset")
+	}
+}
+
+// TestPresetsByProviderGroups verifies each provider surfaces at least one
+// preset and that the returned entries all belong to that provider.
+func TestPresetsByProviderGroups(t *testing.T) {
+	for _, name := range []string{"openrouter", "nvidia", "ollama"} {
+		got := PresetsByProvider(name)
+		if len(got) == 0 {
+			t.Errorf("provider %q has no presets", name)
+		}
+		for _, m := range got {
+			if m.Provider != name {
+				t.Errorf("PresetsByProvider(%q) returned entry for %q", name, m.Provider)
+			}
+		}
+	}
+}
+
+// TestPresetProvidersHaveCredentialMapping verifies every non-local preset
+// provider has an API-key env var mapping in providerEnvVars, so a selected
+// preset can actually resolve a credential. Ollama is local and keyless.
+func TestPresetProvidersHaveCredentialMapping(t *testing.T) {
+	for _, pv := range PresetProviders {
+		if pv.Name == "ollama" {
+			continue
+		}
+		if _, ok := providerEnvVars[pv.Name]; !ok {
+			t.Errorf("preset provider %q has no credential env var mapping", pv.Name)
+		}
+	}
+}
+
+// TestPresetLabelFallsBackToID verifies Label uses DisplayName when set and
+// falls back to the id otherwise.
+func TestPresetLabelFallsBackToID(t *testing.T) {
+	if got := (PresetModel{ID: "x", DisplayName: "X"}).Label(); got != "X" {
+		t.Errorf("Label = %q, want X", got)
+	}
+	if got := (PresetModel{ID: "x"}).Label(); got != "x" {
+		t.Errorf("Label = %q, want x", got)
+	}
+}

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -39,6 +39,9 @@ import (
 const (
 	openRouterBaseURL = "https://openrouter.ai/api/v1"
 	ollamaBaseURL     = "http://localhost:11434/v1"
+	// nvidiaBaseURL is NVIDIA's hosted NIM endpoint. It speaks the OpenAI
+	// Chat Completions wire format, so it rides openAICompatDriver unchanged.
+	nvidiaBaseURL = "https://integrate.api.nvidia.com/v1"
 	// bedrockBaseURL is a placeholder default; real Bedrock endpoints are
 	// region-specific (bedrock-runtime.<region>.amazonaws.com) and supplied at
 	// construction. It is exported as a field so callers set the resolved URL.
@@ -362,6 +365,22 @@ func NewOllamaProvider(baseURL string, models []Model) Provider {
 		baseURL:      baseURL,
 		models:       models,
 		requiresAuth: false,
+	}
+}
+
+// NewNvidiaProvider builds the NVIDIA provider (hosted NIM, OpenAI-compatible,
+// Bearer auth). baseURL defaults to the public integrate endpoint when empty.
+// The API key is resolved by the "nvidia" provider name (NVIDIA_API_KEY);
+// secret values are never logged.
+func NewNvidiaProvider(baseURL string, models []Model) Provider {
+	if baseURL == "" {
+		baseURL = nvidiaBaseURL
+	}
+	return &openAICompatDriver{
+		name:         "nvidia",
+		baseURL:      baseURL,
+		models:       models,
+		requiresAuth: true,
 	}
 }
 

--- a/internal/provider/providers_test.go
+++ b/internal/provider/providers_test.go
@@ -184,6 +184,48 @@ func TestBedrockMissingKeyIsEarlyError(t *testing.T) {
 	}
 }
 
+// TestNvidiaProviderStreamsChatCompletions verifies the NVIDIA NIM provider
+// rides the OpenAI-compatible driver: it POSTs to /chat/completions with a
+// Bearer token and streams through OpenAIDecoder, exactly like OpenRouter.
+func TestNvidiaProviderStreamsChatCompletions(t *testing.T) {
+	cs := newCaptureServer(t, openaiToolCallSSE)
+	p := NewNvidiaProvider(cs.srv.URL, []Model{{Provider: "nvidia", ID: "meta/llama-3.3-70b-instruct"}})
+	if p.Name() != "nvidia" {
+		t.Errorf("name = %q, want nvidia", p.Name())
+	}
+	stream, err := p.StreamCompletion(context.Background(), CompletionRequest{
+		Model:   "meta/llama-3.3-70b-instruct",
+		Context: LlmContext{Messages: agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("hi")}}}},
+		Config:  StreamConfig{APIKey: "nvapi-test"},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	kinds, _ := drainStream(t, stream)
+	if kinds[len(kinds)-1] != StreamEventDone {
+		t.Errorf("last event = %q, want done", kinds[len(kinds)-1])
+	}
+	if cs.path != "/chat/completions" {
+		t.Errorf("path = %q, want /chat/completions", cs.path)
+	}
+	if got := cs.headers.Get("Authorization"); got != "Bearer nvapi-test" {
+		t.Errorf("auth header = %q, want Bearer nvapi-test", got)
+	}
+}
+
+// TestNvidiaMissingKeyIsEarlyError verifies NVIDIA requires an API key and
+// reports the missing key as an early error naming the provider (never a value).
+func TestNvidiaMissingKeyIsEarlyError(t *testing.T) {
+	p := NewNvidiaProvider("", nil)
+	_, err := p.StreamCompletion(context.Background(), CompletionRequest{Model: "m"})
+	if err == nil {
+		t.Fatal("missing API key must return an early error")
+	}
+	if !strings.Contains(err.Error(), "nvidia") {
+		t.Errorf("error should name the provider, got %v", err)
+	}
+}
+
 // TestProvidersRegisterInModelRegistry verifies the shared driver providers plug
 // into the model registry (US-011) and resolve their models.
 func TestProvidersRegisterInModelRegistry(t *testing.T) {


### PR DESCRIPTION
## Summary
- 像 pi agent 一样支持预制的 provider/model 选择：新增 curated preset catalog，用户无需了解各网关的 wire 细节即可选用经过验证的 OpenRouter / NVIDIA / Ollama 模型。
- 新增 NVIDIA NIM 作为 OpenAI 兼容 provider（复用 `openAICompatDriver`，无新增 wire 代码），并映射 `NVIDIA_API_KEY` 凭据。
- 新增 `internal/provider/presets.go`：`PresetModel`、`PresetProviders`、`PresetCatalog`、`LookupPreset`、`PresetsByProvider`。
- `resolveProvider` 解析顺序调整为：preset catalog → `ollama/` / `nvidia/` 前缀 → 默认 OpenRouter。
- 新增 `/models` 命令，按 provider 分组列出预制模型（仅显示 env var 名称，绝不显示密钥值）；`/model <id>` 可在其间切换。

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l`（无输出）
- [x] `go test ./internal/provider/ ./cmd/pigo/`（全部通过）