### PR TITLE
compaction: 实现 FindCutPoint 会话切点计算

### DIFF
--- a/docs/issue#0118.html
+++ b/docs/issue#0118.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0118</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/118">#118</a> &mdash; 会话切点计算 FindCutPoint &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 适配到扁平 message 列表而非 pi 的 SessionTreeEntry</h3>
+      <p><strong>Ambiguity:</strong> pi 的 <code>findCutPoint</code> 操作 <code>SessionTreeEntry[]</code>（含 branch_summary/model_change/compaction 等非消息条目），并带 startIndex/endIndex 参数；pigo 当前是扁平 <code>[]agentcore.Message</code>。</p>
+      <p><strong>Choice:</strong> 签名简化为 <code>FindCutPoint(msgs, keepRecentTokens)</code>，去掉 start/end 与非消息条目分支。</p>
+      <p><strong>Rationale:</strong> pigo 尚无会话树（#121 才引入 id/parentId），当前只有线性消息。保留 pi 的核心算法（反向累加 + 最近合法切点 + split-turn 判定），省去暂不存在的条目类型；等 #121 落地后如需可再引入范围参数。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 合法切点 = user | assistant，其余（含 toolResult）不可切</h3>
+      <p><strong>Ambiguity:</strong> pi 的 <code>findValidCutPoints</code> 把 bashExecution/custom/branchSummary 等也算合法切点。</p>
+      <p><strong>Choice:</strong> pigo 只有 user/assistant/toolResult 三种消息角色，切点判定为 user||assistant，toolResult 明确排除。</p>
+      <p><strong>Rationale:</strong> 严格保证 toolCall 与其 toolResult 不被拆开——这是 AC 的硬要求。其他角色 pigo 目前不存在，default 分支自然排除。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 省略 pi 的 cutIndex 回退循环</h3>
+      <p><strong>Spec said:</strong> pi 在选定 cutIndex 后有一个 <code>while (cutIndex &gt; startIndex)</code> 循环，越过前面的非 message / 非 compaction 条目把 cutIndex 往前挪。</p>
+      <p><strong>Implemented:</strong> pigo 未实现该循环。</p>
+      <p><strong>Why:</strong> 该循环的作用是跳过 SessionTreeEntry 中夹杂的元数据条目（model_change 等）。pigo 扁平列表中每个元素都是消息，循环恒为 no-op，实现它反而引入无意义代码。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 无合法切点时保留全部而非报错</h3>
+      <p><strong>Alternatives:</strong> (A) 返回 <code>FirstKeptIndex=0</code> 表示"整段保留"；(B) 返回错误要求调用方处理。</p>
+      <p><strong>Chosen:</strong> A，与 pi 一致（<code>firstKeptEntryIndex: startIndex</code>）。</p>
+      <p><strong>Why:</strong> 只有 toolResult 的消息序列在正常会话中几乎不会出现；保守地"不切"比让上层处理错误更简单，且压缩本就是尽力而为。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> #121 引入会话树后是否需要范围参数</h3>
+      <p><strong>Assumption:</strong> 当前扁平列表签名够用。</p>
+      <p><strong>Verify:</strong> 增量压缩（从上次压缩点到本次 cut）需要 startIndex 语义。#119/#121 落地时可能要把 <code>FindCutPoint</code> 扩展为接受 start/end，或由调用方先切片再传入。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/compaction/cutpoint.go
+++ b/internal/compaction/cutpoint.go
@@ -1,0 +1,97 @@
+package compaction
+
+import "github.com/smallnest/pigo/internal/agentcore"
+
+// CutPointResult describes the cut selected for compaction, mirroring pi's
+// CutPointResult (adapted to pigo's flat message list).
+type CutPointResult struct {
+	// FirstKeptIndex is the index of the first message retained after
+	// compaction; everything before it is summarized.
+	FirstKeptIndex int
+	// TurnStartIndex is the index of the user message that starts the turn the
+	// cut falls inside, or -1 when the cut lands on a clean turn boundary.
+	TurnStartIndex int
+	// IsSplitTurn reports whether the cut splits an in-progress assistant turn.
+	IsSplitTurn bool
+}
+
+// isValidCutPoint reports whether a message may serve as a cut point. A cut may
+// land on a user or assistant message but never on a toolResult, because a
+// toolResult must stay attached to the toolCall that produced it (pi semantics).
+func isValidCutPoint(msg agentcore.Message) bool {
+	switch msg.Role() {
+	case agentcore.RoleUser, agentcore.RoleAssistant:
+		return true
+	default: // toolResult and any custom kinds are not cuttable.
+		return false
+	}
+}
+
+// findValidCutPoints returns the indices of all messages that may serve as cut
+// points, in ascending order.
+func findValidCutPoints(msgs []agentcore.Message) []int {
+	var pts []int
+	for i, m := range msgs {
+		if isValidCutPoint(m) {
+			pts = append(pts, i)
+		}
+	}
+	return pts
+}
+
+// findTurnStartIndex scans backwards from idx to find the user message that
+// starts the turn containing idx, returning -1 if none is found.
+func findTurnStartIndex(msgs []agentcore.Message, idx int) int {
+	for i := idx; i >= 0; i-- {
+		if msgs[i].Role() == agentcore.RoleUser {
+			return i
+		}
+	}
+	return -1
+}
+
+// FindCutPoint finds the compaction cut that keeps approximately
+// keepRecentTokens worth of the most recent messages. It accumulates token
+// estimates from the newest message backwards; once the retained budget is
+// reached it snaps to the nearest valid cut point at or after that message,
+// never splitting a toolCall from its toolResult. This mirrors pi's findCutPoint.
+//
+// When no valid cut point exists, it keeps everything (FirstKeptIndex 0).
+func FindCutPoint(msgs []agentcore.Message, keepRecentTokens int) CutPointResult {
+	cutPoints := findValidCutPoints(msgs)
+	if len(cutPoints) == 0 {
+		return CutPointResult{FirstKeptIndex: 0, TurnStartIndex: -1, IsSplitTurn: false}
+	}
+
+	// Default to the earliest valid cut point (keep as much as possible) when
+	// the retained budget is never reached.
+	cutIndex := cutPoints[0]
+
+	accumulated := 0
+	for i := len(msgs) - 1; i >= 0; i-- {
+		accumulated += EstimateTokens(msgs[i])
+		if accumulated >= keepRecentTokens {
+			// Snap to the nearest valid cut point at or after i, so the kept
+			// window starts on a cuttable boundary.
+			for _, c := range cutPoints {
+				if c >= i {
+					cutIndex = c
+					break
+				}
+			}
+			break
+		}
+	}
+
+	cutOnUser := msgs[cutIndex].Role() == agentcore.RoleUser
+	turnStart := -1
+	if !cutOnUser {
+		turnStart = findTurnStartIndex(msgs, cutIndex)
+	}
+
+	return CutPointResult{
+		FirstKeptIndex: cutIndex,
+		TurnStartIndex: turnStart,
+		IsSplitTurn:    !cutOnUser && turnStart != -1,
+	}
+}

