### PR TITLE
图像输入：Content 块 + 两家 provider 编码 (#126)

### DIFF
--- a/cmd/pigo/imageref.go
+++ b/cmd/pigo/imageref.go
@@ -1,0 +1,119 @@
+// This file implements the local-image input syntax for prompts (US-010/#126).
+// A prompt may reference local image files with either `@image:<path>` or the
+// Markdown image form `![alt](<path>)`. Each reference is read from disk,
+// base64-encoded, and attached to the user message as an agentcore.ImageContent
+// block so a multimodal model can see it. The remaining (non-reference) text is
+// kept as a TextContent block. References that cannot be read are reported as an
+// error rather than silently dropped, so the user knows the image was not sent.
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// imageRefPattern matches the two supported image-reference syntaxes:
+//   - @image:<path>              (path runs to the next whitespace)
+//   - ![alt](<path>)             (Markdown image; alt text is ignored)
+//
+// The path in the Markdown form may contain spaces; the @image form may not
+// (whitespace terminates it), matching the convention that @image is a bare
+// token while the Markdown form is explicitly delimited by parentheses.
+var imageRefPattern = regexp.MustCompile(`!\[[^\]]*\]\(([^)]+)\)|@image:(\S+)`)
+
+// buildUserContent turns a raw prompt line into a content list. When the prompt
+// contains no image references it returns a single TextContent (the common
+// case). Otherwise it returns the interleaved text and image blocks, reading and
+// base64-encoding each referenced file. It returns an error if any referenced
+// file cannot be read, so the caller can surface it instead of sending a prompt
+// that silently omits the image.
+func buildUserContent(prompt string) (agentcore.ContentList, error) {
+	locs := imageRefPattern.FindAllStringSubmatchIndex(prompt, -1)
+	if len(locs) == 0 {
+		return agentcore.ContentList{agentcore.NewTextContent(prompt)}, nil
+	}
+
+	var content agentcore.ContentList
+	// addText appends a text block for the given [lo,hi) slice of prompt,
+	// trimming surrounding whitespace and skipping empties so we don't emit
+	// blank text blocks around the references.
+	addText := func(lo, hi int) {
+		if lo >= hi {
+			return
+		}
+		if t := strings.TrimSpace(prompt[lo:hi]); t != "" {
+			content = append(content, agentcore.NewTextContent(t))
+		}
+	}
+
+	prev := 0
+	for _, loc := range locs {
+		start, end := loc[0], loc[1]
+		addText(prev, start)
+		// Group 1 is the Markdown path; group 2 is the @image path. Exactly one
+		// is set per match.
+		var path string
+		if loc[2] >= 0 {
+			path = prompt[loc[2]:loc[3]]
+		} else if loc[4] >= 0 {
+			path = prompt[loc[4]:loc[5]]
+		}
+		img, err := loadImageContent(strings.TrimSpace(path))
+		if err != nil {
+			return nil, err
+		}
+		content = append(content, img)
+		prev = end
+	}
+	addText(prev, len(prompt))
+
+	if len(content) == 0 {
+		content = agentcore.ContentList{agentcore.NewTextContent("")}
+	}
+	return content, nil
+}
+
+// loadImageContent reads an image file and returns an ImageContent with the
+// data base64-encoded and the mime type sniffed from the file extension (with a
+// content-sniff fallback). It errors if the file cannot be read or is not a
+// recognizable image type.
+func loadImageContent(path string) (agentcore.ImageContent, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return agentcore.ImageContent{}, fmt.Errorf("read image %q: %w", path, err)
+	}
+	mime := mimeFromPath(path)
+	if mime == "" {
+		// Fall back to content sniffing when the extension is unknown.
+		mime = http.DetectContentType(data)
+	}
+	if !strings.HasPrefix(mime, "image/") {
+		return agentcore.ImageContent{}, fmt.Errorf("%q is not a recognized image (detected %q)", path, mime)
+	}
+	enc := base64.StdEncoding.EncodeToString(data)
+	return agentcore.NewImageContent(enc, mime), nil
+}
+
+// mimeFromPath maps a file extension to an image mime type. It returns "" for
+// unknown extensions so the caller can fall back to content sniffing.
+func mimeFromPath(path string) string {
+	lower := strings.ToLower(path)
+	switch {
+	case strings.HasSuffix(lower, ".png"):
+		return "image/png"
+	case strings.HasSuffix(lower, ".jpg"), strings.HasSuffix(lower, ".jpeg"):
+		return "image/jpeg"
+	case strings.HasSuffix(lower, ".gif"):
+		return "image/gif"
+	case strings.HasSuffix(lower, ".webp"):
+		return "image/webp"
+	default:
+		return ""
+	}
+}

