### PR TITLE
会话树 id/parentId 结构与 v3 迁移

### DIFF
--- a/docs/issue#0121.html
+++ b/docs/issue#0121.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0121</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block; font-size: 0.6875rem; font-weight: 500;
+      padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    code { background: #F0EEEA; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.8125rem; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/121">#121</a> &mdash; 会话树 id/parentId 结构与迁移 (US-005) &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Entry 包裹器 + 独立 JSON 编解码，而非给每个 Message 加 id 字段</h3>
+      <p><strong>Ambiguity:</strong> Spec 只说“每条持久化 entry 增加 ID/ParentID”，没规定 id 存在消息内还是消息外。</p>
+      <p><strong>Choice:</strong> 新增 <code>Entry{ID, ParentID, Timestamp, Message}</code> 包裹器，落盘形状为 <code>{"id","parentId","timestamp","message":{…}}</code>；内层 message 用 <code>json.RawMessage</code> 承载并复用 <code>MessageList</code> 的角色判别解码。</p>
+      <p><strong>Rationale:</strong> 树元数据是持久化层的关注点，不该污染 <code>agentcore.Message</code> 这个跨层共享的密封接口。包裹器让 message 编解码逻辑保持零改动，与 pi 的 <code>SessionEntryBase</code> 分层一致。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> entry id 用 4 字节 crypto/rand（8 位十六进制），不复刻 uuidv7</h3>
+      <p><strong>Ambiguity:</strong> Spec 只要求“补 id”，未规定 id 生成算法。pi 用 <code>uuidv7().slice(-8)</code>。</p>
+      <p><strong>Choice:</strong> <code>newEntryID()</code> 返回 4 随机字节的 8 位 hex；<code>crypto/rand</code> 极罕见失败时退化为时间戳派生 id，保证写入永不中断。</p>
+      <p><strong>Rationale:</strong> entry 顺序由 ParentID 链给出，无需 uuidv7 的时间排序性；8 位宽度与 pi 对齐，单文件内碰撞概率可忽略。避免引入 uuid 依赖。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Load 保持扁平返回值，新增 LoadEntries 暴露树</h3>
+      <p><strong>Ambiguity:</strong> 引入树后，既有 <code>Load</code> 调用方（resume 走 <code>Load(opts.resumeID)</code>）该不该变签名。</p>
+      <p><strong>Choice:</strong> <code>Load</code> 内部改调 <code>LoadEntries</code> 再摊平成 <code>MessageList</code>，签名与行为完全不变；新增 <code>LoadEntries(id) (SessionHeader, []Entry, error)</code> 给需要 id/parentId 的场景。</p>
+      <p><strong>Rationale:</strong> 不破坏现有 resume/REPL 调用方，同时满足验收条件 (c) 的树访问需求。是最小改动的正确边界。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> PathToLeaf 对断链/环“容错止步”，不像 pi 那样抛错</h3>
+      <p><strong>Spec:</strong> 验收条件 (c) 只要求“沿 parentId 回溯得线性路径”。pi 的 <code>getPathToRoot</code> 在父节点缺失时直接 throw。</p>
+      <p><strong>Implemented:</strong> <code>PathToLeaf</code> 遇到缺失父节点或环时停在最后一个可解析祖先，返回已恢复的前缀（空/未知 leafID 返回 nil）。</p>
+      <p><strong>Why:</strong> 部分损坏的会话文件仍应尽力恢复，符合 <code>List</code>“跳过损坏而非整体失败”的既有容错风格。抛错会让一条坏链毁掉整个 resume。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 加载时迁移 vs. 就地重写旧文件</h3>
+      <p><strong>Alternatives:</strong> (A) 读到 v1/v2 文件时合成 id/parentId 只存内存；(B) 加载后立即把文件重写为 v3。</p>
+      <p><strong>Chosen:</strong> A（<code>readSession</code> 按 <code>header.Version >= 3</code> 判断是包裹 entry 还是裸 message，裸行现补 id 并链 parentId 到前一条）。</p>
+      <p><strong>Why:</strong> 只读加载不产生意外写盘，旧文件保持原样直到下次显式 <code>Save</code> 才升到 v3，行为可预测、无副作用。代价是每次加载旧文件都要重新合成 id（旧文件 id 不稳定），但旧文件本就没有树语义，可接受。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 迁移时 Timestamp 用 header.UpdatedAt vs. 零值</h3>
+      <p><strong>Alternatives:</strong> (A) 旧行合成 entry 的 Timestamp 填 <code>header.UpdatedAt</code>；(B) 填零值。</p>
+      <p><strong>Chosen:</strong> A。</p>
+      <p><strong>Why:</strong> 旧格式无逐条时间戳，<code>UpdatedAt</code> 是文件级唯一可用的时间近似，比零值更有意义；且不影响 ParentID 链（顺序仍由行序决定）。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 是否需要暴露 fork/clone/getChildren 等完整树导航 API？</h3>
+      <p>本 issue 只落地 id/parentId 结构、迁移与 <code>PathToLeaf</code>。pi 还有 <code>getBranch</code>/<code>getChildren</code>/fork。若后续 issue 要真正的分叉会话，需要在此基础上补这些 API 与写入分叉 entry 的路径。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Append 每次 load-modify-save 会给已有消息重新生成 id</h3>
+      <p>当前 <code>Append</code> 复用 <code>Save</code>（整文件重写），因此每次 append 后全体 entry 的 id 都会变。线性会话下无碍（链仍自洽），但若将来有外部引用某条 entry 的稳定 id（如书签、分叉点），需改为真正的增量追加以保持 id 稳定。请确认当前无稳定 id 引用需求。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -15,6 +15,8 @@ package session
 
 import (
 	"bufio"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -32,9 +34,15 @@ import (
 // hard error so a newer file is never silently misread by an older binary.
 //
 // v2 adds the inline "compaction" message role (US-003): a compaction
-// checkpoint persisted as one message line. v1 files have no such lines and
-// remain fully readable, so the bump is backward-compatible on read.
-const SchemaVersion = 2
+// checkpoint persisted as one message line.
+//
+// v3 gives every persisted entry an id/parentId, forming a tree (US-005, #121)
+// — the prerequisite for fork/clone/tree navigation. Each message line is
+// wrapped as {"id","parentId","timestamp","message":{…}}. v1/v2 files (bare
+// message lines) remain fully readable: readSession migrates them on load by
+// synthesizing ids and chaining parentId to the previous entry, so old sessions
+// still load and resume.
+const SchemaVersion = 3
 
 // sessionScanBufInit / sessionScanBufMax bound the line scanner used to read a
 // session file. A single line holds one message, which can be large (a long
@@ -62,6 +70,114 @@ type SessionHeader struct {
 	// SystemPrompt is the system prompt the session ran under. Persisted so the
 	// resumed context is faithful. Optional.
 	SystemPrompt string `json:"systemPrompt,omitempty"`
+}
+
+// Entry wraps one persisted message with the tree metadata introduced in schema
+// v3 (US-005, #121): a stable ID plus the ParentID it descends from. A linear
+// session is the degenerate tree where every entry's ParentID is the previous
+// entry's ID; the first entry has an empty ParentID (a root). The wrapper is
+// what lets a session fork/clone later — PathToLeaf walks the ParentID chain to
+// reconstruct the linear conversation feeding any leaf.
+type Entry struct {
+	// ID is this entry's stable identifier (see newEntryID). Unique within a file.
+	ID string
+	// ParentID is the ID this entry descends from; empty for a root entry.
+	ParentID string
+	// Timestamp is when the entry was persisted (RFC 3339, UTC).
+	Timestamp time.Time
+	// Message is the wrapped agent message (user / assistant / toolResult / …).
+	Message agentcore.Message
+}
+
+// entryWire is the on-disk JSON shape of an Entry: the message is carried as a
+// raw object so it round-trips through MessageList's role-discriminated decoder
+// (agentcore.Message is a sealed interface with no default unmarshaler).
+type entryWire struct {
+	ID        string          `json:"id"`
+	ParentID  string          `json:"parentId,omitempty"`
+	Timestamp time.Time       `json:"timestamp"`
+	Message   json.RawMessage `json:"message"`
+}
+
+// MarshalJSON emits the entry as {"id","parentId","timestamp","message":{…}}.
+func (e Entry) MarshalJSON() ([]byte, error) {
+	mb, err := json.Marshal(e.Message)
+	if err != nil {
+		return nil, fmt.Errorf("session: encode entry message: %w", err)
+	}
+	return json.Marshal(entryWire{ID: e.ID, ParentID: e.ParentID, Timestamp: e.Timestamp, Message: mb})
+}
+
+// UnmarshalJSON decodes an entry line, decoding the inner message with the same
+// discriminated logic as agentcore.MessageList (by wrapping it in a one-element
+// array).
+func (e *Entry) UnmarshalJSON(data []byte) error {
+	var w entryWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	e.ID = w.ID
+	e.ParentID = w.ParentID
+	e.Timestamp = w.Timestamp
+	if len(w.Message) == 0 {
+		return fmt.Errorf("session: entry missing message")
+	}
+	var one agentcore.MessageList
+	if err := json.Unmarshal([]byte("["+string(w.Message)+"]"), &one); err != nil {
+		return fmt.Errorf("session: decode entry message: %w", err)
+	}
+	if len(one) != 1 {
+		return fmt.Errorf("session: entry decoded to %d messages, want 1", len(one))
+	}
+	e.Message = one[0]
+	return nil
+}
+
+// newEntryID returns a fresh 8-hex-character entry id (4 random bytes). This
+// mirrors pi's generateEntryId (uuidv7().slice(-8)) in width; pigo does not need
+// the time-ordering of uuidv7 because entry order is already given by the
+// ParentID chain, so a simple random id suffices and collisions within a single
+// file are astronomically unlikely.
+func newEntryID() string {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand.Read never fails in practice; fall back to a timestamp-derived
+		// id so a session write never aborts on this path.
+		return fmt.Sprintf("%08x", time.Now().UnixNano()&0xffffffff)
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// PathToLeaf walks the ParentID chain from the entry identified by leafID back
+// to its root and returns the entries in root→leaf order — the linear
+// conversation that feeds the given leaf (US-005 acceptance criterion c). An
+// empty leafID (or an unknown one) yields nil. If the chain references a missing
+// parent the walk stops at the last resolvable ancestor rather than failing, so
+// a partially corrupt file still yields the recoverable prefix.
+func PathToLeaf(entries []Entry, leafID string) []Entry {
+	if leafID == "" {
+		return nil
+	}
+	byID := make(map[string]Entry, len(entries))
+	for _, e := range entries {
+		byID[e.ID] = e
+	}
+	var rev []Entry
+	seen := make(map[string]bool, len(entries))
+	for id := leafID; id != ""; {
+		e, ok := byID[id]
+		if !ok || seen[id] {
+			break // missing parent or a cycle: stop at the last good ancestor
+		}
+		seen[id] = true
+		rev = append(rev, e)
+		id = e.ParentID
+	}
+	// rev is leaf→root; reverse to root→leaf.
+	for i, j := 0, len(rev)-1; i < j; i, j = i+1, j-1 {
+		rev[i], rev[j] = rev[j], rev[i]
+	}
+	return rev
 }
 
 // FileName returns the on-disk file name for a session id (id + ".jsonl").
@@ -134,24 +250,50 @@ func (s *Store) Save(header SessionHeader, messages agentcore.MessageList) error
 	return nil
 }
 
-// writeSession emits the header line followed by one line per message.
+// writeSession emits the header line followed by one entry line per message.
+// Each message is wrapped in an Entry: ids are generated fresh and ParentID is
+// chained to the previous entry so a linear session is persisted as a linear
+// tree (schema v3). The chain is what PathToLeaf later walks.
 func writeSession(w io.Writer, header SessionHeader, messages agentcore.MessageList) error {
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(header); err != nil {
 		return fmt.Errorf("session: encode header: %w", err)
 	}
+	now := time.Now().UTC()
+	parentID := ""
 	for i, m := range messages {
-		if err := enc.Encode(m); err != nil {
+		e := Entry{ID: newEntryID(), ParentID: parentID, Timestamp: now, Message: m}
+		if err := enc.Encode(e); err != nil {
 			return fmt.Errorf("session: encode message[%d]: %w", i, err)
 		}
+		parentID = e.ID
 	}
 	return nil
 }
 
 // Load reads a session file and returns its header and messages. It validates
-// the schema version (an unknown version is rejected) and decodes each message
-// line using the same role-discriminated logic as agentcore.MessageList.
+// the schema version (an unknown version is rejected) and decodes each entry
+// line, returning the messages in file order (root→leaf for a linear session).
+// Old v1/v2 files (bare message lines) are migrated transparently. Load is the
+// linear view; LoadEntries exposes the id/parentId tree metadata.
 func (s *Store) Load(id string) (SessionHeader, agentcore.MessageList, error) {
+	header, entries, err := s.LoadEntries(id)
+	if err != nil {
+		return SessionHeader{}, nil, err
+	}
+	msgs := make(agentcore.MessageList, len(entries))
+	for i, e := range entries {
+		msgs[i] = e.Message
+	}
+	return header, msgs, nil
+}
+
+// LoadEntries reads a session file and returns its header plus the tree entries
+// (id/parentId + message) in file order. v1/v2 files are migrated on load:
+// every bare message line is wrapped in an Entry with a synthesized id and its
+// ParentID chained to the previous entry, so old sessions load and resume
+// exactly as they did before (US-005 acceptance criterion b/d).
+func (s *Store) LoadEntries(id string) (SessionHeader, []Entry, error) {
 	f, err := os.Open(s.path(id))
 	if err != nil {
 		return SessionHeader{}, nil, fmt.Errorf("session: open %s: %w", id, err)
@@ -160,8 +302,11 @@ func (s *Store) Load(id string) (SessionHeader, agentcore.MessageList, error) {
 	return readSession(f)
 }
 
-// readSession decodes a session stream: header line first, then messages.
-func readSession(r io.Reader) (SessionHeader, agentcore.MessageList, error) {
+// readSession decodes a session stream: header line first, then entries. For
+// schema v3 each line is an Entry ({id,parentId,timestamp,message}). For older
+// v1/v2 files each line is a bare message; readSession migrates them by
+// synthesizing ids and chaining parentId to the previous entry.
+func readSession(r io.Reader) (SessionHeader, []Entry, error) {
 	sc := bufio.NewScanner(r)
 	// Session lines can be large (long tool results); grow the buffer well past
 	// the default 64KB token cap.
@@ -183,25 +328,40 @@ func readSession(r io.Reader) (SessionHeader, agentcore.MessageList, error) {
 	if header.Version > SchemaVersion {
 		return SessionHeader{}, nil, fmt.Errorf("session: file schema version %d newer than supported %d", header.Version, SchemaVersion)
 	}
+	// v3+ lines are wrapped entries; v1/v2 lines are bare messages that we migrate.
+	wrapped := header.Version >= 3
 
-	var messages agentcore.MessageList
+	var entries []Entry
+	parentID := ""
 	for line := 2; sc.Scan(); line++ {
 		raw := sc.Bytes()
 		if len(strings.TrimSpace(string(raw))) == 0 {
 			continue // tolerate blank lines
 		}
-		// Reuse MessageList's discriminated decoding by wrapping the single object
-		// in a one-element array.
-		var one agentcore.MessageList
-		if err := json.Unmarshal([]byte("["+string(raw)+"]"), &one); err != nil {
-			return SessionHeader{}, nil, fmt.Errorf("session: parse message line %d: %w", line, err)
+		var e Entry
+		if wrapped {
+			if err := json.Unmarshal(raw, &e); err != nil {
+				return SessionHeader{}, nil, fmt.Errorf("session: parse entry line %d: %w", line, err)
+			}
+		} else {
+			// Migrate a bare v1/v2 message line: reuse MessageList's discriminated
+			// decoding, then synthesize the tree metadata (id + parentId chain).
+			var one agentcore.MessageList
+			if err := json.Unmarshal([]byte("["+string(raw)+"]"), &one); err != nil {
+				return SessionHeader{}, nil, fmt.Errorf("session: parse message line %d: %w", line, err)
+			}
+			if len(one) != 1 {
+				return SessionHeader{}, nil, fmt.Errorf("session: message line %d decoded to %d messages, want 1", line, len(one))
+			}
+			e = Entry{ID: newEntryID(), ParentID: parentID, Timestamp: header.UpdatedAt, Message: one[0]}
 		}
-		messages = append(messages, one...)
+		entries = append(entries, e)
+		parentID = e.ID
 	}
 	if err := sc.Err(); err != nil {
 		return SessionHeader{}, nil, fmt.Errorf("session: scan: %w", err)
 	}
-	return header, messages, nil
+	return header, entries, nil
 }
 
 // List returns the headers of all sessions in the store, sorted by UpdatedAt

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -189,7 +189,161 @@ func TestLoadV1FileStillReadable(t *testing.T) {
 	}
 }
 
-// TestSaveLoadCompactionEntry verifies a compaction checkpoint round-trips
+// TestSaveWritesV3TreeEntries verifies Save persists each message as a wrapped
+// v3 entry: the file header is version 3, every entry carries a non-empty id,
+// the first entry is a root (empty parentId), and each subsequent entry's
+// parentId chains to the previous entry's id — a linear tree.
+func TestSaveWritesV3TreeEntries(t *testing.T) {
+	s := newStore(t)
+	now := time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+	header := SessionHeader{ID: NewID(now), CreatedAt: now, UpdatedAt: now}
+	if err := s.Save(header, sampleMessages()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	h, entries, err := s.LoadEntries(header.ID)
+	if err != nil {
+		t.Fatalf("LoadEntries: %v", err)
+	}
+	if h.Version != 3 {
+		t.Fatalf("version = %d, want 3", h.Version)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("entry count = %d, want 4", len(entries))
+	}
+	if entries[0].ParentID != "" {
+		t.Errorf("root entry parentId = %q, want empty", entries[0].ParentID)
+	}
+	seen := map[string]bool{}
+	for i, e := range entries {
+		if e.ID == "" {
+			t.Errorf("entry[%d] has empty id", i)
+		}
+		if seen[e.ID] {
+			t.Errorf("entry[%d] id %q is duplicated", i, e.ID)
+		}
+		seen[e.ID] = true
+		if i > 0 && e.ParentID != entries[i-1].ID {
+			t.Errorf("entry[%d] parentId = %q, want %q (previous entry)", i, e.ParentID, entries[i-1].ID)
+		}
+	}
+}
+
+// TestPathToLeaf verifies PathToLeaf walks the parentId chain from a leaf back
+// to the root and returns the entries in root→leaf order.
+func TestPathToLeaf(t *testing.T) {
+	s := newStore(t)
+	now := time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+	header := SessionHeader{ID: NewID(now), CreatedAt: now, UpdatedAt: now}
+	if err := s.Save(header, sampleMessages()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	_, entries, err := s.LoadEntries(header.ID)
+	if err != nil {
+		t.Fatalf("LoadEntries: %v", err)
+	}
+	leaf := entries[len(entries)-1]
+	path := PathToLeaf(entries, leaf.ID)
+	if len(path) != len(entries) {
+		t.Fatalf("path length = %d, want %d (linear session)", len(path), len(entries))
+	}
+	for i := range entries {
+		if path[i].ID != entries[i].ID {
+			t.Errorf("path[%d].ID = %q, want %q", i, path[i].ID, entries[i].ID)
+		}
+	}
+	// A mid-chain leaf yields only its ancestors + itself.
+	mid := PathToLeaf(entries, entries[1].ID)
+	if len(mid) != 2 || mid[0].ID != entries[0].ID || mid[1].ID != entries[1].ID {
+		t.Errorf("PathToLeaf(entries[1]) = %+v, want [root, entries[1]]", mid)
+	}
+	// Unknown / empty leaf ids yield nil.
+	if got := PathToLeaf(entries, "nope"); got != nil {
+		t.Errorf("PathToLeaf(unknown) = %+v, want nil", got)
+	}
+	if got := PathToLeaf(entries, ""); got != nil {
+		t.Errorf("PathToLeaf(empty) = %+v, want nil", got)
+	}
+}
+
+// TestLoadV2FileMigratesToEntries verifies a v2 file (bare message lines, no
+// id/parentId) still loads and resumes: readSession back-fills a synthesized id
+// per line and chains parentId to the previous entry, so the migrated entries
+// form a linear tree while the flat Load view is unchanged.
+func TestLoadV2FileMigratesToEntries(t *testing.T) {
+	s := newStore(t)
+	v2 := `{"version":2,"id":"legacy","createdAt":"2026-07-10T00:00:00Z","updatedAt":"2026-07-10T00:00:00Z"}` + "\n" +
+		`{"role":"user","content":[{"type":"text","text":"hi"}]}` + "\n" +
+		`{"role":"assistant","content":[{"type":"text","text":"hello"}],"stopReason":"end_turn"}` + "\n"
+	path := filepath.Join(s.Dir(), FileName("legacy"))
+	if err := writeFile(path, v2); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	// Flat Load view is unchanged by the migration.
+	h, msgs, err := s.Load("legacy")
+	if err != nil {
+		t.Fatalf("Load v2: %v", err)
+	}
+	if h.Version != 2 {
+		t.Fatalf("version = %d, want 2", h.Version)
+	}
+	if len(msgs) != 2 || msgs[0].Role() != agentcore.RoleUser || msgs[1].Role() != agentcore.RoleAssistant {
+		t.Fatalf("messages: got %+v", msgs)
+	}
+	// Entry view is back-filled into a linear tree.
+	_, entries, err := s.LoadEntries("legacy")
+	if err != nil {
+		t.Fatalf("LoadEntries v2: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("entry count = %d, want 2", len(entries))
+	}
+	if entries[0].ID == "" || entries[0].ParentID != "" {
+		t.Errorf("root entry = %+v, want non-empty id and empty parentId", entries[0])
+	}
+	if entries[1].ParentID != entries[0].ID {
+		t.Errorf("entry[1].parentId = %q, want %q", entries[1].ParentID, entries[0].ID)
+	}
+	// The migrated entries reconstruct the full conversation via PathToLeaf.
+	path2 := PathToLeaf(entries, entries[1].ID)
+	if len(path2) != 2 {
+		t.Errorf("PathToLeaf on migrated v2 = %d entries, want 2", len(path2))
+	}
+}
+
+// TestAppendPreservesChain verifies Append grows the linear tree: after
+// appending, the file still loads with a valid root and an unbroken parentId
+// chain across the combined message set.
+func TestAppendPreservesChain(t *testing.T) {
+	s := newStore(t)
+	now := time.Now().UTC()
+	h := SessionHeader{ID: "grow", CreatedAt: now, UpdatedAt: now}
+	if err := s.Save(h, sampleMessages()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	extra := agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("more")}}}
+	if err := s.Append("grow", now.Add(time.Minute), extra); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	_, entries, err := s.LoadEntries("grow")
+	if err != nil {
+		t.Fatalf("LoadEntries: %v", err)
+	}
+	if len(entries) != 5 {
+		t.Fatalf("entry count = %d, want 5", len(entries))
+	}
+	if entries[0].ParentID != "" {
+		t.Errorf("root parentId = %q, want empty", entries[0].ParentID)
+	}
+	for i := 1; i < len(entries); i++ {
+		if entries[i].ParentID != entries[i-1].ID {
+			t.Errorf("entry[%d] parentId = %q, want %q", i, entries[i].ParentID, entries[i-1].ID)
+		}
+	}
+	if path := PathToLeaf(entries, entries[4].ID); len(path) != 5 {
+		t.Errorf("PathToLeaf after append = %d, want 5", len(path))
+	}
+}
+
 // through the JSONL store as a first-class message line under schema v2.
 func TestSaveLoadCompactionEntry(t *testing.T) {
 	s := newStore(t)


### PR DESCRIPTION
## Summary
- 新增 `Entry{ID, ParentID, Timestamp, Message}` 包裹器，落盘形状 `{"id","parentId","timestamp","message":{…}}`，内层 message 复用 `MessageList` 角色判别解码
- `SchemaVersion` 升到 3；`newEntryID` 用 4 字节 crypto/rand 的 8 位 hex（对齐 pi 的 8 位宽度）
- `PathToLeaf(entries, leafID) []Entry`：沿 parentId 回溯得 root→leaf 线性路径，断链/环时容错止步
- v1/v2 旧文件加载时迁移：裸 message 行补合成 id、parentId 链到前一条；`Load` 扁平视图行为不变，新增 `LoadEntries` 暴露树
- 旧会话仍能 load 与 resume（回归测试覆盖）

Closes #121

## Test plan
- [x] `go test ./internal/session/...` 通过（新增 v3 树落盘 / PathToLeaf / v2 迁移回归 / Append 保持链 测试）
- [x] `go test ./...` 全绿
- [x] `go vet` / `gofmt` clean