### PR TITLE
Add webfetch tool

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -121,6 +121,7 @@ func builtinTools(cwd string, disabled bool) []agentcore.AgentTool {
 		&agenttool.FindTool{Root: cwd},
 		&agenttool.BashTool{Dir: cwd},
 		&agenttool.TodoTool{Store: agenttool.NewTodoStore()},
+		&agenttool.WebFetchTool{},
 	}
 }
 

--- a/docs/issue#0128.html
+++ b/docs/issue#0128.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0128</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/128">#128</a> &mdash; WebFetch 工具 &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Hand-rolled HTML→Markdown reducer instead of a library</h3>
+      <p><strong>Ambiguity:</strong> The spec says "HTML→markdown 简化" but does not mandate fidelity or a specific library.</p>
+      <p><strong>Choice:</strong> A small <code>htmlToMarkdown</code> walks the <code>golang.org/x/net/html</code> parse tree, dropping chrome/script elements and emitting light Markdown (headings, links, lists, code, emphasis).</p>
+      <p><strong>Rationale:</strong> The goal is readable text for a model, not a round-trip converter. A full library (e.g. JohannesKaufmann/html-to-markdown) adds a heavy dependency for output the model reads loosely. x/net/html was already pulled transitively and is the standard, lenient parser.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Cross-origin redirect reported as a normal result, not an error</h3>
+      <p><strong>Ambiguity:</strong> "跨域重定向返回调用方而非自动跟随" — return to caller, but as an error or as content?</p>
+      <p><strong>Choice:</strong> A blocked redirect returns a non-error <code>AgentToolResult</code> whose text names the target URL and invites an explicit re-fetch, with <code>Details.redirect</code> set.</p>
+      <p><strong>Rationale:</strong> This is not a failure — it is a safety decision the model should act on. Framing it as content (not an error) lets the model read the target and decide, which is the point of "return to caller".</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> prompt is echoed, not executed</h3>
+      <p><strong>Ambiguity:</strong> "输入 URL + 可选 prompt" — does the tool summarize per the prompt?</p>
+      <p><strong>Choice:</strong> The prompt is echoed into the result framing ("Prompt: ..."); the tool does not itself call a model.</p>
+      <p><strong>Rationale:</strong> Summarization is the agent loop's job — the tool returns raw material plus the stated intent, keeping the tool deterministic and testable without a model dependency.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None — implementation followed the spec as written.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> HTTP→HTTPS upgrade vs. reject plain HTTP</h3>
+      <p><strong>Alternatives:</strong> (a) reject <code>http://</code> outright; (b) silently upgrade to <code>https://</code>.</p>
+      <p><strong>Chosen:</strong> (b) upgrade in <code>normalizeFetchURL</code>, exactly as the acceptance criterion states ("HTTP 升级为 HTTPS").</p>
+      <p><strong>Why:</strong> Upgrading is friendlier (most sites serve HTTPS) and matches the spec verbatim. A site that only serves plain HTTP will fail the request, surfaced as a structured error — acceptable given the security intent.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Redirect blocking via CheckRedirect vs. manual hop loop</h3>
+      <p><strong>Alternatives:</strong> (a) set <code>Client.CheckRedirect</code> to reject cross-origin hops; (b) disable redirects and follow them manually with per-hop origin checks.</p>
+      <p><strong>Chosen:</strong> (a) — same-host/same-scheme redirects are followed, cross-origin ones stop with a typed <code>errRedirectBlocked</code> that <code>errors.As</code> unwraps from the <code>*url.Error</code>.</p>
+      <p><strong>Why:</strong> CheckRedirect is the idiomatic hook; it preserves in-origin redirects (common, harmless) while blocking cross-origin ones. The manual loop would re-implement stdlib redirect handling for no added safety.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Are the size/time caps right for typical use?</h3>
+      <p>Defaults: 30s timeout, 5&nbsp;MiB body read, 100&nbsp;KiB rendered Markdown. These bound context and memory but may truncate long articles. Verify the Markdown cap is generous enough for the intended pages, or whether it should be configurable per call.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should webfetch be gated behind project trust?</h3>
+      <p>The tool makes outbound network requests. Issue #134 (Project Trust) may want to gate network-capable tools. Confirm whether webfetch should be disabled in untrusted projects once #134 lands.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,8 @@ go 1.27rc1
 require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/pflag v1.0.10