--- a/cmd/pigo/imageref_test.go
+++ b/cmd/pigo/imageref_test.go
@@ -1,0 +1,123 @@
+package main
+
+// Tests for the prompt image-reference syntax (US-010, #126): @image:<path> and
+// the Markdown ![alt](<path>) form. They write a tiny real PNG to a temp file so
+// loadImageContent exercises the real read + base64 + mime path, and assert that
+// a missing file is an error (not a silently dropped image).
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// pngBytes is a minimal 1x1 PNG (valid signature + IHDR) so mime detection and
+// the image/ prefix check pass without pulling in an image library.
+var pngBytes = []byte{
+	0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+	0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+	0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+	0x89,
+}
+
+func writeTempPNG(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pixel.png")
+	if err := os.WriteFile(path, pngBytes, 0o644); err != nil {
+		t.Fatalf("write temp png: %v", err)
+	}
+	return path
+}
+
+// TestBuildUserContentNoImage: a plain prompt yields a single text block.
+func TestBuildUserContentNoImage(t *testing.T) {
+	content, err := buildUserContent("just some text")
+	if err != nil {
+		t.Fatalf("buildUserContent: %v", err)
+	}
+	if len(content) != 1 {
+		t.Fatalf("content len = %d, want 1", len(content))
+	}
+	if tc, ok := content[0].(agentcore.TextContent); !ok || tc.Text != "just some text" {
+		t.Errorf("content[0] = %#v, want text \"just some text\"", content[0])
+	}
+}
+
+// TestBuildUserContentAtImageSyntax: @image:<path> attaches an ImageContent and
+// keeps the surrounding text.
+func TestBuildUserContentAtImageSyntax(t *testing.T) {
+	path := writeTempPNG(t)
+	content, err := buildUserContent("look at @image:" + path + " please")
+	if err != nil {
+		t.Fatalf("buildUserContent: %v", err)
+	}
+	assertTextThenImage(t, content, "look at", "image/png")
+}
+
+// TestBuildUserContentMarkdownSyntax: ![alt](path) attaches an ImageContent.
+func TestBuildUserContentMarkdownSyntax(t *testing.T) {
+	path := writeTempPNG(t)
+	content, err := buildUserContent("before ![a pixel](" + path + ") after")
+	if err != nil {
+		t.Fatalf("buildUserContent: %v", err)
+	}
+	// text "before", image, text "after"
+	if len(content) != 3 {
+		t.Fatalf("content len = %d, want 3", len(content))
+	}
+	if _, ok := content[1].(agentcore.ImageContent); !ok {
+		t.Errorf("content[1] = %T, want ImageContent", content[1])
+	}
+}
+
+// TestBuildUserContentMissingFile: a missing referenced file is an error.
+func TestBuildUserContentMissingFile(t *testing.T) {
+	_, err := buildUserContent("@image:/no/such/file.png")
+	if err == nil {
+		t.Fatal("buildUserContent accepted a missing image file, want error")
+	}
+}
+
+// TestLoadImageContentBase64: the encoded data must match the file bytes.
+func TestLoadImageContentBase64(t *testing.T) {
+	path := writeTempPNG(t)
+	img, err := loadImageContent(path)
+	if err != nil {
+		t.Fatalf("loadImageContent: %v", err)
+	}
+	if img.MimeType != "image/png" {
+		t.Errorf("mime = %q, want image/png", img.MimeType)
+	}
+	if want := base64.StdEncoding.EncodeToString(pngBytes); img.Data != want {
+		t.Errorf("data mismatch")
+	}
+}
+
+func assertTextThenImage(t *testing.T, content agentcore.ContentList, wantText, wantMime string) {
+	t.Helper()
+	var sawText, sawImage bool
+	for _, c := range content {
+		switch b := c.(type) {
+		case agentcore.TextContent:
+			if strings.Contains(b.Text, wantText) {
+				sawText = true
+			}
+		case agentcore.ImageContent:
+			if b.MimeType == wantMime {
+				sawImage = true
+			}
+		}
+	}
+	if !sawText {
+		t.Errorf("no text block containing %q in %#v", wantText, content)
+	}
+	if !sawImage {
+		t.Errorf("no image block with mime %q in %#v", wantMime, content)
+	}
+}

