### PR TITLE
/compact 命令 + loop 自动压缩接入

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -102,11 +102,12 @@ func runInteractive(opts interactiveOptions) error {
 	// takes effect on the next turn; header is updated so the switch is persisted
 	// with the session.
 	live := &liveRunConfig{
-		model:        opts.model,
-		providerName: opts.providerName,
-		provider:     opts.provider,
-		baseURL:      opts.baseURL,
-		protocol:     opts.protocol,
+		model:         opts.model,
+		providerName:  opts.providerName,
+		provider:      opts.provider,
+		baseURL:       opts.baseURL,
+		protocol:      opts.protocol,
+		contextWindow: defaultContextWindow,
 	}
 
 	// Wire slash-commands: built-ins (compile-time) plus any user templates under
@@ -271,7 +272,18 @@ type liveRunConfig struct {
 	provider     provider.Provider
 	baseURL      string
 	protocol     string
+	// contextWindow is the model's total context-token budget, used to gate
+	// automatic compaction. When 0 the window is unknown and auto-compaction is
+	// disabled; the REPL seeds it with a conservative default so long sessions
+	// still compact rather than overflow.
+	contextWindow int
 }
+
+// defaultContextWindow is the fallback context-token budget used when a model's
+// true window is unknown. It is deliberately large so auto-compaction only fires
+// on genuinely long sessions (threshold = window - ReserveTokens), never on
+// ordinary short exchanges.
+const defaultContextWindow = 128000
 
 // registerLiveCommands installs the built-in action commands that need live
 // runtime state. /model views or switches the active model; /help lists the
@@ -320,14 +332,18 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 			return b.String()
 		},
 	})
-	// /exit and /quit are intercepted by the REPL loop before slash resolution
-	// (they must return from the loop, which an Action closure cannot do). They
-	// are registered here only so /help lists them; their Action is never
-	// actually reached.
-	for _, name := range []string{"exit", "quit"} {
+	// /exit, /quit and /compact are intercepted by the REPL loop before slash
+	// resolution (they must return from the loop or run an agent stream + mutate
+	// the shared context, which an Action closure cannot do). They are registered
+	// here only so /help lists them; their Action is never actually reached.
+	for _, c := range []struct{ name, desc string }{
+		{"exit", "exit the REPL"},
+		{"quit", "exit the REPL"},
+		{"compact", "summarize and compact the conversation context now"},
+	} {
 		reg.AddBuiltin(runtime.SlashCommand{
-			Name:        name,
-			Description: "exit the REPL",
+			Name:        c.name,
+			Description: c.desc,
 			Action:      func(string) string { return "" },
 		})
 	}

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/compaction"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 	"github.com/smallnest/pigo/internal/session"
@@ -100,6 +101,17 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 		if line == "/exit" || line == "/quit" {
 			return nil
 		}
+		if line == "/compact" {
+			// /compact is intercepted here (like /exit) because compaction must run
+			// an agent stream and mutate the shared context — neither of which a
+			// slash Action closure (string in, string out) can do.
+			runManualCompact(out, deps)
+			deps.header.UpdatedAt = time.Now().UTC()
+			if err := deps.store.Save(deps.header, deps.agentCtx.Messages); err != nil {
+				fmt.Fprintf(out, "pigo: session save failed: %v\n", err)
+			}
+			continue
+		}
 
 		// Resolve slash-commands: an action command runs and prints its message
 		// (no agent run); a prompt command or skill expands to the text we run; an
@@ -149,10 +161,12 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 	})
 	cfg := runtime.RunConfig{
 		LoopConfig: runtime.LoopConfig{
-			Model:     deps.live.model,
-			Provider:  deps.live.providerName,
-			Stream:    provider.StreamFnFromProvider(deps.live.provider),
-			GetAPIKey: deps.creds.GetAPIKey,
+			Model:         deps.live.model,
+			Provider:      deps.live.providerName,
+			Stream:        provider.StreamFnFromProvider(deps.live.provider),
+			GetAPIKey:     deps.creds.GetAPIKey,
+			ContextWindow: deps.live.contextWindow,
+			Compaction:    compaction.DefaultCompactionSettings,
 		},
 		Batch: agenttool.BatchConfig{
 			ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: deps.reg},
@@ -191,6 +205,44 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 			fmt.Fprintf(out, "error: %v\n", err)
 		}
 	}
