### PR TITLE
新增 internal/compaction：token 会计与压缩触发判定

### DIFF
--- a/docs/issue#0117.html
+++ b/docs/issue#0117.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0117</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/117">#117</a> &mdash; 上下文 token 会计与压缩触发判定 &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 用 type switch 而非 pi 的 role 字符串分派</h3>
+      <p><strong>Ambiguity:</strong> pi 的 <code>estimateTokens</code> 用 <code>message.role</code> 字符串 switch；pigo 的消息是密封接口（<code>UserMessage</code>/<code>AssistantMessage</code>/<code>ToolResultMessage</code>）。</p>
+      <p><strong>Choice:</strong> 用 Go type switch 分派到具体类型，未知类型返回 0。</p>
+      <p><strong>Rationale:</strong> 与 agentcore 既有的 discriminated-union 惯例一致（content.go / message.go 都用 type switch），编译期类型安全，无需运行时字符串比较。</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>calculateContextTokens</code> 只求和 input+output</h3>
+      <p><strong>Ambiguity:</strong> pi 的 <code>calculateContextTokens</code> 折叠了 <code>cacheRead</code>/<code>cacheWrite</code>/<code>totalTokens</code>，而 pigo 的 <code>agentcore.Usage</code> 只有 <code>InputTokens</code>/<code>OutputTokens</code>。</p>
+      <p><strong>Choice:</strong> 返回 <code>InputTokens + OutputTokens</code>。</p>
+      <p><strong>Rationale:</strong> pigo 目前不追踪缓存 token；两家 provider（anthropic/openai）解码时也只填 input/output。如果将来 Usage 扩展缓存字段，此函数是唯一的改点。</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>ShouldCompact</code> 额外守卫 contextWindow &lt;= 0</h3>
+      <p><strong>Ambiguity:</strong> pi 只检查 <code>enabled</code>，未处理 contextWindow 未知（0）的情况。</p>
+      <p><strong>Choice:</strong> contextWindow &lt;= 0 时直接返回 false。</p>
+      <p><strong>Rationale:</strong> <code>provider.ModelInfo.ContextWindow</code> 显式定义 0 表示未知；若不守卫，未知窗口会退化成 <code>contextTokens &gt; -reserveTokens</code> 恒为真，导致每轮都误触发压缩。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> <code>LastUsageIndex</code> 用 -1 而非 null 表示"无"</h3>
+      <p><strong>Spec said:</strong> pi 的 <code>ContextUsageEstimate.lastUsageIndex</code> 是 <code>number | null</code>。</p>
+      <p><strong>Implemented:</strong> Go 用 <code>int</code> 字段，无 usage 时取 <code>-1</code>。</p>
+      <p><strong>Why:</strong> Go 无 nullable int；-1 哨兵是惯用做法，且切片索引本就非负，语义无歧义。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> toolCall 参数按 RawMessage 字节长度计</h3>
+      <p><strong>Alternatives:</strong> (A) 直接用 <code>len(c.Arguments)</code>（已是紧凑 JSON 字节）；(B) 反序列化后再 <code>json.Marshal</code> 规范化再计长度。</p>
+      <p><strong>Chosen:</strong> A —— 非空时直接取字节长度，仅在空 RawMessage 时 marshal 出 <code>"null"</code> 补 4 字符。</p>
+      <p><strong>Why:</strong> 这是保守估算而非精确计费，规范化不值得额外分配；pi 用 <code>safeJsonStringify(arguments)</code>，字符数量级一致。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 缓存 token 是否要纳入 Usage</h3>
+      <p><strong>Assumption:</strong> 当前只算 input+output 已足够触发判定。</p>
+      <p><strong>Verify:</strong> 如果 Anthropic prompt caching 上线后缓存读取占比很大，<code>calculateContextTokens</code> 会低估上下文规模，可能延迟压缩触发。届时需扩展 <code>agentcore.Usage</code> 并更新此函数。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> ToolResultMessage 的 image 块估算</h3>
+      <p><strong>Assumption:</strong> tool result 中的 image 块按 4800 字符（同 user/assistant）估算。</p>
+      <p><strong>Verify:</strong> pi 对 toolResult 走同一 <code>estimateTextAndImageContentChars</code>，pigo 复用 <code>contentListChars</code> 行为一致——待多模态（US-010）落地后回归确认。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/compaction/tokens.go
+++ b/internal/compaction/tokens.go
@@ -1,0 +1,186 @@
+// Package compaction implements context-window token accounting and the
+// decision of when a long session must be compacted, mirroring pi's
+// harness/compaction/compaction.ts.
+//
+// This file (US-001) covers the token side: estimating a message's token
+// footprint from a character heuristic, deriving the current context-token
+// usage (preferring provider-reported Usage over estimation), and the
+// ShouldCompact threshold check. Cut-point finding (US-002) and summarization
+// (US-003) live in sibling files.
+package compaction
+
+import (
+	"encoding/json"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// CompactionSettings holds the thresholds and retention knobs for compaction,
+// mirroring pi's CompactionSettings.
+type CompactionSettings struct {
+	// Enabled gates automatic compaction decisions.
+	Enabled bool
+	// ReserveTokens is reserved for the summary prompt and its output; the
+	// effective usable window is contextWindow - ReserveTokens.
+	ReserveTokens int
+	// KeepRecentTokens is the approximate recent-context token budget to retain
+	// after compaction (consumed by FindCutPoint in US-002).
+	KeepRecentTokens int
+}
+
+// DefaultCompactionSettings matches pi's DEFAULT_COMPACTION_SETTINGS.
+var DefaultCompactionSettings = CompactionSettings{
+	Enabled:          true,
+	ReserveTokens:    16384,
+	KeepRecentTokens: 20000,
+}
+
+// estimatedImageChars is the fixed character budget attributed to an image
+// block, matching pi's ESTIMATED_IMAGE_CHARS.
+const estimatedImageChars = 4800
+
+// charsPerToken is the conservative characters-per-token divisor pi uses.
+const charsPerToken = 4
+
+// ceilDiv returns ceil(a / b) for non-negative a and positive b.
+func ceilDiv(a, b int) int {
+	if a <= 0 {
+		return 0
+	}
+	return (a + b - 1) / b
+}
+
+// contentListChars sums the character footprint of a content list, counting
+// text/thinking/toolCall blocks by their text length and each image block as a
+// fixed estimatedImageChars, mirroring pi's estimateTextAndImageContentChars
+// plus its assistant-block handling.
+func contentListChars(content agentcore.ContentList) int {
+	chars := 0
+	for _, block := range content {
+		switch c := block.(type) {
+		case agentcore.TextContent:
+			chars += len(c.Text)
+		case agentcore.ThinkingContent:
+			chars += len(c.Thinking)
+		case agentcore.ToolCallContent:
+			// name + serialized arguments, matching pi's toolCall accounting.
+			chars += len(c.Name)
+			if len(c.Arguments) > 0 {
+				chars += len(c.Arguments)
+			} else {
+				// nil/empty RawMessage serializes to "null" downstream.
+				b, _ := json.Marshal(json.RawMessage(c.Arguments))
+				chars += len(b)
+			}
+		case agentcore.ImageContent:
+			chars += estimatedImageChars
+		}
+	}
+	return chars
+}
+
+// EstimateTokens returns a conservative token estimate for one message using
+// the same character heuristic as pi's estimateTokens (ceil(chars / 4)).
+func EstimateTokens(msg agentcore.Message) int {
+	switch m := msg.(type) {
+	case agentcore.UserMessage:
+		return ceilDiv(contentListChars(m.Content), charsPerToken)
+	case agentcore.AssistantMessage:
+		return ceilDiv(contentListChars(m.Content), charsPerToken)
+	case agentcore.ToolResultMessage:
+		return ceilDiv(contentListChars(m.Content), charsPerToken)
+	default:
+		return 0
+	}
+}
+
+// calculateContextTokens derives total context tokens from a provider usage
+// block. pigo's Usage only reports input/output, so we sum them (pi additionally
+// folds cache read/write, which pigo does not track).
+func calculateContextTokens(u agentcore.Usage) int {
+	return u.InputTokens + u.OutputTokens
+}
+
+// assistantUsage returns a usable Usage from an assistant message, skipping
+// aborted/error responses and zero-token usage, mirroring pi's getAssistantUsage.
+func assistantUsage(msg agentcore.Message) (agentcore.Usage, bool) {
+	a, ok := msg.(agentcore.AssistantMessage)
+	if !ok || a.Usage == nil {
+		return agentcore.Usage{}, false
+	}
+	if a.StopReason == agentcore.StopReasonAborted || a.StopReason == agentcore.StopReasonError {
+		return agentcore.Usage{}, false
+	}
+	if calculateContextTokens(*a.Usage) <= 0 {
+		return agentcore.Usage{}, false
+	}
+	return *a.Usage, true
+}
+
+// ContextUsageEstimate reports the derived context-token usage for a message
+// list, mirroring pi's ContextUsageEstimate.
+type ContextUsageEstimate struct {
+	// Tokens is the estimated total context tokens.
+	Tokens int
+	// UsageTokens is the tokens reported by the most recent assistant usage block.
+	UsageTokens int
+	// TrailingTokens is the estimated tokens after that usage block.
+	TrailingTokens int
+	// LastUsageIndex is the index of the message that provided usage, or -1 when
+	// none exists.
+	LastUsageIndex int
+}
+
+// EstimateContextTokens computes context-token usage for messages, preferring
+// the most recent valid assistant Usage block and estimating only the messages
+// that follow it. When no usage is available it estimates every message. This
+// mirrors pi's estimateContextTokens.
+func EstimateContextTokens(msgs []agentcore.Message) ContextUsageEstimate {
+	lastIdx := -1
+	var lastUsage agentcore.Usage
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if u, ok := assistantUsage(msgs[i]); ok {
+			lastIdx = i
+			lastUsage = u
+			break
+		}
+	}
+
+	if lastIdx < 0 {
+		estimated := 0
+		for _, m := range msgs {
+			estimated += EstimateTokens(m)
+		}
+		return ContextUsageEstimate{
+			Tokens:         estimated,
+			UsageTokens:    0,
+			TrailingTokens: estimated,
+			LastUsageIndex: -1,
+		}
+	}
+
+	usageTokens := calculateContextTokens(lastUsage)
+	trailing := 0
+	for i := lastIdx + 1; i < len(msgs); i++ {
+		trailing += EstimateTokens(msgs[i])
+	}
+	return ContextUsageEstimate{
+		Tokens:         usageTokens + trailing,
+		UsageTokens:    usageTokens,
+		TrailingTokens: trailing,
+		LastUsageIndex: lastIdx,
+	}
+}
+
+// ShouldCompact reports whether context usage has exceeded the usable window,
+// matching pi: contextTokens > contextWindow - reserveTokens. Disabled settings
+// or a non-positive contextWindow (unknown) never trigger compaction.
+func ShouldCompact(contextTokens, contextWindow int, settings CompactionSettings) bool {
+	if !settings.Enabled {
+		return false
+	}
+	if contextWindow <= 0 {
+		return false
+	}
+	return contextTokens > contextWindow-settings.ReserveTokens
+}