--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -69,9 +69,9 @@ func resolveProvider(model, baseURL, protocol string) (provider.Provider, string
 		if strings.TrimSpace(baseURL) == "" {
 			return nil, "", fmt.Errorf("--protocol openai requires --base-url")
 		}
-		return provider.NewOpenAICompatibleProvider(baseURL, []provider.Model{{Provider: "openai", ID: model}}), "openai", nil
+		return provider.NewOpenAICompatibleProvider(baseURL, []provider.Model{{Provider: "openai", ID: model, SupportsImages: true}}), "openai", nil
 	case "anthropic":
-		return provider.NewAnthropicProvider(baseURL, []provider.Model{{Provider: "anthropic", ID: model}}), "anthropic", nil
+		return provider.NewAnthropicProvider(baseURL, []provider.Model{{Provider: "anthropic", ID: model, SupportsImages: true}}), "anthropic", nil
 	case "":
 		// fall through to heuristic resolution
 	default:
@@ -82,27 +82,27 @@ func resolveProvider(model, baseURL, protocol string) (provider.Provider, string
 	if p, ok := provider.LookupPreset(model); ok {
 		switch p.Provider {
 		case "nvidia":
-			return provider.NewNvidiaProvider(baseURL, []provider.Model{{Provider: "nvidia", ID: model}}), "nvidia", nil
+			return provider.NewNvidiaProvider(baseURL, []provider.Model{{Provider: "nvidia", ID: model, SupportsImages: true}}), "nvidia", nil
 		case "ollama":
 			id := strings.TrimPrefix(model, "ollama/")
-			return provider.NewOllamaProvider(baseURL, []provider.Model{{Provider: "ollama", ID: id}}), "ollama", nil
+			return provider.NewOllamaProvider(baseURL, []provider.Model{{Provider: "ollama", ID: id, SupportsImages: true}}), "ollama", nil
 		default: // openrouter and any OpenAI-compatible upstream
-			return provider.NewOpenRouterProvider(baseURL, []provider.Model{{Provider: "openrouter", ID: model}}), "openrouter", nil
+			return provider.NewOpenRouterProvider(baseURL, []provider.Model{{Provider: "openrouter", ID: model, SupportsImages: true}}), "openrouter", nil
 		}
 	}
 
 	// 2. Local Ollama by prefix or port.
 	if strings.HasPrefix(model, "ollama/") || strings.Contains(baseURL, "11434") {
 		id := strings.TrimPrefix(model, "ollama/")
-		return provider.NewOllamaProvider(baseURL, []provider.Model{{Provider: "ollama", ID: id}}), "ollama", nil
+		return provider.NewOllamaProvider(baseURL, []provider.Model{{Provider: "ollama", ID: id, SupportsImages: true}}), "ollama", nil
 	}
 	// 3. NVIDIA NIM by prefix.
 	if strings.HasPrefix(model, "nvidia/") {
 		id := strings.TrimPrefix(model, "nvidia/")
-		return provider.NewNvidiaProvider(baseURL, []provider.Model{{Provider: "nvidia", ID: id}}), "nvidia", nil
+		return provider.NewNvidiaProvider(baseURL, []provider.Model{{Provider: "nvidia", ID: id, SupportsImages: true}}), "nvidia", nil
 	}
 	// 4. Default: OpenRouter.
-	return provider.NewOpenRouterProvider(baseURL, []provider.Model{{Provider: "openrouter", ID: model}}), "openrouter", nil
+	return provider.NewOpenRouterProvider(baseURL, []provider.Model{{Provider: "openrouter", ID: model, SupportsImages: true}}), "openrouter", nil
 }
 
 // builtinTools returns the default file/shell tool set rooted at cwd, or nil

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -249,9 +249,14 @@ func persistTurn(out io.Writer, deps *replDeps) {
 // the run ends. The context grows in place so the next prompt continues the
 // conversation.
 func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string) {
+	content, err := buildUserContent(prompt)
+	if err != nil {
+		fmt.Fprintf(out, "pigo: %v\n", err)
+		return
+	}
 	deps.agentCtx.Messages = append(deps.agentCtx.Messages, agentcore.UserMessage{
 		RoleField: agentcore.RoleUser,
-		Content:   agentcore.ContentList{agentcore.NewTextContent(prompt)},
+		Content:   content,
 	})
 	cfg := runtime.RunConfig{
 		LoopConfig: runtime.LoopConfig{
@@ -272,7 +277,7 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 	// turn-end flush adds a newline only after streamed text (and tool activity
 	// is surfaced on its own lines below the reply).
 	atLineStart := true
-	_, err := runtime.DrainStream(ctx, stream, runtime.StreamHandler{
+	_, err = runtime.DrainStream(ctx, stream, runtime.StreamHandler{
 		OnText: func(delta string) {
 			fmt.Fprint(out, delta)
 			if delta != "" {

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -158,10 +158,15 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
 		return 1
 	}
+	promptContent, err := buildUserContent(opts.prompt)
+	if err != nil {
+		fmt.Fprintf(errOut, "pigo: %v\n", err)
+		return 1
+	}
 	agentCtx := &agentcore.AgentContext{
 		SystemPrompt: env.sysPrompt,
 		Messages: agentcore.MessageList{
-			agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent(opts.prompt)}},
+			agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: promptContent},
 		},
 		Tools: env.tools,
 	}

--- a/docs/issue#0126.html
+++ b/docs/issue#0126.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0126</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.8em; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/126">#126</a> &mdash; 图像输入：Content 块 + 两家 provider 编码 (US-010) &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Reused existing <code>ImageContent</code> — no new content type added</h3>
+      <p><strong>Ambiguity:</strong> The first acceptance criterion asks to "add an image block type (base64 + media type)".</p>
+      <p><strong>Choice:</strong> <code>agentcore.ImageContent{Type, Data, MimeType}</code> and <code>NewImageContent</code> already existed (with the <code>ContentTypeImage</code> discriminant and a decode case), so the criterion was already satisfied. The work was provider encoding + input syntax + a capability guard.</p>
+      <p><strong>Rationale:</strong> Re-adding the type would duplicate a working discriminated-union member. Verified the existing type covers base64 data + mime type exactly as specified.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> User content collapses to a plain string when no image is present</h3>
+      <p><strong>Ambiguity:</strong> The spec mandates the array/block form for images but is silent on text-only messages.</p>
+      <p><strong>Choice:</strong> <code>openAIUserContent</code> / <code>anthropicUserContent</code> return a plain string for text-only messages and switch to the array/block form only when an <code>ImageContent</code> is present.</p>
+      <p><strong>Rationale:</strong> Preserves the existing text-only wire shape byte-for-byte (many OpenAI-compatible gateways are picky), so this change is a no-op for the overwhelmingly common non-image turn. Mirrors pi's <code>hasImages</code> branch in <code>anthropic-messages.ts</code> / <code>openai-completions.ts</code>.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Two input syntaxes: <code>@image:&lt;path&gt;</code> and Markdown <code>![alt](path)</code></h3>
+      <p><strong>Ambiguity:</strong> The spec offers both syntaxes as examples ("如 @image:./a.png 或 ![](path)") without mandating one.</p>
+      <p><strong>Choice:</strong> A single regexp matches both; <code>@image:</code> paths run to the next whitespace (bare token), Markdown paths are delimited by parentheses (may contain spaces). Non-reference text becomes interleaved <code>TextContent</code> blocks.</p>
+      <p><strong>Rationale:</strong> Supporting both costs one alternation in the pattern and matches the two conventions users would reach for. Delimiting rules follow each syntax's natural shape.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Capability guard via new <code>Model.SupportsImages</code> flag, checked at <code>StreamCompletion</code></h3>
+      <p><strong>Ambiguity:</strong> "非多模态模型收到图片输入时清晰报错" — where and how to detect capability.</p>
+      <p><strong>Choice:</strong> Added <code>SupportsImages bool</code> to <code>Model</code>. <code>checkImageSupport</code> runs at the top of both drivers' <code>StreamCompletion</code> (right after the API-key check) and returns a "cannot build the stream" error — the same failure class as a missing key.</p>
+      <p><strong>Rationale:</strong> The error surfaces before any network round-trip, consistent with the provider interface's dual failure model (build-time error vs. mid-stream terminal event).</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None — implementation followed the spec. All four functional criteria (image block type, two-provider encoding, input syntax, clear error on non-multimodal model) plus both test criteria are covered.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Unknown models (absent from catalog) are treated permissively</h3>
+      <p><strong>Alternatives:</strong> (a) fail closed — reject image input for any model not in the catalog; (b) fail open — allow it and let the provider validate.</p>
+      <p><strong>Chosen:</strong> Fail open. <code>checkImageSupport</code> only errors when the model <em>is</em> in the catalog and declares <code>SupportsImages:false</code>. A model resolved via <code>--protocol</code>/prefix (built with <code>SupportsImages:true</code> in <code>resolveProvider</code>) or genuinely unknown defers to the upstream.</p>
+      <p><strong>Why it won:</strong> The catalog is not exhaustive (arbitrary base-url + model id). Failing closed would block legitimate multimodal models the catalog simply hasn't enumerated. The guard's job is catching the <em>known</em> text-only case, not policing every id.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Mime type from extension, with content-sniff fallback</h3>
+      <p><strong>Alternatives:</strong> (a) always content-sniff via <code>http.DetectContentType</code>; (b) extension-only; (c) extension first, sniff fallback.</p>
+      <p><strong>Chosen:</strong> (c) — <code>mimeFromPath</code> maps common extensions (png/jpg/jpeg/gif/webp); unknown extensions fall back to <code>http.DetectContentType</code>. Non-<code>image/</code> results are rejected.</p>
+      <p><strong>Why it won:</strong> Extensions are cheap and unambiguous for the common cases; the sniff fallback handles odd extensions without a hard dependency on file contents, and the <code>image/</code> prefix check prevents attaching a text file as an image.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should REPL-side image input be persisted/rendered specially in the session tree?</h3>
+      <p>Image blocks are stored in the message like any other content and round-trip through the session store, but the REPL echoes only text and the HTML export (from #124) has no image rendering. Confirm whether inline image thumbnails in <code>/tree</code> or the HTML export are wanted as a follow-up, or if raw base64 persistence is sufficient for now.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Are all catalog/preset models actually multimodal?</h3>
+      <p><code>resolveProvider</code> marks every resolved model <code>SupportsImages:true</code> because pigo can't know per-id vision capability without a richer catalog. This means a text-only model reached through pigo will not get the clear error until the upstream rejects it. If precise per-model capability matters, the preset catalog would need a vision flag per entry — flagged as potential follow-up.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/provider/image_test.go
+++ b/internal/provider/image_test.go
@@ -1,0 +1,157 @@
+package provider
+
+// Tests for image (multimodal) input encoding on both provider wires (US-010,
+// #126). They exercise encodeOpenAIMessage / encodeAnthropicMessage directly
+// (unit-level, no HTTP) to assert the exact wire shape of image blocks, plus the
+// checkImageSupport guard that turns image input on a text-only model into a
+// clear error rather than a silent drop.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// imageUserMessage builds a user message carrying one text block and one image
+// block, the common multimodal input shape.
+func imageUserMessage(text, data, mime string) agentcore.UserMessage {
+	return agentcore.UserMessage{
+		RoleField: agentcore.RoleUser,
+		Content: agentcore.ContentList{
+			agentcore.NewTextContent(text),
+			agentcore.NewImageContent(data, mime),
+		},
+	}
+}
+
+// TestEncodeOpenAIMessageImageBlock asserts a user message with an image encodes
+// to the multimodal array form with an image_url data URI.
+func TestEncodeOpenAIMessageImageBlock(t *testing.T) {
+	msg := imageUserMessage("what is this?", "QUJD", "image/png")
+	out := encodeOpenAIMessage(msg)
+	if len(out) != 1 {
+		t.Fatalf("encodeOpenAIMessage returned %d entries, want 1", len(out))
+	}
+	entry := out[0]
+	if entry["role"] != "user" {
+		t.Errorf("role = %v, want user", entry["role"])
+	}
+	parts, ok := entry["content"].([]map[string]any)
+	if !ok {
+		t.Fatalf("content is %T, want []map[string]any (array form)", entry["content"])
+	}
+	if len(parts) != 2 {
+		t.Fatalf("content has %d parts, want 2 (text + image)", len(parts))
+	}
+	if parts[0]["type"] != "text" || parts[0]["text"] != "what is this?" {
+		t.Errorf("text part = %#v", parts[0])
+	}
+	if parts[1]["type"] != "image_url" {
+		t.Fatalf("image part type = %v, want image_url", parts[1]["type"])
+	}
+	iu, ok := parts[1]["image_url"].(map[string]any)
+	if !ok {
+		t.Fatalf("image_url is %T", parts[1]["image_url"])
+	}
+	if want := "data:image/png;base64,QUJD"; iu["url"] != want {
+		t.Errorf("image_url.url = %v, want %v", iu["url"], want)
+	}
+}
+
+// TestEncodeOpenAIMessageNoImageIsString asserts a text-only user message stays
+// a plain string (not the array form), preserving the common-case wire shape.
+func TestEncodeOpenAIMessageNoImageIsString(t *testing.T) {
+	msg := agentcore.UserMessage{
+		RoleField: agentcore.RoleUser,
+		Content:   agentcore.ContentList{agentcore.NewTextContent("hello")},
+	}
+	out := encodeOpenAIMessage(msg)
+	if s, ok := out[0]["content"].(string); !ok || s != "hello" {
+		t.Errorf("content = %#v, want string \"hello\"", out[0]["content"])
+	}
+}
+
+// TestEncodeAnthropicMessageImageBlock asserts a user message with an image
+// encodes to the content-block array form with a base64 image source.
+func TestEncodeAnthropicMessageImageBlock(t *testing.T) {
+	msg := imageUserMessage("describe", "REVG", "image/jpeg")
+	entry := encodeAnthropicMessage(msg)
+	if entry["role"] != "user" {
+		t.Errorf("role = %v, want user", entry["role"])
+	}
+	blocks, ok := entry["content"].([]map[string]any)
+	if !ok {
+		t.Fatalf("content is %T, want []map[string]any (array form)", entry["content"])
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("content has %d blocks, want 2 (text + image)", len(blocks))
+	}
+	if blocks[0]["type"] != "text" || blocks[0]["text"] != "describe" {
+		t.Errorf("text block = %#v", blocks[0])
+	}
+	if blocks[1]["type"] != "image" {
+		t.Fatalf("image block type = %v, want image", blocks[1]["type"])
+	}
+	src, ok := blocks[1]["source"].(map[string]any)
+	if !ok {
+		t.Fatalf("source is %T", blocks[1]["source"])
+	}
+	if src["type"] != "base64" || src["media_type"] != "image/jpeg" || src["data"] != "REVG" {
+		t.Errorf("source = %#v", src)
+	}
+}
+
+// TestEncodeAnthropicMessageNoImageIsString asserts a text-only user message
+// stays a plain string on the Anthropic wire.
+func TestEncodeAnthropicMessageNoImageIsString(t *testing.T) {
+	msg := agentcore.UserMessage{
+		RoleField: agentcore.RoleUser,
+		Content:   agentcore.ContentList{agentcore.NewTextContent("hi")},
+	}
+	entry := encodeAnthropicMessage(msg)
+	if s, ok := entry["content"].(string); !ok || s != "hi" {
+		t.Errorf("content = %#v, want string \"hi\"", entry["content"])
+	}
+}
+
+// TestImageBlocksAreJSONSerializable guards against map value types that
+// json.Marshal cannot encode: both wire shapes must round-trip to JSON.
+func TestImageBlocksAreJSONSerializable(t *testing.T) {
+	msg := imageUserMessage("x", "QQ==", "image/webp")
+	if _, err := json.Marshal(encodeOpenAIMessage(msg)); err != nil {
+		t.Errorf("marshal openai image message: %v", err)
+	}
+	if _, err := json.Marshal(encodeAnthropicMessage(msg)); err != nil {
+		t.Errorf("marshal anthropic image message: %v", err)
+	}
+}
+
+// TestCheckImageSupport asserts the capability guard: image input on a model
+// that declares SupportsImages passes; on a text-only model it errors; and a
+// text-only prompt always passes regardless of the model.
+func TestCheckImageSupport(t *testing.T) {
+	models := []Model{
+		{ID: "vision-1", SupportsImages: true},
+		{ID: "text-1", SupportsImages: false},
+	}
+	imgMsgs := []agentcore.Message{imageUserMessage("q", "QQ==", "image/png")}
+	textMsgs := []agentcore.Message{agentcore.UserMessage{
+		RoleField: agentcore.RoleUser,
+		Content:   agentcore.ContentList{agentcore.NewTextContent("no image")},
+	}}
+
+	if err := checkImageSupport("p", "vision-1", models, imgMsgs); err != nil {
+		t.Errorf("vision model rejected image input: %v", err)
+	}
+	if err := checkImageSupport("p", "text-1", models, imgMsgs); err == nil {
+		t.Error("text-only model accepted image input, want error")
+	}
+	if err := checkImageSupport("p", "text-1", models, textMsgs); err != nil {
+		t.Errorf("text-only prompt on text model errored: %v", err)
+	}
+	// Unknown model (not in catalog) defers to provider validation → no error.
+	if err := checkImageSupport("p", "unknown", models, imgMsgs); err != nil {
+		t.Errorf("unknown model errored on image input: %v", err)
+	}
+}

--- a/internal/provider/provider_interface.go
+++ b/internal/provider/provider_interface.go
@@ -36,6 +36,10 @@ type Model struct {
 	SupportsThinking bool `json:"supportsThinking,omitempty"`
 	// SupportsTools reports whether the model can call tools.
 	SupportsTools bool `json:"supportsTools,omitempty"`
+	// SupportsImages reports whether the model accepts image (multimodal) input.
+	// When false, an image block in the request is reported as a hard error
+	// rather than silently dropped, so the user learns the model cannot see it.
+	SupportsImages bool `json:"supportsImages,omitempty"`
 	// ThinkingLevels maps unified thinking levels to this model's wire values.
 	// nil when the model does not support thinking (decision #10).
 	ThinkingLevels agentcore.ThinkingLevelMap `json:"-"`

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -82,6 +82,9 @@ func (d *openAICompatDriver) StreamCompletion(ctx context.Context, req Completio
 		// Early "cannot build the stream": reference the provider, never a value.
 		return nil, fmt.Errorf("%s: missing API key", d.name)
 	}
+	if err := checkImageSupport(d.name, req.Model, d.models, req.Context.Messages); err != nil {
+		return nil, err
+	}
 	body, err := encodeOpenAIRequest(req)
 	if err != nil {
 		return nil, fmt.Errorf("%s: build request body: %w", d.name, err)
@@ -132,11 +135,11 @@ func encodeOpenAIRequest(req CompletionRequest) ([]byte, error) {
 func encodeOpenAIMessage(m agentcore.Message) []map[string]any {
 	switch msg := m.(type) {
 	case agentcore.UserMessage:
-		return []map[string]any{{"role": "user", "content": agentcore.ContentToText(msg.Content)}}
+		return []map[string]any{{"role": "user", "content": openAIUserContent(msg.Content)}}
 	case agentcore.CompactionMessage:
 		// A compaction checkpoint stands in for compacted history as user text.
 		u := msg.AsUserMessage()
-		return []map[string]any{{"role": "user", "content": agentcore.ContentToText(u.Content)}}
+		return []map[string]any{{"role": "user", "content": openAIUserContent(u.Content)}}
 	case agentcore.AssistantMessage:
 		entry := map[string]any{"role": "assistant"}
 		entry["content"] = agentcore.ContentToText(msg.Content)
@@ -166,6 +169,42 @@ func encodeOpenAIMessage(m agentcore.Message) []map[string]any {
 	default:
 		return nil
 	}
+}
+
+// openAIUserContent shapes a user content list for the OpenAI wire. When there
+// are no images it collapses to a plain string (the common case, and what most
+// OpenAI-compatible gateways expect). When images are present it emits the
+// multimodal array form: text parts plus image_url parts carrying a base64 data
+// URI (data:<mime>;base64,<data>).
+func openAIUserContent(content agentcore.ContentList) any {
+	hasImage := false
+	for _, c := range content {
+		if _, ok := c.(agentcore.ImageContent); ok {
+			hasImage = true
+			break
+		}
+	}
+	if !hasImage {
+		return agentcore.ContentToText(content)
+	}
+	parts := make([]map[string]any, 0, len(content))
+	for _, c := range content {
+		switch b := c.(type) {
+		case agentcore.TextContent:
+			if b.Text == "" {
+				continue
+			}
+			parts = append(parts, map[string]any{"type": "text", "text": b.Text})
+		case agentcore.ImageContent:
+			parts = append(parts, map[string]any{
+				"type": "image_url",
+				"image_url": map[string]any{
+					"url": fmt.Sprintf("data:%s;base64,%s", b.MimeType, b.Data),
+				},
+			})
+		}
+	}
+	return parts
 }
 
 // encodeOpenAITools maps AgentTools onto the OpenAI function-tool schema.
@@ -217,6 +256,9 @@ func (d *anthropicCompatDriver) Models() []Model { return d.models }
 func (d *anthropicCompatDriver) StreamCompletion(ctx context.Context, req CompletionRequest) (*AssistantMessageEventStream, error) {
 	if strings.TrimSpace(req.Config.APIKey) == "" {
 		return nil, fmt.Errorf("%s: missing API key", d.name)
+	}
+	if err := checkImageSupport(d.name, req.Model, d.models, req.Context.Messages); err != nil {
+		return nil, err
 	}
 	body, err := encodeAnthropicRequest(req)
 	if err != nil {
@@ -276,10 +318,10 @@ func encodeAnthropicRequest(req CompletionRequest) ([]byte, error) {
 func encodeAnthropicMessage(m agentcore.Message) map[string]any {
 	switch msg := m.(type) {
 	case agentcore.UserMessage:
-		return map[string]any{"role": "user", "content": agentcore.ContentToText(msg.Content)}
+		return map[string]any{"role": "user", "content": anthropicUserContent(msg.Content)}
 	case agentcore.CompactionMessage:
 		u := msg.AsUserMessage()
-		return map[string]any{"role": "user", "content": agentcore.ContentToText(u.Content)}
+		return map[string]any{"role": "user", "content": anthropicUserContent(u.Content)}
 	case agentcore.AssistantMessage:
 		var blocks []map[string]any
 		for _, c := range msg.Content {
@@ -307,6 +349,86 @@ func encodeAnthropicMessage(m agentcore.Message) map[string]any {
 	default:
 		return nil
 	}
+}
+
+// anthropicUserContent shapes a user content list for the Anthropic Messages
+// wire. When there are no images it collapses to a plain string. When images
+// are present it emits the content-block array form: text blocks plus image
+// blocks with a base64 source ({"type":"image","source":{"type":"base64",
+// "media_type":<mime>,"data":<b64>}}).
+func anthropicUserContent(content agentcore.ContentList) any {
+	hasImage := false
+	for _, c := range content {
+		if _, ok := c.(agentcore.ImageContent); ok {
+			hasImage = true
+			break
+		}
+	}
+	if !hasImage {
+		return agentcore.ContentToText(content)
+	}
+	blocks := make([]map[string]any, 0, len(content))
+	for _, c := range content {
+		switch b := c.(type) {
+		case agentcore.TextContent:
+			if b.Text == "" {
+				continue
+			}
+			blocks = append(blocks, map[string]any{"type": "text", "text": b.Text})
+		case agentcore.ImageContent:
+			blocks = append(blocks, map[string]any{
+				"type": "image",
+				"source": map[string]any{
+					"type":       "base64",
+					"media_type": b.MimeType,
+					"data":       b.Data,
+				},
+			})
+		}
+	}
+	return blocks
+}
+
+// contextHasImage reports whether any message in the context carries an image
+// content block, so a driver can reject image input on a non-multimodal model.
+func contextHasImage(msgs []agentcore.Message) bool {
+	for _, m := range msgs {
+		var content agentcore.ContentList
+		switch msg := m.(type) {
+		case agentcore.UserMessage:
+			content = msg.Content
+		case agentcore.CompactionMessage:
+			content = msg.AsUserMessage().Content
+		default:
+			continue
+		}
+		for _, c := range content {
+			if _, ok := c.(agentcore.ImageContent); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// checkImageSupport returns a clear error when the request carries image input
+// but the named model (looked up in models) does not declare SupportsImages.
+// A model absent from the catalog is treated permissively (unknown capability),
+// deferring to the provider's own validation. This turns the silent drop of
+// image blocks on a text-only model into an actionable message.
+func checkImageSupport(providerName, model string, models []Model, msgs []agentcore.Message) error {
+	if !contextHasImage(msgs) {
+		return nil
+	}
+	for _, m := range models {
+		if m.ID == model {
+			if !m.SupportsImages {
+				return fmt.Errorf("%s: model %q does not support image input", providerName, model)
+			}
+			return nil
+		}
+	}
+	return nil
 }
 
 // encodeAnthropicTools maps AgentTools onto the Anthropic tool schema.


### PR DESCRIPTION
## Summary
- 两家 provider 编码 `agentcore.ImageContent`：OpenAI 走 `image_url` data URI，Anthropic 走 base64 image source block
- 用户消息无图片时仍折叠为纯字符串，保持文本-only 的既有 wire 形态不变
- 新增 `Model.SupportsImages` + `checkImageSupport` 守卫：已知的非多模态模型收到图片输入时在建流阶段清晰报错，而非静默丢弃
- prompt 支持 `@image:<path>` 与 Markdown `![alt](path)` 两种语法引用本地图片，自动读取 + base64 + 嗅探 mime；文件缺失即报错。REPL 与 headless 两条输入路径均已接入

Closes #126

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/provider/... ./cmd/pigo/...`（新增图片块序列化 + 能力守卫 + 输入语法单测）
- [x] `go test ./...`
- [x] gofmt clean（改动文件）