### PR TITLE
/tree 分支导航：文件内分支存储 + 纯文本树渲染 (#123)

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -70,14 +70,22 @@ func runInteractive(opts interactiveOptions) error {
 		agentCtx *agentcore.AgentContext
 		header   session.SessionHeader
 		history  []agentcore.AgentMessage
+		curLeaf  string // active leaf id on resume; "" for a fresh session
 	)
 	if opts.resumeID != "" {
 		// Interactive resume always appends a fresh user message before running,
 		// so a session that ended normally (trailing assistant reply) is resumable
 		// here. Load the raw session and rebuild the context directly.
-		h, msgs, err := store.Load(opts.resumeID)
+		h, entries, err := store.LoadEntries(opts.resumeID)
 		if err != nil {
 			return err
+		}
+		msgs := make(agentcore.MessageList, len(entries))
+		for i, e := range entries {
+			msgs[i] = e.Message
+		}
+		if len(entries) > 0 {
+			curLeaf = entries[len(entries)-1].ID
 		}
 		header = h
 		agentCtx = &agentcore.AgentContext{SystemPrompt: h.SystemPrompt, Messages: msgs, Tools: opts.tools}
@@ -126,13 +134,15 @@ func runInteractive(opts interactiveOptions) error {
 	}
 
 	return runREPL(os.Stdin, os.Stdout, replDeps{
-		store:    store,
-		header:   header,
-		agentCtx: agentCtx,
-		live:     live,
-		reg:      reg,
-		slash:    slash,
-		creds:    creds,
+		store:     store,
+		header:    header,
+		agentCtx:  agentCtx,
+		live:      live,
+		reg:       reg,
+		slash:     slash,
+		creds:     creds,
+		curLeaf:   curLeaf,
+		persisted: len(history),
 	})
 }
 
@@ -332,10 +342,10 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 			return b.String()
 		},
 	})