-	golang.org/x/text v0.30.0
+	golang.org/x/net v0.57.0
+	golang.org/x/text v0.40.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,10 @@ github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEV
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-golang.org/x/text v0.30.0 h1:yznKA/E9zq54KzlzBEAWn1NXSQ8DIp/NYMy88xJjl4k=
-golang.org/x/text v0.30.0/go.mod h1:yDdHFIX9t+tORqspjENWgzaCVXgk0yYnYuSZ8UzzBVM=
+golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
+golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
+golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
+golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/agenttool/htmlmarkdown.go
+++ b/internal/agenttool/htmlmarkdown.go
@@ -1,0 +1,191 @@
+// This file implements the minimal HTML→Markdown reduction used by the webfetch
+// tool (US-012, #128). It is deliberately small: the goal is readable text for a
+// model, not a faithful Markdown round-trip. We walk the parsed node tree,
+// dropping non-content elements (script/style/nav/etc.), turning headings, links,
+// list items, code and paragraphs into light Markdown, and collapsing runs of
+// blank lines. No external Markdown library is pulled in.
+package agenttool
+
+import (
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// skipElements are dropped whole (element + subtree): they carry no readable body
+// content or are chrome/noise for a text extraction.
+var skipElements = map[string]bool{
+	"script": true, "style": true, "noscript": true, "head": true,
+	"nav": true, "footer": true, "header": true, "aside": true,
+	"svg": true, "form": true, "iframe": true, "template": true,
+}
+
+// htmlToMarkdown parses body as HTML and renders a simplified Markdown string.
+// A parse error (malformed HTML) is not fatal — the parser is lenient — so this
+// never returns an error; unparseable input yields whatever text was recovered.
+func htmlToMarkdown(body []byte) string {
+	doc, err := html.Parse(strings.NewReader(string(body)))
+	if err != nil {
+		return string(body)
+	}
+	var b strings.Builder
+	renderNode(&b, doc)
+	return collapseBlankLines(b.String())
+}
+
+// renderNode walks n depth-first, appending Markdown for content nodes to b.
+func renderNode(b *strings.Builder, n *html.Node) {
+	switch n.Type {
+	case html.TextNode:
+		// Collapse internal whitespace runs to single spaces, but preserve a
+		// single leading/trailing space so inline text around elements (links,
+		// bold) does not get glued together ("A <a>x</a> b" must keep its spaces).
+		text := collapseInlineSpace(n.Data)
+		if text != "" {
+			b.WriteString(text)
+		}
+		return
+	case html.ElementNode:
+		if skipElements[n.Data] {
+			return
+		}
+	}
+
+	switch n.Data {
+	case "h1", "h2", "h3", "h4", "h5", "h6":
+		level := int(n.Data[1] - '0')
+		b.WriteString("\n\n")
+		b.WriteString(strings.Repeat("#", level))
+		b.WriteString(" ")
+		renderChildren(b, n)
+		b.WriteString("\n\n")
+		return
+	case "p", "div", "section", "article":
+		b.WriteString("\n\n")
+		renderChildren(b, n)
+		b.WriteString("\n\n")
+		return
+	case "br":
+		b.WriteString("\n")
+		return
+	case "li":
+		b.WriteString("\n- ")
+		renderChildren(b, n)
+		return
+	case "a":
+		renderLink(b, n)
+		return
+	case "code":
+		b.WriteString("`")
+		renderChildren(b, n)
+		b.WriteString("`")
+		return
+	case "pre":
+		b.WriteString("\n\n```\n")
+		renderChildren(b, n)
+		b.WriteString("\n```\n\n")
+		return
+	case "strong", "b":
+		b.WriteString("**")
+		renderChildren(b, n)
+		b.WriteString("**")
+		return
+	case "em", "i":
+		b.WriteString("*")
+		renderChildren(b, n)
+		b.WriteString("*")
+		return
+	case "tr":
+		b.WriteString("\n")
+		renderChildren(b, n)
+		return
+	case "td", "th":
+		renderChildren(b, n)
+		b.WriteString(" | ")
+		return
+	}
+
+	renderChildren(b, n)
+}
+
+// renderChildren renders every child of n in order.
+func renderChildren(b *strings.Builder, n *html.Node) {
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		renderNode(b, c)
+	}
+}
+
+// renderLink renders an <a> as "[text](href)" when an href is present and
+// differs from the text, else just the text.
+func renderLink(b *strings.Builder, n *html.Node) {
+	href := ""
+	for _, attr := range n.Attr {
+		if attr.Key == "href" {
+			href = strings.TrimSpace(attr.Val)
+			break
+		}
+	}
+	var inner strings.Builder
+	renderChildren(&inner, n)
+	text := strings.TrimSpace(inner.String())
+	if href == "" || strings.HasPrefix(href, "#") || strings.HasPrefix(href, "javascript:") {
+		b.WriteString(text)
+		return
+	}
+	if text == "" {
+		text = href
+	}
+	b.WriteString("[")
+	b.WriteString(text)
+	b.WriteString("](")
+	b.WriteString(href)
+	b.WriteString(")")
+}
+
+// collapseInlineSpace collapses internal whitespace runs in a text node to
+// single spaces while preserving a single leading or trailing space when the
+// original had one — so adjacent inline elements keep the spaces between them.
+// An all-whitespace node collapses to a single space (not empty), which is what
+// separates two inline siblings; block-level collapsing later trims stray runs.
+func collapseInlineSpace(s string) string {
+	if strings.TrimSpace(s) == "" {
+		if s == "" {
+			return ""
+		}
+		return " "
+	}
+	leading := s[0] == ' ' || s[0] == '\t' || s[0] == '\n' || s[0] == '\r'
+	last := s[len(s)-1]
+	trailing := last == ' ' || last == '\t' || last == '\n' || last == '\r'
+	out := strings.Join(strings.Fields(s), " ")
+	if leading {
+		out = " " + out
+	}
+	if trailing {
+		out = out + " "
+	}
+	return out
+}
+
+// collapseBlankLines trims trailing spaces per line and collapses 3+ consecutive
+// newlines down to a blank-line separator, then trims the whole string.
+func collapseBlankLines(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, ln := range lines {
+		lines[i] = strings.TrimRight(ln, " \t")
+	}
+	var out []string
+	blank := 0
+	for _, ln := range lines {
+		if strings.TrimSpace(ln) == "" {
+			blank++
+			if blank > 1 {
+				continue
+			}
+		} else {
+			blank = 0
+		}
+		out = append(out, ln)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}

--- a/internal/agenttool/htmlmarkdown_test.go
+++ b/internal/agenttool/htmlmarkdown_test.go
@@ -1,0 +1,67 @@
+// Tests for the HTML→Markdown reduction (US-012, #128): headings, links, lists,
+// code, and dropped chrome/script elements.
+package agenttool
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestHTMLToMarkdownBasics checks headings, paragraphs, and links render.
+func TestHTMLToMarkdownBasics(t *testing.T) {
+	html := `<html><body>
+		<h2>Section</h2>
+		<p>Some <strong>bold</strong> and a <a href="https://go.dev">link</a>.</p>
+	</body></html>`
+	md := htmlToMarkdown([]byte(html))
+	for _, want := range []string{"## Section", "**bold**", "[link](https://go.dev)"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("markdown missing %q in:\n%s", want, md)
+		}
+	}
+}
+
+// TestHTMLToMarkdownDropsChrome checks script/style/nav content is removed.
+func TestHTMLToMarkdownDropsChrome(t *testing.T) {
+	html := `<html><head><style>.x{}</style></head><body>
+		<nav>menu links</nav>
+		<script>tracker()</script>
+		<p>real content</p>
+		<footer>copyright</footer>
+	</body></html>`
+	md := htmlToMarkdown([]byte(html))
+	if !strings.Contains(md, "real content") {
+		t.Errorf("body content dropped: %q", md)
+	}
+	for _, gone := range []string{"tracker()", ".x{}", "menu links", "copyright"} {
+		if strings.Contains(md, gone) {
+			t.Errorf("chrome/noise %q leaked into: %q", gone, md)
+		}
+	}
+}
+
+// TestHTMLToMarkdownLists checks list items become dashes.
+func TestHTMLToMarkdownLists(t *testing.T) {
+	html := `<ul><li>one</li><li>two</li></ul>`
+	md := htmlToMarkdown([]byte(html))
+	if !strings.Contains(md, "- one") || !strings.Contains(md, "- two") {
+		t.Errorf("list not rendered: %q", md)
+	}
+}
+
+// TestHTMLToMarkdownInlineSpacing checks spaces around inline elements survive
+// (regression: "A <a>link</a> here" must not become "Alinkhere").
+func TestHTMLToMarkdownInlineSpacing(t *testing.T) {
+	md := htmlToMarkdown([]byte(`<p>A <a href="https://x.io">link</a> here.</p>`))
+	if !strings.Contains(md, "A [link](https://x.io) here.") {
+		t.Errorf("inline spacing lost: %q", md)
+	}
+}
+
+// TestCollapseBlankLines checks 3+ newlines collapse to a single blank line.
+func TestCollapseBlankLines(t *testing.T) {
+	got := collapseBlankLines("a\n\n\n\nb")
+	if got != "a\n\nb" {
+		t.Errorf("collapseBlankLines = %q, want %q", got, "a\n\nb")
+	}
+}