+}
+
+// runManualCompact compacts the shared context on an explicit /compact request:
+// it runs the summarization stream, replaces the context with the checkpoint +
+// retained tail, and prints the before/after token counts and retained message
+// count. A failure is reported but non-fatal — the original context is kept
+// unchanged (US-004). It uses the same provider/model as the live run.
+func runManualCompact(out io.Writer, deps replDeps) {
+	msgs := deps.agentCtx.Messages
+	settings := compaction.DefaultCompactionSettings
+	before := compaction.EstimateContextTokens(msgs).Tokens
+
+	stream := provider.StreamFnFromProvider(deps.live.provider)
+	model := provider.Model{Provider: deps.live.providerName, ID: deps.live.model, ContextWindow: deps.live.contextWindow}
+
+	// Resolve the API key like a normal turn so summarization authenticates
+	// against auth-requiring providers (otherwise Compact fails with
+	// "missing API key" and /compact would always report a non-fatal failure).
+	scfg := provider.StreamConfig{}
+	if deps.creds != nil {
+		scfg.APIKey = deps.creds.GetAPIKey(context.Background(), deps.live.providerName)
+	}
+	res, err := compaction.Compact(context.Background(), stream, model, msgs, settings, -1, nil, "", scfg)
+	if err != nil {
+		fmt.Fprintf(out, "compaction failed: %v (context left unchanged)\n", err)
+		return
+	}
+	if res == nil {
+		fmt.Fprintf(out, "nothing to compact (%d tokens, %d messages)\n", before, len(msgs))
+		return
+	}
+	now := time.Now().UnixMilli()
+	rebuilt := res.RebuildContext(msgs, now)
+	deps.agentCtx.Messages = rebuilt
+	after := compaction.EstimateContextTokens(rebuilt).Tokens
+	summarized := len(msgs) - (len(rebuilt) - 1)
+	fmt.Fprintf(out, "compacted: %d → %d tokens, summarized %d messages, kept %d\n",
+		before, after, summarized, len(rebuilt)-1)
 }
 
 // replayTranscript prints a resumed session's prior messages to out so the user