-	// /exit, /quit, /compact, /fork and /clone are intercepted by the REPL loop
-	// before slash resolution (they must return from the loop, run an agent
-	// stream, or swap the active session — none of which an Action closure can
-	// do). They are registered here only so /help lists them; their Action is
+	// /exit, /quit, /compact, /fork, /clone and /tree are intercepted by the REPL
+	// loop before slash resolution (they must return from the loop, run an agent
+	// stream, or swap the active session/leaf — none of which an Action closure
+	// can do). They are registered here only so /help lists them; their Action is
 	// never actually reached.
 	for _, c := range []struct{ name, desc string }{
 		{"exit", "exit the REPL"},
@@ -343,6 +353,7 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 		{"compact", "summarize and compact the conversation context now"},
 		{"fork", "branch from a historical message into a new session: /fork [n]"},
 		{"clone", "duplicate the current session into an independent branch"},
+		{"tree", "show the session branch tree; switch active branch: /tree [n]"},
 	} {
 		reg.AddBuiltin(runtime.SlashCommand{
 			Name:        c.name,

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -14,6 +14,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -41,6 +42,18 @@ type replDeps struct {
 	reg      *agenttool.ToolRegistry
 	slash    *runtime.SlashRegistry
 	creds    *provider.CredentialStore
+
+	// curLeaf is the id of the entry the conversation currently descends from —
+	// the active leaf of the on-disk session tree (US-007, #123). A fresh session
+	// starts empty (""); each persisted turn advances it to the newly written
+	// leaf. /tree can move it to a historical entry so the next turn branches from
+	// there rather than the tip.
+	curLeaf string
+	// persisted is the number of agentCtx.Messages already written to disk. The
+	// per-turn persist appends only Messages[persisted:] as a branch descending
+	// from curLeaf, so switching leaves and continuing grows a real tree instead
+	// of rewriting the file as a single linear chain.
+	persisted int
 }
 
 // replScanBufInit / replScanBufMax bound the line scanner. bufio.Scanner caps
@@ -105,11 +118,19 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 		if line == "/compact" {
 			// /compact is intercepted here (like /exit) because compaction must run
 			// an agent stream and mutate the shared context — neither of which a
-			// slash Action closure (string in, string out) can do.
+			// slash Action closure (string in, string out) can do. Compaction
+			// replaces the whole message list with a summary + tail, so the session
+			// is rewritten linearly (Save) and the branch-tracking state is reset to
+			// the new flattened leaf.
 			runManualCompact(out, deps)
 			deps.header.UpdatedAt = time.Now().UTC()
 			if err := deps.store.Save(deps.header, deps.agentCtx.Messages); err != nil {
 				fmt.Fprintf(out, "pigo: session save failed: %v\n", err)
+			}
+			deps.persisted = len(deps.agentCtx.Messages)
+			deps.curLeaf = ""
+			if _, entries, err := deps.store.LoadEntries(deps.header.ID); err == nil && len(entries) > 0 {
+				deps.curLeaf = entries[len(entries)-1].ID
 			}
 			continue
 		}
@@ -120,6 +141,14 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 			// cannot do. runForkClone saves the current session, forks it, and
 			// swaps deps.header / deps.agentCtx to the new branch on success.
 			runForkClone(out, &deps, line)
+			continue
+		}
+		if line == "/tree" || strings.HasPrefix(line, "/tree ") {
+			// /tree is intercepted here (like /fork) because "/tree <n>" moves the
+			// active leaf and rebuilds the shared context in place — mutating
+			// per-run state a slash Action closure cannot reach. With no argument
+			// it just prints the tree.
+			runTree(out, &deps, line)
 			continue
 		}
 
@@ -150,14 +179,39 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 		cancel()
 		setCancel(nil)
 
-		// Persist the session after each settled run.
-		deps.header.UpdatedAt = time.Now().UTC()
+		// Persist the turn as a branch descending from the active leaf, so a
+		// prior /tree leaf-switch produces a real sibling branch on disk rather
+		// than a truncated linear rewrite.
 		deps.header.Model = deps.live.model
 		deps.header.Provider = deps.live.providerName
-		if err := deps.store.Save(deps.header, deps.agentCtx.Messages); err != nil {
-			fmt.Fprintf(out, "pigo: session save failed: %v\n", err)
-		}
+		persistTurn(out, &deps)
 	}
+}
+
+// persistTurn writes the messages produced since the last persist as a new
+// branch descending from deps.curLeaf, advancing curLeaf to the new leaf and
+// persisted to the current message count (US-007, #123). Growing the tree with
+// AppendBranch (rather than rewriting the whole file linearly with Save) is what
+// lets a /tree leaf-switch fork the on-disk history instead of clobbering it. If
+// nothing new was produced it is a no-op: the on-disk tree is already current, so
+// the file is left untouched (rewriting it would regenerate ids and flatten the
+// tree).
+func persistTurn(out io.Writer, deps *replDeps) {
+	tail := deps.agentCtx.Messages[deps.persisted:]
+	if len(tail) == 0 {
+		// Nothing new to persist. Do NOT rewrite the file: Save regenerates entry
+		// ids and flattens the tree, which would invalidate curLeaf and drop any
+		// sibling branches. The on-disk tree is already current.
+		return
+	}
+	deps.header.UpdatedAt = time.Now().UTC()
+	leaf, err := deps.store.AppendBranch(deps.header, deps.curLeaf, tail)
+	if err != nil {
+		fmt.Fprintf(out, "pigo: session save failed: %v\n", err)
+		return
+	}
+	deps.curLeaf = leaf
+	deps.persisted = len(deps.agentCtx.Messages)
 }
 
 // streamRun appends the prompt to the shared context, starts an agent run, and
@@ -234,14 +288,12 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 // deps.agentCtx to the new session in place so subsequent prompts continue on
 // the branch. resume of either session id later walks to its own leaf.
 func runForkClone(out io.Writer, deps *replDeps, line string) {
-	// Persist the current session so Fork copies an up-to-date, saved tree.
-	deps.header.UpdatedAt = time.Now().UTC()
-	if err := deps.store.Save(deps.header, deps.agentCtx.Messages); err != nil {
-		fmt.Fprintf(out, "pigo: session save failed: %v\n", err)
-		return
-	}
+	// Persist the current turn as a branch so Fork copies an up-to-date tree
+	// without flattening any existing branches (a plain Save would rewrite the
+	// file linearly and drop siblings).
+	persistTurn(out, deps)
 	_, entries, err := deps.store.LoadEntries(deps.header.ID)
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		fmt.Fprintf(out, "pigo: cannot read session tree: %v\n", err)
 		return
 	}