--- a/internal/compaction/tokens_test.go
+++ b/internal/compaction/tokens_test.go
@@ -1,0 +1,189 @@
+package compaction
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+func userMsg(text string) agentcore.UserMessage {
+	return agentcore.UserMessage{
+		RoleField: agentcore.RoleUser,
+		Content:   agentcore.ContentList{agentcore.NewTextContent(text)},
+	}
+}
+
+func assistantMsg(text string, usage *agentcore.Usage, stop string) agentcore.AssistantMessage {
+	return agentcore.AssistantMessage{
+		RoleField:  agentcore.RoleAssistant,
+		Content:    agentcore.ContentList{agentcore.NewTextContent(text)},
+		Usage:      usage,
+		StopReason: stop,
+	}
+}
+
+func TestEstimateTokensText(t *testing.T) {
+	// 8 chars / 4 = 2 tokens.
+	if got := EstimateTokens(userMsg("abcdefgh")); got != 2 {
+		t.Fatalf("text estimate: got %d, want 2", got)
+	}
+	// 9 chars -> ceil(9/4) = 3.
+	if got := EstimateTokens(userMsg("abcdefghi")); got != 3 {
+		t.Fatalf("ceil estimate: got %d, want 3", got)
+	}
+	// empty -> 0.
+	if got := EstimateTokens(userMsg("")); got != 0 {
+		t.Fatalf("empty estimate: got %d, want 0", got)
+	}
+}
+
+func TestEstimateTokensImage(t *testing.T) {
+	m := agentcore.UserMessage{
+		RoleField: agentcore.RoleUser,
+		Content:   agentcore.ContentList{agentcore.NewImageContent("data", "image/png")},
+	}
+	// estimatedImageChars (4800) / 4 = 1200.
+	if got := EstimateTokens(m); got != 1200 {
+		t.Fatalf("image estimate: got %d, want 1200", got)
+	}
+}
+
+func TestEstimateTokensAssistantToolCall(t *testing.T) {
+	args := json.RawMessage(`{"path":"a.go"}`) // 15 chars
+	m := agentcore.AssistantMessage{
+		RoleField: agentcore.RoleAssistant,
+		Content: agentcore.ContentList{
+			agentcore.NewToolCallContent("id1", "read", args), // name "read" = 4 chars
+		},
+	}
+	// (4 + 15) / 4 = ceil(19/4) = 5.
+	if got := EstimateTokens(m); got != 5 {
+		t.Fatalf("toolcall estimate: got %d, want 5", got)
+	}
+}
+
+func TestEstimateTokensUnknownRoleZero(t *testing.T) {
+	if got := EstimateTokens(agentcore.ToolResultMessage{}); got != 0 {
+		t.Fatalf("empty tool result: got %d, want 0", got)
+	}
+}
+
+func TestEstimateContextTokensNoUsageFallsBackToEstimate(t *testing.T) {
+	msgs := []agentcore.Message{
+		userMsg("abcdefgh"),                   // 2
+		assistantMsg("abcd", nil, "end_turn"), // 1
+	}
+	est := EstimateContextTokens(msgs)
+	if est.LastUsageIndex != -1 {
+		t.Fatalf("LastUsageIndex: got %d, want -1", est.LastUsageIndex)
+	}
+	if est.Tokens != 3 {
+		t.Fatalf("Tokens: got %d, want 3", est.Tokens)
+	}
+	if est.TrailingTokens != 3 || est.UsageTokens != 0 {
+		t.Fatalf("trailing/usage: got %d/%d, want 3/0", est.TrailingTokens, est.UsageTokens)
+	}
+}
+
+func TestEstimateContextTokensPrefersUsage(t *testing.T) {
+	usage := &agentcore.Usage{InputTokens: 1000, OutputTokens: 200}
+	msgs := []agentcore.Message{
+		userMsg("first"),
+		assistantMsg("reply", usage, "end_turn"),
+		userMsg("abcdefgh"), // trailing: 2 tokens
+	}
+	est := EstimateContextTokens(msgs)
+	if est.LastUsageIndex != 1 {
+		t.Fatalf("LastUsageIndex: got %d, want 1", est.LastUsageIndex)
+	}
+	if est.UsageTokens != 1200 {
+		t.Fatalf("UsageTokens: got %d, want 1200", est.UsageTokens)
+	}
+	if est.TrailingTokens != 2 {
+		t.Fatalf("TrailingTokens: got %d, want 2", est.TrailingTokens)
+	}
+	if est.Tokens != 1202 {
+		t.Fatalf("Tokens: got %d, want 1202", est.Tokens)
+	}
+}
+
+func TestEstimateContextTokensSkipsAbortedAndErrorUsage(t *testing.T) {
+	good := &agentcore.Usage{InputTokens: 500, OutputTokens: 0}
+	bad := &agentcore.Usage{InputTokens: 9999, OutputTokens: 0}
+	msgs := []agentcore.Message{
+		assistantMsg("ok", good, "end_turn"),
+		assistantMsg("aborted", bad, agentcore.StopReasonAborted),
+		assistantMsg("errored", bad, agentcore.StopReasonError),
+	}
+	est := EstimateContextTokens(msgs)
+	if est.LastUsageIndex != 0 {
+		t.Fatalf("LastUsageIndex: got %d, want 0 (should skip aborted/error)", est.LastUsageIndex)
+	}
+	if est.UsageTokens != 500 {
+		t.Fatalf("UsageTokens: got %d, want 500", est.UsageTokens)
+	}
+}
+
+func TestEstimateContextTokensSkipsZeroUsage(t *testing.T) {
+	zero := &agentcore.Usage{InputTokens: 0, OutputTokens: 0}
+	msgs := []agentcore.Message{
+		userMsg("abcdefgh"), // 2
+		assistantMsg("reply", zero, "end_turn"),
+	}
+	est := EstimateContextTokens(msgs)
+	// zero usage is ignored, so falls back to full estimation.
+	if est.LastUsageIndex != -1 {
+		t.Fatalf("LastUsageIndex: got %d, want -1", est.LastUsageIndex)
+	}
+}
+
+func TestShouldCompactThresholdBoundaries(t *testing.T) {
+	s := CompactionSettings{Enabled: true, ReserveTokens: 16384}
+	window := 200000
+	usable := window - s.ReserveTokens // 183616
+
+	tests := []struct {
+		name          string
+		contextTokens int
+		want          bool
+	}{
+		{"far below", 1000, false},
+		{"equal to usable", usable, false}, // strictly greater required
+		{"one over usable", usable + 1, true},
+		{"far over", window * 2, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldCompact(tt.contextTokens, window, s); got != tt.want {
+				t.Fatalf("ShouldCompact(%d): got %v, want %v", tt.contextTokens, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldCompactDisabled(t *testing.T) {
+	s := CompactionSettings{Enabled: false, ReserveTokens: 16384}
+	if ShouldCompact(1_000_000, 200000, s) {
+		t.Fatal("disabled settings must never compact")
+	}
+}
+
+func TestShouldCompactUnknownWindow(t *testing.T) {
+	s := CompactionSettings{Enabled: true, ReserveTokens: 16384}
+	if ShouldCompact(1_000_000, 0, s) {
+		t.Fatal("unknown (0) context window must never compact")
+	}
+}
+
+func TestDefaultCompactionSettings(t *testing.T) {
+	if DefaultCompactionSettings.ReserveTokens != 16384 {
+		t.Fatalf("ReserveTokens: got %d, want 16384", DefaultCompactionSettings.ReserveTokens)
+	}
+	if DefaultCompactionSettings.KeepRecentTokens != 20000 {
+		t.Fatalf("KeepRecentTokens: got %d, want 20000", DefaultCompactionSettings.KeepRecentTokens)
+	}
+	if !DefaultCompactionSettings.Enabled {
+		t.Fatal("default settings should be enabled")
+	}
+}


### PR DESCRIPTION
## Summary
- 新增 `internal/compaction` 包（对标 pi harness/compaction）
- `EstimateTokens`：字符启发式估算，ceil(chars/4)，image 块按 4800 字符
- `EstimateContextTokens`：优先用最近有效 assistant Usage（跳过 aborted/error/零 usage），叠加尾部消息估算
- `ShouldCompact`：`contextTokens > contextWindow - reserveTokens`；disabled 或未知窗口(0) 不触发
- `CompactionSettings` 默认 reserve 16384 / keepRecent 20000

Closes #117

## Test plan
- [x] go build ./... 通过
- [x] go test ./internal/compaction/... 通过
- [x] go vet 干净