--- a/docs/issue#0120.html
+++ b/docs/issue#0120.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0120</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block; font-size: 0.6875rem; font-weight: 500;
+      padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    code { background: #F0EEEA; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.8125rem; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/120">#120</a> &mdash; /compact 命令 + loop 自动压缩接入 &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 自动压缩放在 runLoop 内部的 afterTurn，而非 PrepareNextTurn 钩子</h3>
+      <p><strong>Ambiguity:</strong> Spec 只要求“每轮结束调用 ShouldCompact 并在超阈值时压缩”，未指定接入点。</p>
+      <p><strong>Choice:</strong> 在 <code>afterTurn</code> 中新增 <code>maybeAutoCompact</code>，并给 <code>afterTurn</code> 注入一个 <code>emit</code> 闭包。</p>
+      <p><strong>Rationale:</strong> 现有钩子(PrepareNextTurn/ShouldStopAfterTurn)签名只能读写 agentCtx，无法发出事件。CompactionEvent 必须进入事件流(供 headless/stream-json 观察)，因此压缩逻辑只能住在能拿到 stream.Emit 的 runLoop 内。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> /compact 在 REPL 循环中直接拦截，不走 SlashCommand.Action</h3>
+      <p><strong>Ambiguity:</strong> 其它斜杠命令都用 Action 闭包实现。</p>
+      <p><strong>Choice:</strong> 像 <code>/exit</code>/<code>/quit</code> 一样在 <code>runREPL</code> 循环里拦截 <code>/compact</code>，调用 <code>runManualCompact</code>；仅在注册表登记以便 <code>/help</code> 列出。</p>
+      <p><strong>Rationale:</strong> Action 的签名是 <code>func(string) string</code>，既不能跑 summarization stream 也不能改写共享的 agentCtx.Messages。手动压缩两者都要做。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> ContextWindow 经 LoopConfig / liveRunConfig 下沉，默认 128000</h3>
+      <p><strong>Ambiguity:</strong> runLoop 原本拿不到模型的 context window。</p>
+      <p><strong>Choice:</strong> 给 <code>LoopConfig</code> 加 <code>ContextWindow int</code>，REPL 的 <code>liveRunConfig</code> 用 <code>defaultContextWindow=128000</code> 兜底。<code>&lt;=0</code> 时禁用自动压缩。</p>
+      <p><strong>Rationale:</strong> 窗口未知时宁可不压缩也不误伤；128000 足够大，只有真正的长会话才触发。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 压缩流复用主轮的 API key 解析</h3>
+      <p><strong>Spec:</strong> 未提及 summarization 请求的鉴权。</p>
+      <p><strong>Implemented:</strong> <code>runCompaction</code> 与 <code>runManualCompact</code> 都按主轮方式解析 key(动态 GetAPIKey 优先、静态 APIKey 兜底)后再构造 StreamConfig。</p>
+      <p><strong>Why:</strong> 否则对需要鉴权的 provider，<code>Compact</code> 会以 “missing API key” 失败，自动/手动压缩形同虚设。此为 review-it 阶段发现并修复的真实缺陷。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 压缩失败非致命 vs. 中断会话</h3>
+      <p><strong>Alternatives:</strong> (A) 失败即中断 run；(B) 失败保留原上下文并发出带 ErrorMessage 的 CompactionEvent。</p>
+      <p><strong>Chosen:</strong> B。</p>
+      <p><strong>Why:</strong> US-004 明确要求压缩失败不打断会话；保留原始上下文让用户可继续对话，失败通过事件可观察而非静默。代价是超长上下文可能继续增长，但这比丢会话可接受。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> defaultContextWindow 是否应随模型真实窗口动态设置？</h3>
+      <p>当前 REPL 固定 128000 兜底。若 provider 的 preset 已知真实 ContextWindow，理想情况下应读取 preset 覆盖默认值，让阈值更精确。可作为后续 issue 跟进。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> CompactionEvent.Reason 目前自动路径固定 "threshold"</h3>
+      <p>结构预留了 "manual"/"overflow" 语义，但手动 <code>/compact</code> 当前直接打印而不发事件(REPL 未接入事件流)。若将来手动压缩也要走 stream-json，需要补 "manual" reason 的发射。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agentcore/event.go
+++ b/internal/agentcore/event.go
@@ -22,6 +22,7 @@ const (
 	EventToolExecutionStart  = "tool_execution_start"
 	EventToolExecutionUpdate = "tool_execution_update"
 	EventToolExecutionEnd    = "tool_execution_end"
+	EventCompaction          = "compaction"
 )
 
 // AgentStartEvent is emitted once when a loop run begins.
@@ -82,6 +83,29 @@ type ToolExecutionEndEvent struct {
 	IsError    bool
 }
 
+// CompactionEvent is emitted when the loop compacts the context window, either
+// automatically (threshold/overflow) or on an explicit /compact request. It
+// carries before/after token counts and how many messages were summarized vs.
+// retained. When compaction fails it is still emitted with ErrorMessage set and
+// the token/count fields describing the unchanged context, so consumers can
+// surface the failure without the session aborting (US-004).
+type CompactionEvent struct {
+	// Reason is why compaction ran: "manual", "threshold", or "overflow".
+	Reason string
+	// TokensBefore is the estimated context tokens prior to compaction.
+	TokensBefore int
+	// TokensAfter is the estimated context tokens after compaction (equals
+	// TokensBefore when compaction failed or was a no-op).
+	TokensAfter int
+	// SummarizedCount is the number of messages folded into the summary.
+	SummarizedCount int
+	// KeptCount is the number of recent messages retained verbatim.
+	KeptCount int
+	// ErrorMessage is non-empty when compaction failed; the original context is
+	// preserved in that case.
+	ErrorMessage string
+}
+
 func (AgentStartEvent) isAgentEvent()          {}
 func (AgentEndEvent) isAgentEvent()            {}
 func (TurnStartEvent) isAgentEvent()           {}
@@ -92,6 +116,7 @@ func (MessageEndEvent) isAgentEvent()          {}
 func (ToolExecutionStartEvent) isAgentEvent()  {}
 func (ToolExecutionUpdateEvent) isAgentEvent() {}
 func (ToolExecutionEndEvent) isAgentEvent()    {}
+func (CompactionEvent) isAgentEvent()          {}
 
 func (AgentStartEvent) EventType() string          { return EventAgentStart }
 func (AgentEndEvent) EventType() string            { return EventAgentEnd }
@@ -103,3 +128,4 @@ func (MessageEndEvent) EventType() string          { return EventMessageEnd }
 func (ToolExecutionStartEvent) EventType() string  { return EventToolExecutionStart }
 func (ToolExecutionUpdateEvent) EventType() string { return EventToolExecutionUpdate }
 func (ToolExecutionEndEvent) EventType() string    { return EventToolExecutionEnd }
+func (CompactionEvent) EventType() string          { return EventCompaction }

--- a/internal/runtime/compaction_test.go
+++ b/internal/runtime/compaction_test.go
@@ -1,0 +1,189 @@
+package runtime
+
+// Tests for auto-compaction wiring into the loop (US-004, #120): when context
+// usage exceeds the usable window after a turn settles, runLoop compacts in
+// place and emits a CompactionEvent; a compaction failure is non-fatal and is
+// reported via a CompactionEvent carrying an error while the original context is
+// preserved.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/compaction"
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+// bigUserMessages returns n user messages each carrying `chars` characters, used
+// to inflate estimated context tokens past a small window.
+func bigUserMessages(n, chars int) agentcore.MessageList {
+	body := strings.Repeat("x", chars)
+	msgs := make(agentcore.MessageList, 0, n)
+	for i := 0; i < n; i++ {
+		msgs = append(msgs, agentcore.UserMessage{
+			RoleField: agentcore.RoleUser,
+			Content:   agentcore.ContentList{agentcore.NewTextContent(body)},
+		})
+	}
+	return msgs
+}
+
+// findCompaction returns the first CompactionEvent emitted, or nil.
+func findCompaction(events []agentcore.AgentEvent) *agentcore.CompactionEvent {
+	for _, ev := range events {
+		if c, ok := ev.(agentcore.CompactionEvent); ok {
+			return &c
+		}
+	}
+	return nil
+}
+
+// collectEvents drains a stream returning the concrete events (not just kinds).
+func collectEvents(t *testing.T, s *LoopEventStream) []agentcore.AgentEvent {
+	t.Helper()
+	var out []agentcore.AgentEvent
+	for ev := range s.Events() {
+		out = append(out, ev)
+	}
+	if _, err := s.Result(context.Background()); err != nil {
+		t.Fatalf("stream result: %v", err)
+	}
+	return out
+}
+
+// summaryStream yields a fixed summary text as an end_turn assistant message,
+// standing in for the summarization model.
+func summaryStream(text string) provider.StreamFn {
+	return func(ctx context.Context, model string, llm provider.LlmContext, cfg provider.StreamConfig) (*provider.AssistantMessageEventStream, error) {
+		msg := agentcore.AssistantMessage{
+			RoleField:  agentcore.RoleAssistant,
+			StopReason: agentcore.StopReasonEndTurn,
+			Content:    agentcore.ContentList{agentcore.NewTextContent(text)},
+		}
+		s := provider.NewAssistantMessageEventStream(0)
+		go func() { _ = s.Emit(ctx, provider.StreamDoneEvent{Message: msg}); s.Close() }()
+		return s, nil
+	}
+}
+
+func TestAutoCompactionFiresOnThreshold(t *testing.T) {
+	// Main stream just ends the turn with text; the summary stream is separate so
+	// the summarization does not consume main-stream scripted turns.
+	main := scriptedStream([]agentcore.AssistantMessage{
+		{RoleField: agentcore.RoleAssistant, StopReason: agentcore.StopReasonEndTurn, Content: agentcore.ContentList{agentcore.NewTextContent("ok")}},
+	})
+	cfg := newRunCfg(main)
+	cfg.SummaryStream = summaryStream("## Goal\ncompacted")
+	// Small window + reserve so a handful of fat messages exceed the threshold.
+	cfg.ContextWindow = 2000
+	cfg.Compaction = compaction.CompactionSettings{Enabled: true, ReserveTokens: 500, KeepRecentTokens: 100}
+
+	// Seed a long history so EstimateContextTokens > window-reserve.
+	agentCtx := &agentcore.AgentContext{Messages: bigUserMessages(12, 800)}
+
+	events := collectEvents(t, agentLoop(context.Background(), agentCtx, cfg))
+	ce := findCompaction(events)
+	if ce == nil {
+		t.Fatalf("expected a CompactionEvent, got events %+v", events)
+	}
+	if ce.ErrorMessage != "" {
+		t.Fatalf("compaction should have succeeded, got error %q", ce.ErrorMessage)
+	}
+	if ce.TokensAfter >= ce.TokensBefore {
+		t.Errorf("compaction should reduce tokens: before=%d after=%d", ce.TokensBefore, ce.TokensAfter)
+	}
+	if ce.SummarizedCount <= 0 {
+		t.Errorf("expected some messages summarized, got %d", ce.SummarizedCount)
+	}
+	// The context must now begin with a compaction checkpoint.
+	if len(agentCtx.Messages) == 0 || agentCtx.Messages[0].Role() != agentcore.RoleCompaction {
+		t.Errorf("context should start with a compaction checkpoint, got %+v", agentCtx.Messages)
+	}
+}
+
+func TestAutoCompactionDisabledWhenWindowUnknown(t *testing.T) {
+	main := scriptedStream([]agentcore.AssistantMessage{
+		{RoleField: agentcore.RoleAssistant, StopReason: agentcore.StopReasonEndTurn, Content: agentcore.ContentList{agentcore.NewTextContent("ok")}},
+	})
+	cfg := newRunCfg(main)
+	cfg.SummaryStream = summaryStream("unused")
+	cfg.ContextWindow = 0 // unknown → disabled
+	cfg.Compaction = compaction.CompactionSettings{Enabled: true, ReserveTokens: 500, KeepRecentTokens: 100}
+
+	agentCtx := &agentcore.AgentContext{Messages: bigUserMessages(12, 800)}
+	before := len(agentCtx.Messages)
+
+	events := collectEvents(t, agentLoop(context.Background(), agentCtx, cfg))
+	if ce := findCompaction(events); ce != nil {
+		t.Fatalf("no compaction expected when window unknown, got %+v", ce)
+	}
+	// Context grows by one assistant reply only (no checkpoint replacement).
+	if len(agentCtx.Messages) != before+1 {
+		t.Errorf("context should be untouched by compaction, got %d messages", len(agentCtx.Messages))
+	}
+}
+
+func TestCompactionEventEnvelope(t *testing.T) {
+	env := eventEnvelope(agentcore.CompactionEvent{
+		Reason:          "threshold",
+		TokensBefore:    1000,
+		TokensAfter:     400,
+		SummarizedCount: 8,
+		KeptCount:       3,
+	})
+	if env["type"] != agentcore.EventCompaction {
+		t.Errorf("type = %v, want %q", env["type"], agentcore.EventCompaction)
+	}
+	if env["tokensBefore"] != 1000 || env["tokensAfter"] != 400 {
+		t.Errorf("token fields wrong: %+v", env)
+	}
+	if env["summarizedCount"] != 8 || env["keptCount"] != 3 {
+		t.Errorf("count fields wrong: %+v", env)
+	}
+	if _, hasErr := env["error"]; hasErr {
+		t.Errorf("no error key expected on success: %+v", env)
+	}
+	// Failure envelope carries the error.
+	failEnv := eventEnvelope(agentcore.CompactionEvent{Reason: "threshold", ErrorMessage: "boom"})
+	if failEnv["error"] != "boom" {
+		t.Errorf("error key expected on failure, got %+v", failEnv)
+	}
+}
+
+func TestAutoCompactionFailureIsNonFatal(t *testing.T) {
+	main := scriptedStream([]agentcore.AssistantMessage{
+		{RoleField: agentcore.RoleAssistant, StopReason: agentcore.StopReasonEndTurn, Content: agentcore.ContentList{agentcore.NewTextContent("ok")}},
+	})
+	cfg := newRunCfg(main)
+	// Summary stream that fails to build: forces compaction.Compact to error.
+	cfg.SummaryStream = func(ctx context.Context, model string, llm provider.LlmContext, c provider.StreamConfig) (*provider.AssistantMessageEventStream, error) {
+		return nil, errors.New("summarizer down")
+	}
+	cfg.ContextWindow = 2000
+	cfg.Compaction = compaction.CompactionSettings{Enabled: true, ReserveTokens: 500, KeepRecentTokens: 100}
+
+	agentCtx := &agentcore.AgentContext{Messages: bigUserMessages(12, 800)}
+
+	events := collectEvents(t, agentLoop(context.Background(), agentCtx, cfg))
+	ce := findCompaction(events)
+	if ce == nil {
+		t.Fatalf("expected a CompactionEvent reporting the failure")
+	}
+	if ce.ErrorMessage == "" {
+		t.Errorf("failed compaction must carry an ErrorMessage")
+	}
+	if ce.TokensAfter != ce.TokensBefore {
+		t.Errorf("on failure tokens must be unchanged: before=%d after=%d", ce.TokensBefore, ce.TokensAfter)
+	}
+	// The run must still end normally.
+	if events[len(events)-1].EventType() != agentcore.EventAgentEnd {
+		t.Errorf("run must end with agent_end despite compaction failure")
+	}
+	// No compaction checkpoint should have been inserted.
+	if len(agentCtx.Messages) > 0 && agentCtx.Messages[0].Role() == agentcore.RoleCompaction {
+		t.Errorf("failed compaction must not insert a checkpoint")
+	}
+}

--- a/internal/runtime/headless.go
+++ b/internal/runtime/headless.go
@@ -173,6 +173,15 @@ func eventEnvelope(ev agentcore.AgentEvent) map[string]any {
 		env["toolCallId"] = e.ToolCallID
 		env["toolName"] = e.ToolName
 		env["isError"] = e.IsError
+	case agentcore.CompactionEvent:
+		env["reason"] = e.Reason
+		env["tokensBefore"] = e.TokensBefore
+		env["tokensAfter"] = e.TokensAfter
+		env["summarizedCount"] = e.SummarizedCount
+		env["keptCount"] = e.KeptCount
+		if e.ErrorMessage != "" {
+			env["error"] = e.ErrorMessage
+		}
 	}
 	return env
 }