@@ -255,8 +307,11 @@ func runForkClone(out io.Writer, deps *replDeps, line string) {
 
 	var leafID string
 	if cmd == "/clone" {
-		// Clone the whole conversation at the current leaf (last entry).
-		leafID = entries[len(entries)-1].ID
+		// Clone the whole conversation at the current active leaf.
+		leafID = deps.curLeaf
+		if leafID == "" {
+			leafID = entries[len(entries)-1].ID
+		}
 	} else { // /fork
 		// Collect the historical user messages, in order, with their entry index.
 		type userMsg struct {
@@ -306,12 +361,75 @@ func runForkClone(out io.Writer, deps *replDeps, line string) {
 	}
 	deps.header = newHeader
 	deps.agentCtx.Messages = msgs
+	// The new file already holds the copied path verbatim, so mark it all
+	// persisted and set the active leaf to the copied tip.
+	deps.persisted = len(path)
+	deps.curLeaf = ""
+	if len(path) > 0 {
+		deps.curLeaf = path[len(path)-1].ID
+	}
 
 	action := "cloned"
 	if cmd == "/fork" {
 		action = "forked"
 	}
 	fmt.Fprintf(out, "%s session %s → %s (%d messages)\n", action, newHeader.ParentSession, newHeader.ID, len(msgs))
+}
+
+// runTree handles the /tree command (US-007, #123): the branch-navigation view
+// for a pure line REPL.
+//
+//   - "/tree" with no argument persists the current turn, then prints the
+//     session's entry tree with ├─/└─ connectors, tagging the active leaf with
+//     "← current". Each printed row is numbered so it can be selected.
+//   - "/tree N" switches the active leaf to the N-th printed entry: it rebuilds
+//     the shared context to the root→leaf path feeding that entry, so the next
+//     prompt continues from there. Because persistTurn appends new turns as a
+//     branch descending from the (moved) leaf, continuing after a switch grows a
+//     real sibling branch on disk rather than truncating history.
+func runTree(out io.Writer, deps *replDeps, line string) {
+	// Persist any un-saved turn first so the tree reflects the live conversation.
+	persistTurn(out, deps)
+	_, entries, err := deps.store.LoadEntries(deps.header.ID)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		fmt.Fprintf(out, "pigo: cannot read session tree: %v\n", err)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(out, "session tree is empty — send a message first")
+		return
+	}
+
+	lines := session.RenderTreeLines(entries, deps.curLeaf)
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		// Print the numbered tree for selection.
+		fmt.Fprintln(out, "session tree (run /tree <n> to switch the active branch):")
+		for i, l := range lines {
+			fmt.Fprintf(out, "  %d. %s\n", i+1, l.Text)
+		}
+		return
+	}
+
+	n, convErr := strconv.Atoi(fields[1])
+	if convErr != nil || n < 1 || n > len(lines) {
+		fmt.Fprintf(out, "invalid selection %q — run /tree to list nodes (1..%d)\n", fields[1], len(lines))
+		return
+	}
+
+	// Switch the active leaf to the chosen node and rebuild the context from its
+	// root→leaf path. The chosen entry is already persisted, so persisted stays at
+	// the rebuilt length; the next turn branches from curLeaf.
+	target := lines[n-1].Entry
+	path := session.PathToLeaf(entries, target.ID)
+	msgs := make(agentcore.MessageList, len(path))
+	for i, e := range path {
+		msgs[i] = e.Message
+	}
+	deps.agentCtx.Messages = msgs
+	deps.curLeaf = target.ID
+	deps.persisted = len(msgs)
+	fmt.Fprintf(out, "switched to branch at node %d (%d messages) — next prompt continues from here\n", n, len(msgs))
 }
 
 // runManualCompact compacts the shared context on an explicit /compact request:

--- a/cmd/pigo/repl_test.go
+++ b/cmd/pigo/repl_test.go
@@ -269,7 +269,75 @@ func TestReplayTranscriptRendersRoles(t *testing.T) {
 	}
 }
 
