### PR TITLE
/copy 与 /session 命令 (US-009, #125)

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -342,11 +342,11 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 			return b.String()
 		},
 	})
-	// /exit, /quit, /compact, /fork, /clone, /tree, /export and /import are
-	// intercepted by the REPL loop before slash resolution (they must return from
-	// the loop, run an agent stream, or swap the active session/leaf — none of
-	// which an Action closure can do). They are registered here only so /help
-	// lists them; their Action is never actually reached.
+	// /exit, /quit, /compact, /fork, /clone, /tree, /export, /import, /copy and
+	// /session are intercepted by the REPL loop before slash resolution (they must
+	// return from the loop, run an agent stream, or read/swap the active
+	// session/leaf — none of which an Action closure can do). They are registered
+	// here only so /help lists them; their Action is never actually reached.
 	for _, c := range []struct{ name, desc string }{
 		{"exit", "exit the REPL"},
 		{"quit", "exit the REPL"},
@@ -356,6 +356,8 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 		{"tree", "show the session branch tree; switch active branch: /tree [n]"},
 		{"export", "export the session to a file: /export [path.jsonl|path.html]"},
 		{"import", "import a JSONL export as a new session: /import <path.jsonl>"},
+		{"copy", "copy the most recent assistant reply to the clipboard"},
+		{"session", "show session stats: messages, tokens, model, compactions"},
 	} {
 		reg.AddBuiltin(runtime.SlashCommand{
 			Name:        c.name,

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/clipboard"
 	"github.com/smallnest/pigo/internal/compaction"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
@@ -164,6 +165,20 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 			// swapping deps.header / deps.agentCtx in place — which a slash Action
 			// closure cannot do. The guard keeps "/important" from matching.
 			runImport(out, &deps, line)
+			continue
+		}
+		if line == "/copy" {
+			// /copy writes the most recent assistant text to the clipboard. It is
+			// intercepted here (not a slash Action) because it must read the live
+			// message list, which an Action closure cannot reach.
+			runCopy(out, &deps)
+			continue
+		}
+		if line == "/session" {
+			// /session prints live session stats (message count, tokens, compactions)
+			// derived from deps.header + the in-memory context — state a pure
+			// string→string Action closure cannot see.
+			runSession(out, &deps)
 			continue
 		}
 
@@ -513,6 +528,70 @@ func runImport(out io.Writer, deps *replDeps, line string) {
 		deps.curLeaf = entries[len(entries)-1].ID
 	}
 	fmt.Fprintf(out, "imported %d entries from %s → session %s\n", len(entries), path, newHeader.ID)
+}
+
+// runCopy handles the /copy command (US-009, #125): it copies the most recent
+// assistant text message to the system clipboard. When no clipboard utility is
+// available it degrades to printing the text with a notice, so the content is
+// never lost. An empty conversation (no assistant reply yet) is reported.
+func runCopy(out io.Writer, deps *replDeps) {
+	text := ""
+	for i := len(deps.agentCtx.Messages) - 1; i >= 0; i-- {
+		if a, ok := deps.agentCtx.Messages[i].(agentcore.AssistantMessage); ok {
+			if t := strings.TrimSpace(agentcore.ContentToText(a.Content)); t != "" {
+				text = t
+				break
+			}
+		}
+	}
+	if text == "" {
+		fmt.Fprintln(out, "nothing to copy — no assistant reply yet")
+		return
+	}
+	if err := clipboard.Copy(text); err != nil {
+		if errors.Is(err, clipboard.ErrUnavailable) {
+			// Degrade gracefully: print the text and tell the user why it was not
+			// copied, so the content is still recoverable.
+			fmt.Fprintln(out, "no clipboard utility found (install pbcopy/wl-copy/xclip/xsel); printing instead:")
+			fmt.Fprintln(out, text)
+			return
+		}
+		fmt.Fprintf(out, "pigo: copy failed: %v\n", err)
+		return
+	}
+	fmt.Fprintf(out, "copied last reply to clipboard (%d chars)\n", len(text))
+}
+
+// runSession handles the /session command (US-009, #125): it prints a summary of
+// the live session — id, message count, estimated token usage, model/provider,
+// creation time, and how many compaction checkpoints it contains. Counts are
+// derived from the in-memory context (the source of truth for the live turn) so
+// the numbers reflect unsaved messages too.
+func runSession(out io.Writer, deps *replDeps) {
+	msgs := deps.agentCtx.Messages
+	tokens := compaction.EstimateContextTokens(msgs).Tokens
+	compactions := 0
+	for _, m := range msgs {
+		if _, ok := m.(agentcore.CompactionMessage); ok {
+			compactions++
+		}
+	}
+	fmt.Fprintf(out, "session:      %s\n", deps.header.ID)
+	fmt.Fprintf(out, "messages:     %d\n", len(msgs))
+	fmt.Fprintf(out, "tokens (est): %d\n", tokens)
+	model := deps.live.model
+	providerName := deps.live.providerName
+	if model == "" {
+		model = deps.header.Model
+	}
+	if providerName == "" {
+		providerName = deps.header.Provider
+	}
+	fmt.Fprintf(out, "model:        %s (provider: %s)\n", model, providerName)
+	if !deps.header.CreatedAt.IsZero() {
+		fmt.Fprintf(out, "created:      %s\n", deps.header.CreatedAt.Format(time.RFC3339))
+	}
+	fmt.Fprintf(out, "compactions:  %d\n", compactions)
 }
 
 // runManualCompact compacts the shared context on an explicit /compact request:

--- a/cmd/pigo/repl_test.go
+++ b/cmd/pigo/repl_test.go
@@ -456,3 +456,65 @@ func TestREPLImportTokenBoundary(t *testing.T) {
 		t.Errorf("/important should not launch a run, got %d calls", p.calls)
 	}
 }