--- a/internal/runtime/loop.go
+++ b/internal/runtime/loop.go
@@ -21,10 +21,17 @@ package runtime
 
 import (
 	"context"
+	"time"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/compaction"
+	"github.com/smallnest/pigo/internal/provider"
 )
+
+// nowMillis returns the current Unix time in milliseconds, the timestamp unit
+// used for CompactionMessage checkpoints.
+func nowMillis() int64 { return time.Now().UnixMilli() }
 
 // TurnUpdate is the optional result of PrepareNextTurn: any non-nil field
 // replaces the corresponding piece of loop state before the next turn. It lets
@@ -142,7 +149,7 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 					finish()
 					return
 				}
-				if afterTurn(ctx, agentCtx, &cfg, true) {
+				if afterTurn(ctx, agentCtx, &cfg, true, emit) {
 					finish()
 					return
 				}
@@ -161,7 +168,7 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 					finish()
 					return
 				}
-				if afterTurn(ctx, agentCtx, &cfg, false) {
+				if afterTurn(ctx, agentCtx, &cfg, false, emit) {
 					finish()
 					return
 				}
@@ -183,7 +190,7 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 				finish()
 				return
 			}
-			if afterTurn(ctx, agentCtx, &cfg, true) {
+			if afterTurn(ctx, agentCtx, &cfg, true, emit) {
 				finish()
 				return
 			}
@@ -205,9 +212,10 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 
 // afterTurn runs the per-turn hooks after a turn_end. When hadToolExecution is
 // true it first pulls getSteeringMessages and injects them before the next turn
-// (pi per-turn semantics). It then applies prepareNextTurn and finally consults
+// (pi per-turn semantics). It then applies prepareNextTurn, runs auto-compaction
+// when the context has outgrown its window, and finally consults
 // shouldStopAfterTurn, returning true when the run should end.
-func afterTurn(ctx context.Context, agentCtx *agentcore.AgentContext, cfg *RunConfig, hadToolExecution bool) (stop bool) {
+func afterTurn(ctx context.Context, agentCtx *agentcore.AgentContext, cfg *RunConfig, hadToolExecution bool, emit func(agentcore.AgentEvent) error) (stop bool) {
 	if hadToolExecution && cfg.GetSteeringMessages != nil {
 		if steer := cfg.GetSteeringMessages(ctx); len(steer) > 0 {
 			agentCtx.Messages = append(agentCtx.Messages, steer...)
@@ -218,10 +226,80 @@ func afterTurn(ctx context.Context, agentCtx *agentcore.AgentContext, cfg *RunCo
 			applyTurnUpdate(agentCtx, cfg, upd)
 		}
 	}
+	maybeAutoCompact(ctx, agentCtx, cfg, emit)
 	if cfg.ShouldStopAfterTurn != nil {
 		return cfg.ShouldStopAfterTurn(ctx, agentCtx)
 	}
 	return false
+}
+
+// maybeAutoCompact checks whether the context has outgrown its usable window and,
+// if so, compacts it in place and emits a CompactionEvent. Compaction is a no-op
+// when disabled, when the context window is unknown (<= 0), or when usage is
+// under threshold. A compaction failure is non-fatal: the original context is
+// preserved and a CompactionEvent carrying ErrorMessage is emitted so the failure
+// is observable without aborting the run (US-004).
+func maybeAutoCompact(ctx context.Context, agentCtx *agentcore.AgentContext, cfg *RunConfig, emit func(agentcore.AgentEvent) error) {
+	if !cfg.Compaction.Enabled || cfg.ContextWindow <= 0 {
+		return
+	}
+	before := compaction.EstimateContextTokens(agentCtx.Messages).Tokens
+	if !compaction.ShouldCompact(before, cfg.ContextWindow, cfg.Compaction) {
+		return
+	}
+	res, err := runCompaction(ctx, agentCtx.Messages, cfg)
+	kept := len(agentCtx.Messages)
+	if err != nil {
+		_ = emit(agentcore.CompactionEvent{
+			Reason:       "threshold",
+			TokensBefore: before,
+			TokensAfter:  before,
+			KeptCount:    kept,
+			ErrorMessage: err.Error(),
+		})
+		return
+	}
+	if res == nil {
+		// Nothing to summarize (cut point left no prefix); leave context as-is.
+		return
+	}
+	now := nowMillis()
+	rebuilt := res.RebuildContext(agentCtx.Messages, now)
+	summarized := len(agentCtx.Messages) - (len(rebuilt) - 1)
+	agentCtx.Messages = rebuilt
+	after := compaction.EstimateContextTokens(rebuilt).Tokens
+	_ = emit(agentcore.CompactionEvent{
+		Reason:          "threshold",
+		TokensBefore:    before,
+		TokensAfter:     after,
+		SummarizedCount: summarized,
+		KeptCount:       len(rebuilt) - 1,
+	})
+}
+
+// runCompaction invokes compaction.Compact with the loop's summarization config,
+// falling back to the primary Stream/Model when the summary-specific fields are
+// unset. Compact derives the cut point from settings.KeepRecentTokens.
+func runCompaction(ctx context.Context, msgs agentcore.MessageList, cfg *RunConfig) (*compaction.CompactionResult, error) {
+	stream := cfg.SummaryStream
+	if stream == nil {
+		stream = cfg.Stream
+	}
+	model := cfg.SummaryModel
+	if model.ID == "" {
+		model = provider.Model{Provider: cfg.Provider, ID: cfg.Model, ContextWindow: cfg.ContextWindow}
+	}
+	// Resolve the API key the same way the primary turn does (dynamic key wins,
+	// static APIKey is the fallback) so the summarization stream authenticates
+	// against auth-requiring providers instead of failing with "missing API key".
+	key := cfg.APIKey
+	if cfg.GetAPIKey != nil {
+		if dyn := cfg.GetAPIKey(ctx, cfg.Provider); dyn != "" {
+			key = dyn
+		}
+	}
+	scfg := provider.StreamConfig{APIKey: key, ThinkingLevel: cfg.ThinkingLevel}
+	return compaction.Compact(ctx, stream, model, msgs, cfg.Compaction, -1, nil, "", scfg)
 }
 
 // applyTurnUpdate applies a non-nil TurnUpdate to the mutable loop state: any

--- a/internal/runtime/stream_response.go
+++ b/internal/runtime/stream_response.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/compaction"
 	"github.com/smallnest/pigo/internal/provider"
 )
 
@@ -37,6 +38,21 @@ type LoopConfig struct {
 	GetAPIKey func(ctx context.Context, provider string) string
 	// Provider is the provider name passed to GetAPIKey.
 	Provider string
+
+	// ContextWindow is the model's total context-token budget, used to decide
+	// automatic compaction. When <= 0 the window is unknown and auto-compaction
+	// is disabled (ShouldCompact returns false), so the loop behaves exactly as
+	// before for callers that do not plumb it through.
+	ContextWindow int
+	// Compaction holds the thresholds/retention knobs for auto-compaction. Its
+	// Enabled flag gates the feature independently of ContextWindow.
+	Compaction compaction.CompactionSettings
+	// SummaryStream produces the provider stream used to generate compaction
+	// summaries. Defaults to Stream when nil.
+	SummaryStream provider.StreamFn
+	// SummaryModel is the model used for summarization. When zero, a model is
+	// synthesized from Model/ContextWindow.
+	SummaryModel provider.Model
 
 	// Extra is forwarded to StreamConfig.Extra.
 	Extra map[string]any


### PR DESCRIPTION
## Summary
- 新增 `CompactionEvent` 事件类型（before/after token、summarized/kept 计数、失败 ErrorMessage）
- `runLoop.afterTurn` 每轮结束调用 `ShouldCompact`，超阈值时自动压缩并经 `emit` 闭包发出 `CompactionEvent`
- `ContextWindow` 经 `LoopConfig`/`liveRunConfig` 下沉，默认 128000，`<=0` 时禁用自动压缩
- `/compact` 在 REPL 循环拦截，`runManualCompact` 打印 before→after tokens 与保留消息数
- 压缩流复用主轮 API key 解析（动态优先、静态兜底），避免鉴权 provider 报 "missing API key"
- 压缩失败非致命：保留原始上下文，事件携带 `ErrorMessage`（US-004）
- headless / stream-json 的 `eventEnvelope` 序列化 `CompactionEvent`

Closes #120

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` 全通过（新增 compaction_test.go 4 项：阈值触发 / 窗口未知禁用 / envelope 映射 / 失败非致命）