-// TestREPLStreamsAndAccumulatesHistory verifies a plain prompt runs, its reply
+// TestREPLTreePrintsAndSwitchesBranch drives the /tree command end to end over
+// the REPL: after two turns, "/tree" prints a numbered tree with the current-leaf
+// marker; "/tree 1" switches the active leaf to the first node, so the next
+// prompt branches from there — leaving the original branch intact on disk (US-007,
+// #123).
+func TestREPLTreePrintsAndSwitchesBranch(t *testing.T) {
+	p := &replProvider{reply: "reply"}
+	deps, store := newTestDeps(t, p)
+	var out bytes.Buffer
+	// Two turns build a linear history (4 messages), then /tree lists it, /tree 1
+	// switches to the first node, a new prompt branches, then /exit.
+	in := strings.NewReader("first\nsecond\n/tree\n/tree 1\nbranched\n/exit\n")
+	if err := runREPL(in, &out, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "← current") {
+		t.Errorf("/tree should mark the current leaf, out=%q", s)
+	}
+	if !strings.Contains(s, "1. user:") {
+		t.Errorf("/tree should number entries starting at the root user message, out=%q", s)
+	}
+	if !strings.Contains(s, "switched to branch at node 1") {
+		t.Errorf("/tree 1 should confirm the switch, out=%q", s)
+	}
+	// The on-disk tree must retain both branches: the original 4-message line plus
+	// the new branch off node 1. Reload and confirm the root has 2 children.
+	_, entries, err := store.LoadEntries(deps.header.ID)
+	if err != nil {
+		t.Fatalf("LoadEntries: %v", err)
+	}
+	rootID := ""
+	for _, e := range entries {
+		if e.ParentID == "" {
+			rootID = e.ID
+			break
+		}
+	}
+	if rootID == "" {
+		t.Fatal("no root entry found")
+	}
+	kids := 0
+	for _, e := range entries {
+		if e.ParentID == rootID {
+			kids++
+		}
+	}
+	if kids != 2 {
+		t.Errorf("root should have 2 children after branching, got %d (entries=%d)", kids, len(entries))
+	}
+}
+
+// TestREPLTreeEmptyNoop verifies /tree on a fresh session (no messages) prints a
+// friendly notice and does not crash or run.
+func TestREPLTreeEmptyNoop(t *testing.T) {
+	p := &replProvider{reply: "hi"}
+	deps, _ := newTestDeps(t, p)
+	var out bytes.Buffer
+	if err := runREPL(strings.NewReader("/tree\n/exit\n"), &out, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	if p.calls != 0 {
+		t.Errorf("/tree must not launch a run, got %d calls", p.calls)
+	}
+	if !strings.Contains(out.String(), "empty") {
+		t.Errorf("/tree on empty session should say so, out=%q", out.String())
+	}
+}
+
 // is printed, and history accumulates across two turns in the shared context.
 func TestREPLStreamsAndAccumulatesHistory(t *testing.T) {
 	p := &replProvider{reply: "the answer"}

--- a/docs/issue#0123.html
+++ b/docs/issue#0123.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0123</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue #0123 &mdash; /tree 分支导航 (US-007) &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 在文件内引入分支存储（<code>AppendBranch</code>），而非重写为线性链</h3>
+      <p><strong>Ambiguity:</strong> Spec 要求 “/tree 选择某节点作为新活动 leaf 并从该节点延续”，但 pigo 会话文件此前始终是线性的（每次 <code>Save</code> 重写整个文件）。线性写入无法保留切换后产生的兄弟分支。</p>
+      <p><strong>Choice:</strong> 新增 <code>Store.AppendBranch(header, parentLeafID, messages)</code>，保留所有既有 entry，只把新消息链接到指定父 leaf 之后，返回新 leaf id。REPL 用 <code>curLeaf</code>/<code>persisted</code> 跟踪活动 leaf 与已落盘条数，每轮以分支形式追加。</p>
+      <p><strong>Rationale:</strong> 这是唯一能让 “切换 leaf 后继续” 在磁盘上真正生成兄弟分支、而不截断历史的方式。与 schema v3 的 entry 树（#121）自然衔接。</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 纯文本 ├─/└─ 树渲染，放弃移植 pi 的 TUI</h3>
+      <p><strong>Ambiguity:</strong> pi 的 <code>tree-selector.ts</code> 是全屏光标交互 TUI；spec 只要求 “纯行式 REPL 下可读（无需 TUI）”。</p>
+      <p><strong>Choice:</strong> 在 <code>session</code> 包实现 <code>RenderTreeLines(entries, leafID) []TreeLine</code>：pre-order DFS，├─/└─ 连线，活动 leaf 标 “← current”，每行返回对应 Entry 以便按序号选择。</p>
+      <p><strong>Rationale:</strong> pigo 已用行式 REPL 替代 bubbletea TUI（#106），文本渲染与该架构一致，且可被单测直接断言输出。</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> /tree 在 REPL 循环中拦截，而非走 SlashRegistry Action</h3>
+      <p><strong>Ambiguity:</strong> 多数 slash 命令是纯 <code>string→string</code> 的 Action；/tree 需要改写共享 <code>agentCtx.Messages</code> 与 <code>curLeaf</code>。</p>
+      <p><strong>Choice:</strong> 与 /compact /fork /clone 一致，在 <code>runREPL</code> 内直接拦截；同时在 <code>registerLiveCommands</code> 注册为 no-op builtin，仅为让 /help 列出。</p>
+      <p><strong>Rationale:</strong> Action 闭包无法触及每轮可变状态；沿用既有拦截模式保持一致性。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> resume 路径改用 <code>LoadEntries</code> 重建 curLeaf</h3>
+      <p><strong>Spec:</strong> 未规定 resume 时如何设定活动 leaf。</p>
+      <p><strong>Implemented:</strong> <code>runInteractive</code> 恢复会话时用 <code>LoadEntries</code>（而非 <code>Load</code>）读取 entry 树，并把 <code>curLeaf</code> 设为最后一个 entry，使 resume 后 /tree 能立即正确定位。</p>
+      <p><strong>Why:</strong> 若不设 curLeaf，resume 后首个 /tree 会误判活动分支，破坏 “从当前 leaf 延续” 的语义。属于为满足验收条件而做的必要补齐，非偏离本意。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 空 tail 时 persistTurn 直接 return，不重写文件</h3>
+      <p><strong>Alternatives:</strong> (A) 每次都 <code>Save</code> 刷新 header 的 UpdatedAt；(B) 无新消息时直接 return。</p>
+      <p><strong>Pros/Cons:</strong> A 会让 <code>Save</code> 重新生成 entry id 并把树拍平，直接使 <code>curLeaf</code> 失效、丢弃兄弟分支（正是首次测试失败的根因）；B 保留磁盘树完好，仅牺牲空轮时 UpdatedAt 的即时刷新。</p>
+      <p><strong>Winner:</strong> B。分支完整性远重于空轮刷新时间戳；实际有新消息的轮次仍会 bump UpdatedAt。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 分支渲染在超大树下的可读性</h3>
+      <p><strong>Assumption:</strong> 会话 entry 数在人类可浏览范围内（数十条）。</p>
+      <p><strong>Verify:</strong> 若单会话累积成百上千 entry，纯文本树会很长；是否需要分页或折叠子树？当前实现全量打印。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -18,6 +18,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -186,6 +187,131 @@ func PathToLeaf(entries []Entry, leafID string) []Entry {
 
 // FileName returns the on-disk file name for a session id (id + ".jsonl").
 func FileName(id string) string { return id + ".jsonl" }
+
+// TreeLine pairs one entry with its rendered display line, so a caller can print
+// the tree AND map a 1-based selection index back to the entry it refers to (the
+// slice order is the render order — a stable pre-order DFS). See RenderTreeLines.
+type TreeLine struct {
+	Entry Entry
+	Text  string
+}
+
+// RenderTreeLines renders the entry forest as human-readable lines for a pure
+// line REPL — no TUI, no cursor control (US-007, #123). Each entry becomes one
+// line with ├─/└─ connectors showing structure; the entry whose id == leafID is
+// tagged "← current" so the active branch is obvious. Roots (entries with an
+// empty or dangling ParentID) anchor the forest; children are ordered by
+// timestamp then id for stable output. The returned slice is in render order, so
+// element i corresponds to the i-th printed line (and 1-based selector n → [n-1]).
+func RenderTreeLines(entries []Entry, leafID string) []TreeLine {
+	present := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		present[e.ID] = true
+	}
+	childrenOf := make(map[string][]Entry, len(entries))
+	var roots []Entry
+	for _, e := range entries {
+		if e.ParentID == "" || !present[e.ParentID] {
+			roots = append(roots, e)
+		} else {
+			childrenOf[e.ParentID] = append(childrenOf[e.ParentID], e)
+		}
+	}
+	sortEntries(roots)
+	for k := range childrenOf {
+		sortEntries(childrenOf[k])
+	}
+
+	var lines []TreeLine
+	var walk func(e Entry, prefix string, isRoot, isLast bool)
+	walk = func(e Entry, prefix string, isRoot, isLast bool) {
+		connector := ""
+		if !isRoot {
+			if isLast {
+				connector = "└─ "
+			} else {
+				connector = "├─ "
+			}
+		}
+		marker := ""
+		if e.ID == leafID {
+			marker = "  ← current"
+		}
+		lines = append(lines, TreeLine{Entry: e, Text: prefix + connector + entrySummary(e) + marker})
+
+		childPrefix := prefix
+		if !isRoot {
+			if isLast {
+				childPrefix += "   "
+			} else {
+				childPrefix += "│  "
+			}
+		}
+		kids := childrenOf[e.ID]
+		for i, k := range kids {
+			walk(k, childPrefix, false, i == len(kids)-1)
+		}
+	}
+	for i, r := range roots {
+		walk(r, "", true, i == len(roots)-1)
+	}
+	return lines
+}
+
+// sortEntries orders entries by timestamp, breaking ties by id so the render is
+// deterministic even when entries share a timestamp (common within one turn).
+func sortEntries(es []Entry) {
+	sort.SliceStable(es, func(i, j int) bool {
+		if !es[i].Timestamp.Equal(es[j].Timestamp) {
+			return es[i].Timestamp.Before(es[j].Timestamp)
+		}
+		return es[i].ID < es[j].ID
+	})
+}
+
+// entrySummary renders a one-line, role-tagged preview of an entry's message for
+// the tree display (a full message would wrap and ruin the ASCII structure).
+func entrySummary(e Entry) string {
+	switch m := e.Message.(type) {
+	case agentcore.UserMessage:
+		return "user: " + treeOneLine(agentcore.ContentToText(m.Content))
+	case agentcore.AssistantMessage:
+		text := treeOneLine(agentcore.ContentToText(m.Content))
+		calls := m.ToolCalls()
+		if len(calls) > 0 {
+			names := make([]string, len(calls))
+			for i, c := range calls {
+				names[i] = c.Name
+			}
+			tools := "[→ " + strings.Join(names, ", ") + "]"
+			if text != "" {
+				return "assistant: " + text + " " + tools
+			}
+			return "assistant " + tools
+		}
+		return "assistant: " + text
+	case agentcore.ToolResultMessage:
+		return "tool result: " + treeOneLine(agentcore.ContentToText(m.Content))
+	case agentcore.CompactionMessage:
+		return "compaction: " + treeOneLine(m.Summary)
+	default:
+		return e.Message.Role()
+	}
+}
+
+// treeOneLine collapses a possibly multi-line message into a single trimmed,
+// truncated line so tree rows stay on one physical line.
+func treeOneLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i] + " …"
+	}
+	const max = 72
+	if len(s) > max {
+		s = s[:max] + " …"
+	}
+	return s
+}
 
 // NewID returns a time-ordered session id: a UTC timestamp stem that sorts
 // lexicographically by creation time (e.g. "20260710-142530-uniq"). The suffix
