### PR TITLE
Add todo task-tracking tool

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -106,7 +106,9 @@ func resolveProvider(model, baseURL, protocol string) (provider.Provider, string
 }
 
 // builtinTools returns the default file/shell tool set rooted at cwd, or nil
-// when tools are disabled.
+// when tools are disabled. The todo tool is stateful: a single TodoStore is
+// created here and held by the one TodoTool instance, so the task list persists
+// across calls within a run (a later write replaces the plan).
 func builtinTools(cwd string, disabled bool) []agentcore.AgentTool {
 	if disabled {
 		return nil
@@ -118,6 +120,7 @@ func builtinTools(cwd string, disabled bool) []agentcore.AgentTool {
 		&agenttool.GrepTool{Root: cwd},
 		&agenttool.FindTool{Root: cwd},
 		&agenttool.BashTool{Dir: cwd},
+		&agenttool.TodoTool{Store: agenttool.NewTodoStore()},
 	}
 }
 

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -293,7 +293,7 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 				fmt.Fprintf(out, "  → tool: %s\n", toolCallLabel(c))
 			}
 			for _, tr := range results {
-				fmt.Fprintf(out, "  ← result: %s\n", oneLine(agentcore.ContentToText(tr.Content)))
+				renderToolResult(out, tr)
 			}
 		},
 	})
@@ -657,6 +657,23 @@ func replayTranscript(out io.Writer, messages []agentcore.AgentMessage) {
 			fmt.Fprintf(out, "  ← result: %s\n", oneLine(agentcore.ContentToText(msg.Content)))
 		}
 	}
+}
+
+// renderToolResult prints a single tool result under the compact status. Most
+// results collapse to a one-line "← result:" summary, but the todo tool's
+// progress block is rendered in full (indented, multi-line) so the user sees the
+// live task checklist after each update — that visible progress is the point of
+// the tool (US-011).
+func renderToolResult(out io.Writer, tr agentcore.ToolResultMessage) {
+	text := agentcore.ContentToText(tr.Content)
+	if tr.ToolName == "todo" && !tr.IsError {
+		fmt.Fprintln(out, "  ← todo:")
+		for _, line := range strings.Split(text, "\n") {
+			fmt.Fprintf(out, "    %s\n", line)
+		}
+		return
+	}
+	fmt.Fprintf(out, "  ← result: %s\n", oneLine(text))
 }
 
 // toolCallLabel renders a tool call as "name args" for the compact "→ tool:"

--- a/cmd/pigo/repl_test.go
+++ b/cmd/pigo/repl_test.go
@@ -249,6 +249,32 @@ func TestREPLPersistsModelIntoHeader(t *testing.T) {
 	}
 }
 
+// TestRenderToolResultTodoFull verifies the todo tool's multi-line progress
+// block is rendered in full under a "← todo:" header (US-011: REPL shows
+// progress on update), while a non-todo result stays a one-line summary.
+func TestRenderToolResultTodoFull(t *testing.T) {
+	var out bytes.Buffer
+	renderToolResult(&out, agentcore.ToolResultMessage{
+		RoleField: agentcore.RoleToolResult, ToolName: "todo",
+		Content: agentcore.ContentList{agentcore.NewTextContent("Todos:\n  [x] a\n  [ ] b\n(1/2 completed)")},
+	})
+	s := out.String()
+	for _, want := range []string{"← todo:", "[x] a", "[ ] b", "(1/2 completed)"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("todo render missing %q, out=%q", want, s)
+		}
+	}
+
+	out.Reset()
+	renderToolResult(&out, agentcore.ToolResultMessage{
+		RoleField: agentcore.RoleToolResult, ToolName: "bash",
+		Content: agentcore.ContentList{agentcore.NewTextContent("line1\nline2")},
+	})
+	if got := out.String(); !strings.Contains(got, "← result: line1") {
+		t.Errorf("non-todo render = %q, want a one-line summary", got)
+	}
+}
+
 // TestReplayTranscriptRendersRoles verifies a resumed session's prior messages
 // are echoed by role (user / assistant / tool result) before the first new
 // prompt (US-006 acceptance: resumed conversation is replayed).

