### PR TITLE
会话导出/导入 /export /import (US-008, #124)

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -342,11 +342,11 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 			return b.String()
 		},
 	})
-	// /exit, /quit, /compact, /fork, /clone and /tree are intercepted by the REPL
-	// loop before slash resolution (they must return from the loop, run an agent
-	// stream, or swap the active session/leaf — none of which an Action closure
-	// can do). They are registered here only so /help lists them; their Action is
-	// never actually reached.
+	// /exit, /quit, /compact, /fork, /clone, /tree, /export and /import are
+	// intercepted by the REPL loop before slash resolution (they must return from
+	// the loop, run an agent stream, or swap the active session/leaf — none of
+	// which an Action closure can do). They are registered here only so /help
+	// lists them; their Action is never actually reached.
 	for _, c := range []struct{ name, desc string }{
 		{"exit", "exit the REPL"},
 		{"quit", "exit the REPL"},
@@ -354,6 +354,8 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 		{"fork", "branch from a historical message into a new session: /fork [n]"},
 		{"clone", "duplicate the current session into an independent branch"},
 		{"tree", "show the session branch tree; switch active branch: /tree [n]"},
+		{"export", "export the session to a file: /export [path.jsonl|path.html]"},
+		{"import", "import a JSONL export as a new session: /import <path.jsonl>"},
 	} {
 		reg.AddBuiltin(runtime.SlashCommand{
 			Name:        c.name,

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -151,6 +151,21 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 			runTree(out, &deps, line)
 			continue
 		}
+		if line == "/export" || strings.HasPrefix(line, "/export ") {
+			// /export writes the current session to a file. It is intercepted here
+			// (not a slash Action) because it must first persist the live turn so the
+			// export reflects unsaved messages. The exact-or-space-prefix guard keeps
+			// "/exporter" from being mistaken for "/export".
+			runExport(out, &deps, line)
+			continue
+		}
+		if line == "/import" || strings.HasPrefix(line, "/import ") {
+			// /import loads a JSONL export as a fresh session and switches to it,
+			// swapping deps.header / deps.agentCtx in place — which a slash Action
+			// closure cannot do. The guard keeps "/important" from matching.
+			runImport(out, &deps, line)
+			continue
+		}
 
 		// Resolve slash-commands: an action command runs and prints its message
 		// (no agent run); a prompt command or skill expands to the text we run; an
@@ -430,6 +445,74 @@ func runTree(out io.Writer, deps *replDeps, line string) {
 	deps.curLeaf = target.ID
 	deps.persisted = len(msgs)
 	fmt.Fprintf(out, "switched to branch at node %d (%d messages) — next prompt continues from here\n", n, len(msgs))
+}
+
+// pathCommandArg extracts the path argument for a "/cmd <path>" line, enforcing a
+// command-token boundary (so "/exporter x" is NOT "/export" with arg "x") and
+// stripping a single layer of surrounding double quotes (so a path with spaces
+// can be given as /export "my session.html"). It returns "" when line is not the
+// given command or carries no argument.
+func pathCommandArg(line, cmd string) string {
+	if line != cmd && !strings.HasPrefix(line, cmd+" ") {
+		return ""
+	}
+	arg := strings.TrimSpace(strings.TrimPrefix(line, cmd))
+	if len(arg) >= 2 && strings.HasPrefix(arg, `"`) && strings.HasSuffix(arg, `"`) {
+		arg = arg[1 : len(arg)-1]
+	}
+	return arg
+}
+
+// runExport handles the /export command (US-008, #124): it persists the live
+// turn, then writes the current session to a file. "/export" with no path
+// defaults to "<session-id>.jsonl" in the working directory; "/export path.html"
+// (or .htm) writes a self-contained HTML transcript; any other extension writes
+// JSONL. The JSONL form round-trips losslessly through /import.
+func runExport(out io.Writer, deps *replDeps, line string) {
+	persistTurn(out, deps)
+	path := pathCommandArg(line, "/export")
+	if path == "" {
+		path = deps.header.ID + ".jsonl"
+	}
+	n, err := deps.store.Export(deps.header.ID, path)
+	if err != nil {
+		fmt.Fprintf(out, "pigo: export failed: %v\n", err)
+		return
+	}
+	fmt.Fprintf(out, "exported %d entries to %s\n", n, path)
+}
+
+// runImport handles the /import command (US-008, #124): it reads a JSONL export
+// and materializes it as a fresh, independent session, then switches the live
+// REPL to it (swapping header + shared context in place) so the next prompt
+// continues the imported conversation. The original file is untouched; the new
+// session records the source id as its ParentSession.
+func runImport(out io.Writer, deps *replDeps, line string) {
+	path := pathCommandArg(line, "/import")
+	if path == "" {
+		fmt.Fprintln(out, "usage: /import <path.jsonl>")
+		return
+	}
+	newHeader, entries, err := deps.store.Import(path, time.Now().UTC())
+	if err != nil {
+		fmt.Fprintf(out, "pigo: import failed: %v\n", err)
+		return
+	}
+	// Swap the live session to the imported one: rebuild the flat message list and
+	// point the REPL at the new header. The imported file already holds the entries
+	// verbatim, so mark them all persisted and set the active leaf to the tip.
+	msgs := make(agentcore.MessageList, len(entries))
+	for i, e := range entries {
+		msgs[i] = e.Message
+	}
+	deps.header = newHeader
+	deps.agentCtx.Messages = msgs
+	deps.persisted = len(entries)
+	deps.curLeaf = ""
+	if len(entries) > 0 {
+		deps.curLeaf = entries[len(entries)-1].ID
+	}
+	fmt.Fprintf(out, "imported %d entries from %s → session %s\n", len(entries), path, newHeader.ID)
 }
 
 // runManualCompact compacts the shared context on an explicit /compact request:

--- a/cmd/pigo/repl_test.go
+++ b/cmd/pigo/repl_test.go
@@ -10,6 +10,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -369,5 +371,88 @@ func TestREPLStreamsAndAccumulatesHistory(t *testing.T) {
 	}
 	if len(headers) != 1 {
 		t.Errorf("expected 1 saved session, got %d", len(headers))
+	}
+}
+
+// TestREPLExportImportRoundTrip drives /export and /import end to end over the
+// REPL: after a turn, "/export <path>" writes a JSONL file, then "/import
+// <path>" materializes it as a fresh session and switches to it (US-008, #124).
+func TestREPLExportImportRoundTrip(t *testing.T) {
+	p := &replProvider{reply: "the answer"}
+	deps, store := newTestDeps(t, p)
+	origID := deps.header.ID
+	out := filepath.Join(t.TempDir(), "sess.jsonl")
+
+	var buf bytes.Buffer
+	in := strings.NewReader("hello\n/export " + out + "\n/import " + out + "\n/exit\n")
+	if err := runREPL(in, &buf, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	s := buf.String()
+	if !strings.Contains(s, "exported") {
+		t.Errorf("/export should confirm, out=%q", s)
+	}
+	if !strings.Contains(s, "imported") {
+		t.Errorf("/import should confirm, out=%q", s)
+	}
+	// The export file must exist and be non-empty.
+	if info, err := os.Stat(out); err != nil || info.Size() == 0 {
+		t.Fatalf("export file missing or empty: err=%v", err)
+	}
+	// The import creates a new session distinct from the original, so the store
+	// should now hold at least 2 sessions.
+	headers, err := store.List()
+	if err != nil {
+		t.Fatalf("store.List: %v", err)
+	}
+	var foundNew bool
+	for _, h := range headers {
+		if h.ID != origID && h.ParentSession == origID {
+			foundNew = true
+		}
+	}
+	if !foundNew {
+		t.Errorf("expected an imported session with ParentSession=%q, headers=%+v", origID, headers)
+	}
+}
+
+// TestREPLExportDefaultsToJSONL verifies "/export" with no path defaults to
+// "<session-id>.jsonl" and does not launch an agent run.
+func TestREPLExportDefaultsToJSONL(t *testing.T) {
+	p := &replProvider{reply: "ok"}
+	deps, _ := newTestDeps(t, p)
+	dir := t.TempDir()
+	// Run inside a temp dir so the default relative filename lands there.
+	cwd, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(cwd)
+
+	var buf bytes.Buffer
+	if err := runREPL(strings.NewReader("hi\n/export\n/exit\n"), &buf, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	want := deps.header.ID + ".jsonl"
+	if _, err := os.Stat(filepath.Join(dir, want)); err != nil {
+		t.Errorf("default export file %q not created: %v", want, err)
+	}
+}
+
+// TestREPLImportTokenBoundary verifies that a command sharing a prefix with
+// /import (e.g. "/important") is NOT treated as /import — it falls through to
+// slash resolution and reports an unknown command rather than importing.
+func TestREPLImportTokenBoundary(t *testing.T) {
+	p := &replProvider{reply: "ok"}
+	deps, _ := newTestDeps(t, p)
+	var buf bytes.Buffer
+	if err := runREPL(strings.NewReader("/important\n/exit\n"), &buf, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	if strings.Contains(buf.String(), "imported") {
+		t.Errorf("/important must not trigger /import, out=%q", buf.String())
+	}
+	if p.calls != 0 {
+		t.Errorf("/important should not launch a run, got %d calls", p.calls)
 	}
 }

--- a/docs/issue#0124.html
+++ b/docs/issue#0124.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0124</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.8em; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/124">#124</a> &mdash; /export 与 /import 会话 (US-008) &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> JSONL export reuses the exact on-disk session schema</h3>
+      <p><strong>Ambiguity:</strong> The spec required a lossless round-trip but did not prescribe the export wire format.</p>
+      <p><strong>Choice:</strong> <code>WriteJSONL</code> delegates to the same <code>writeSessionEntries</code> the store uses to persist a session (header line 1, one <code>Entry</code> per line), and <code>ReadJSONL</code> delegates to <code>readSession</code> (with the same v1/v2 migration <code>LoadEntries</code> applies).</p>
+      <p><strong>Rationale:</strong> A <code>WriteJSONL → ReadJSONL</code> round-trip is lossless by construction — entry ids and parentIds survive verbatim, so the tree (and thus <code>PathToLeaf</code>/resume) behaves identically. No parallel serializer to drift out of sync.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Import materializes a fresh, independent session with lineage</h3>
+      <p><strong>Ambiguity:</strong> "resume 为新会话" — but how should the imported session relate to the source?</p>
+      <p><strong>Choice:</strong> <code>Import</code> assigns a fresh <code>NewID(now)</code>, copies Model/Provider/SystemPrompt, records the source id as <code>ParentSession</code>, and writes the entries verbatim (ids/parentIds preserved) via <code>SaveEntries</code>.</p>
+      <p><strong>Rationale:</strong> Mirrors the <code>Fork</code> primitive's lineage model (#122). The import is a new, independently resumable file that never touches the original; the parent link keeps provenance queryable.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Self-contained HTML with inline CSS only, everything escaped</h3>
+      <p><strong>Ambiguity:</strong> "样式内联，不依赖外部网络资源" left the exact rendering open.</p>
+      <p><strong>Choice:</strong> <code>WriteHTML</code> emits one <code>&lt;style&gt;</code> block, no <code>&lt;script&gt;</code>, no <code>&lt;link&gt;</code>, no external fonts or URLs; every piece of session-derived text passes through <code>html.EscapeString</code> before reaching the document.</p>
+      <p><strong>Rationale:</strong> The file renders identically offline and cannot phone home. Escaping is XSS defense against a hostile session (a crafted <code>&lt;/script&gt;</code> or markup cannot break out).</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> /export and /import intercepted in the REPL loop, not as slash Actions</h3>
+      <p><strong>Ambiguity:</strong> pigo has two command mechanisms — Action closures (string→string) and REPL interceptors.</p>
+      <p><strong>Choice:</strong> Both are intercepted directly in <code>runREPL</code> (like <code>/fork</code>/<code>/tree</code>). <code>/export</code> must first <code>persistTurn</code> so the export reflects unsaved messages; <code>/import</code> must swap <code>deps.header</code>/<code>agentCtx</code>/<code>curLeaf</code>/<code>persisted</code> in place. Both are still registered as no-op builtins so <code>/help</code> lists them.</p>
+      <p><strong>Rationale:</strong> A pure string→string Action closure cannot persist state or swap the live session — the same reason <code>/fork</code>/<code>/clone</code>/<code>/tree</code> are intercepted.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None — implementation followed the spec as written. All acceptance criteria (default JSONL export, HTML export with role/tool-call highlighting, lossless round-trip, inline self-contained styles, passing session tests) are met.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Token-boundary guard duplicated at interceptor and in pathCommandArg</h3>
+      <p><strong>Alternatives:</strong> (a) guard only in the REPL interceptor; (b) guard only in <code>pathCommandArg</code>; (c) guard in both.</p>
+      <p><strong>Chosen:</strong> Both. The interceptor uses <code>line == "/export" || HasPrefix(line, "/export ")</code> to decide whether to handle the line at all (so <code>/exporter</code> falls through to slash resolution and reports "unknown command"); <code>pathCommandArg</code> repeats the check defensively when extracting the arg.</p>
+      <p><strong>Why it won:</strong> The interceptor guard is the functional one (routing); the helper guard makes <code>pathCommandArg</code> safe to call in isolation and self-documenting. Minor redundancy, no behavioral risk. Verified by <code>TestREPLImportTokenBoundary</code>.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> HTML/JSONL selection by file extension</h3>
+      <p><strong>Alternatives:</strong> (a) an explicit <code>--format</code> flag; (b) infer from the output path extension.</p>
+      <p><strong>Chosen:</strong> Extension-based (<code>.html</code>/<code>.htm</code> → HTML, everything else → JSONL), matching pi's ergonomics and the acceptance criteria's implied <code>/export path.html</code> syntax.</p>
+      <p><strong>Why it won:</strong> Zero extra syntax for the common case; <code>/export</code> with no path defaults to <code>&lt;id&gt;.jsonl</code>. The cost is that a mistyped extension silently picks a format — acceptable for a REPL convenience command.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> /import does not persist the current turn before switching away</h3>
+      <p><strong>Alternatives:</strong> (a) persist the outgoing session first (as <code>/fork</code> does); (b) just switch.</p>
+      <p><strong>Chosen:</strong> Just switch. The REPL already calls <code>persistTurn</code> at the end of every turn, so by the time <code>/import</code> runs there are no unsaved messages to lose; the outgoing session file is already current on disk.</p>
+      <p><strong>Why it won:</strong> Avoids an unnecessary write. <code>/import</code> is abandoning the current live view, not branching from it, so the <code>/fork</code>-style pre-persist is not needed.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should HTML export be importable too?</h3>
+      <p>Currently <code>/import</code> of an HTML file fails (it isn't valid JSONL) — verified by <code>TestImportRejectsHTML</code>. This is intentional (HTML is a read-only share format), but confirm that a clear error is the desired behavior rather than, say, a friendlier "HTML exports cannot be imported" message.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/session/export.go
+++ b/internal/session/export.go
@@ -1,0 +1,112 @@
+// This file implements session export/import (US-008, #124): a session can be
+// exported to a self-contained JSONL or HTML file, and a JSONL export can be
+// imported back as a fresh, resumable session. The JSONL form is the same
+// role-discriminated schema the store persists, so an export → import round-trip
+// is lossless (message contents and the id/parentId tree survive verbatim); the
+// HTML form is a read-only, self-contained transcript with inline styles and no
+// external network resources, suitable for sharing.
+package session
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// WriteJSONL writes header + entries as JSONL in the store's on-disk schema
+// (header line first, then one entry line each, ids/parentIds preserved). It is
+// the export counterpart to writeSessionEntries and the exact input ReadJSONL
+// expects, so a WriteJSONL → ReadJSONL round-trip is lossless.
+func WriteJSONL(w io.Writer, header SessionHeader, entries []Entry) error {
+	header.Version = SchemaVersion
+	return writeSessionEntries(w, header, entries)
+}
+
+// ReadJSONL decodes a JSONL export (as produced by WriteJSONL or a raw session
+// file) into a header and entries, migrating v1/v2 bare-message files the same
+// way LoadEntries does. It is the import counterpart to WriteJSONL.
+func ReadJSONL(r io.Reader) (SessionHeader, []Entry, error) {
+	return readSession(r)
+}
+
+// Export writes the session identified by id to outPath. The format is chosen
+// by outPath's extension: ".html"/".htm" produces a self-contained HTML
+// transcript; anything else (including ".jsonl") produces JSONL. The parent
+// directory of outPath must already exist. It returns the number of entries
+// written so a caller can report progress.
+func (s *Store) Export(id, outPath string) (int, error) {
+	header, entries, err := s.LoadEntries(id)
+	if err != nil {
+		return 0, err
+	}
+	f, err := os.Create(outPath)
+	if err != nil {
+		return 0, fmt.Errorf("session: create export %s: %w", outPath, err)
+	}
+	defer f.Close()
+	ext := strings.ToLower(filepath.Ext(outPath))
+	if ext == ".html" || ext == ".htm" {
+		if err := WriteHTML(f, header, entries); err != nil {
+			return 0, err
+		}
+	} else {
+		if err := WriteJSONL(f, header, entries); err != nil {
+			return 0, err
+		}
+	}
+	if err := f.Close(); err != nil {
+		return 0, fmt.Errorf("session: finalize export %s: %w", outPath, err)
+	}
+	return len(entries), nil
+}
+
+// Import reads a JSONL export at inPath and materializes it as a fresh session
+// in the store: a new id (derived from now) is assigned, the original id is
+// recorded as ParentSession for lineage, and the entries are written verbatim
+// (ids/parentIds preserved) so the tree — and thus PathToLeaf/resume — behaves
+// exactly as in the source. It returns the new header and the imported entries.
+// An HTML file (or any non-JSONL input) fails to parse and returns an error
+// rather than importing garbage.
+func (s *Store) Import(inPath string, now time.Time) (SessionHeader, []Entry, error) {
+	f, err := os.Open(inPath)
+	if err != nil {
+		return SessionHeader{}, nil, fmt.Errorf("session: open import %s: %w", inPath, err)
+	}
+	defer f.Close()
+	srcHeader, entries, err := ReadJSONL(f)
+	if err != nil {
+		return SessionHeader{}, nil, err
+	}
+	newHeader := SessionHeader{
+		ID:            NewID(now),
+		CreatedAt:     now,
+		UpdatedAt:     now,
+		Model:         srcHeader.Model,
+		Provider:      srcHeader.Provider,
+		SystemPrompt:  srcHeader.SystemPrompt,
+		ParentSession: srcHeader.ID,
+	}
+	if err := s.SaveEntries(newHeader, entries); err != nil {
+		return SessionHeader{}, nil, err
+	}
+	return newHeader, entries, nil
+}
+
+// WriteHTML writes a self-contained HTML transcript of the session: inline CSS
+// only (no external stylesheets, fonts, scripts, or network resources), role
+// color-coding, and tool-call/result blocks. All message text is HTML-escaped
+// so a transcript containing markup or a crafted "</script>" cannot break out of
+// its container or inject active content (defensive against a hostile session).
+func WriteHTML(w io.Writer, header SessionHeader, entries []Entry) error {
+	var b strings.Builder
+	b.WriteString(htmlHead(header))
+	for _, e := range entries {
+		b.WriteString(renderEntryHTML(e))
+	}
+	b.WriteString(htmlFoot())
+	_, err := io.WriteString(w, b.String())
+	return err
+}

--- a/internal/session/export_html.go
+++ b/internal/session/export_html.go
@@ -1,0 +1,125 @@
+// This file holds the HTML rendering helpers for session export (US-008, #124).
+// The output is a single self-contained document: all CSS is inlined in a
+// <style> block, there are no <script> tags, no external fonts, and no network
+// requests, so the transcript renders identically offline and cannot phone home.
+// Every piece of session-derived text is escaped via html.EscapeString before it
+// reaches the document.
+package session
+
+import (
+	"fmt"
+	"html"
+	"strings"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// htmlHead emits the document head + opening container, embedding the session
+// metadata (all escaped). The CSS is deliberately inline and minimal so the file
+// is self-contained and depends on no external resource.
+func htmlHead(header SessionHeader) string {
+	title := header.ID
+	if title == "" {
+		title = "session"
+	}
+	meta := []string{}
+	if header.Model != "" {
+		meta = append(meta, "model: "+html.EscapeString(header.Model))
+	}
+	if header.Provider != "" {
+		meta = append(meta, "provider: "+html.EscapeString(header.Provider))
+	}
+	if !header.UpdatedAt.IsZero() {
+		meta = append(meta, "updated: "+html.EscapeString(header.UpdatedAt.Format(time.RFC3339)))
+	}
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>pigo session — %s</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2rem 1.5rem; line-height: 1.6; }
+.container { max-width: 820px; margin: 0 auto; }
+h1 { font-size: 1.25rem; font-weight: 700; margin-bottom: 0.25rem; }
+.meta { color: #8B8680; font-size: 0.8rem; margin-bottom: 1.5rem; }
+.msg { border-radius: 8px; padding: 0.75rem 1rem; margin-bottom: 0.75rem; border: 1px solid #E8E4DE; background: #fff; }
+.role { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.4rem; }
+.msg.user { background: #F0F4F8; border-color: #4A6FA5; }
+.msg.user .role { color: #4A6FA5; }
+.msg.assistant { background: #F5F8F6; border-color: #5B8A72; }
+.msg.assistant .role { color: #5B8A72; }
+.msg.tool { background: #FDF8F0; border-color: #D4A843; }
+.msg.tool .role { color: #B8860B; }
+.msg.compaction { background: #FFF5F0; border-color: #D97757; }
+.msg.compaction .role { color: #D97757; }
+.text { white-space: pre-wrap; word-break: break-word; font-size: 0.875rem; }
+.toolcall { margin-top: 0.5rem; padding: 0.5rem 0.75rem; background: #F0EEE9; border-radius: 6px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.78rem; white-space: pre-wrap; word-break: break-word; }
+.toolcall .tname { font-weight: 600; color: #B8860B; }
+.footer { text-align: center; margin-top: 2rem; color: #B0AAA4; font-size: 0.7rem; }
+</style>
+</head>
+<body>
+<div class="container">
+<h1>pigo session — %s</h1>
+<p class="meta">%s</p>
+`, html.EscapeString(title), html.EscapeString(title), strings.Join(meta, " · "))
+}
+
+// htmlFoot closes the container and document.
+func htmlFoot() string {
+	return `<p class="footer">Exported by pigo /export</p>
+</div>
+</body>
+</html>
+`
+}
+
+// renderEntryHTML renders one entry as a role-colored message block. Text and
+// tool arguments are escaped so no session content can inject markup.
+func renderEntryHTML(e Entry) string {
+	switch m := e.Message.(type) {
+	case agentcore.UserMessage:
+		return msgBlock("user", "User", html.EscapeString(agentcore.ContentToText(m.Content)), "")
+	case agentcore.AssistantMessage:
+		var tools strings.Builder
+		for _, c := range m.ToolCalls() {
+			args := strings.TrimSpace(string(c.Arguments))
+			tools.WriteString(fmt.Sprintf(`<div class="toolcall"><span class="tname">→ %s</span> %s</div>`,
+				html.EscapeString(c.Name), html.EscapeString(args)))
+		}
+		return msgBlock("assistant", "Assistant", html.EscapeString(agentcore.ContentToText(m.Content)), tools.String())
+	case agentcore.ToolResultMessage:
+		label := "Tool Result"
+		if m.ToolName != "" {
+			label = "Tool Result: " + m.ToolName
+		}
+		return msgBlock("tool", html.EscapeString(label), html.EscapeString(agentcore.ContentToText(m.Content)), "")
+	case agentcore.CompactionMessage:
+		return msgBlock("compaction", "Compaction", html.EscapeString(m.Summary), "")
+	default:
+		return msgBlock("assistant", html.EscapeString(e.Message.Role()), "", "")
+	}
+}
+
+// msgBlock assembles one .msg block with a role class, a role label, the escaped
+// body text, and optional pre-rendered tool-call HTML. Callers MUST pass already
+// escaped text/label; extra is trusted HTML built here from escaped parts.
+func msgBlock(class, label, escapedText, extra string) string {
+	var b strings.Builder
+	b.WriteString(`<div class="msg `)
+	b.WriteString(class)
+	b.WriteString(`"><div class="role">`)
+	b.WriteString(label)
+	b.WriteString(`</div>`)
+	if escapedText != "" {
+		b.WriteString(`<div class="text">`)
+		b.WriteString(escapedText)
+		b.WriteString(`</div>`)
+	}
+	b.WriteString(extra)
+	b.WriteString("</div>\n")
+	return b.String()
+}

--- a/internal/session/export_test.go
+++ b/internal/session/export_test.go
@@ -1,0 +1,197 @@
+package session
+
+// Tests for session export/import (US-008, #124). They cover the lossless
+// JSONL round-trip (export → import preserves the header fields, message
+// sequence, and entry tree), the self-contained HTML export (inline styles, no
+// external network resources, HTML-escaped content), and format selection by
+// file extension.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// seedSession writes a small multi-turn session and returns its header.
+func seedSession(t *testing.T, s *Store) SessionHeader {
+	t.Helper()
+	now := time.Date(2026, 7, 17, 9, 0, 0, 0, time.UTC)
+	header := SessionHeader{
+		ID:           NewID(now),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		Model:        "anthropic/claude-opus-4",
+		Provider:     "anthropic",
+		SystemPrompt: "You are pigo.",
+	}
+	if err := s.Save(header, sampleMessages()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	return header
+}
+
+// TestExportImportJSONLRoundTrip is the core acceptance check: exporting a
+// session to JSONL and importing it back yields the same message sequence and
+// header carry-over, with the source id recorded as the import's parent.
+func TestExportImportJSONLRoundTrip(t *testing.T) {
+	s := newStore(t)
+	header := seedSession(t, s)
+
+	out := filepath.Join(t.TempDir(), "export.jsonl")
+	n, err := s.Export(header.ID, out)
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if n != len(sampleMessages()) {
+		t.Errorf("exported %d entries, want %d", n, len(sampleMessages()))
+	}
+
+	now := time.Date(2026, 7, 17, 10, 0, 0, 0, time.UTC)
+	newHeader, entries, err := s.Import(out, now)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if newHeader.ID == header.ID {
+		t.Errorf("import must assign a fresh id, got the source id %q", newHeader.ID)
+	}
+	if newHeader.ParentSession != header.ID {
+		t.Errorf("ParentSession = %q, want source id %q", newHeader.ParentSession, header.ID)
+	}
+	if newHeader.Model != header.Model || newHeader.Provider != header.Provider || newHeader.SystemPrompt != header.SystemPrompt {
+		t.Errorf("header fields not carried over: %+v", newHeader)
+	}
+	if len(entries) != len(sampleMessages()) {
+		t.Fatalf("imported %d entries, want %d", len(entries), len(sampleMessages()))
+	}
+
+	// The imported session must be independently loadable with the same roles.
+	_, gotMsgs, err := s.Load(newHeader.ID)
+	if err != nil {
+		t.Fatalf("Load imported: %v", err)
+	}
+	wantRoles := []string{agentcore.RoleUser, agentcore.RoleAssistant, agentcore.RoleToolResult, agentcore.RoleAssistant}
+	if len(gotMsgs) != len(wantRoles) {
+		t.Fatalf("imported message count = %d, want %d", len(gotMsgs), len(wantRoles))
+	}
+	for i, m := range gotMsgs {
+		if m.Role() != wantRoles[i] {
+			t.Errorf("message[%d] role = %q, want %q", i, m.Role(), wantRoles[i])
+		}
+	}
+	// The tool call must survive the round-trip.
+	a, ok := gotMsgs[1].(agentcore.AssistantMessage)
+	if !ok {
+		t.Fatalf("message[1] is not AssistantMessage: %T", gotMsgs[1])
+	}
+	if calls := a.ToolCalls(); len(calls) != 1 || calls[0].Name != "read" {
+		t.Errorf("tool calls = %+v, want one 'read'", calls)
+	}
+}
+
+// TestWriteReadJSONLPreservesTree checks the lower-level primitives: WriteJSONL
+// then ReadJSONL preserves entry ids and parentIds verbatim (so the tree — and
+// thus resume/PathToLeaf — behaves identically).
+func TestWriteReadJSONLPreservesTree(t *testing.T) {
+	s := newStore(t)
+	header := seedSession(t, s)
+	_, entries, err := s.LoadEntries(header.ID)
+	if err != nil {
+		t.Fatalf("LoadEntries: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := WriteJSONL(&buf, header, entries); err != nil {
+		t.Fatalf("WriteJSONL: %v", err)
+	}
+	gotHeader, gotEntries, err := ReadJSONL(&buf)
+	if err != nil {
+		t.Fatalf("ReadJSONL: %v", err)
+	}
+	if gotHeader.Version != SchemaVersion {
+		t.Errorf("version = %d, want %d", gotHeader.Version, SchemaVersion)
+	}
+	if len(gotEntries) != len(entries) {
+		t.Fatalf("entry count = %d, want %d", len(gotEntries), len(entries))
+	}
+	for i := range entries {
+		if gotEntries[i].ID != entries[i].ID || gotEntries[i].ParentID != entries[i].ParentID {
+			t.Errorf("entry[%d] tree ids changed: got {%q,%q} want {%q,%q}",
+				i, gotEntries[i].ID, gotEntries[i].ParentID, entries[i].ID, entries[i].ParentID)
+		}
+	}
+}
+
+// TestExportHTMLSelfContained verifies the HTML export is a self-contained
+// document: it carries inline styles, has no external network resources (no
+// http(s):// URLs, no <script>, no <link>), and HTML-escapes session content.
+func TestExportHTMLSelfContained(t *testing.T) {
+	s := newStore(t)
+	now := time.Date(2026, 7, 17, 9, 0, 0, 0, time.UTC)
+	header := SessionHeader{
+		ID:        NewID(now),
+		CreatedAt: now,
+		UpdatedAt: now,
+		Model:     "anthropic/claude-opus-4",
+		Provider:  "anthropic",
+	}
+	// Include a message with HTML-significant characters to exercise escaping.
+	msgs := agentcore.MessageList{
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("<script>alert('xss')</script>")}},
+		agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant, Content: agentcore.ContentList{agentcore.NewTextContent("safe & sound")}, StopReason: agentcore.StopReasonEndTurn},
+	}
+	if err := s.Save(header, msgs); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	out := filepath.Join(t.TempDir(), "export.html")
+	if _, err := s.Export(header.ID, out); err != nil {
+		t.Fatalf("Export html: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	doc := string(data)
+
+	if !strings.Contains(doc, "<style>") {
+		t.Error("HTML export must inline a <style> block")
+	}
+	if strings.Contains(doc, "<script") {
+		t.Error("HTML export must not contain <script> tags")
+	}
+	if strings.Contains(doc, "<link") {
+		t.Error("HTML export must not reference external stylesheets via <link>")
+	}
+	if strings.Contains(doc, "http://") || strings.Contains(doc, "https://") {
+		t.Error("HTML export must not reference external network resources (http/https)")
+	}
+	// The raw script tag from the user message must be escaped, not live.
+	if strings.Contains(doc, "<script>alert") {
+		t.Error("session content must be HTML-escaped (found live <script>alert)")
+	}
+	if !strings.Contains(doc, "&lt;script&gt;alert") {
+		t.Error("expected escaped user content &lt;script&gt;alert in HTML export")
+	}
+	if !strings.Contains(doc, "safe &amp; sound") {
+		t.Error("expected escaped ampersand in assistant content")
+	}
+}
+
+// TestImportRejectsHTML verifies importing a non-JSONL file (e.g. an HTML
+// export) fails rather than materializing garbage.
+func TestImportRejectsHTML(t *testing.T) {
+	s := newStore(t)
+	header := seedSession(t, s)
+	out := filepath.Join(t.TempDir(), "export.html")
+	if _, err := s.Export(header.ID, out); err != nil {
+		t.Fatalf("Export html: %v", err)
+	}
+	if _, _, err := s.Import(out, time.Now()); err == nil {
+		t.Error("Import of an HTML file should fail, got nil error")
+	}
+}


### PR DESCRIPTION
## Summary
- 新增 `internal/session/export.go`：`WriteJSONL`/`ReadJSONL` 复用磁盘 schema（`writeSessionEntries`/`readSession`），保证 `/export`→`/import` 无损往返（entry id/parentId 逐字保留，树/resume 行为一致）
- `Store.Export` 按输出扩展名选择格式（`.html`/`.htm` → 自包含 HTML，其余 → JSONL）；`Store.Import` 生成带 `ParentSession` 血缘的新会话，原文件不受影响
- 新增 `internal/session/export_html.go`：自包含 HTML 导出，仅内联 `<style>`，无 `<script>`/`<link>`/外部字体/网络资源；角色 + 工具调用高亮；全文 `html.EscapeString` 转义（XSS 安全）
- REPL 拦截 `/export` `/import`（`/export` 先 persistTurn；`/import` 原地切换 header/context/leaf），token 边界守卫防止 `/exporter`、`/important` 误匹配，并在 `/help` 中登记

Closes #124

## Test plan
- [x] `TestExportImportJSONLRoundTrip` — 无损往返，header 字段延续，ParentSession 血缘
- [x] `TestWriteReadJSONLPreservesTree` — entry id/parentId 逐字保留
- [x] `TestExportHTMLSelfContained` — 内联样式、无 script/link/http、内容转义
- [x] `TestImportRejectsHTML` — 导入非 JSONL 报错
- [x] `TestREPLExportImportRoundTrip` / `TestREPLExportDefaultsToJSONL` / `TestREPLImportTokenBoundary`
- [x] `go build ./... && go vet ./... && go test ./...` 全绿；`gofmt -l` 无新增