### PR TITLE
支持 /fork 与 /clone 命令 (US-006)

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -332,14 +332,17 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 			return b.String()
 		},
 	})
-	// /exit, /quit and /compact are intercepted by the REPL loop before slash
-	// resolution (they must return from the loop or run an agent stream + mutate
-	// the shared context, which an Action closure cannot do). They are registered
-	// here only so /help lists them; their Action is never actually reached.
+	// /exit, /quit, /compact, /fork and /clone are intercepted by the REPL loop
+	// before slash resolution (they must return from the loop, run an agent
+	// stream, or swap the active session — none of which an Action closure can
+	// do). They are registered here only so /help lists them; their Action is
+	// never actually reached.
 	for _, c := range []struct{ name, desc string }{
 		{"exit", "exit the REPL"},
 		{"quit", "exit the REPL"},
 		{"compact", "summarize and compact the conversation context now"},
+		{"fork", "branch from a historical message into a new session: /fork [n]"},
+		{"clone", "duplicate the current session into an independent branch"},
 	} {
 		reg.AddBuiltin(runtime.SlashCommand{
 			Name:        c.name,

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -110,6 +111,15 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 			if err := deps.store.Save(deps.header, deps.agentCtx.Messages); err != nil {
 				fmt.Fprintf(out, "pigo: session save failed: %v\n", err)
 			}
+			continue
+		}
+		if line == "/clone" || line == "/fork" || strings.HasPrefix(line, "/fork ") {
+			// /fork and /clone are intercepted here (like /compact) because they
+			// switch the active session — replacing the header and the shared
+			// context in place — which a slash Action closure (pure string→string)
+			// cannot do. runForkClone saves the current session, forks it, and
+			// swaps deps.header / deps.agentCtx to the new branch on success.
+			runForkClone(out, &deps, line)
 			continue
 		}
 
@@ -205,6 +215,103 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 			fmt.Fprintf(out, "error: %v\n", err)
 		}
 	}
+}
+
+// runForkClone handles the /fork and /clone commands (US-006, #122), which
+// branch the conversation tree into a new, independent session.
+//
+//   - "/clone" duplicates the entire current conversation at its current leaf
+//     into a fresh session and switches to it. Appending to the clone never
+//     affects the original (they are separate files).
+//   - "/fork" with no argument lists the historical user messages, numbered, so
+//     the user can pick one.
+//   - "/fork N" branches from BEFORE the N-th listed user message: the new
+//     session holds everything up to (but excluding) that message, so the user
+//     re-prompts from that point on an independent branch.
+//
+// Both first persist the current session (so the fork copies a saved tree),
+// then call store.Fork to write the new branch, and finally swap deps.header and
+// deps.agentCtx to the new session in place so subsequent prompts continue on
+// the branch. resume of either session id later walks to its own leaf.
+func runForkClone(out io.Writer, deps *replDeps, line string) {
+	// Persist the current session so Fork copies an up-to-date, saved tree.
+	deps.header.UpdatedAt = time.Now().UTC()
+	if err := deps.store.Save(deps.header, deps.agentCtx.Messages); err != nil {
+		fmt.Fprintf(out, "pigo: session save failed: %v\n", err)
+		return
+	}
+	_, entries, err := deps.store.LoadEntries(deps.header.ID)
+	if err != nil {
+		fmt.Fprintf(out, "pigo: cannot read session tree: %v\n", err)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(out, "nothing to fork yet — send a message first")
+		return
+	}
+
+	fields := strings.Fields(line)
+	cmd := fields[0]
+
+	var leafID string
+	if cmd == "/clone" {
+		// Clone the whole conversation at the current leaf (last entry).
+		leafID = entries[len(entries)-1].ID
+	} else { // /fork
+		// Collect the historical user messages, in order, with their entry index.
+		type userMsg struct {
+			idx  int // index into entries
+			text string
+		}
+		var users []userMsg
+		for i, e := range entries {
+			if u, ok := e.Message.(agentcore.UserMessage); ok {
+				users = append(users, userMsg{idx: i, text: agentcore.ContentToText(u.Content)})
+			}
+		}
+		if len(users) == 0 {
+			fmt.Fprintln(out, "no user messages to fork from")
+			return
+		}
+		if len(fields) < 2 {
+			// List the user messages for selection.
+			fmt.Fprintln(out, "fork from which message? run /fork <n>:")
+			for n, u := range users {
+				fmt.Fprintf(out, "  %d. %s\n", n+1, oneLine(u.text))
+			}
+			return
+		}
+		n, convErr := strconv.Atoi(fields[1])
+		if convErr != nil || n < 1 || n > len(users) {
+			fmt.Fprintf(out, "invalid selection %q — run /fork to list messages (1..%d)\n", fields[1], len(users))
+			return
+		}
+		// Fork BEFORE the chosen user message: its parent becomes the new leaf, so
+		// the copied branch excludes that message and everything after it.
+		leafID = entries[users[n-1].idx].ParentID
+	}
+
+	newHeader, path, err := deps.store.Fork(deps.header.ID, leafID, time.Now().UTC())
+	if err != nil {
+		fmt.Fprintf(out, "pigo: fork failed: %v\n", err)
+		return
+	}
+
+	// Swap the live session to the new branch: rebuild the flat message list from
+	// the copied path and point the REPL at the new header. Subsequent prompts
+	// grow the branch, never the original.
+	msgs := make(agentcore.MessageList, len(path))
+	for i, e := range path {
+		msgs[i] = e.Message
+	}
+	deps.header = newHeader
+	deps.agentCtx.Messages = msgs
+
+	action := "cloned"
+	if cmd == "/fork" {
+		action = "forked"
+	}
+	fmt.Fprintf(out, "%s session %s → %s (%d messages)\n", action, newHeader.ParentSession, newHeader.ID, len(msgs))
 }
 
 // runManualCompact compacts the shared context on an explicit /compact request:

--- a/docs/issue#0122.html
+++ b/docs/issue#0122.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0122</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block; font-size: 0.6875rem; font-weight: 500;
+      padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    code { background: #F0EEEA; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.8125rem; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/122">#122</a> &mdash; /fork 与 /clone 命令 (US-006) &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> fork = 复制 root→leaf 路径到全新会话文件，而非在同一文件内分叉</h3>
+      <p><strong>Ambiguity:</strong> Spec 说“以选定消息为父创建新 leaf”“复制新分支不影响原分支”，但没规定分支是同文件多叶子还是独立文件。</p>
+      <p><strong>Choice:</strong> <code>Store.Fork(sourceID, leafID, now)</code> 用 <code>PathToLeaf</code> 取出 root→leaf 的线性路径，<code>SaveEntries</code> 原样(保留 id/parentId)写入一个新 id 的会话文件，header 记 <code>ParentSession=sourceID</code>。</p>
+      <p><strong>Rationale:</strong> 独立文件天然满足“互不污染”——向任一会话 Append 都不碰另一个。对齐 pi 的 <code>createBranchedSession</code>(也是复制路径到新文件 + <code>parentSession</code> 血缘)。多叶子单文件会让 resume/List 复杂化且违背既有“一个会话一个文件”的模型。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> /clone 与 /fork 共用一个 Fork 原语，只是 leafID 取法不同</h3>
+      <p><strong>Ambiguity:</strong> pi 里 clone 是 <code>fork(leafId, {position:"at"})</code>，fork 是 <code>fork(entryId, {position:"before"})</code>——两者是否该是两个函数。</p>
+      <p><strong>Choice:</strong> 后端只有一个 <code>Fork</code>。<code>/clone</code> 传当前 leaf(最后一条 entry)的 id → 复制整段；<code>/fork n</code> 传第 n 条 user 消息的 <code>ParentID</code> → 复制到该消息之前。</p>
+      <p><strong>Rationale:</strong> “position before/at”本质就是“选哪个 entry 当新 leaf”，无需两条代码路径。REPL 层负责把用户意图翻译成 leafID。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> /fork 交互拆成两步：无参列消息、<code>/fork n</code> 选择</h3>
+      <p><strong>Ambiguity:</strong> Spec 要求“列出历史 user 消息供选择”，但行式 REPL 无弹窗/方向键选择器(pi 有 <code>showUserMessageSelector</code>)。</p>
+      <p><strong>Choice:</strong> <code>/fork</code> 无参时编号打印所有历史 user 消息(<code>oneLine</code> 截断)；<code>/fork n</code> 按编号选定。越界/非数字给出清晰错误。</p>
+      <p><strong>Rationale:</strong> 与本仓库既有的纯行式 REPL 风格一致(#106 去掉了 bubbletea TUI)，无需引入交互式选择器依赖。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> /fork 与 /clone 在 REPL 循环里直接拦截，不走 SlashRegistry Action</h3>
+      <p><strong>Spec:</strong> 只要求命令存在并生效，未规定注册方式。</p>
+      <p><strong>Implemented:</strong> 与 <code>/compact</code>/<code>/exit</code> 一样在 <code>runREPL</code> 循环里拦截，因为它们要替换共享的 <code>deps.header</code> 和 <code>deps.agentCtx</code>——而 Action 闭包签名是纯 <code>func(string) string</code>，够不到这些 per-run 状态。仍在 <code>registerLiveCommands</code> 注册占位以便 <code>/help</code> 能列出。</p>
+      <p><strong>Why:</strong> 沿用仓库已确立的“需要改运行时状态的命令在循环里拦截”约定，避免给 Action 闭包硬塞可变状态。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> fork 前先整文件 Save，再 LoadEntries 复制</h3>
+      <p><strong>Alternatives:</strong> (A) fork 前把当前内存 context 落盘、再从磁盘读 entry 树复制；(B) 直接用内存里的 message 列表重建 entry 复制。</p>
+      <p><strong>Chosen:</strong> A。</p>
+      <p><strong>Why:</strong> 磁盘上的 entry 树是 id/parentId 的权威来源(内存里只有扁平 MessageList，没有 entry id)。多一次读盘换来 fork 的 id 保真与逻辑简单，对交互式命令的延迟无感。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 抽出 atomicWrite 复用给 Save/SaveEntries</h3>
+      <p><strong>Alternatives:</strong> (A) SaveEntries 复制粘贴 Save 的临时文件+rename 逻辑；(B) 提取 <code>atomicWrite(id, write func(io.Writer) error)</code> 共用。</p>
+      <p><strong>Chosen:</strong> B。</p>
+      <p><strong>Why:</strong> 消除重复的原子写样板，两个写入者共享同一份“临时文件→flush→close→rename”正确性保证。代价是多一层闭包间接，可接受。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> fork/clone 后是否需要自动切换 resume 目标或提示 session id？</h3>
+      <p>当前实现打印新 session id，用户下次 <code>--resume &lt;id&gt;</code> 可走到该 leaf。是否需要一个 <code>/session</code> 展示当前活动 id(将在 #125 落地)或 fork 后写入 “last session” 指针，待确认。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 空 fork(在首条消息之前)产出空会话是否符合预期？</h3>
+      <p><code>/fork 1</code> 会 fork 到第一条 user 消息之前 → 新会话为空(仅 header)。实现按“合法的空分支”处理，resume 后从零开始但保留 systemPrompt/model。若期望禁止此操作请确认。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -70,6 +70,10 @@ type SessionHeader struct {
 	// SystemPrompt is the system prompt the session ran under. Persisted so the
 	// resumed context is faithful. Optional.
 	SystemPrompt string `json:"systemPrompt,omitempty"`
+	// ParentSession is the id of the session this one was forked/cloned from
+	// (US-006, #122). Empty for a session created from scratch. It records
+	// lineage only; a fork is otherwise a fully independent session file.
+	ParentSession string `json:"parentSession,omitempty"`
 }
 
 // Entry wraps one persisted message with the tree metadata introduced in schema
@@ -222,13 +226,39 @@ func (s *Store) Save(header SessionHeader, messages agentcore.MessageList) error
 	if header.ID == "" {
 		return fmt.Errorf("session: header ID must not be empty")
 	}
-	tmp := s.path(header.ID) + ".tmp"
+	return s.atomicWrite(header.ID, func(w io.Writer) error {
+		return writeSession(w, header, messages)
+	})
+}
+
+// SaveEntries writes header plus the given entries verbatim — preserving each
+// entry's id/parentId — to a fresh session file, overwriting any existing file
+// for header.ID. Unlike Save (which generates fresh ids and a linear chain from
+// a MessageList), SaveEntries persists an already-known tree, which is what Fork
+// needs: it copies a path of existing entries into a new session file without
+// disturbing their identifiers. The header's Version is forced to SchemaVersion.
+func (s *Store) SaveEntries(header SessionHeader, entries []Entry) error {
+	header.Version = SchemaVersion
+	if header.ID == "" {
+		return fmt.Errorf("session: header ID must not be empty")
+	}
+	return s.atomicWrite(header.ID, func(w io.Writer) error {
+		return writeSessionEntries(w, header, entries)
+	})
+}
+
+// atomicWrite writes a session file for id by streaming through write into a
+// temp file and atomically renaming it into place, so a concurrent reader never
+// sees a half-written file. It is the shared write plumbing behind Save and
+// SaveEntries.
+func (s *Store) atomicWrite(id string, write func(w io.Writer) error) error {
+	tmp := s.path(id) + ".tmp"
 	f, err := os.Create(tmp)
 	if err != nil {
 		return fmt.Errorf("session: create %s: %w", tmp, err)
 	}
 	w := bufio.NewWriter(f)
-	if err := writeSession(w, header, messages); err != nil {
+	if err := write(w); err != nil {
 		f.Close()
 		os.Remove(tmp)
 		return err
@@ -243,9 +273,9 @@ func (s *Store) Save(header SessionHeader, messages agentcore.MessageList) error
 		return fmt.Errorf("session: close %s: %w", tmp, err)
 	}
 	// Atomic replace so a reader never sees a half-written file.
-	if err := os.Rename(tmp, s.path(header.ID)); err != nil {
+	if err := os.Rename(tmp, s.path(id)); err != nil {
 		os.Remove(tmp)
-		return fmt.Errorf("session: commit %s: %w", header.ID, err)
+		return fmt.Errorf("session: commit %s: %w", id, err)
 	}
 	return nil
 }
@@ -267,6 +297,22 @@ func writeSession(w io.Writer, header SessionHeader, messages agentcore.MessageL
 			return fmt.Errorf("session: encode message[%d]: %w", i, err)
 		}
 		parentID = e.ID
+	}
+	return nil
+}
+
+// writeSessionEntries emits the header line followed by the given entries
+// verbatim, preserving their ids and parentIds. It is the whole-tree counterpart
+// to writeSession (which synthesizes a fresh linear chain from a MessageList).
+func writeSessionEntries(w io.Writer, header SessionHeader, entries []Entry) error {
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(header); err != nil {
+		return fmt.Errorf("session: encode header: %w", err)
+	}
+	for i, e := range entries {
+		if err := enc.Encode(e); err != nil {
+			return fmt.Errorf("session: encode entry[%d]: %w", i, err)
+		}
 	}
 	return nil
 }
@@ -431,4 +477,44 @@ func (s *Store) Append(id string, updatedAt time.Time, messages agentcore.Messag
 	header.UpdatedAt = updatedAt
 	existing = append(existing, messages...)
 	return s.Save(header, existing)
+}
+
+// Fork creates a new session whose contents are the linear path from the root
+// down to leafID in the source session, copied verbatim (each entry keeps its
+// id/parentId). The new session gets a fresh id (derived from now) and its
+// header carries ParentSession = sourceID so the lineage is recorded. It returns
+// the new session's header and its entries.
+//
+// This is the primitive behind /fork and /clone (US-006, #122):
+//
+//   - /clone passes the current leaf id → the entire current conversation is
+//     duplicated into an independent session (position "at").
+//   - /fork passes a historical user message's PARENT id → the new session holds
+//     everything up to but excluding that message, so the user re-prompts from
+//     that point on a fresh branch (position "before").
+//
+// Because the copy lands in a brand-new file, appending to either the source or
+// the fork never touches the other — the two branches are fully isolated. An
+// empty leafID copies nothing but the header (an empty new session rooted at the
+// source), which is the correct behavior for forking before the very first
+// message.
+func (s *Store) Fork(sourceID, leafID string, now time.Time) (SessionHeader, []Entry, error) {
+	srcHeader, entries, err := s.LoadEntries(sourceID)
+	if err != nil {
+		return SessionHeader{}, nil, err
+	}
+	path := PathToLeaf(entries, leafID)
+	newHeader := SessionHeader{
+		ID:            NewID(now),
+		CreatedAt:     now,
+		UpdatedAt:     now,
+		Model:         srcHeader.Model,
+		Provider:      srcHeader.Provider,
+		SystemPrompt:  srcHeader.SystemPrompt,
+		ParentSession: sourceID,
+	}
+	if err := s.SaveEntries(newHeader, path); err != nil {
+		return SessionHeader{}, nil, err
+	}
+	return newHeader, path, nil
 }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -344,6 +344,121 @@ func TestAppendPreservesChain(t *testing.T) {
 	}
 }
 
+// TestForkClonesFullConversation verifies Fork(sourceID, lastLeaf) — the /clone
+// case — copies the entire conversation verbatim into a new, independent session:
+// the new header records ParentSession, the copied entries keep their ids, and
+// appending to the fork does NOT touch the source (branch isolation).
+func TestForkClonesFullConversation(t *testing.T) {
+	s := newStore(t)
+	now := time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+	src := SessionHeader{ID: NewID(now), CreatedAt: now, UpdatedAt: now, Model: "m", Provider: "p", SystemPrompt: "sp"}
+	if err := s.Save(src, sampleMessages()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	_, srcEntries, err := s.LoadEntries(src.ID)
+	if err != nil {
+		t.Fatalf("LoadEntries: %v", err)
+	}
+	leaf := srcEntries[len(srcEntries)-1].ID
+
+	forkHeader, forkEntries, err := s.Fork(src.ID, leaf, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+	if forkHeader.ID == src.ID {
+		t.Fatal("fork must get a new id, got the source id")
+	}
+	if forkHeader.ParentSession != src.ID {
+		t.Errorf("ParentSession = %q, want %q", forkHeader.ParentSession, src.ID)
+	}
+	// Header metadata is inherited from the source.
+	if forkHeader.Model != "m" || forkHeader.Provider != "p" || forkHeader.SystemPrompt != "sp" {
+		t.Errorf("fork header did not inherit source metadata: %+v", forkHeader)
+	}
+	if len(forkEntries) != len(srcEntries) {
+		t.Fatalf("fork entry count = %d, want %d (full clone)", len(forkEntries), len(srcEntries))
+	}
+	// Copied entries keep their ids/parentIds verbatim.
+	for i := range srcEntries {
+		if forkEntries[i].ID != srcEntries[i].ID || forkEntries[i].ParentID != srcEntries[i].ParentID {
+			t.Errorf("entry[%d] id/parent = (%q,%q), want (%q,%q)", i,
+				forkEntries[i].ID, forkEntries[i].ParentID, srcEntries[i].ID, srcEntries[i].ParentID)
+		}
+	}
+
+	// Branch isolation: appending to the fork must not change the source.
+	extra := agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("on the fork only")}}}
+	if err := s.Append(forkHeader.ID, now.Add(2*time.Hour), extra); err != nil {
+		t.Fatalf("Append to fork: %v", err)
+	}
+	_, srcAfter, err := s.Load(src.ID)
+	if err != nil {
+		t.Fatalf("Load source: %v", err)
+	}
+	if len(srcAfter) != len(sampleMessages()) {
+		t.Errorf("source message count changed to %d after fork append, want %d (branches must be isolated)", len(srcAfter), len(sampleMessages()))
+	}
+	_, forkAfter, err := s.Load(forkHeader.ID)
+	if err != nil {
+		t.Fatalf("Load fork: %v", err)
+	}
+	if len(forkAfter) != len(sampleMessages())+1 {
+		t.Errorf("fork message count = %d, want %d", len(forkAfter), len(sampleMessages())+1)
+	}
+}
+
+// TestForkBeforeUserMessage verifies Fork(sourceID, parentOfUserMsg) — the
+// /fork case — copies only the prefix up to (excluding) a chosen user message,
+// so the branch can re-prompt from that point. Forking before the very first
+// user message (empty leafID) yields an empty session rooted at the source.
+func TestForkBeforeUserMessage(t *testing.T) {
+	s := newStore(t)
+	now := time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+	src := SessionHeader{ID: NewID(now), CreatedAt: now, UpdatedAt: now}
+	if err := s.Save(src, sampleMessages()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	_, entries, err := s.LoadEntries(src.ID)
+	if err != nil {
+		t.Fatalf("LoadEntries: %v", err)
+	}
+	// sampleMessages()[0] is the first user message (a root). Forking before it
+	// uses its ParentID (empty) → an empty branch.
+	if entries[0].ParentID != "" {
+		t.Fatalf("precondition: first entry should be a root")
+	}
+	emptyHeader, emptyPath, err := s.Fork(src.ID, entries[0].ParentID, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Fork before first message: %v", err)
+	}
+	if len(emptyPath) != 0 {
+		t.Errorf("fork before first message = %d entries, want 0", len(emptyPath))
+	}
+	if emptyHeader.ParentSession != src.ID {
+		t.Errorf("ParentSession = %q, want %q", emptyHeader.ParentSession, src.ID)
+	}
+	// Reloading the empty fork yields a valid, empty session.
+	_, reload, err := s.LoadEntries(emptyHeader.ID)
+	if err != nil {
+		t.Fatalf("LoadEntries(empty fork): %v", err)
+	}
+	if len(reload) != 0 {
+		t.Errorf("reloaded empty fork = %d entries, want 0", len(reload))
+	}
+
+	// Forking before the SECOND-turn user message (there is only one user message
+	// in sampleMessages, so simulate a two-user transcript) — copy just the prefix.
+	// Here we fork at the parent of the last entry to get all but the last message.
+	lastParent := entries[len(entries)-1].ParentID
+	_, prefix, err := s.Fork(src.ID, lastParent, now.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("Fork at last parent: %v", err)
+	}
+	if len(prefix) != len(entries)-1 {
+		t.Errorf("prefix fork = %d entries, want %d", len(prefix), len(entries)-1)
+	}
+}
+
 // through the JSONL store as a first-class message line under schema v2.
 func TestSaveLoadCompactionEntry(t *testing.T) {
 	s := newStore(t)


### PR DESCRIPTION
## Summary
- 新增 `session.Fork` 原语：把 root→leaf 路径复制到全新会话文件(保留 id/parentId)，落在独立文件天然实现分支隔离
- 新增 `SaveEntries`/`writeSessionEntries` 逐条 verbatim 写入，抽出 `atomicWrite` 复用原子写逻辑；`SessionHeader` 加 `ParentSession` 血缘字段
- REPL 层 `runForkClone` 拦截 `/fork`(无参列历史 user 消息、`/fork n` 选定其父为新 leaf)与 `/clone`(当前 leaf 整段复制)，切换活动会话
- `/help` 列出 fork/clone；两条新测试覆盖全量克隆与前缀 fork 的分支互不污染

Closes #122

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./...` pass（含 TestForkClonesFullConversation、TestForkBeforeUserMessage）
- [x] gofmt clean（除 master 上既有的 color_test.go）