--- a/docs/issue#0127.html
+++ b/docs/issue#0127.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0127</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/127">#127</a> &mdash; TODO 任务追踪工具 &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Whole-list replacement instead of incremental item edits</h3>
+      <p><strong>Ambiguity:</strong> The spec says the schema must contain a task list (content / status) but does not say whether a call submits the full list or a delta.</p>
+      <p><strong>Choice:</strong> Each <code>todo</code> call submits the ENTIRE list; <code>TodoStore.Set</code> replaces the previous list wholesale.</p>
+      <p><strong>Rationale:</strong> Matches Claude Code's TodoWrite (the stated reference — "对标 Claude Code"). Whole-list writes are idempotent, avoid item-id bookkeeping, and make the rendered progress trivially correct — the store always mirrors the model's latest intent.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Store held by the tool instance, created in builtinTools</h3>
+      <p><strong>Ambiguity:</strong> "存于当前会话状态" — the spec names session state but the codebase has no single session-state struct threaded into tools.</p>
+      <p><strong>Choice:</strong> A <code>*TodoStore</code> is created once in <code>builtinTools</code> and held by the single <code>TodoTool</code> instance for the run's lifetime, so successive calls accumulate into the same store.</p>
+      <p><strong>Rationale:</strong> Tools are already constructed per-run rooted at cwd; hanging the store off the one instance is the least invasive way to get run-scoped persistence without inventing a new session-state plumbing seam. The store is mutex-guarded so a parallel batch cannot race.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Todo guide appended to DefaultBaseInstruction</h3>
+      <p><strong>Ambiguity:</strong> "系统提示加入 todo 工具使用引导" — where in the prompt the guide lives is unspecified.</p>
+      <p><strong>Choice:</strong> Added a <code>todoGuide</code> constant concatenated onto <code>DefaultBaseInstruction</code>, so every run using the default prompt gets it; a caller supplying a custom BaseInstruction opts out.</p>
+      <p><strong>Rationale:</strong> Keeps the guidance with the agent's identity text, one edit point, and honors the existing override contract (custom BaseInstruction fully replaces the default).</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None — implementation followed the spec as written.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> REPL renders the todo block in full vs. one-line summary</h3>
+      <p><strong>Alternatives:</strong> (a) collapse todo results to a single line like every other tool; (b) render the full multi-line checklist under a dedicated <code>← todo:</code> header.</p>
+      <p><strong>Chosen:</strong> (b) — <code>renderToolResult</code> special-cases <code>ToolName == "todo"</code> and prints each line indented.</p>
+      <p><strong>Why:</strong> Visible progress is the entire point of the tool (US-011: "REPL 在更新时渲染进度"). A one-line summary would hide the checklist, defeating the feature. Non-todo results keep the compact one-liner.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Validate status in Execute vs. rely on JSON Schema enum</h3>
+      <p><strong>Alternatives:</strong> (a) trust the registry's schema <code>enum</code> to reject bad statuses; (b) also re-validate content/status inside Execute.</p>
+      <p><strong>Chosen:</strong> (b) belt-and-suspenders — Execute checks empty content and invalid status, returning an error result without mutating the store.</p>
+      <p><strong>Why:</strong> Not every call path guarantees schema pre-validation (e.g. direct tests, future callers), and the acceptance criteria demand a status-transition test. In-tool validation keeps the invariant local and testable, at the cost of minor duplication with the schema enum.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should the todo list persist into the saved session file?</h3>
+      <p>The store is run-scoped (in-memory, held by the tool). It is not serialized into the session transcript, so a resumed session starts with an empty todo list even though the tool-call/result messages are replayed. Verify whether persisting the live checklist across resume is desired, or whether replaying the last todo result is sufficient.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Single in_progress invariant is advisory, not enforced</h3>
+      <p>The prompt guide asks the model to keep exactly one item <code>in_progress</code>, but the tool does not reject a list with several in_progress items. Confirm this should stay advisory (matching Claude Code's lenient behavior) rather than a hard validation error.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agenttool/todo_tool.go
+++ b/internal/agenttool/todo_tool.go
@@ -1,0 +1,186 @@
+// This file implements the todo tool (US-011, #127): a structured task list the
+// model uses to plan and track multi-step work, with progress visible to the
+// user. Unlike the file tools this one is stateful — the written list lives in a
+// per-session TodoStore the tool holds, so a later write replaces the plan and
+// the REPL can render the current progress after each update.
+//
+// pi itself has no such tool; this mirrors Claude Code's TodoWrite: the model
+// submits the WHOLE list each call (not incremental edits), each item carries a
+// content string and a status of pending | in_progress | completed.
+package agenttool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// TodoStatus is the lifecycle state of a single todo item.
+type TodoStatus string
+
+const (
+	// TodoPending is a task not yet started.
+	TodoPending TodoStatus = "pending"
+	// TodoInProgress is the task currently being worked on.
+	TodoInProgress TodoStatus = "in_progress"
+	// TodoCompleted is a finished task.
+	TodoCompleted TodoStatus = "completed"
+)
+
+// validTodoStatus reports whether s is one of the three accepted statuses.
+func validTodoStatus(s TodoStatus) bool {
+	switch s {
+	case TodoPending, TodoInProgress, TodoCompleted:
+		return true
+	default:
+		return false
+	}
+}
+
+// TodoItem is one entry in the task list.
+type TodoItem struct {
+	// Content is the human-readable task description.
+	Content string `json:"content"`
+	// Status is the item's lifecycle state.
+	Status TodoStatus `json:"status"`
+}
+
+// TodoStore holds the current task list for a session. It is safe for concurrent
+// use so the tool (which may run in a batch) and the REPL renderer can touch it
+// without racing. A single store is shared for a session's lifetime.
+type TodoStore struct {
+	mu    sync.RWMutex
+	items []TodoItem
+}
+
+// NewTodoStore returns an empty store.
+func NewTodoStore() *TodoStore { return &TodoStore{} }
+
+// Set replaces the whole list with items (a copy, so the caller's slice can be
+// reused).
+func (s *TodoStore) Set(items []TodoItem) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items = append(s.items[:0:0], items...)
+}
+
+// Snapshot returns a copy of the current list, safe to read without holding the
+// lock.
+func (s *TodoStore) Snapshot() []TodoItem {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]TodoItem(nil), s.items...)
+}
+
+// TodoTool is the stateful todo-list tool. It writes the submitted list into
+// Store, replacing any previous list, and returns a rendered progress view.
+type TodoTool struct {
+	// Store holds the session task list. Must be non-nil; NewTodoStore builds one.
+	Store *TodoStore
+}
+
+// todoToolArgs is the decoded argument shape: the full task list to store.
+type todoToolArgs struct {
+	Todos []TodoItem `json:"todos"`
+}
+
+// Name implements AgentTool.
+func (t *TodoTool) Name() string { return "todo" }
+
+// Description implements AgentTool.
+func (t *TodoTool) Description() string {
+	return "Record and update a structured task list to plan and track multi-step " +
+		"work. Submit the ENTIRE list every call; it replaces the previous list. " +
+		"Each item has a content string and a status of pending, in_progress, or " +
+		"completed. Keep exactly one item in_progress at a time and mark items " +
+		"completed as soon as they are done."
+}
+
+// Schema implements AgentTool.
+func (t *TodoTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "todos": {
+      "type": "array",
+      "description": "The full task list, replacing any previous list.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "content": {"type": "string", "description": "Task description."},
+          "status":  {"type": "string", "enum": ["pending", "in_progress", "completed"], "description": "Task lifecycle state."}
+        },
+        "required": ["content", "status"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["todos"],
+  "additionalProperties": false
+}`)
+}
+
+// ExecutionMode implements AgentTool. Updating the shared list mutates session
+// state → sequential so a batch cannot interleave two list writes.
+func (t *TodoTool) ExecutionMode() agentcore.ToolExecutionMode {
+	return agentcore.ToolExecutionSequential
+}
+
+// Execute implements AgentTool. It validates every item's status, stores the
+// list, and returns the rendered progress as the result content. Invalid input
+// degrades to an error result (matching the file tools) rather than a Go error.
+func (t *TodoTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+	a, bad := decodeArgs[todoToolArgs](args, "todo")
+	if bad != nil {
+		return *bad, nil
+	}
+	for i, it := range a.Todos {
+		if strings.TrimSpace(it.Content) == "" {
+			return errorResult(fmt.Sprintf("todo: item %d has empty content", i+1)), nil
+		}
+		if !validTodoStatus(it.Status) {
+			return errorResult(fmt.Sprintf("todo: item %d has invalid status %q (want pending|in_progress|completed)", i+1, it.Status)), nil
+		}
+	}
+
+	if t.Store == nil {
+		t.Store = NewTodoStore()
+	}
+	t.Store.Set(a.Todos)
+
+	rendered := RenderTodoList(a.Todos)
+	return agentcore.AgentToolResult{
+		Content: agentcore.ContentList{agentcore.NewTextContent(rendered)},
+		Details: map[string]any{"todos": a.Todos},
+	}, nil
+}
+
+// RenderTodoList renders items as a checkbox progress block, one line per task,
+// with a trailing summary count. An empty list renders as a single "(no tasks)"
+// line so an intentional clear is still visible. The marks are: [ ] pending,
+// [~] in_progress, [x] completed.
+func RenderTodoList(items []TodoItem) string {
+	if len(items) == 0 {
+		return "Todos: (no tasks)"
+	}
+	var b strings.Builder
+	done := 0
+	b.WriteString("Todos:")
+	for _, it := range items {
+		mark := " "
+		switch it.Status {
+		case TodoInProgress:
+			mark = "~"
+		case TodoCompleted:
+			mark = "x"
+			done++
+		}
+		fmt.Fprintf(&b, "\n  [%s] %s", mark, it.Content)
+	}
+	fmt.Fprintf(&b, "\n(%d/%d completed)", done, len(items))
+	return b.String()
+}

--- a/internal/agenttool/todo_tool_test.go
+++ b/internal/agenttool/todo_tool_test.go
@@ -1,0 +1,143 @@
+// Tests for the todo tool (US-011, #127): registration/validation, status
+// transitions across successive writes, and the rendered progress view.
+package agenttool
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// execTodo runs the tool with the given JSON args and returns the result.
+func execTodo(t *testing.T, tool *TodoTool, args string) agentcore.AgentToolResult {
+	t.Helper()
+	res, err := tool.Execute(context.Background(), "call-1", json.RawMessage(args), nil)
+	if err != nil {
+		t.Fatalf("Execute returned Go error: %v", err)
+	}
+	return res
+}
+
+// TestTodoToolRegisters checks the tool registers cleanly (valid schema) and is
+// retrievable — the "注册进 agenttool registry" acceptance criterion.
+func TestTodoToolRegisters(t *testing.T) {
+	reg := NewToolRegistry()
+	tool := &TodoTool{Store: NewTodoStore()}
+	if err := reg.Register(tool); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	got, ok := reg.Get("todo")
+	if !ok {
+		t.Fatal("todo tool not found after Register")
+	}
+	if got.Name() != "todo" {
+		t.Errorf("Name = %q, want todo", got.Name())
+	}
+}
+
+// TestTodoToolStoresList checks a write lands in the session store.
+func TestTodoToolStoresList(t *testing.T) {
+	store := NewTodoStore()
+	tool := &TodoTool{Store: store}
+	execTodo(t, tool, `{"todos":[
+		{"content":"first","status":"in_progress"},
+		{"content":"second","status":"pending"}
+	]}`)
+
+	items := store.Snapshot()
+	if len(items) != 2 {
+		t.Fatalf("Snapshot len = %d, want 2", len(items))
+	}
+	if items[0].Content != "first" || items[0].Status != TodoInProgress {
+		t.Errorf("item 0 = %+v", items[0])
+	}
+	if items[1].Status != TodoPending {
+		t.Errorf("item 1 status = %q, want pending", items[1].Status)
+	}
+}
+
+// TestTodoToolStatusTransition checks a later write replaces the previous list,
+// reflecting a status flow pending → in_progress → completed.
+func TestTodoToolStatusTransition(t *testing.T) {
+	store := NewTodoStore()
+	tool := &TodoTool{Store: store}
+
+	execTodo(t, tool, `{"todos":[{"content":"build feature","status":"pending"}]}`)
+	if s := store.Snapshot()[0].Status; s != TodoPending {
+		t.Fatalf("after write 1 status = %q, want pending", s)
+	}
+
+	execTodo(t, tool, `{"todos":[{"content":"build feature","status":"in_progress"}]}`)
+	if s := store.Snapshot()[0].Status; s != TodoInProgress {
+		t.Fatalf("after write 2 status = %q, want in_progress", s)
+	}
+
+	execTodo(t, tool, `{"todos":[{"content":"build feature","status":"completed"}]}`)
+	items := store.Snapshot()
+	if len(items) != 1 {
+		t.Fatalf("after write 3 len = %d, want 1", len(items))
+	}
+	if items[0].Status != TodoCompleted {
+		t.Errorf("after write 3 status = %q, want completed", items[0].Status)
+	}
+}
+
+// TestTodoToolRejectsInvalidStatus checks an unknown status degrades to an error
+// result and does not mutate the store.
+func TestTodoToolRejectsInvalidStatus(t *testing.T) {
+	store := NewTodoStore()
+	tool := &TodoTool{Store: store}
+	res := execTodo(t, tool, `{"todos":[{"content":"x","status":"done"}]}`)
+	if !strings.Contains(agentcore.ContentToText(res.Content), "invalid status") {
+		t.Errorf("expected invalid-status error, got %q", agentcore.ContentToText(res.Content))
+	}
+	if len(store.Snapshot()) != 0 {
+		t.Error("store mutated despite invalid input")
+	}
+}
+
+// TestTodoToolRejectsEmptyContent checks a blank content is rejected.
+func TestTodoToolRejectsEmptyContent(t *testing.T) {
+	tool := &TodoTool{Store: NewTodoStore()}
+	res := execTodo(t, tool, `{"todos":[{"content":"  ","status":"pending"}]}`)
+	if !strings.Contains(agentcore.ContentToText(res.Content), "empty content") {
+		t.Errorf("expected empty-content error, got %q", agentcore.ContentToText(res.Content))
+	}
+}
+
+// TestRenderTodoList checks the rendered progress view: marks per status and a
+// completion count.
+func TestRenderTodoList(t *testing.T) {
+	out := RenderTodoList([]TodoItem{
+		{Content: "alpha", Status: TodoCompleted},
+		{Content: "beta", Status: TodoInProgress},
+		{Content: "gamma", Status: TodoPending},
+	})
+	for _, want := range []string{"[x] alpha", "[~] beta", "[ ] gamma", "(1/3 completed)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("render missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestRenderTodoListEmpty checks an empty list renders visibly (an intentional
+// clear should still show).
+func TestRenderTodoListEmpty(t *testing.T) {
+	if out := RenderTodoList(nil); !strings.Contains(out, "no tasks") {
+		t.Errorf("empty render = %q, want a (no tasks) marker", out)
+	}
+}
+
+// TestTodoToolResultRenders checks Execute returns the rendered list as content
+// so the REPL has something to display.
+func TestTodoToolResultRenders(t *testing.T) {
+	tool := &TodoTool{Store: NewTodoStore()}
+	res := execTodo(t, tool, `{"todos":[{"content":"do it","status":"completed"}]}`)
+	text := agentcore.ContentToText(res.Content)
+	if !strings.Contains(text, "[x] do it") || !strings.Contains(text, "(1/1 completed)") {
+		t.Errorf("result content = %q", text)
+	}
+}

--- a/internal/runtime/prompt.go
+++ b/internal/runtime/prompt.go
@@ -52,7 +52,17 @@ type PromptConfig struct {
 // DefaultBaseInstruction is the leading system-prompt text used when
 // PromptConfig.BaseInstruction is empty.
 const DefaultBaseInstruction = "You are pigo, a helpful coding agent. " +
-	"Use the available tools to inspect files and accomplish the user's request precisely and concisely."
+	"Use the available tools to inspect files and accomplish the user's request precisely and concisely.\n\n" +
+	todoGuide
+
+// todoGuide instructs the model on how to drive the todo tool. It is appended to
+// the default base instruction so multi-step work is planned and its progress is
+// made visible to the user (US-011).
+const todoGuide = "When a task has multiple steps or is non-trivial, use the todo tool to plan " +
+	"and track your work. Submit the entire task list each call (it replaces the previous " +
+	"list); each item has a content string and a status of pending, in_progress, or completed. " +
+	"Keep exactly one item in_progress at a time, and mark an item completed as soon as it is " +
+	"done before starting the next. Skip the todo tool for trivial single-step requests."
 
 // BuildSystemPrompt assembles the full system prompt from cfg: base instruction,
 // environment block, then AGENTS.md files ordered general-to-specific from Root


### PR DESCRIPTION
## Summary
- New stateful `todo` built-in tool registered in the agenttool registry; schema is a task list of `{content, status: pending|in_progress|completed}`
- Whole-list replacement into a run-scoped `TodoStore` (mutex-guarded), matching Claude Code's TodoWrite semantics
- REPL renders the full checklist under a `← todo:` header on each update (visible progress, US-011)
- Default system prompt gains a todo-tool usage guide
- Tests cover registration, status transitions, input validation, and rendering

Closes #127

## Test plan
- [x] `go test ./internal/agenttool/...` passes
- [x] `go build ./... && go vet ./...` clean
- [x] full `go test ./...` passes; gofmt clean