--- a/internal/agenttool/webfetch_tool.go
+++ b/internal/agenttool/webfetch_tool.go
@@ -1,0 +1,231 @@
+// This file implements the webfetch tool (US-012, #128): fetch a URL and return
+// its main text as simplified Markdown. pi has no such tool; this mirrors Claude
+// Code's WebFetch. Safety properties required by the issue:
+//
+//   - HTTP URLs are upgraded to HTTPS before the request.
+//   - Cross-origin redirects are NOT followed automatically; the redirect target
+//     is returned to the caller (the model) so it can decide whether to fetch it.
+//   - A request timeout and a response-body size cap bound the work.
+//   - A failed fetch (timeout, non-2xx, unreachable) degrades to a structured
+//     error result, never a panic.
+//
+// The optional "prompt" argument is accepted and echoed back in the result
+// framing so the model keeps its intent alongside the fetched content; the tool
+// does not itself call a model to summarize (that is the agent loop's job).
+package agenttool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// webFetchTimeout bounds a single fetch. webFetchMaxBytes caps how much of the
+// response body is read (protects the model's context and memory from huge
+// pages). webFetchMaxMarkdown caps the rendered Markdown length.
+const (
+	webFetchTimeout     = 30 * time.Second
+	webFetchMaxBytes    = 5 * 1024 * 1024
+	webFetchMaxMarkdown = 100 * 1024
+)
+
+// WebFetchTool fetches a URL and returns its text as simplified Markdown. The
+// zero value is usable; Client defaults to a redirect-blocking http.Client with
+// webFetchTimeout.
+type WebFetchTool struct {
+	// Client performs the HTTP request. When nil, a default client is built that
+	// blocks cross-origin redirects and enforces webFetchTimeout. Injected for
+	// tests so a fake transport can serve canned responses.
+	Client *http.Client
+}
+
+// webFetchArgs is the decoded argument shape for WebFetchTool.
+type webFetchArgs struct {
+	// URL is the page to fetch. An http:// URL is upgraded to https://.
+	URL string `json:"url"`
+	// Prompt is an optional instruction describing what the caller wants from the
+	// page; it is echoed into the result framing, not acted on by the tool.
+	Prompt string `json:"prompt,omitempty"`
+}
+
+// Name implements AgentTool.
+func (t *WebFetchTool) Name() string { return "webfetch" }
+
+// Description implements AgentTool.
+func (t *WebFetchTool) Description() string {
+	return "Fetch a URL and return its main text content as simplified Markdown. " +
+		"HTTP URLs are upgraded to HTTPS. Cross-origin redirects are not followed; " +
+		"the redirect target is returned so you can fetch it explicitly. Use the " +
+		"optional prompt to note what you are looking for on the page."
+}
+
+// Schema implements AgentTool.
+func (t *WebFetchTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "url":    {"type": "string", "description": "The URL to fetch. http:// is upgraded to https://."},
+    "prompt": {"type": "string", "description": "Optional: what to extract or look for on the page."}
+  },
+  "required": ["url"],
+  "additionalProperties": false
+}`)
+}
+
+// ExecutionMode implements AgentTool. A fetch has no local side effects and is
+// safe to run alongside other reads → parallel.
+func (t *WebFetchTool) ExecutionMode() agentcore.ToolExecutionMode {
+	return agentcore.ToolExecutionParallel
+}
+
+// errRedirectBlocked is returned by the client's CheckRedirect to stop a
+// cross-origin redirect; the target is carried so Execute can report it.
+type errRedirectBlocked struct{ target string }
+
+func (e *errRedirectBlocked) Error() string { return "cross-origin redirect blocked to " + e.target }
+
+// newWebFetchClient builds the default redirect-blocking client. A redirect is
+// allowed only when it stays on the same host (scheme+host); a cross-origin hop
+// stops with errRedirectBlocked carrying the target URL.
+func newWebFetchClient() *http.Client {
+	return &http.Client{
+		Timeout: webFetchTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) == 0 {
+				return nil
+			}
+			orig := via[0].URL
+			if req.URL.Host != orig.Host || req.URL.Scheme != orig.Scheme {
+				return &errRedirectBlocked{target: req.URL.String()}
+			}
+			if len(via) >= 10 {
+				return errors.New("stopped after 10 redirects")
+			}
+			return nil
+		},
+	}
+}
+
+// Execute implements AgentTool. Fetch failures are encoded as error results (the
+// returned Go error is always nil), matching the file tools' contract.
+func (t *WebFetchTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+	a, bad := decodeArgs[webFetchArgs](args, "webfetch")
+	if bad != nil {
+		return *bad, nil
+	}
+	raw := strings.TrimSpace(a.URL)
+	if raw == "" {
+		return errorResult("webfetch: url is required"), nil
+	}
+
+	target, err := normalizeFetchURL(raw)
+	if err != nil {
+		return errorResult("webfetch: " + err.Error()), nil
+	}
+
+	client := t.Client
+	if client == nil {
+		client = newWebFetchClient()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return errorResult("webfetch: " + err.Error()), nil
+	}
+	req.Header.Set("User-Agent", "pigo-webfetch/1.0")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.8")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		// A blocked cross-origin redirect is reported specially so the model can
+		// choose to fetch the target explicitly. errors.As unwraps the *url.Error
+		// http.Client wraps CheckRedirect failures in.
+		var blocked *errRedirectBlocked
+		if errors.As(err, &blocked) {
+			return agentcore.AgentToolResult{
+				Content: agentcore.ContentList{agentcore.NewTextContent(
+					fmt.Sprintf("webfetch: cross-origin redirect not followed.\nTarget: %s\nFetch it explicitly if you want its content.", blocked.target))},
+				Details: map[string]any{"redirect": blocked.target, "followed": false},
+			}, nil
+		}
+		return errorResult(fmt.Sprintf("webfetch: request failed: %v", err)), nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return errorResult(fmt.Sprintf("webfetch: %s returned HTTP %d %s", target, resp.StatusCode, http.StatusText(resp.StatusCode))), nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, webFetchMaxBytes))
+	if err != nil {
+		return errorResult(fmt.Sprintf("webfetch: reading response body: %v", err)), nil
+	}
+
+	ctype := resp.Header.Get("Content-Type")
+	var text string
+	if strings.Contains(ctype, "html") || looksLikeHTML(body) {
+		text = htmlToMarkdown(body)
+	} else {
+		text = string(body)
+	}
+	text = strings.TrimSpace(text)
+	truncated := false
+	if len(text) > webFetchMaxMarkdown {
+		text = text[:webFetchMaxMarkdown]
+		truncated = true
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Fetched %s (HTTP %d)\n", target, resp.StatusCode)
+	if a.Prompt != "" {
+		fmt.Fprintf(&b, "Prompt: %s\n", a.Prompt)
+	}
+	if truncated {
+		b.WriteString("(content truncated)\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(text)
+
+	return agentcore.AgentToolResult{
+		Content: agentcore.ContentList{agentcore.NewTextContent(b.String())},
+		Details: map[string]any{"url": target, "status": resp.StatusCode, "truncated": truncated},
+	}, nil
+}
+
+// normalizeFetchURL parses raw, upgrades an http scheme to https, and rejects
+// anything that is not an absolute http(s) URL with a host.
+func normalizeFetchURL(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid url: %v", err)
+	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "https" // upgrade
+	case "https":
+		// ok
+	case "":
+		return "", fmt.Errorf("url must be absolute with an http(s) scheme: %q", raw)
+	default:
+		return "", fmt.Errorf("unsupported url scheme %q (want http or https)", u.Scheme)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("url has no host: %q", raw)
+	}
+	return u.String(), nil
+}
+
+// looksLikeHTML sniffs whether body begins with an HTML marker, used when the
+// server omits or mislabels Content-Type.
+func looksLikeHTML(body []byte) bool {
+	head := strings.ToLower(strings.TrimSpace(string(body[:min(512, len(body))])))
+	return strings.HasPrefix(head, "<!doctype html") || strings.HasPrefix(head, "<html") || strings.Contains(head, "<body")
+}

--- a/internal/agenttool/webfetch_tool_test.go
+++ b/internal/agenttool/webfetch_tool_test.go
@@ -1,0 +1,197 @@
+// Tests for the webfetch tool (US-012, #128): URL normalization (http→https),
+// HTML→Markdown reduction, size/timeout bounds, cross-origin redirect blocking,
+// and structured errors on failure. A fake RoundTripper serves canned responses
+// so no network is touched.
+package agenttool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// mustParse parses a URL or fails the test.
+func mustParse(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return u
+}
+
+// errorAsRedirect unwraps err onto *errRedirectBlocked.
+func errorAsRedirect(err error, target **errRedirectBlocked) bool {
+	return errors.As(err, target)
+}
+
+// roundTripFunc adapts a function to http.RoundTripper.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// makeResp builds a canned *http.Response with the given status/content-type/body.
+func makeResp(status int, ctype, body string) *http.Response {
+	h := http.Header{}
+	if ctype != "" {
+		h.Set("Content-Type", ctype)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// execWebFetch runs the tool with a client whose transport is fn.
+func execWebFetch(t *testing.T, fn roundTripFunc, args string) agentcore.AgentToolResult {
+	t.Helper()
+	tool := &WebFetchTool{Client: &http.Client{Transport: fn}}
+	res, err := tool.Execute(context.Background(), "c1", json.RawMessage(args), nil)
+	if err != nil {
+		t.Fatalf("Execute returned Go error: %v", err)
+	}
+	return res
+}
+
+// TestWebFetchUpgradesHTTP checks an http:// URL is fetched over https://.
+func TestWebFetchUpgradesHTTP(t *testing.T) {
+	var gotURL string
+	res := execWebFetch(t, func(r *http.Request) (*http.Response, error) {
+		gotURL = r.URL.String()
+		return makeResp(200, "text/html", "<html><body><p>hi</p></body></html>"), nil
+	}, `{"url":"http://example.com/page"}`)
+	if !strings.HasPrefix(gotURL, "https://") {
+		t.Errorf("request URL = %q, want https upgrade", gotURL)
+	}
+	if txt := agentcore.ContentToText(res.Content); !strings.Contains(txt, "hi") {
+		t.Errorf("result missing body text: %q", txt)
+	}
+}
+
+// TestWebFetchHTMLToMarkdown checks basic HTML is reduced to Markdown.
+func TestWebFetchHTMLToMarkdown(t *testing.T) {
+	body := `<html><body><h1>Title</h1><p>A <a href="https://x.io">link</a> here.</p><script>ignore()</script></body></html>`
+	res := execWebFetch(t, func(r *http.Request) (*http.Response, error) {
+		return makeResp(200, "text/html; charset=utf-8", body), nil
+	}, `{"url":"https://example.com"}`)
+	txt := agentcore.ContentToText(res.Content)
+	if !strings.Contains(txt, "# Title") {
+		t.Errorf("missing heading markdown in %q", txt)
+	}
+	if !strings.Contains(txt, "[link](https://x.io)") {
+		t.Errorf("missing link markdown in %q", txt)
+	}
+	if strings.Contains(txt, "ignore()") {
+		t.Errorf("script content leaked into output: %q", txt)
+	}
+}
+
+// TestWebFetchNon2xxIsError checks a non-2xx status degrades to a structured
+// error result (not a panic, not a Go error).
+func TestWebFetchNon2xxIsError(t *testing.T) {
+	res := execWebFetch(t, func(r *http.Request) (*http.Response, error) {
+		return makeResp(404, "text/html", "not found"), nil
+	}, `{"url":"https://example.com/missing"}`)
+	txt := agentcore.ContentToText(res.Content)
+	if !strings.Contains(txt, "HTTP 404") {
+		t.Errorf("expected HTTP 404 error, got %q", txt)
+	}
+}
+
+// TestWebFetchPromptEchoed checks the optional prompt is echoed into the framing.
+func TestWebFetchPromptEchoed(t *testing.T) {
+	res := execWebFetch(t, func(r *http.Request) (*http.Response, error) {
+		return makeResp(200, "text/plain", "plain body"), nil
+	}, `{"url":"https://example.com","prompt":"find the price"}`)
+	if txt := agentcore.ContentToText(res.Content); !strings.Contains(txt, "Prompt: find the price") {
+		t.Errorf("prompt not echoed: %q", txt)
+	}
+}
+
+// TestWebFetchRejectsBadScheme checks a non-http(s) scheme is rejected up front.
+func TestWebFetchRejectsBadScheme(t *testing.T) {
+	res := execWebFetch(t, func(r *http.Request) (*http.Response, error) {
+		t.Fatal("transport should not be called for a bad scheme")
+		return nil, nil
+	}, `{"url":"ftp://example.com/file"}`)
+	if txt := agentcore.ContentToText(res.Content); !strings.Contains(txt, "unsupported url scheme") {
+		t.Errorf("expected scheme rejection, got %q", txt)
+	}
+}
+
+// TestWebFetchMissingURL checks an empty url is rejected.
+func TestWebFetchMissingURL(t *testing.T) {
+	tool := &WebFetchTool{}
+	res, err := tool.Execute(context.Background(), "c1", json.RawMessage(`{"url":"  "}`), nil)
+	if err != nil {
+		t.Fatalf("Execute Go error: %v", err)
+	}
+	if txt := agentcore.ContentToText(res.Content); !strings.Contains(txt, "url is required") {
+		t.Errorf("expected url-required error, got %q", txt)
+	}
+}
+
+// TestWebFetchCrossOriginRedirectBlocked drives the real redirect-blocking
+// client (newWebFetchClient) via CheckRedirect: a cross-origin redirect must not
+// be followed, and the target is reported back.
+func TestWebFetchCrossOriginRedirectBlocked(t *testing.T) {
+	client := newWebFetchClient()
+	// Two hops: same-host allowed, cross-host blocked.
+	same := mustParse(t, "https://a.example.com/1")
+	cross := mustParse(t, "https://b.other.com/2")
+
+	// Same-origin redirect: allowed (nil error).
+	viaSame := []*http.Request{{URL: mustParse(t, "https://a.example.com/0")}}
+	if err := client.CheckRedirect(&http.Request{URL: same}, viaSame); err != nil {
+		t.Errorf("same-origin redirect blocked unexpectedly: %v", err)
+	}
+
+	// Cross-origin redirect: blocked with target carried.
+	viaCross := []*http.Request{{URL: mustParse(t, "https://a.example.com/0")}}
+	err := client.CheckRedirect(&http.Request{URL: cross}, viaCross)
+	var blocked *errRedirectBlocked
+	if err == nil || !errorAsRedirect(err, &blocked) {
+		t.Fatalf("cross-origin redirect not blocked: %v", err)
+	}
+	if blocked.target != "https://b.other.com/2" {
+		t.Errorf("blocked target = %q", blocked.target)
+	}
+}
+
+// TestNormalizeFetchURL covers the scheme/host rules directly.
+func TestNormalizeFetchURL(t *testing.T) {
+	cases := []struct {
+		in, want string
+		wantErr  bool
+	}{
+		{"http://x.com/a", "https://x.com/a", false},
+		{"https://x.com", "https://x.com", false},
+		{"x.com/a", "", true},     // no scheme
+		{"ftp://x.com", "", true}, // bad scheme
+		{"https://", "", true},    // no host
+	}
+	for _, c := range cases {
+		got, err := normalizeFetchURL(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("normalizeFetchURL(%q) = %q, want error", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("normalizeFetchURL(%q) error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("normalizeFetchURL(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- New `webfetch` built-in tool (US-012): fetch a URL, return main text as simplified Markdown
- HTTP→HTTPS upgrade; cross-origin redirects returned to caller (not auto-followed)
- Timeout + body/markdown size caps; failures degrade to structured error results
- Small HTML→Markdown reducer over golang.org/x/net/html (drops script/style/nav chrome)

Closes #128

## Test plan
- [x] go test ./... passes (webfetch + htmlmarkdown suites)
- [x] go vet clean, gofmt clean