+
+// TestREPLSessionStats drives the /session command: after a turn it prints the
+// session id, message count, token estimate, model, and compaction count without
+// launching another run (US-009, #125).
+func TestREPLSessionStats(t *testing.T) {
+	p := &replProvider{reply: "the answer"}
+	deps, _ := newTestDeps(t, p)
+	var out bytes.Buffer
+	if err := runREPL(strings.NewReader("hello\n/session\n/exit\n"), &out, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	if p.calls != 1 {
+		t.Errorf("/session must not launch a run (only the prompt), got %d calls", p.calls)
+	}
+	s := out.String()
+	for _, want := range []string{"session:", "messages:", "tokens (est):", "model:", "compactions:"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("/session output missing %q, out=%q", want, s)
+		}
+	}
+	// After one turn the context holds user + assistant = 2 messages.
+	if !strings.Contains(s, "messages:     2") {
+		t.Errorf("/session should report 2 messages, out=%q", s)
+	}
+}
+
+// TestREPLCopyEmpty verifies /copy on a session with no assistant reply prints a
+// friendly notice rather than copying or crashing.
+func TestREPLCopyEmpty(t *testing.T) {
+	p := &replProvider{reply: "hi"}
+	deps, _ := newTestDeps(t, p)
+	var out bytes.Buffer
+	if err := runREPL(strings.NewReader("/copy\n/exit\n"), &out, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	if p.calls != 0 {
+		t.Errorf("/copy must not launch a run, got %d calls", p.calls)
+	}
+	if !strings.Contains(out.String(), "nothing to copy") {
+		t.Errorf("/copy on empty session should say so, out=%q", out.String())
+	}
+}
+
+// TestREPLCopyDegradesToPrint verifies /copy degrades to printing the last reply
+// when no clipboard utility is available (PATH pointed at an empty dir), so the
+// content is never lost.
+func TestREPLCopyDegradesToPrint(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	p := &replProvider{reply: "the important answer"}
+	deps, _ := newTestDeps(t, p)
+	var out bytes.Buffer
+	if err := runREPL(strings.NewReader("ask\n/copy\n/exit\n"), &out, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	s := out.String()
+	if !strings.Contains(s, "no clipboard utility") {
+		t.Errorf("/copy should report missing clipboard utility, out=%q", s)
+	}
+	if !strings.Contains(s, "the important answer") {
+		t.Errorf("/copy should print the reply when degrading, out=%q", s)
+	}
+}

--- a/docs/issue#0125.html
+++ b/docs/issue#0125.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0125</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.8em; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/125">#125</a> &mdash; /copy 与 /session 命令 (US-009) &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Clipboard via shell-out, no cgo / third-party dependency</h3>
+      <p><strong>Ambiguity:</strong> The spec named pbcopy/xclip/wl-copy but did not mandate an implementation strategy.</p>
+      <p><strong>Choice:</strong> A new <code>internal/clipboard</code> package probes for platform utilities (pbcopy on darwin; wl-copy → xclip → xsel on linux; clip on windows) via <code>exec.LookPath</code> and pipes the payload to the first found.</p>
+      <p><strong>Rationale:</strong> Keeps the dependency graph pure-stdlib (no cgo, no atotto/clipboard), matching the project's zero-external-dep posture. <code>ErrUnavailable</code> lets the caller degrade cleanly.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> /copy targets the most recent non-empty assistant text</h3>
+      <p><strong>Ambiguity:</strong> "最近一条 assistant 文本" — assistant messages can be tool-call-only with no text.</p>
+      <p><strong>Choice:</strong> Walk the message list backwards, skipping assistant messages whose text (via <code>ContentToText</code>) is empty, and copy the first with real text.</p>
+      <p><strong>Rationale:</strong> A tool-call-only turn has nothing meaningful to copy; the user means the last thing the agent actually said.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> /session stats derived from the in-memory context</h3>
+      <p><strong>Ambiguity:</strong> Stats could come from the on-disk file or the live context.</p>
+      <p><strong>Choice:</strong> Message count, token estimate (<code>compaction.EstimateContextTokens</code>), and compaction count are computed from <code>deps.agentCtx.Messages</code>; id/created/model come from the header + live run config.</p>
+      <p><strong>Rationale:</strong> The live context is the source of truth for the current turn and includes not-yet-persisted messages, so the numbers match what the user sees.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None — implementation followed the spec. /copy degrades to printing when no utility is present (explicitly required); /session shows session name, message count, tokens, model, creation time, and compaction count as specified.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Clipboard test cannot assert the real OS clipboard changed</h3>
+      <p><strong>Alternatives:</strong> (a) integration test against the real clipboard; (b) contract test with a fake utility on PATH.</p>
+      <p><strong>Chosen:</strong> Contract test — empty PATH → <code>ErrUnavailable</code>; a planted shell shim named after the platform candidate → success. The REPL-side degrade path is covered by <code>TestREPLCopyDegradesToPrint</code>.</p>
+      <p><strong>Why it won:</strong> A real-clipboard test is non-hermetic (would clobber the developer's clipboard and fail in CI without a display server). The contract is exactly what the REPL relies on.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> /session token count is an estimate, not exact</h3>
+      <p><strong>Alternatives:</strong> (a) call the provider's tokenizer; (b) reuse the existing heuristic estimator.</p>
+      <p><strong>Chosen:</strong> Reuse <code>EstimateContextTokens</code> (prefers the last real usage block, estimates the trailing tail) — the same number <code>/compact</code> reports.</p>
+      <p><strong>Why it won:</strong> Consistency with /compact and zero extra network round-trips; the label "tokens (est)" makes the approximation explicit.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should /copy support copying a specific message (e.g. /copy N)?</h3>
+      <p>Current /copy always takes the latest assistant reply. pi's behavior is the same, so I kept it minimal, but a "/copy N" selector (like /fork N) could be a small follow-up if users want to grab an earlier reply. Confirm whether the latest-only behavior is sufficient.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -1,0 +1,74 @@
+// Package clipboard writes text to the system clipboard by shelling out to the
+// platform's clipboard utility (US-009, #125). It deliberately avoids any cgo or
+// third-party dependency: it probes for the standard command-line tools
+// (pbcopy on macOS, wl-copy / xclip / xsel on Linux) and pipes text to the first
+// one found. When no utility is available it reports ErrUnavailable so the
+// caller can degrade gracefully (e.g. print the text instead).
+package clipboard
+
+import (
+	"errors"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// ErrUnavailable is returned by Copy when no supported clipboard utility is
+// found on the host, so the caller can fall back to printing the content.
+var ErrUnavailable = errors.New("clipboard: no clipboard utility available")
+
+// candidate is a clipboard-writing command: the executable plus the args that
+// make it read the payload from stdin.
+type candidate struct {
+	name string
+	args []string
+}
+
+// candidates returns the clipboard-write commands to try, in priority order,
+// for the current OS. On macOS pbcopy is always present; on Linux the Wayland
+// tool is preferred, then the two common X11 tools.
+func candidates() []candidate {
+	switch runtime.GOOS {
+	case "darwin":
+		return []candidate{{name: "pbcopy"}}
+	case "windows":
+		return []candidate{{name: "clip"}}
+	default: // linux and other unixes
+		return []candidate{
+			{name: "wl-copy"},
+			{name: "xclip", args: []string{"-selection", "clipboard"}},
+			{name: "xsel", args: []string{"--clipboard", "--input"}},
+		}
+	}
+}
+
+// Copy writes text to the system clipboard using the first available platform
+// utility. It returns ErrUnavailable if none is found (so callers can fall back
+// to printing), or the underlying exec error if a utility was found but failed.
+func Copy(text string) error {
+	for _, c := range candidates() {
+		path, err := exec.LookPath(c.name)
+		if err != nil {
+			continue
+		}
+		cmd := exec.Command(path, c.args...)
+		cmd.Stdin = strings.NewReader(text)
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+		return nil
+	}
+	return ErrUnavailable
+}
+
+// Available reports whether a clipboard utility is present, without writing
+// anything. Useful for a caller that wants to phrase its output differently when
+// it knows the copy will fail.
+func Available() bool {
+	for _, c := range candidates() {
+		if _, err := exec.LookPath(c.name); err == nil {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -1,0 +1,61 @@
+package clipboard
+
+// Tests for the clipboard helper (US-009, #125). Copy shells out to a platform
+// utility, so we cannot assert the OS clipboard actually changed in a hermetic
+// test. Instead we verify the graceful-degradation contract: with no utility on
+// PATH, Copy returns ErrUnavailable (so the REPL can fall back to printing) and
+// Available reports false. We control the environment by pointing PATH at an
+// empty temp dir.
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+// TestCopyUnavailableWhenNoUtility verifies Copy returns ErrUnavailable and
+// Available returns false when PATH holds no clipboard utility. This is the
+// contract the REPL relies on to degrade to printing.
+func TestCopyUnavailableWhenNoUtility(t *testing.T) {
+	// Point PATH at an empty dir so exec.LookPath finds no pbcopy/xclip/etc.
+	empty := t.TempDir()
+	t.Setenv("PATH", empty)
+
+	if Available() {
+		t.Error("Available() = true with empty PATH, want false")
+	}
+	err := Copy("hello")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Errorf("Copy err = %v, want ErrUnavailable", err)
+	}
+}
+
+// TestCopyUsesUtilityOnPath verifies Copy invokes a discovered utility and
+// succeeds when the utility exits 0. We plant a fake executable named after the
+// current platform's first candidate on PATH and confirm Copy returns nil.
+func TestCopyUsesUtilityOnPath(t *testing.T) {
+	cands := candidates()
+	if len(cands) == 0 {
+		t.Skip("no clipboard candidates for this platform")
+	}
+	dir := t.TempDir()
+	name := cands[0].name
+	if os.PathSeparator == '\\' {
+		t.Skip("fake-executable planting not supported on Windows in this test")
+	}
+	// A trivial script that drains stdin and exits 0, using only shell builtins
+	// (the test empties PATH, so external commands like `cat` are unavailable).
+	script := "#!/bin/sh\nwhile read _; do :; done\nexit 0\n"
+	path := dir + string(os.PathSeparator) + name
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake %s: %v", name, err)
+	}
+	t.Setenv("PATH", dir)
+
+	if !Available() {
+		t.Fatal("Available() = false after planting fake utility")
+	}
+	if err := Copy("payload"); err != nil {
+		t.Errorf("Copy err = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary
- 新增 `internal/clipboard` 纯 stdlib 剪贴板包：按平台探测 pbcopy/wl-copy/xclip/xsel（Windows clip），管道写入；无工具时返回 `ErrUnavailable` 供调用方降级
- REPL 拦截 `/copy`：复制最近一条非空 assistant 文本；无剪贴板工具时降级打印文本（内容不丢失），空会话给出提示
- REPL 拦截 `/session`：显示会话 id、消息条数、token 估算、模型/provider、创建时间、压缩次数
- 两命令在 `/help` 中登记

Closes #125

## Test plan
- [x] `internal/clipboard`：空 PATH → ErrUnavailable / Available()=false；植入 fake 工具 → Copy 成功
- [x] `TestREPLSessionStats` / `TestREPLCopyEmpty` / `TestREPLCopyDegradesToPrint`
- [x] `go build/vet/test ./...` 全绿；`gofmt -l` 无新增