### PR TITLE
摘要生成与 CompactionEntry 落盘 (#119)

### DIFF
--- a/docs/issue#0119.html
+++ b/docs/issue#0119.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0119</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/119">#119</a> &mdash; 摘要生成与 CompactionEntry 落盘 &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> CompactionMessage as a first-class message role, not a separate session-entry type</h3>
+      <p><strong>Ambiguity:</strong> The spec says "结果作为一条 CompactionEntry 写入 session JSONL" but pigo has no entry-type abstraction — it uses a flat <code>[]agentcore.Message</code>, whereas pi uses a tree of <code>SessionTreeEntry</code>.</p>
+      <p><strong>Choice:</strong> Added <code>RoleCompaction = "compaction"</code> and a <code>CompactionMessage</code> struct that implements the sealed <code>agentcore.Message</code> interface, wired into <code>decodeMessage</code>.</p>
+      <p><strong>Rationale:</strong> A compaction checkpoint then flows unchanged through the existing <code>MessageList</code> decode, session JSONL append/load, and provider encoders. No parallel persistence path or entry-type switch is needed.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Store CompactionDetails as <code>json.RawMessage</code> in agentcore</h3>
+      <p><strong>Ambiguity:</strong> The details (readFiles/modifiedFiles) shape is owned by the compaction package, but the message lives in agentcore.</p>
+      <p><strong>Choice:</strong> <code>CompactionMessage.Details</code> is a <code>json.RawMessage</code>; the <code>compaction</code> package marshals/unmarshals its own <code>CompactionDetails</code> struct.</p>
+      <p><strong>Rationale:</strong> Keeps <code>agentcore</code> free of any dependency on <code>compaction</code>, avoiding an import cycle while still round-tripping the metadata through JSONL.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Index-based <code>FirstKeptIndex</code> instead of pi's <code>firstKeptEntryId</code></h3>
+      <p><strong>Ambiguity:</strong> pi identifies the cut boundary by tree entry id; pigo has no ids.</p>
+      <p><strong>Choice:</strong> <code>CompactionResult.FirstKeptIndex</code> is a slice index into the flat message list; <code>RebuildContext</code> returns <code>[checkpoint] + msgs[FirstKeptIndex:]</code>.</p>
+      <p><strong>Rationale:</strong> Matches pigo's existing flat-list model; the cut point is naturally an index from <code>FindCutPoint</code>.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Usage tokens summed as input+output only</h3>
+      <p><strong>Spec/pi:</strong> pi folds cache-read and cache-write tokens into the context-token total.</p>
+      <p><strong>Implemented:</strong> <code>calculateContextTokens</code> sums only <code>InputTokens + OutputTokens</code>.</p>
+      <p><strong>Why:</strong> pigo's <code>Usage</code> struct does not track cache tokens, so there is nothing to fold in. Behavior is faithful to the data pigo actually has; if cache accounting is added later, this is the one place to extend.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> maxTokens cap via <code>cfg.Extra["max_tokens"]</code> rather than a typed field</h3>
+      <p><strong>Alternatives:</strong> (a) add a dedicated <code>MaxTokens int</code> to <code>StreamConfig</code>; (b) pass through the existing <code>Extra map[string]any</code>.</p>
+      <p><strong>Chosen (b):</strong> providers already read <code>Extra["max_tokens"]</code> via <code>maxOutputTokensFor</code>, so summarization reuses that path with no signature change across every provider.</p>
+      <p><strong>Cost:</strong> loses compile-time typing on the key, but keeps the provider interface stable and avoids touching Bedrock/OpenAI/Ollama constructors.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Deterministic tool-call serialization (sorted keys)</h3>
+      <p><strong>Alternatives:</strong> serialize tool-call args in map iteration order, or sort keys.</p>
+      <p><strong>Chosen:</strong> <code>formatToolCall</code> sorts keys before emitting <code>name(key=value, ...)</code>.</p>
+      <p><strong>Why:</strong> stable output makes <code>serializeConversation</code> testable and reproducible; the small sort cost is irrelevant at compaction scale.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Wiring compaction into the live agent loop</h3>
+      <p><strong>Assumption:</strong> #119 delivers the summarization + persistence machinery; the actual trigger (<code>/compact</code> command and auto-compaction when <code>ShouldCompact</code> fires) is scoped to #120.</p>
+      <p><strong>Verify:</strong> confirm the loop integration in #120 calls <code>Compact</code> + <code>RebuildContext</code> and appends the <code>CompactionMessage</code> to the session store.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Image-block handling in serialized conversations</h3>
+      <p><strong>Assumption:</strong> <code>serializeConversation</code> renders text/thinking/tool-call/tool-result content; image blocks contribute only their token estimate (4800 chars) and are not textually summarized.</p>
+      <p><strong>Verify:</strong> confirm this matches expectations — pi similarly does not inline image bytes into the summary prompt.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agentcore/message.go
+++ b/internal/agentcore/message.go
@@ -10,6 +10,11 @@ const (
 	RoleUser       = "user"
 	RoleAssistant  = "assistant"
 	RoleToolResult = "toolResult"
+	// RoleCompaction marks a compaction checkpoint persisted inline in the
+	// message list: it replaces the history summarized before it (pi's
+	// "compactionSummary"). It is not sent to the model verbatim; the LLM
+	// conversion turns it into a user text block.
+	RoleCompaction = "compaction"
 )
 
 // Message is the sealed interface implemented by the three message roles.
@@ -92,6 +97,45 @@ type ToolResultMessage struct {
 func (ToolResultMessage) isMessage()     {}
 func (m ToolResultMessage) Role() string { return RoleToolResult }
 
+// CompactionMessage is a summarization checkpoint persisted inline in the
+// message list. It stands in for the history compacted before it: Summary is
+// the structured checkpoint text and TokensBefore records the estimated context
+// size at compaction time (for observability). Details optionally holds the
+// file operations extracted from the compacted range. Mirrors pi's
+// CompactionSummaryMessage + CompactionEntry.
+type CompactionMessage struct {
+	RoleField    string `json:"role"`
+	Summary      string `json:"summary"`
+	TokensBefore int    `json:"tokensBefore,omitempty"`
+	// Details is opaque at this layer (the compaction package owns its shape);
+	// kept as raw JSON so agentcore stays free of a compaction dependency.
+	Details   json.RawMessage `json:"details,omitempty"`
+	Timestamp int64           `json:"timestamp"`
+}
+
+func (CompactionMessage) isMessage()     {}
+func (m CompactionMessage) Role() string { return RoleCompaction }
+
+// compactionSummaryPrefix / compactionSummarySuffix wrap a compaction summary
+// when it is rendered into an LLM user message, matching pi's
+// COMPACTION_SUMMARY_PREFIX / COMPACTION_SUMMARY_SUFFIX.
+const (
+	compactionSummaryPrefix = "The conversation history before this point was compacted into the following summary:\n\n<summary>\n"
+	compactionSummarySuffix = "\n</summary>"
+)
+
+// AsUserMessage renders a compaction checkpoint as the user text message that
+// stands in for the compacted history when building the LLM request. The
+// provider encoders call this so a persisted compaction line replays as
+// context rather than being dropped.
+func (m CompactionMessage) AsUserMessage() UserMessage {
+	return UserMessage{
+		RoleField: RoleUser,
+		Content:   ContentList{NewTextContent(compactionSummaryPrefix + m.Summary + compactionSummarySuffix)},
+		Timestamp: m.Timestamp,
+	}
+}
+
 // StopReason values, matching pi.
 const (
 	StopReasonEndTurn = "end_turn"
@@ -148,6 +192,12 @@ func decodeMessage(raw json.RawMessage) (Message, error) {
 		return m, nil
 	case RoleToolResult:
 		var m ToolResultMessage
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return nil, err
+		}
+		return m, nil
+	case RoleCompaction:
+		var m CompactionMessage
 		if err := json.Unmarshal(raw, &m); err != nil {
 			return nil, err
 		}

--- a/internal/compaction/compact.go
+++ b/internal/compaction/compact.go
@@ -1,0 +1,133 @@
+// This file (US-003) ties the compaction pieces together: given a message list
+// and settings, it finds the cut point, extracts file operations from the
+// summarized range, generates the structured summary, and returns a
+// CompactionResult ready to be persisted as a session compaction entry and used
+// to rebuild the agent context. Mirrors pi's prepareCompaction + compact.
+package compaction
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+// CompactionDetails records the files touched in the compacted history, stored
+// alongside a compaction entry so a later iterative compaction can seed its
+// file lists. Mirrors pi's CompactionDetails.
+type CompactionDetails struct {
+	// ReadFiles are files read but not modified in the compacted range.
+	ReadFiles []string `json:"readFiles"`
+	// ModifiedFiles are files written or edited in the compacted range.
+	ModifiedFiles []string `json:"modifiedFiles"`
+}
+
+// CompactionResult is the outcome of a compaction: the summary text (with file
+// metadata appended), the index where retained history begins, the estimated
+// tokens before compaction, and the extracted file details. Mirrors pi's
+// CompactionResult, adapted to pigo's flat message list (index vs entry id).
+type CompactionResult struct {
+	// Summary is the structured summary that replaces the compacted history.
+	Summary string
+	// FirstKeptIndex is the index of the first retained message.
+	FirstKeptIndex int
+	// TokensBefore is the estimated context tokens before compaction.
+	TokensBefore int
+	// Details holds the file operations extracted from the compacted range.
+	Details CompactionDetails
+}
+
+// Compact prepares and generates a compaction over msgs. It cuts at
+// FindCutPoint(msgs, settings.KeepRecentTokens), summarizes messages in
+// [prevCompactionIndex+1, firstKeptIndex) (seeding file ops from a prior
+// compaction's details when provided), and appends <read-files>/<modified-files>
+// metadata to the summary. previousSummary, when non-empty, switches to the
+// iterative update template.
+//
+// prevCompactionIndex is the index of the last already-applied compaction point
+// (-1 when none); summarization starts just after it so each compaction only
+// covers the newly accumulated history. prevDetails carries that compaction's
+// file lists so long-lived reads/edits survive across successive compactions.
+//
+// It returns (nil, nil) when there is nothing to compact (no valid cut point or
+// an empty summarization range).
+func Compact(
+	ctx context.Context,
+	stream provider.StreamFn,
+	model provider.Model,
+	msgs []agentcore.Message,
+	settings CompactionSettings,
+	prevCompactionIndex int,
+	prevDetails *CompactionDetails,
+	previousSummary string,
+	cfg provider.StreamConfig,
+) (*CompactionResult, error) {
+	cut := FindCutPoint(msgs, settings.KeepRecentTokens)
+
+	start := prevCompactionIndex + 1
+	if start < 0 {
+		start = 0
+	}
+	if start >= cut.FirstKeptIndex {
+		// Nothing new to summarize.
+		return nil, nil
+	}
+	toSummarize := msgs[start:cut.FirstKeptIndex]
+
+	// Seed file ops from the previous compaction, then fold in this range.
+	ops := NewFileOps()
+	if prevDetails != nil {
+		for _, f := range prevDetails.ReadFiles {
+			ops.Read[f] = struct{}{}
+		}
+		for _, f := range prevDetails.ModifiedFiles {
+			ops.Edited[f] = struct{}{}
+		}
+	}
+	for _, m := range toSummarize {
+		extractFileOpsFromMessage(m, ops)
+	}
+	readFiles, modifiedFiles := computeFileLists(ops)
+
+	summary, err := GenerateSummary(ctx, stream, model, toSummarize, settings.ReserveTokens, previousSummary, cfg)
+	if err != nil {
+		return nil, err
+	}
+	summary += formatFileOperations(readFiles, modifiedFiles)
+
+	return &CompactionResult{
+		Summary:        summary,
+		FirstKeptIndex: cut.FirstKeptIndex,
+		TokensBefore:   EstimateContextTokens(msgs).Tokens,
+		Details:        CompactionDetails{ReadFiles: readFiles, ModifiedFiles: modifiedFiles},
+	}, nil
+}
+
+// Message builds the CompactionMessage to persist for this result: the summary
+// text plus the estimated tokens-before and the file details (as raw JSON).
+func (r *CompactionResult) Message(now int64) agentcore.CompactionMessage {
+	var details json.RawMessage
+	if b, err := json.Marshal(r.Details); err == nil {
+		details = b
+	}
+	return agentcore.CompactionMessage{
+		RoleField:    agentcore.RoleCompaction,
+		Summary:      r.Summary,
+		TokensBefore: r.TokensBefore,
+		Details:      details,
+		Timestamp:    now,
+	}
+}
+
+// RebuildContext returns the post-compaction message list: the compaction
+// checkpoint followed by the retained recent messages (msgs[FirstKeptIndex:]).
+// The summarized prefix is dropped and replaced by the single checkpoint,
+// keeping context continuous while staying within the window. Mirrors pi's
+// post-compact context reconstruction (summary entry + retained tail).
+func (r *CompactionResult) RebuildContext(msgs []agentcore.Message, now int64) agentcore.MessageList {
+	out := make(agentcore.MessageList, 0, len(msgs)-r.FirstKeptIndex+1)
+	out = append(out, r.Message(now))
+	out = append(out, msgs[r.FirstKeptIndex:]...)
+	return out
+}

--- a/internal/compaction/summary.go
+++ b/internal/compaction/summary.go
@@ -1,0 +1,367 @@
+// This file (US-003) covers summarization: the structured prompts, the
+// conversation serializer, file-operation extraction, and GenerateSummary,
+// which drives a provider stream to turn compacted history into a structured
+// checkpoint summary. It mirrors pi's harness/compaction/compaction.ts prompts
+// and utils.ts helpers, adapted to pigo's flat message list and Provider stream.
+package compaction
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+// SUMMARIZATION_SYSTEM_PROMPT instructs the model to only emit the structured
+// summary and never continue the conversation. Verbatim from pi.
+const SUMMARIZATION_SYSTEM_PROMPT = `You are a context summarization assistant. Your task is to read a conversation between a user and an AI assistant, then produce a structured summary following the exact format specified.
+
+Do NOT continue the conversation. Do NOT respond to any questions in the conversation. ONLY output the structured summary.`
+
+// summarizationPrompt is the first-time summary template (pi's SUMMARIZATION_PROMPT).
+const summarizationPrompt = `The messages above are a conversation to summarize. Create a structured context checkpoint summary that another LLM will use to continue the work.
+
+Use this EXACT format:
+
+## Goal
+[What is the user trying to accomplish? Can be multiple items if the session covers different tasks.]
+
+## Constraints & Preferences
+- [Any constraints, preferences, or requirements mentioned by user]
+- [Or "(none)" if none were mentioned]
+
+## Progress
+### Done
+- [x] [Completed tasks/changes]
+
+### In Progress
+- [ ] [Current work]
+
+### Blocked
+- [Issues preventing progress, if any]
+
+## Key Decisions
+- **[Decision]**: [Brief rationale]
+
+## Next Steps
+1. [Ordered list of what should happen next]
+
+## Critical Context
+- [Any data, examples, or references needed to continue]
+- [Or "(none)" if not applicable]
+
+Keep each section concise. Preserve exact file paths, function names, and error messages.`
+
+// updateSummarizationPrompt incorporates new messages into an existing summary
+// (pi's UPDATE_SUMMARIZATION_PROMPT).
+const updateSummarizationPrompt = `The messages above are NEW conversation messages to incorporate into the existing summary provided in <previous-summary> tags.
+
+Update the existing structured summary with new information. RULES:
+- PRESERVE all existing information from the previous summary
+- ADD new progress, decisions, and context from the new messages
+- UPDATE the Progress section: move items from "In Progress" to "Done" when completed
+- UPDATE "Next Steps" based on what was accomplished
+- PRESERVE exact file paths, function names, and error messages
+- If something is no longer relevant, you may remove it
+
+Use this EXACT format:
+
+## Goal
+[Preserve existing goals, add new ones if the task expanded]
+
+## Constraints & Preferences
+- [Preserve existing, add new ones discovered]
+
+## Progress
+### Done
+- [x] [Include previously done items AND newly completed items]
+
+### In Progress
+- [ ] [Current work - update based on progress]
+
+### Blocked
+- [Current blockers - remove if resolved]
+
+## Key Decisions
+- **[Decision]**: [Brief rationale] (preserve all previous, add new)
+
+## Next Steps
+1. [Update based on current state]
+
+## Critical Context
+- [Preserve important context, add new if needed]
+
+Keep each section concise. Preserve exact file paths, function names, and error messages.`
+
+// FileOperations accumulates the file paths a compaction range touched, split
+// by access kind. Mirrors pi's FileOperations.
+type FileOperations struct {
+	// Read holds files read but not necessarily modified.
+	Read map[string]struct{}
+	// Written holds files written by full-file write operations.
+	Written map[string]struct{}
+	// Edited holds files modified by edit operations.
+	Edited map[string]struct{}
+}
+
+// NewFileOps returns an empty file-operation accumulator.
+func NewFileOps() FileOperations {
+	return FileOperations{
+		Read:    map[string]struct{}{},
+		Written: map[string]struct{}{},
+		Edited:  map[string]struct{}{},
+	}
+}
+
+// extractFileOpsFromMessage adds file operations from an assistant message's
+// tool calls to the accumulator, keyed on the tool name (read/write/edit) and
+// the string "path" argument. Non-assistant messages are ignored, matching pi.
+func extractFileOpsFromMessage(msg agentcore.Message, ops FileOperations) {
+	a, ok := msg.(agentcore.AssistantMessage)
+	if !ok {
+		return
+	}
+	for _, call := range a.ToolCalls() {
+		path := toolCallPath(call.Arguments)
+		if path == "" {
+			continue
+		}
+		switch call.Name {
+		case "read":
+			ops.Read[path] = struct{}{}
+		case "write":
+			ops.Written[path] = struct{}{}
+		case "edit":
+			ops.Edited[path] = struct{}{}
+		}
+	}
+}
+
+// toolCallPath extracts a string "path" argument from a tool call's raw
+// arguments, returning "" when absent or not a string.
+func toolCallPath(args json.RawMessage) string {
+	if len(args) == 0 {
+		return ""
+	}
+	var decoded struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(args, &decoded); err != nil {
+		return ""
+	}
+	return decoded.Path
+}
+
+// computeFileLists derives sorted read-only and modified (edited∪written) file
+// lists, excluding modified files from the read-only list. Mirrors pi.
+func computeFileLists(ops FileOperations) (readFiles, modifiedFiles []string) {
+	modified := map[string]struct{}{}
+	for f := range ops.Edited {
+		modified[f] = struct{}{}
+	}
+	for f := range ops.Written {
+		modified[f] = struct{}{}
+	}
+	for f := range ops.Read {
+		if _, isMod := modified[f]; !isMod {
+			readFiles = append(readFiles, f)
+		}
+	}
+	for f := range modified {
+		modifiedFiles = append(modifiedFiles, f)
+	}
+	sort.Strings(readFiles)
+	sort.Strings(modifiedFiles)
+	return readFiles, modifiedFiles
+}
+
+// formatFileOperations renders the file lists as <read-files>/<modified-files>
+// metadata blocks appended to a summary, or "" when both lists are empty.
+func formatFileOperations(readFiles, modifiedFiles []string) string {
+	var sections []string
+	if len(readFiles) > 0 {
+		sections = append(sections, "<read-files>\n"+strings.Join(readFiles, "\n")+"\n</read-files>")
+	}
+	if len(modifiedFiles) > 0 {
+		sections = append(sections, "<modified-files>\n"+strings.Join(modifiedFiles, "\n")+"\n</modified-files>")
+	}
+	if len(sections) == 0 {
+		return ""
+	}
+	return "\n\n" + strings.Join(sections, "\n\n")
+}
+
+// toolResultMaxChars caps a tool result's serialized text in the summarization
+// prompt, matching pi's TOOL_RESULT_MAX_CHARS.
+const toolResultMaxChars = 2000
+
+// truncateForSummary caps text at maxChars, appending a truncation marker.
+func truncateForSummary(text string, maxChars int) string {
+	if len(text) <= maxChars {
+		return text
+	}
+	return fmt.Sprintf("%s\n\n[... %d more characters truncated]", text[:maxChars], len(text)-maxChars)
+}
+
+// textOf concatenates the text blocks of a content list.
+func textOf(content agentcore.ContentList) string {
+	var b strings.Builder
+	for _, c := range content {
+		if t, ok := c.(agentcore.TextContent); ok {
+			b.WriteString(t.Text)
+		}
+	}
+	return b.String()
+}
+
+// serializeConversation renders messages as a plain-text transcript for the
+// summarization prompt, mirroring pi's serializeConversation: user text,
+// assistant thinking/text/tool-call lines, and truncated tool results.
+func serializeConversation(msgs []agentcore.Message) string {
+	var parts []string
+	for _, msg := range msgs {
+		switch m := msg.(type) {
+		case agentcore.UserMessage:
+			if s := textOf(m.Content); s != "" {
+				parts = append(parts, "[User]: "+s)
+			}
+		case agentcore.AssistantMessage:
+			var textParts, thinkingParts, toolCalls []string
+			for _, block := range m.Content {
+				switch c := block.(type) {
+				case agentcore.TextContent:
+					textParts = append(textParts, c.Text)
+				case agentcore.ThinkingContent:
+					thinkingParts = append(thinkingParts, c.Thinking)
+				case agentcore.ToolCallContent:
+					toolCalls = append(toolCalls, formatToolCall(c))
+				}
+			}
+			if len(thinkingParts) > 0 {
+				parts = append(parts, "[Assistant thinking]: "+strings.Join(thinkingParts, "\n"))
+			}
+			if len(textParts) > 0 {
+				parts = append(parts, "[Assistant]: "+strings.Join(textParts, "\n"))
+			}
+			if len(toolCalls) > 0 {
+				parts = append(parts, "[Assistant tool calls]: "+strings.Join(toolCalls, "; "))
+			}
+		case agentcore.ToolResultMessage:
+			if s := textOf(m.Content); s != "" {
+				parts = append(parts, "[Tool result]: "+truncateForSummary(s, toolResultMaxChars))
+			}
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// formatToolCall renders a tool call as name(key=value, ...) with each value
+// JSON-encoded, mirroring pi's serialization of tool-call arguments.
+func formatToolCall(c agentcore.ToolCallContent) string {
+	if len(c.Arguments) == 0 {
+		return c.Name + "()"
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(c.Arguments, &m); err != nil {
+		// Not an object: fall back to the raw argument text.
+		return fmt.Sprintf("%s(%s)", c.Name, string(c.Arguments))
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // deterministic order (Go map iteration is random)
+	pairs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, k+"="+string(m[k]))
+	}
+	return fmt.Sprintf("%s(%s)", c.Name, strings.Join(pairs, ", "))
+}
+
+// GenerateSummary drives a provider stream to summarize msgs into a structured
+// checkpoint. When previousSummary is non-empty it uses the update template and
+// embeds the prior summary in <previous-summary> tags; otherwise it uses the
+// first-time template. maxTokens is bounded to min(0.8*reserveTokens,
+// model.MaxOutputTokens) as in pi. The returned text is the concatenation of
+// the assistant response's text blocks. A terminal error/aborted response is
+// surfaced as an error.
+func GenerateSummary(
+	ctx context.Context,
+	stream provider.StreamFn,
+	model provider.Model,
+	msgs []agentcore.Message,
+	reserveTokens int,
+	previousSummary string,
+	cfg provider.StreamConfig,
+) (string, error) {
+	base := summarizationPrompt
+	if previousSummary != "" {
+		base = updateSummarizationPrompt
+	}
+
+	conversation := serializeConversation(msgs)
+	var b strings.Builder
+	b.WriteString("<conversation>\n")
+	b.WriteString(conversation)
+	b.WriteString("\n</conversation>\n\n")
+	if previousSummary != "" {
+		b.WriteString("<previous-summary>\n")
+		b.WriteString(previousSummary)
+		b.WriteString("\n</previous-summary>\n\n")
+	}
+	b.WriteString(base)
+
+	promptMsg := agentcore.UserMessage{
+		RoleField: agentcore.RoleUser,
+		Content:   agentcore.ContentList{agentcore.NewTextContent(b.String())},
+	}
+
+	// Bound the summary output to min(0.8*reserveTokens, model max output).
+	maxTokens := (reserveTokens * 8) / 10
+	if model.MaxOutputTokens > 0 && model.MaxOutputTokens < maxTokens {
+		maxTokens = model.MaxOutputTokens
+	}
+	extra := map[string]any{}
+	for k, v := range cfg.Extra {
+		extra[k] = v
+	}
+	if maxTokens > 0 {
+		extra["max_tokens"] = maxTokens
+	}
+	cfg.Extra = extra
+
+	llm := provider.LlmContext{
+		SystemPrompt: SUMMARIZATION_SYSTEM_PROMPT,
+		Messages:     agentcore.MessageList{promptMsg},
+	}
+	s, err := stream(ctx, model.ID, llm, cfg)
+	if err != nil {
+		return "", fmt.Errorf("compaction: build summary stream: %w", err)
+	}
+
+	// Drain events so the stream's result is populated, then read the final
+	// message. Failures ride the stream as a terminal message per the provider
+	// contract, so inspect StopReason rather than only the returned error.
+	for range s.Events() {
+	}
+	final, resErr := s.Result(ctx)
+	if resErr != nil {
+		return "", fmt.Errorf("compaction: summary stream: %w", resErr)
+	}
+	switch final.StopReason {
+	case agentcore.StopReasonAborted:
+		return "", fmt.Errorf("compaction: summarization aborted: %s", final.ErrorMessage)
+	case agentcore.StopReasonError:
+		return "", fmt.Errorf("compaction: summarization failed: %s", final.ErrorMessage)
+	}
+
+	summary := textOf(final.Content)
+	if strings.TrimSpace(summary) == "" {
+		return "", fmt.Errorf("compaction: summarization produced empty output")
+	}
+	return summary, nil
+}

--- a/internal/compaction/summary_test.go
+++ b/internal/compaction/summary_test.go
@@ -1,0 +1,274 @@
+package compaction
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+func TestExtractFileOpsAndLists(t *testing.T) {
+	readArgs, _ := json.Marshal(map[string]string{"path": "a.go"})
+	writeArgs, _ := json.Marshal(map[string]string{"path": "b.go"})
+	editArgs, _ := json.Marshal(map[string]string{"path": "a.go"}) // a.go also edited -> modified wins
+	msgs := []agentcore.Message{
+		assistantToolCall("1", "read"),
+		assistantToolCall("2", "write"),
+		assistantToolCall("3", "edit"),
+	}
+	// Attach args by rebuilding with arguments.
+	msgs[0] = agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant, Content: agentcore.ContentList{agentcore.NewToolCallContent("1", "read", readArgs)}}
+	msgs[1] = agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant, Content: agentcore.ContentList{agentcore.NewToolCallContent("2", "write", writeArgs)}}
+	msgs[2] = agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant, Content: agentcore.ContentList{agentcore.NewToolCallContent("3", "edit", editArgs)}}
+
+	ops := NewFileOps()
+	for _, m := range msgs {
+		extractFileOpsFromMessage(m, ops)
+	}
+	read, modified := computeFileLists(ops)
+	// a.go was read AND edited -> only in modified; b.go written -> modified.
+	if len(read) != 0 {
+		t.Fatalf("readFiles: got %v, want []", read)
+	}
+	if strings.Join(modified, ",") != "a.go,b.go" {
+		t.Fatalf("modifiedFiles: got %v, want [a.go b.go]", modified)
+	}
+}
+
+func TestFormatFileOperations(t *testing.T) {
+	if got := formatFileOperations(nil, nil); got != "" {
+		t.Fatalf("empty: got %q, want empty", got)
+	}
+	got := formatFileOperations([]string{"r.go"}, []string{"m.go"})
+	if !strings.Contains(got, "<read-files>\nr.go\n</read-files>") {
+		t.Fatalf("missing read-files block: %q", got)
+	}
+	if !strings.Contains(got, "<modified-files>\nm.go\n</modified-files>") {
+		t.Fatalf("missing modified-files block: %q", got)
+	}
+}
+
+func TestSerializeConversation(t *testing.T) {
+	args, _ := json.Marshal(map[string]any{"path": "x.go", "n": 1})
+	msgs := []agentcore.Message{
+		userMsg("hello"),
+		agentcore.AssistantMessage{
+			RoleField: agentcore.RoleAssistant,
+			Content: agentcore.ContentList{
+				agentcore.NewThinkingContent("thinking hard"),
+				agentcore.NewTextContent("here goes"),
+				agentcore.NewToolCallContent("t1", "read", args),
+			},
+		},
+		toolResult("t1"),
+	}
+	got := serializeConversation(msgs)
+	for _, want := range []string{
+		"[User]: hello",
+		"[Assistant thinking]: thinking hard",
+		"[Assistant]: here goes",
+		"[Assistant tool calls]: read(",
+		"[Tool result]: result",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("serialize missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestTruncateForSummary(t *testing.T) {
+	if got := truncateForSummary("short", 100); got != "short" {
+		t.Fatalf("no truncation expected: %q", got)
+	}
+	long := strings.Repeat("z", 2500)
+	got := truncateForSummary(long, toolResultMaxChars)
+	if !strings.Contains(got, "more characters truncated") {
+		t.Fatalf("expected truncation marker: %q", got[len(got)-60:])
+	}
+}
+
+// fakeStreamFn returns a StreamFn that yields a single done event with the
+// given assistant message, capturing the LlmContext it was called with.
+func fakeStreamFn(final agentcore.AssistantMessage, capture *provider.LlmContext) provider.StreamFn {
+	return func(ctx context.Context, model string, llm provider.LlmContext, cfg provider.StreamConfig) (*provider.AssistantMessageEventStream, error) {
+		if capture != nil {
+			*capture = llm
+		}
+		s := provider.NewAssistantMessageEventStream(4)
+		go func() {
+			_ = s.Emit(ctx, provider.StreamDoneEvent{Message: final})
+			s.SetResult(final)
+			s.Close()
+		}()
+		return s, nil
+	}
+}
+
+func assistantText(text string) agentcore.AssistantMessage {
+	return agentcore.AssistantMessage{
+		RoleField:  agentcore.RoleAssistant,
+		Content:    agentcore.ContentList{agentcore.NewTextContent(text)},
+		StopReason: agentcore.StopReasonEndTurn,
+	}
+}
+
+func TestGenerateSummaryFirstTime(t *testing.T) {
+	var captured provider.LlmContext
+	stream := fakeStreamFn(assistantText("## Goal\ndo the thing"), &captured)
+	model := provider.Model{ID: "m", MaxOutputTokens: 8000}
+	msgs := []agentcore.Message{userMsg("please do X")}
+
+	got, err := GenerateSummary(context.Background(), stream, model, msgs, 16384, "", provider.StreamConfig{})
+	if err != nil {
+		t.Fatalf("GenerateSummary: %v", err)
+	}
+	if !strings.Contains(got, "## Goal") {
+		t.Fatalf("summary text: %q", got)
+	}
+	// System prompt must be the summarization system prompt.
+	if captured.SystemPrompt != SUMMARIZATION_SYSTEM_PROMPT {
+		t.Fatalf("system prompt mismatch")
+	}
+	// First-time prompt uses the non-update template and wraps the conversation.
+	promptText := textOf(captured.Messages[0].(agentcore.UserMessage).Content)
+	if !strings.Contains(promptText, "<conversation>") || strings.Contains(promptText, "<previous-summary>") {
+		t.Fatalf("first-time prompt shape wrong:\n%s", promptText)
+	}
+	if !strings.Contains(promptText, "Create a structured context checkpoint") {
+		t.Fatalf("expected first-time template")
+	}
+}
+
+func TestGenerateSummaryUpdateUsesPrevious(t *testing.T) {
+	var captured provider.LlmContext
+	stream := fakeStreamFn(assistantText("updated summary"), &captured)
+	model := provider.Model{ID: "m"}
+	msgs := []agentcore.Message{userMsg("more work")}
+
+	_, err := GenerateSummary(context.Background(), stream, model, msgs, 16384, "PRIOR SUMMARY", provider.StreamConfig{})
+	if err != nil {
+		t.Fatalf("GenerateSummary: %v", err)
+	}
+	promptText := textOf(captured.Messages[0].(agentcore.UserMessage).Content)
+	if !strings.Contains(promptText, "<previous-summary>\nPRIOR SUMMARY") {
+		t.Fatalf("update prompt should embed previous summary:\n%s", promptText)
+	}
+	if !strings.Contains(promptText, "NEW conversation messages to incorporate") {
+		t.Fatalf("expected update template")
+	}
+}
+
+func TestGenerateSummaryMaxTokensCap(t *testing.T) {
+	var gotMax int
+	stream := func(ctx context.Context, model string, llm provider.LlmContext, cfg provider.StreamConfig) (*provider.AssistantMessageEventStream, error) {
+		if v, ok := cfg.Extra["max_tokens"].(int); ok {
+			gotMax = v
+		}
+		s := provider.NewAssistantMessageEventStream(2)
+		go func() {
+			m := assistantText("ok")
+			_ = s.Emit(ctx, provider.StreamDoneEvent{Message: m})
+			s.SetResult(m)
+			s.Close()
+		}()
+		return s, nil
+	}
+	// 0.8 * 16384 = 13107, but model max output is 5000 -> cap at 5000.
+	model := provider.Model{ID: "m", MaxOutputTokens: 5000}
+	_, err := GenerateSummary(context.Background(), stream, model, []agentcore.Message{userMsg("x")}, 16384, "", provider.StreamConfig{})
+	if err != nil {
+		t.Fatalf("GenerateSummary: %v", err)
+	}
+	if gotMax != 5000 {
+		t.Fatalf("max_tokens: got %d, want 5000", gotMax)
+	}
+}
+
+func TestGenerateSummaryErrorStopReason(t *testing.T) {
+	errMsg := agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant, StopReason: agentcore.StopReasonError, ErrorMessage: "boom"}
+	stream := fakeStreamFn(errMsg, nil)
+	_, err := GenerateSummary(context.Background(), stream, provider.Model{ID: "m"}, []agentcore.Message{userMsg("x")}, 16384, "", provider.StreamConfig{})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected error containing 'boom', got %v", err)
+	}
+}
+
+func TestCompactRebuildsContext(t *testing.T) {
+	readArgs, _ := json.Marshal(map[string]string{"path": "old.go"})
+	msgs := []agentcore.Message{
+		userMsg("turn one"),                                                                                                                                    // 0
+		agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant, Content: agentcore.ContentList{agentcore.NewToolCallContent("t1", "read", readArgs)}}, // 1
+		toolResult("t1"), // 2
+		bigUser(100),     // 3
+		assistantMsg("recent", nil, ""), // 4
+	}
+	stream := fakeStreamFn(assistantText("## Goal\nx"), nil)
+	// Small keepRecentTokens so the cut lands on the recent bigUser(100) turn,
+	// leaving the earlier read/toolResult prefix to be summarized.
+	settings := CompactionSettings{Enabled: true, ReserveTokens: 16384, KeepRecentTokens: 50}
+	res, err := Compact(context.Background(), stream, provider.Model{ID: "m"}, msgs, settings, -1, nil, "", provider.StreamConfig{})
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if res == nil {
+		t.Fatal("Compact returned nil result")
+	}
+	// old.go was read in the summarized prefix.
+	if strings.Join(res.Details.ReadFiles, ",") != "old.go" {
+		t.Fatalf("readFiles: got %v, want [old.go]", res.Details.ReadFiles)
+	}
+	if !strings.Contains(res.Summary, "<read-files>") {
+		t.Fatalf("summary should carry file metadata: %q", res.Summary)
+	}
+	rebuilt := res.RebuildContext(msgs, 123)
+	if rebuilt[0].Role() != agentcore.RoleCompaction {
+		t.Fatalf("first rebuilt message must be compaction, got %s", rebuilt[0].Role())
+	}
+	// Retained tail begins at FirstKeptIndex.
+	if len(rebuilt) != 1+(len(msgs)-res.FirstKeptIndex) {
+		t.Fatalf("rebuilt length: got %d", len(rebuilt))
+	}
+}
+
+func TestCompactNothingToSummarize(t *testing.T) {
+	// prevCompactionIndex already at/after the cut -> nil result.
+	msgs := []agentcore.Message{userMsg("a"), assistantMsg("b", nil, "")}
+	stream := fakeStreamFn(assistantText("unused"), nil)
+	res, err := Compact(context.Background(), stream, provider.Model{ID: "m"}, msgs, DefaultCompactionSettings, 5, nil, "", provider.StreamConfig{})
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("expected nil result when nothing to summarize, got %+v", res)
+	}
+}
+
+func TestCompactionMessageRoundTrip(t *testing.T) {
+	details, _ := json.Marshal(CompactionDetails{ReadFiles: []string{"a"}, ModifiedFiles: []string{"b"}})
+	cm := agentcore.CompactionMessage{
+		RoleField:    agentcore.RoleCompaction,
+		Summary:      "the summary",
+		TokensBefore: 42,
+		Details:      details,
+		Timestamp:    7,
+	}
+	list := agentcore.MessageList{cm}
+	raw, err := json.Marshal(list)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back agentcore.MessageList
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(back) != 1 || back[0].Role() != agentcore.RoleCompaction {
+		t.Fatalf("round-trip role: %+v", back)
+	}
+	got := back[0].(agentcore.CompactionMessage)
+	if got.Summary != "the summary" || got.TokensBefore != 42 {
+		t.Fatalf("round-trip fields: %+v", got)
+	}
+}

--- a/internal/compaction/tokens.go
+++ b/internal/compaction/tokens.go
@@ -89,6 +89,9 @@ func EstimateTokens(msg agentcore.Message) int {
 		return ceilDiv(contentListChars(m.Content), charsPerToken)
 	case agentcore.ToolResultMessage:
 		return ceilDiv(contentListChars(m.Content), charsPerToken)
+	case agentcore.CompactionMessage:
+		// A compaction checkpoint replays as its summary text; estimate from it.
+		return ceilDiv(len(m.Summary), charsPerToken)
 	default:
 		return 0
 	}

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -133,6 +133,10 @@ func encodeOpenAIMessage(m agentcore.Message) []map[string]any {
 	switch msg := m.(type) {
 	case agentcore.UserMessage:
 		return []map[string]any{{"role": "user", "content": agentcore.ContentToText(msg.Content)}}
+	case agentcore.CompactionMessage:
+		// A compaction checkpoint stands in for compacted history as user text.
+		u := msg.AsUserMessage()
+		return []map[string]any{{"role": "user", "content": agentcore.ContentToText(u.Content)}}
 	case agentcore.AssistantMessage:
 		entry := map[string]any{"role": "assistant"}
 		entry["content"] = agentcore.ContentToText(msg.Content)
@@ -273,6 +277,9 @@ func encodeAnthropicMessage(m agentcore.Message) map[string]any {
 	switch msg := m.(type) {
 	case agentcore.UserMessage:
 		return map[string]any{"role": "user", "content": agentcore.ContentToText(msg.Content)}
+	case agentcore.CompactionMessage:
+		u := msg.AsUserMessage()
+		return map[string]any{"role": "user", "content": agentcore.ContentToText(u.Content)}
 	case agentcore.AssistantMessage:
 		var blocks []map[string]any
 		for _, c := range msg.Content {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -30,7 +30,11 @@ import (
 // SchemaVersion is the current session file schema version. It is written into
 // every SessionHeader and checked on read; an unknown (higher) version is a
 // hard error so a newer file is never silently misread by an older binary.
-const SchemaVersion = 1
+//
+// v2 adds the inline "compaction" message role (US-003): a compaction
+// checkpoint persisted as one message line. v1 files have no such lines and
+// remain fully readable, so the bump is backward-compatible on read.
+const SchemaVersion = 2
 
 // sessionScanBufInit / sessionScanBufMax bound the line scanner used to read a
 // session file. A single line holds one message, which can be large (a long

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -166,3 +166,63 @@ func TestLoadRejectsNewerSchema(t *testing.T) {
 		t.Error("Load must reject a newer schema version")
 	}
 }
+
+// TestLoadV1FileStillReadable verifies the v2 schema bump is backward-compatible:
+// an old v1 session file (no compaction lines) loads without error.
+func TestLoadV1FileStillReadable(t *testing.T) {
+	s := newStore(t)
+	v1 := `{"version":1,"id":"old","createdAt":"2026-07-10T00:00:00Z","updatedAt":"2026-07-10T00:00:00Z"}` + "\n" +
+		`{"role":"user","content":[{"type":"text","text":"hi"}],"timestamp":0}` + "\n"
+	path := filepath.Join(s.Dir(), FileName("old"))
+	if err := writeFile(path, v1); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	h, msgs, err := s.Load("old")
+	if err != nil {
+		t.Fatalf("Load v1: %v", err)
+	}
+	if h.Version != 1 {
+		t.Fatalf("version: got %d, want 1", h.Version)
+	}
+	if len(msgs) != 1 || msgs[0].Role() != agentcore.RoleUser {
+		t.Fatalf("messages: got %+v", msgs)
+	}
+}
+
+// TestSaveLoadCompactionEntry verifies a compaction checkpoint round-trips
+// through the JSONL store as a first-class message line under schema v2.
+func TestSaveLoadCompactionEntry(t *testing.T) {
+	s := newStore(t)
+	now := time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+	header := SessionHeader{ID: NewID(now), CreatedAt: now, UpdatedAt: now}
+	msgs := agentcore.MessageList{
+		agentcore.CompactionMessage{
+			RoleField:    agentcore.RoleCompaction,
+			Summary:      "## Goal\nship #119",
+			TokensBefore: 12345,
+			Details:      []byte(`{"readFiles":["a.go"],"modifiedFiles":["b.go"]}`),
+			Timestamp:    now.UnixMilli(),
+		},
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("continue")}},
+	}
+	if err := s.Save(header, msgs); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, back, err := s.Load(header.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.Version != SchemaVersion {
+		t.Fatalf("version: got %d, want %d", loaded.Version, SchemaVersion)
+	}
+	if len(back) != 2 || back[0].Role() != agentcore.RoleCompaction {
+		t.Fatalf("messages: got %+v", back)
+	}
+	cm, ok := back[0].(agentcore.CompactionMessage)
+	if !ok {
+		t.Fatalf("first message is not a CompactionMessage: %T", back[0])
+	}
+	if cm.Summary != "## Goal\nship #119" || cm.TokensBefore != 12345 {
+		t.Fatalf("compaction fields: %+v", cm)
+	}
+}


### PR DESCRIPTION
## Summary
- 新增 `internal/compaction/summary.go`：`SUMMARIZATION_SYSTEM_PROMPT` + 结构化模板（Goal/Constraints/Progress/Key Decisions/Next Steps/Critical Context），复用 `provider.StreamFn` 生成摘要，`maxTokens = min(0.8*reserveTokens, model.MaxOutputTokens)`；从 read/write/edit 工具调用提取 `readFiles/modifiedFiles`
- 新增 `internal/compaction/compact.go`：`Compact` 覆盖上次压缩点→cut point 的消息、`CompactionResult.RebuildContext` 用摘要+保留消息重建上下文
- 新增 `agentcore.CompactionMessage`/`RoleCompaction`/`AsUserMessage`，作为一等消息落入 session JSONL
- `SchemaVersion` 升至 2，v1 旧文件仍可读；provider 编码器与 `EstimateTokens` 补充 CompactionMessage 分支

Closes #119

## Test plan
- [x] go build ./...
- [x] go test ./internal/compaction/... ./internal/session/...
- [x] go vet ./...