--- a/internal/compaction/cutpoint_test.go
+++ b/internal/compaction/cutpoint_test.go
@@ -1,0 +1,119 @@
+package compaction
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// bigUser builds a user message whose estimate is ~tokens tokens (4 chars each).
+func bigUser(tokens int) agentcore.UserMessage {
+	return userMsg(strings.Repeat("x", tokens*4))
+}
+
+func assistantToolCall(id, name string) agentcore.AssistantMessage {
+	return agentcore.AssistantMessage{
+		RoleField: agentcore.RoleAssistant,
+		Content:   agentcore.ContentList{agentcore.NewToolCallContent(id, name, nil)},
+	}
+}
+
+func toolResult(id string) agentcore.ToolResultMessage {
+	return agentcore.ToolResultMessage{
+		RoleField:  agentcore.RoleToolResult,
+		ToolCallID: id,
+		Content:    agentcore.ContentList{agentcore.NewTextContent("result")},
+	}
+}
+
+func TestFindCutPointNoValidCutPoint(t *testing.T) {
+	// Only toolResult messages -> no valid cut point.
+	msgs := []agentcore.Message{toolResult("a"), toolResult("b")}
+	got := FindCutPoint(msgs, 100)
+	if got.FirstKeptIndex != 0 || got.TurnStartIndex != -1 || got.IsSplitTurn {
+		t.Fatalf("no-cutpoint: got %+v, want {0 -1 false}", got)
+	}
+}
+
+func TestFindCutPointOnTurnBoundary(t *testing.T) {
+	// Three complete user/assistant turns, each user ~100 tokens.
+	// keepRecentTokens small so the cut lands on a clean user boundary.
+	msgs := []agentcore.Message{
+		bigUser(100),                // 0
+		assistantMsg("a1", nil, ""), // 1
+		bigUser(100),                // 2
+		assistantMsg("a2", nil, ""), // 3
+		bigUser(100),                // 4
+		assistantMsg("a3", nil, ""), // 5
+	}
+	// keepRecentTokens=50: walking back, msg[5] tiny, msg[4]=100 >= 50 at i=4.
+	// nearest cut point >= 4 is index 4 (a user message) -> clean boundary.
+	got := FindCutPoint(msgs, 50)
+	if got.FirstKeptIndex != 4 {
+		t.Fatalf("FirstKeptIndex: got %d, want 4", got.FirstKeptIndex)
+	}
+	if got.IsSplitTurn {
+		t.Fatalf("IsSplitTurn: got true, want false (landed on user boundary)")
+	}
+	if got.TurnStartIndex != -1 {
+		t.Fatalf("TurnStartIndex: got %d, want -1", got.TurnStartIndex)
+	}
+}
+
+func TestFindCutPointSplitTurn(t *testing.T) {
+	// A turn starting with a user message, a big assistant reply, a toolCall and
+	// its toolResult. If the budget forces the cut onto the assistant message
+	// mid-turn, it's a split turn.
+	msgs := []agentcore.Message{
+		userMsg("older turn"),                           // 0
+		assistantMsg("older reply", nil, ""),            // 1
+		userMsg("current turn start"),                   // 2 user
+		assistantMsg(strings.Repeat("y", 400), nil, ""), // 3 assistant ~100 tokens
+		assistantToolCall("t1", "read"),                 // 4 assistant (valid cut)
+		toolResult("t1"),                                // 5 toolResult (not cuttable)
+	}
+	// keepRecentTokens=50: from end, msg[5]=~2, msg[4]~1, msg[3]=100 >= 50 at i=3.
+	// nearest cut point >= 3 is index 3 (assistant) -> split turn, turn start=2.
+	got := FindCutPoint(msgs, 50)
+	if got.FirstKeptIndex != 3 {
+		t.Fatalf("FirstKeptIndex: got %d, want 3", got.FirstKeptIndex)
+	}
+	if !got.IsSplitTurn {
+		t.Fatalf("IsSplitTurn: got false, want true (cut on assistant mid-turn)")
+	}
+	if got.TurnStartIndex != 2 {
+		t.Fatalf("TurnStartIndex: got %d, want 2", got.TurnStartIndex)
+	}
+}
+
+func TestFindCutPointNeverCutsOnToolResult(t *testing.T) {
+	// Ensure a toolResult is never chosen even when it's the message where the
+	// budget is reached.
+	msgs := []agentcore.Message{
+		userMsg("u0"),                   // 0
+		assistantToolCall("t1", "grep"), // 1
+		toolResult("t1"),                // 2 (budget could land here)
+		assistantMsg("done", nil, ""),   // 3
+	}
+	got := FindCutPoint(msgs, 1) // tiny budget: reached at msg[3]
+	// cut must be a valid point (>=3 is index 3 assistant); never index 2.
+	if got.FirstKeptIndex == 2 {
+		t.Fatalf("cut landed on toolResult (index 2), which is illegal")
+	}
+	if msgs[got.FirstKeptIndex].Role() == agentcore.RoleToolResult {
+		t.Fatalf("FirstKeptIndex points at a toolResult: %d", got.FirstKeptIndex)
+	}
+}
+
+func TestFindCutPointBudgetNeverReachedKeepsEarliest(t *testing.T) {
+	msgs := []agentcore.Message{
+		userMsg("u0"),               // 0
+		assistantMsg("a0", nil, ""), // 1
+	}
+	// Huge budget -> never reached -> keep from earliest valid cut point (0).
+	got := FindCutPoint(msgs, 1_000_000)
+	if got.FirstKeptIndex != 0 {
+		t.Fatalf("FirstKeptIndex: got %d, want 0 (earliest cut point)", got.FirstKeptIndex)
+	}
+}


### PR DESCRIPTION
## Summary
- 实现 `FindCutPoint(msgs, keepRecentTokens) CutPointResult`（对标 pi findCutPoint）
- 从最新反向累加 token，达阈值后落到最近合法切点
- 合法切点 = user | assistant，绝不切在 toolResult 上（toolCall/toolResult 不拆开）
- 落在 assistant 上判定为 split turn，回溯 turn start
- 适配 pigo 扁平消息列表（暂无会话树，见笔记）

Closes #118

## Test plan
- [x] 无可切点 / turn 边界 / split turn / 永不切 toolResult / 预算未达最早切点 单测
- [x] go test ./internal/compaction/... 通过
- [x] go vet 干净