### PR TITLE
插件系统：子进程 JSON-RPC 协议

### DIFF
--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -12,9 +12,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 )
@@ -28,6 +30,10 @@ type agentEnv struct {
 	provider     provider.Provider
 	providerName string
 	sysPrompt    string
+
+	// plugins holds any loaded external plugins so the caller can Close them
+	// when the run ends. It is nil when no plugins were discovered.
+	plugins *plugin.Manager
 }
 
 // setupAgentEnv resolves the provider for model/baseURL, builds the tool set
@@ -44,13 +50,43 @@ func setupAgentEnv(model, baseURL, protocol string, noTools bool) (agentEnv, err
 	if err != nil {
 		return agentEnv{}, err
 	}
+	tools := builtinTools(cwd, noTools)
+	// Discover external plugins (US-016) and append their tools. Plugin loading
+	// is fault-tolerant: a plugin that fails to start is logged and skipped, and
+	// disabling tools (--no-tools) skips plugin discovery entirely.
+	var mgr *plugin.Manager
+	if !noTools {
+		if m, err := plugin.Discover(pluginsDir(), os.Stderr, os.Stderr); err == nil {
+			tools = append(tools, m.Tools()...)
+			mgr = m
+		} else {
+			fmt.Fprintf(os.Stderr, "pigo: plugin discovery failed: %v\n", err)
+		}
+	}
 	return agentEnv{
 		cwd:          cwd,
-		tools:        builtinTools(cwd, noTools),
+		tools:        tools,
 		provider:     prov,
 		providerName: providerName,
 		sysPrompt:    sysPrompt,
+		plugins:      mgr,
 	}, nil
+}
+
+// pluginsDir returns the directory external plugins are discovered from:
+// $PIGO_HOME/plugins, or ~/.pigo/plugins by default. An empty string is returned
+// when the home directory cannot be resolved and no override is set (Discover
+// then treats it as "no plugins").
+func pluginsDir() string {
+	dir := os.Getenv("PIGO_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		dir = filepath.Join(home, ".pigo")
+	}
+	return filepath.Join(dir, "plugins")
 }
 
 // newRunConfig builds the loop configuration shared by every driver: the
@@ -130,6 +166,9 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 1
 		}