@@ -477,6 +603,44 @@ func (s *Store) Append(id string, updatedAt time.Time, messages agentcore.Messag
 	header.UpdatedAt = updatedAt
 	existing = append(existing, messages...)
 	return s.Save(header, existing)
+}
+
+// AppendBranch appends messages as a chain descending from parentLeafID,
+// preserving every existing entry — and therefore any other branches — in the
+// session file (US-007, #123). It is the tree-aware counterpart to Append (which
+// rewrites the file as a single linear chain): where Append flattens, AppendBranch
+// grows the on-disk tree, so switching the active leaf to a historical entry and
+// continuing produces a real sibling branch rather than truncating history.
+//
+// Each message becomes a fresh entry (new id, ParentID chained to the previous
+// one, first chained to parentLeafID). An empty parentLeafID roots the new chain.
+// header (Version forced to SchemaVersion, UpdatedAt as the caller set it) is
+// rewritten as line 1. It returns the id of the new leaf — the last appended
+// entry — so the caller can track the active branch. If the session file does not
+// yet exist it is created (the fresh-session first-turn case).
+func (s *Store) AppendBranch(header SessionHeader, parentLeafID string, messages agentcore.MessageList) (string, error) {
+	if header.ID == "" {
+		return "", fmt.Errorf("session: header ID must not be empty")
+	}
+	var entries []Entry
+	if _, existing, err := s.LoadEntries(header.ID); err == nil {
+		entries = existing
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	now := time.Now().UTC()
+	parent := parentLeafID
+	leaf := parentLeafID
+	for _, m := range messages {
+		e := Entry{ID: newEntryID(), ParentID: parent, Timestamp: now, Message: m}
+		entries = append(entries, e)
+		parent = e.ID
+		leaf = e.ID
+	}
+	if err := s.SaveEntries(header, entries); err != nil {
+		return "", err
+	}
+	return leaf, nil
 }
 
 // Fork creates a new session whose contents are the linear path from the root

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -8,6 +8,7 @@ package session
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -457,6 +458,158 @@ func TestForkBeforeUserMessage(t *testing.T) {
 	if len(prefix) != len(entries)-1 {
 		t.Errorf("prefix fork = %d entries, want %d", len(prefix), len(entries)-1)
 	}
+}
+
+// TestAppendBranchGrowsTree verifies AppendBranch (US-007, #123) preserves all
+// existing entries and chains new messages from a chosen parent leaf — so
+// switching the active leaf to a historical entry and continuing produces a real
+// sibling branch on disk rather than truncating history.
+func TestAppendBranchGrowsTree(t *testing.T) {
+	s := newStore(t)
+	now := time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+	h := SessionHeader{ID: NewID(now), CreatedAt: now, UpdatedAt: now}
+	if err := s.Save(h, sampleMessages()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	_, entries, err := s.LoadEntries(h.ID)
+	if err != nil {
+		t.Fatalf("LoadEntries: %v", err)
+	}
+	// Branch from the FIRST entry (the root user message): append a new user turn
+	// as its child. The result must keep every original entry plus the new one.
+	branchParent := entries[0].ID
+	extra := agentcore.MessageList{
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("a different question")}},
+	}
+	leaf, err := s.AppendBranch(h, branchParent, extra)
+	if err != nil {
+		t.Fatalf("AppendBranch: %v", err)
+	}
+	_, after, err := s.LoadEntries(h.ID)
+	if err != nil {
+		t.Fatalf("LoadEntries after branch: %v", err)
+	}
+	if len(after) != len(entries)+1 {
+		t.Fatalf("entry count = %d, want %d (nothing dropped, one added)", len(after), len(entries)+1)
+	}
+	// The new leaf descends from the chosen parent.
+	var newLeaf *Entry
+	for i := range after {
+		if after[i].ID == leaf {
+			newLeaf = &after[i]
+		}
+	}
+	if newLeaf == nil {
+		t.Fatalf("new leaf %q not found in reloaded entries", leaf)
+	}
+	if newLeaf.ParentID != branchParent {
+		t.Errorf("new leaf parent = %q, want %q", newLeaf.ParentID, branchParent)
+	}
+	// The root now has two children: the original second entry and the new leaf —
+	// a genuine branch point.
+	kids := 0
+	for _, e := range after {
+		if e.ParentID == branchParent {
+			kids++
+		}
+	}
+	if kids != 2 {
+		t.Errorf("branch point should have 2 children, got %d", kids)
+	}
+	// PathToLeaf to the new leaf yields exactly [root, newLeaf].
+	path := PathToLeaf(after, leaf)
+	if len(path) != 2 || path[0].ID != branchParent || path[1].ID != leaf {
+		t.Errorf("PathToLeaf(newLeaf) = %v, want [root, newLeaf]", pathIDs(path))
+	}
+}
+
+// TestAppendBranchCreatesFileWhenMissing verifies AppendBranch creates the
+// session file on first use (the fresh-session first-turn case) rather than
+// erroring like Append does.
+func TestAppendBranchCreatesFileWhenMissing(t *testing.T) {
+	s := newStore(t)
+	now := time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+	h := SessionHeader{ID: NewID(now), CreatedAt: now, UpdatedAt: now}
+	msgs := agentcore.MessageList{
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("hi")}},
+	}
+	leaf, err := s.AppendBranch(h, "", msgs)
+	if err != nil {
+		t.Fatalf("AppendBranch on missing file: %v", err)
+	}
+	_, entries, err := s.LoadEntries(h.ID)
+	if err != nil {
+		t.Fatalf("LoadEntries: %v", err)
+	}
+	if len(entries) != 1 || entries[0].ID != leaf || entries[0].ParentID != "" {
+		t.Errorf("expected one root entry with id=%q, got %v", leaf, entries)
+	}
+}
+
+// TestRenderTreeLinesMarksCurrentAndBranches verifies the pure-text tree render
+// (US-007, #123): every entry gets one numbered-able line in render order, the
+// active leaf is tagged "← current", and a branch point produces two child rows.
+func TestRenderTreeLinesMarksCurrentAndBranches(t *testing.T) {
+	s := newStore(t)
+	now := time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+	h := SessionHeader{ID: NewID(now), CreatedAt: now, UpdatedAt: now}
+	if err := s.Save(h, sampleMessages()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	_, entries, err := s.LoadEntries(h.ID)
+	if err != nil {
+		t.Fatalf("LoadEntries: %v", err)
+	}
+	// Branch off the root to create a fork point.
+	if _, err := s.AppendBranch(h, entries[0].ID, agentcore.MessageList{
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("sibling turn")}},
+	}); err != nil {
+		t.Fatalf("AppendBranch: %v", err)
+	}
+	_, after, err := s.LoadEntries(h.ID)
+	if err != nil {
+		t.Fatalf("LoadEntries after branch: %v", err)
+	}
+
+	leaf := after[len(after)-1].ID
+	lines := RenderTreeLines(after, leaf)
+	if len(lines) != len(after) {
+		t.Fatalf("render produced %d lines, want %d (one per entry)", len(lines), len(after))
+	}
+	// Exactly one line is tagged as current, and it is the leaf.
+	current := 0
+	for _, l := range lines {
+		if strings.Contains(l.Text, "← current") {
+			current++
+			if l.Entry.ID != leaf {
+				t.Errorf("current marker on %q, want leaf %q", l.Entry.ID, leaf)
+			}
+		}
+	}
+	if current != 1 {
+		t.Errorf("expected exactly one ← current line, got %d", current)
+	}
+	// Connector characters must appear (readable branch structure).
+	joined := ""
+	for _, l := range lines {
+		joined += l.Text + "\n"
+	}
+	if !strings.Contains(joined, "├─") && !strings.Contains(joined, "└─") {
+		t.Errorf("tree render lacks connectors:\n%s", joined)
+	}
+	// The first line is a root (no connector prefix) rendering the root user msg.
+	if !strings.HasPrefix(lines[0].Text, "user:") {
+		t.Errorf("first render line should be the root user message, got %q", lines[0].Text)
+	}
+}
+
+// pathIDs is a small test helper: the ids of a path, for readable failures.
+func pathIDs(path []Entry) []string {
+	ids := make([]string, len(path))
+	for i, e := range path {
+		ids[i] = e.ID
+	}
+	return ids
 }
 
 // through the JSONL store as a first-class message line under schema v2.


### PR DESCRIPTION
## Summary
- 新增 `Store.AppendBranch`：保留会话文件中所有既有 entry，从指定父 leaf 链接新消息，返回新 leaf id —— 树感知版的 `Append`，不再拍平为线性链
- REPL 跟踪 `curLeaf`/`persisted`，每轮以分支形式追加，使 `/tree` 切换活动 leaf 后继续对话在磁盘上生成真正的兄弟分支
- 新增 `session.RenderTreeLines`：pre-order DFS，├─/└─ 连线纯文本渲染 entry 树，活动 leaf 标 "← current"
- `/tree` 在 REPL 循环内拦截：无参打印编号树，`/tree N` 切换活动分支并从该节点延续
- resume 路径改用 `LoadEntries` 重建 `curLeaf`

Closes #123

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass（新增 TestAppendBranchGrowsTree / TestRenderTreeLinesMarksCurrentAndBranches / TestREPLTreePrintsAndSwitchesBranch / TestREPLTreeEmptyNoop）
- [x] `gofmt -l` clean