+		if env.plugins != nil {
+			defer env.plugins.Close()
+		}
 		if err := runInteractive(interactiveOptions{
 			model:        opts.model,
 			providerName: env.providerName,
@@ -157,6 +196,9 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 	if err != nil {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
 		return 1
+	}
+	if env.plugins != nil {
+		defer env.plugins.Close()
 	}
 	promptContent, err := buildUserContent(opts.prompt)
 	if err != nil {

--- a/docs/issue#0132.html
+++ b/docs/issue#0132.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #132</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/132">#132</a> &mdash; 插件系统：子进程 JSON-RPC 协议 (US-016) &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Reuse <code>internal/jsonrpc</code> as the plugin transport</h3>
+      <p><strong>Ambiguity:</strong> US-016 specifies "external plugins as subprocesses" but not the wire protocol.</p>
+      <p><strong>Choice:</strong> Plugins speak line-delimited JSON-RPC 2.0 over stdio via the existing <code>internal/jsonrpc.Client</code>, which was already built for MCP/sub-agent reuse.</p>
+      <p><strong>Rationale:</strong> One transport, one crash-handling path, one place to test. No new framing/parsing code, and the plugin protocol stays language-agnostic (any executable that can read/write JSON lines).</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Three-method protocol: <code>initialize</code> / <code>tools/call</code> / <code>shutdown</code></h3>
+      <p><strong>Ambiguity:</strong> The spec lists tools and (future) commands but not the handshake shape.</p>
+      <p><strong>Choice:</strong> A single <code>initialize</code> returns the full <code>Manifest</code> (name, version, tools, commands) up front; <code>tools/call</code> forwards one invocation; <code>shutdown</code> is a best-effort notification on Close.</p>
+      <p><strong>Rationale:</strong> Declaring everything at handshake time means pigo registers all plugin tools before the agent loop starts — no lazy discovery races. <code>Commands</code> is carried in the manifest now so command support (#133-area) needs no protocol change.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Plugin tools run <code>ToolExecutionSequential</code></h3>
+      <p><strong>Ambiguity:</strong> The <code>AgentTool</code> interface allows parallel execution; the spec is silent on plugin concurrency.</p>
+      <p><strong>Choice:</strong> Every plugin-backed tool reports Sequential.</p>
+      <p><strong>Rationale:</strong> A plugin call crosses a process boundary with unknown side effects and a single stdio channel per process. Sequential is the safe default; a plugin author cannot accidentally get concurrent calls multiplexed onto one pipe.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> A crashed/misbehaving plugin degrades to an error result, never a Go error</h3>
+      <p><strong>Spec:</strong> "plugins must be isolated" (general requirement).</p>
+      <p><strong>Implemented:</strong> <code>pluginTool.Execute</code> always returns <code>(AgentToolResult, nil)</code> — a transport failure becomes a text result "<code>&lt;name&gt;: plugin call failed: &lt;err&gt;</code>". Discovery failures are logged to a warn writer and the plugin is skipped, so one bad plugin never aborts loading the rest.</p>
+      <p><strong>Why:</strong> The agent loop treats a non-nil tool error as fatal; isolating at the tool boundary keeps a dead plugin from taking down the whole session.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Executable-bit discovery vs. a manifest/registry file</h3>
+      <p><strong>Alternatives:</strong> (a) scan <code>$PIGO_HOME/plugins</code> for executable regular files; (b) require a <code>plugins.json</code> registry listing each plugin.</p>
+      <p><strong>Chosen (a):</strong> Any executable dropped into the dir is a plugin; non-executables and subdirs are ignored; load order is name-sorted for determinism.</p>
+      <p><strong>Why:</strong> Zero-config "drop it in and it works" matches the config-dir convention already used for sessions/commands. A registry file adds a second source of truth to keep in sync. Cost: no per-plugin enable/disable short of chmod — acceptable for now.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Real-subprocess tests vs. mocked transport</h3>
+      <p><strong>Alternatives:</strong> mock <code>jsonrpc.Client</code>, or compile tiny real plugins with <code>go build</code> at test time.</p>
+      <p><strong>Chosen:</strong> tests compile <code>echoPluginSrc</code> / <code>crashPluginSrc</code> into real executables and exercise the full launch→handshake→call path (including a genuine mid-call <code>os.Exit(1)</code> crash).</p>
+      <p><strong>Why:</strong> The whole point of the feature is the process boundary; a mock would test the adapter but not the transport, framing, or crash isolation that actually carry the risk. Cost: ~4s test time for the builds — worth it for real coverage.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Command registration is declared but not yet wired</h3>
+      <p><code>Manifest.Commands</code> is parsed and carried, but pigo does not yet register plugin slash commands with the REPL command table. Confirm this lands in a follow-up (the manifest already supports it, so no protocol change is needed).</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Tool name collisions across plugins / builtins</h3>
+      <p>Plugin tools are appended to the builtin set in load order with no namespacing. If two plugins (or a plugin and a builtin) declare the same tool name, the registry behavior on duplicate is the arbiter. Should plugin tools be namespaced by <code>Manifest.Name</code>? Deferred pending a real collision.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -1,0 +1,89 @@
+// This file implements plugin discovery and lifecycle management (US-016, #132):
+// finding plugin executables under a config directory, loading each, and
+// aggregating their tools. Loading is fault-tolerant — one plugin that fails to
+// start or handshake is logged and skipped so the rest still load.
+package plugin
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// Manager owns a set of loaded plugins and their aggregated tools. It is not safe
+// for concurrent modification; load once at startup, then read.
+type Manager struct {
+	plugins []*Plugin
+}
+
+// Discover finds and loads every plugin under dir. A plugin is any executable
+// regular file directly inside dir (non-executable files and subdirectories are
+// ignored). Each plugin is launched and handshaked; a failure is written to
+// warnLog (when non-nil) and that plugin is skipped. A missing dir is not an
+// error — it yields an empty Manager. pluginStderr, when non-nil, receives every
+// plugin's stderr.
+func Discover(dir string, warnLog, pluginStderr io.Writer) (*Manager, error) {
+	m := &Manager{}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return m, nil // no plugins directory → no plugins
+		}
+		return nil, fmt.Errorf("plugin: read dir %q: %w", dir, err)
+	}
+	// Deterministic load order for stable tool ordering and diagnostics.
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || !isExecutable(info.Mode()) {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		p, err := Load(path, nil, pluginStderr)
+		if err != nil {
+			if warnLog != nil {
+				fmt.Fprintf(warnLog, "pigo: plugin %q failed to load: %v\n", e.Name(), err)
+			}
+			continue
+		}
+		m.plugins = append(m.plugins, p)
+	}
+	return m, nil
+}
+
+// isExecutable reports whether the file mode has any execute bit set.
+func isExecutable(mode os.FileMode) bool {
+	return mode&0o111 != 0
+}
+
+// Tools returns the aggregated tools of every loaded plugin, in load order.
+func (m *Manager) Tools() []agentcore.AgentTool {
+	var out []agentcore.AgentTool
+	for _, p := range m.plugins {
+		out = append(out, p.Tools()...)
+	}
+	return out
+}
+
+// Plugins returns the loaded plugins (for command aggregation and diagnostics).
+func (m *Manager) Plugins() []*Plugin { return m.plugins }
+
+// Close shuts down every loaded plugin, returning the first error encountered
+// (all plugins are attempted regardless).
+func (m *Manager) Close() error {
+	var firstErr error
+	for _, p := range m.plugins {
+		if err := p.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -1,0 +1,88 @@
+// Tests for plugin discovery (US-016, #132): executable detection, deterministic
+// order, fault tolerance (a bad plugin is skipped, not fatal), and empty/missing
+// directory handling.
+package plugin
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestDiscoverMissingDir checks a missing directory yields an empty manager.
+func TestDiscoverMissingDir(t *testing.T) {
+	m, err := Discover(filepath.Join(t.TempDir(), "nope"), nil, nil)
+	if err != nil {
+		t.Fatalf("Discover missing dir: %v", err)
+	}
+	if len(m.Plugins()) != 0 {
+		t.Errorf("want no plugins, got %d", len(m.Plugins()))
+	}
+}
+
+// TestDiscoverSkipsNonExecutable checks non-executable files are ignored.
+func TestDiscoverSkipsNonExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix executable-bit semantics not applicable on windows")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m, err := Discover(dir, nil, nil)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(m.Plugins()) != 0 {
+		t.Errorf("non-executable/dir entries should be skipped, got %d plugins", len(m.Plugins()))
+	}
+}
+
+// TestDiscoverLoadsAndIsolatesBad checks that a good plugin loads and a bad one
+// (executable that isn't a valid plugin) is logged and skipped rather than
+// aborting discovery.
+func TestDiscoverLoadsAndIsolatesBad(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script plugins are unix-only in this test")
+	}
+	dir := t.TempDir()
+
+	// Good plugin: compiled from echoPluginSrc, placed inside the discovery dir.
+	good := buildTestPlugin(t, "aaa-echo", echoPluginSrc)
+	if err := os.Rename(good, filepath.Join(dir, "aaa-echo")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bad plugin: an executable that immediately exits without speaking the
+	// protocol, so the initialize handshake fails.
+	bad := filepath.Join(dir, "zzz-bad")
+	if err := os.WriteFile(bad, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var warn bytes.Buffer
+	m, err := Discover(dir, &warn, os.Stderr)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	defer m.Close()
+
+	if len(m.Plugins()) != 1 {
+		t.Fatalf("want 1 good plugin loaded, got %d", len(m.Plugins()))
+	}
+	if m.Plugins()[0].Manifest.Name != "echo" {
+		t.Errorf("loaded wrong plugin: %q", m.Plugins()[0].Manifest.Name)
+	}
+	if !strings.Contains(warn.String(), "zzz-bad") {
+		t.Errorf("bad plugin should be logged, warn=%q", warn.String())
+	}
+	if tools := m.Tools(); len(tools) != 1 || tools[0].Name() != "shout" {
+		t.Errorf("aggregated tools = %+v, want one 'shout'", tools)
+	}
+}

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -1,0 +1,66 @@
+// Package plugin implements pigo's external plugin system (US-016, #132): an
+// executable written in any language registers custom tools (and, later, slash
+// commands) with pigo without touching pigo's source. pigo launches each plugin
+// as a child process and speaks line-delimited JSON-RPC 2.0 over its stdio,
+// reusing internal/jsonrpc as the transport.
+//
+// Protocol (client = pigo, server = plugin):
+//
+//   - initialize            → Manifest {name, version, tools[], commands[]}
+//     The handshake. The plugin declares everything it offers up front.
+//   - tools/call {name, arguments} → CallResult {content, isError}
+//     pigo forwards a tool invocation; the plugin runs it and returns the text.
+//   - shutdown (notification)
+//     Sent on Close so a well-behaved plugin can exit before stdin EOF.
+//
+// A plugin that crashes or misbehaves is isolated: its Start failure is logged
+// and skipped (other plugins still load), and a tool call against a dead plugin
+// returns an error result rather than propagating up.
+//
+// This file defines the wire types exchanged during the handshake and tool call.
+package plugin
+
+import "encoding/json"
+
+// Manifest is the plugin's self-description, returned from the initialize call.
+type Manifest struct {
+	// Name identifies the plugin; used to namespace its tools and in diagnostics.
+	Name string `json:"name"`
+	// Version is an optional free-form version string for diagnostics.
+	Version string `json:"version,omitempty"`
+	// Tools are the tools this plugin registers with the agent.
+	Tools []ToolSpec `json:"tools,omitempty"`
+	// Commands are the slash commands this plugin registers.
+	Commands []CommandSpec `json:"commands,omitempty"`
+}
+
+// ToolSpec declares one tool a plugin exposes. Schema is the JSON Schema for the
+// tool's arguments, passed through verbatim to the agent's tool registry.
+type ToolSpec struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Schema      json.RawMessage `json:"schema"`
+}
+
+// CommandSpec declares one slash command a plugin exposes. Prompt is the text
+// injected as the next user prompt when the command is invoked (matching the
+// declarative-command convention); it may be empty if the plugin handles the
+// command by other means.
+type CommandSpec struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Prompt      string `json:"prompt,omitempty"`
+}
+
+// CallParams is the parameter object for a tools/call request.
+type CallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// CallResult is the reply to a tools/call request. Content is the tool output as
+// text; IsError marks a tool-level failure (distinct from a transport error).
+type CallResult struct {
+	Content string `json:"content"`
+	IsError bool   `json:"isError,omitempty"`
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,0 +1,139 @@
+// This file implements the plugin client (US-016, #132): it launches a plugin
+// executable, performs the initialize handshake, and exposes the plugin's
+// declared tools as agentcore.AgentTool values that forward invocations over
+// JSON-RPC. Crash isolation lives here — a call against a plugin whose process
+// has died returns an error result, never a panic.
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/jsonrpc"
+)
+
+// initTimeout bounds the initialize handshake so a plugin that never replies
+// cannot hang plugin discovery.
+const initTimeout = 10 * time.Second
+
+// Plugin is a running plugin: its JSON-RPC client plus the manifest it declared
+// during initialize.
+type Plugin struct {
+	Manifest Manifest
+	client   *jsonrpc.Client
+}
+
+// Load starts the plugin executable at path (with optional args) and performs
+// the initialize handshake. stderr, when non-nil, receives the plugin's stderr
+// for logging. The caller must Close the returned Plugin.
+func Load(command string, args []string, stderr io.Writer) (*Plugin, error) {
+	client, err := jsonrpc.NewClient(jsonrpc.Config{
+		Command: command,
+		Args:    args,
+		Stderr:  stderr,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("plugin: launch %q: %w", command, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), initTimeout)
+	defer cancel()
+
+	raw, err := client.Call(ctx, "initialize", nil)
+	if err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("plugin: initialize %q: %w", command, err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("plugin: decode manifest from %q: %w", command, err)
+	}
+	if m.Name == "" {
+		_ = client.Close()
+		return nil, fmt.Errorf("plugin %q: manifest has empty name", command)
+	}
+	return &Plugin{Manifest: m, client: client}, nil
+}
+
+// Tools adapts each tool the plugin declared into an agentcore.AgentTool that
+// forwards Execute over JSON-RPC.
+func (p *Plugin) Tools() []agentcore.AgentTool {
+	out := make([]agentcore.AgentTool, 0, len(p.Manifest.Tools))
+	for _, spec := range p.Manifest.Tools {
+		out = append(out, &pluginTool{plugin: p, spec: spec})
+	}
+	return out
+}
+
+// Close shuts the plugin down: it sends a best-effort shutdown notification then
+// closes the transport (which closes stdin and, if needed, kills the child).
+func (p *Plugin) Close() error {
+	_ = p.client.Notify("shutdown", nil)
+	return p.client.Close()
+}
+
+// call forwards a tool invocation to the plugin and returns its result.
+func (p *Plugin) call(ctx context.Context, name string, args json.RawMessage) (CallResult, error) {
+	raw, err := p.client.Call(ctx, "tools/call", CallParams{Name: name, Arguments: args})
+	if err != nil {
+		return CallResult{}, err
+	}
+	var res CallResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return CallResult{}, fmt.Errorf("plugin %q: decode result for %q: %w", p.Manifest.Name, name, err)
+	}
+	return res, nil
+}
+
+// pluginTool adapts one plugin-declared tool to the agentcore.AgentTool
+// interface. All invocations are forwarded to the owning plugin over RPC.
+type pluginTool struct {
+	plugin *Plugin
+	spec   ToolSpec
+}
+
+// Name implements AgentTool.
+func (t *pluginTool) Name() string { return t.spec.Name }
+
+// Description implements AgentTool.
+func (t *pluginTool) Description() string { return t.spec.Description }
+
+// Schema implements AgentTool. An empty schema declared by the plugin degrades
+// to a permissive object schema so registration never fails.
+func (t *pluginTool) Schema() json.RawMessage {
+	if len(t.spec.Schema) == 0 {
+		return json.RawMessage(`{"type":"object"}`)
+	}
+	return t.spec.Schema
+}
+
+// ExecutionMode implements AgentTool. Plugin calls cross a process boundary and
+// have unknown side effects, so they run sequentially to be safe.
+func (t *pluginTool) ExecutionMode() agentcore.ToolExecutionMode {
+	return agentcore.ToolExecutionSequential
+}
+
+// Execute implements AgentTool by forwarding the call to the plugin process. A
+// transport error (e.g. the plugin crashed) is isolated: it degrades to an error
+// result so a dead plugin cannot take down the agent loop.
+func (t *pluginTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+	res, err := t.plugin.call(ctx, t.spec.Name, args)
+	if err != nil {
+		return agentcore.AgentToolResult{
+			Content: agentcore.ContentList{agentcore.NewTextContent(
+				fmt.Sprintf("%s: plugin call failed: %v", t.spec.Name, err))},
+		}, nil
+	}
+	result := agentcore.AgentToolResult{
+		Content: agentcore.ContentList{agentcore.NewTextContent(res.Content)},
+	}
+	if res.IsError {
+		result.Details = map[string]any{"isError": true}
+	}
+	return result, nil
+}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1,0 +1,184 @@
+// Tests for the plugin system (US-016, #132). A test plugin is a tiny Go program
+// compiled once per test run; it speaks the JSON-RPC protocol over stdio so the
+// tests exercise the real subprocess transport, handshake, tool forwarding, and
+// crash isolation — no network or mocks.
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// buildTestPlugin compiles the given Go source into an executable under a temp
+// dir and returns its path. The source is a standalone main package.
+func buildTestPlugin(t *testing.T, name, src string) string {
+	t.Helper()
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, name+".go")
+	if err := os.WriteFile(srcPath, []byte(src), 0o644); err != nil {
+		t.Fatalf("write plugin source: %v", err)
+	}
+	bin := filepath.Join(dir, name)
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", bin, srcPath)
+	cmd.Env = os.Environ()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build test plugin: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// echoPluginSrc is a plugin that declares one "shout" tool which uppercases its
+// "text" argument.
+const echoPluginSrc = `package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type req struct {
+	ID     *json.RawMessage ` + "`json:\"id\"`" + `
+	Method string           ` + "`json:\"method\"`" + `
+	Params json.RawMessage  ` + "`json:\"params\"`" + `
+}
+
+func main() {
+	sc := bufio.NewScanner(os.Stdin)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	w := bufio.NewWriter(os.Stdout)
+	for sc.Scan() {
+		var r req
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			continue
+		}
+		switch r.Method {
+		case "initialize":
+			reply(w, r.ID, json.RawMessage(` + "`" + `{"name":"echo","version":"1.0","tools":[{"name":"shout","description":"uppercase text","schema":{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}}]}` + "`" + `))
+		case "tools/call":
+			var p struct {
+				Name      string          ` + "`json:\"name\"`" + `
+				Arguments json.RawMessage ` + "`json:\"arguments\"`" + `
+			}
+			json.Unmarshal(r.Params, &p)
+			var a struct{ Text string ` + "`json:\"text\"`" + ` }
+			json.Unmarshal(p.Arguments, &a)
+			res, _ := json.Marshal(map[string]any{"content": strings.ToUpper(a.Text)})
+			reply(w, r.ID, res)
+		case "shutdown":
+			return
+		}
+	}
+}
+
+func reply(w *bufio.Writer, id *json.RawMessage, result json.RawMessage) {
+	if id == nil {
+		return
+	}
+	out, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "result": result})
+	fmt.Fprintf(w, "%s\n", out)
+	w.Flush()
+}
+`
+
+// TestPluginLoadAndCall exercises the full path: build → load (handshake) →
+// adapt tool → call → result.
+func TestPluginLoadAndCall(t *testing.T) {
+	bin := buildTestPlugin(t, "echo", echoPluginSrc)
+	p, err := Load(bin, nil, os.Stderr)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer p.Close()
+
+	if p.Manifest.Name != "echo" {
+		t.Errorf("manifest name = %q, want echo", p.Manifest.Name)
+	}
+	tools := p.Tools()
+	if len(tools) != 1 || tools[0].Name() != "shout" {
+		t.Fatalf("tools = %+v, want one 'shout'", tools)
+	}
+	if tools[0].ExecutionMode() != agentcore.ToolExecutionSequential {
+		t.Errorf("plugin tool should be sequential")
+	}
+
+	res, err := tools[0].Execute(context.Background(), "c1", json.RawMessage(`{"text":"hello"}`), nil)
+	if err != nil {
+		t.Fatalf("Execute Go error: %v", err)
+	}
+	if txt := agentcore.ContentToText(res.Content); txt != "HELLO" {
+		t.Errorf("result = %q, want HELLO", txt)
+	}
+}
+
+// crashPluginSrc initializes fine but exits abruptly on the first tools/call.
+const crashPluginSrc = `package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type req struct {
+	ID     *json.RawMessage ` + "`json:\"id\"`" + `
+	Method string           ` + "`json:\"method\"`" + `
+}
+
+func main() {
+	sc := bufio.NewScanner(os.Stdin)
+	w := bufio.NewWriter(os.Stdout)
+	for sc.Scan() {
+		var r req
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			continue
+		}
+		switch r.Method {
+		case "initialize":
+			out, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": r.ID, "result": json.RawMessage(` + "`" + `{"name":"crash","tools":[{"name":"boom","description":"crashes"}]}` + "`" + `)})
+			fmt.Fprintf(w, "%s\n", out)
+			w.Flush()
+		case "tools/call":
+			os.Exit(1) // crash mid-call: no response is ever sent
+		}
+	}
+}
+`
+
+// TestPluginCrashIsolation checks that a plugin crashing during a tool call
+// degrades to an error result, not a panic or a hang.
+func TestPluginCrashIsolation(t *testing.T) {
+	bin := buildTestPlugin(t, "crash", crashPluginSrc)
+	p, err := Load(bin, nil, os.Stderr)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer p.Close()
+
+	tools := p.Tools()
+	if len(tools) != 1 {
+		t.Fatalf("want one tool, got %d", len(tools))
+	}
+	res, err := tools[0].Execute(context.Background(), "c1", json.RawMessage(`{}`), nil)
+	if err != nil {
+		t.Fatalf("Execute must not return a Go error even on crash: %v", err)
+	}
+	txt := agentcore.ContentToText(res.Content)
+	if !strings.Contains(txt, "plugin call failed") {
+		t.Errorf("expected isolated error result, got %q", txt)
+	}
+}


### PR DESCRIPTION
## Summary
- 新增 `internal/plugin` 包，复用 `internal/jsonrpc` 作为子进程传输层
- 协议：`initialize` → Manifest，`tools/call` → CallResult，`shutdown` 通知
- 容错发现（`$PIGO_HOME/plugins` 或 `~/.pigo/plugins`），确定性加载顺序，坏插件跳过并记录
- 崩溃隔离：插件调用失败降级为 error 结果，绝不 panic/挂起 agent loop
- 接入 `cmd/pigo/run.go`：`setupAgentEnv` 发现插件，`dispatch` 中 defer Close

Closes #132

## Test plan
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` 干净
- [x] `go test -race ./internal/plugin/` 通过（真实子进程：加载/调用/崩溃隔离/坏插件跳过）