### PR TITLE
插件系统：生命周期事件订阅 (US-017, #133)

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 	"github.com/smallnest/pigo/internal/session"
@@ -48,6 +49,10 @@ type interactiveOptions struct {
 	// resumeID, when non-empty, resumes an existing session: its messages seed
 	// the context and replayed transcript. Otherwise a fresh session is created.
 	resumeID string
+
+	// plugins holds the loaded plugin manager so the REPL can deliver lifecycle
+	// events to subscribed plugins (US-017, #133). It may be nil (no plugins).
+	plugins *plugin.Manager
 }
 
 // runInteractive starts the line-based REPL over a persisted session. It keeps
@@ -143,6 +148,7 @@ func runInteractive(opts interactiveOptions) error {
 		creds:     creds,
 		curLeaf:   curLeaf,
 		persisted: len(history),
+		notifier:  plugin.NewEventNotifier(opts.plugins, os.Stderr),
 	})
 }
 

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/clipboard"
 	"github.com/smallnest/pigo/internal/compaction"
+	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 	"github.com/smallnest/pigo/internal/session"
@@ -43,6 +44,11 @@ type replDeps struct {
 	reg      *agenttool.ToolRegistry
 	slash    *runtime.SlashRegistry
 	creds    *provider.CredentialStore
+
+	// notifier delivers agent lifecycle events to subscribed plugins (US-017,
+	// #133). It is nil when no plugin subscribes; DrainStream's OnEvent stays
+	// unset in that case.
+	notifier *plugin.EventNotifier
 
 	// curLeaf is the id of the entry the conversation currently descends from —
 	// the active leaf of the on-disk session tree (US-007, #123). A fresh session
@@ -65,6 +71,17 @@ const (
 	replScanBufInit = 64 * 1024
 	replScanBufMax  = 4 * 1024 * 1024
 )
+
+// notifierHandle returns the plugin event-delivery callback for this session's
+// runs, or nil when no plugin subscribed. Returning nil (rather than a func that
+// dispatches to a nil notifier) keeps DrainStream's OnEvent unset in the common
+// no-plugin case, so the drain loop skips the per-event call entirely.
+func (deps replDeps) notifierHandle() func(agentcore.AgentEvent) {
+	if deps.notifier == nil {
+		return nil
+	}
+	return deps.notifier.Handle
+}
 
 // runREPL runs the read → run → stream-print loop until EOF, /exit or /quit. It
 // reads from in (os.Stdin in production) and writes prompts, streamed replies
@@ -278,6 +295,7 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 	// is surfaced on its own lines below the reply).
 	atLineStart := true
 	_, err = runtime.DrainStream(ctx, stream, runtime.StreamHandler{
+		OnEvent: deps.notifierHandle(),
 		OnText: func(delta string) {
 			fmt.Fprint(out, delta)
 			if delta != "" {

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -179,6 +179,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			tools:        env.tools,
 			sysPrompt:    env.sysPrompt,
 			resumeID:     resumeID,
+			plugins:      env.plugins,
 		}); err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 1
@@ -221,6 +222,12 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		Mode: mode,
 		Out:  out,
 		Run:  newRunConfig(opts.model, env.providerName, env.provider, creds, toolRegistry(env.tools)),
+	}
+	// Deliver agent lifecycle events to any subscribed plugin (US-017, #133).
+	// NewEventNotifier returns nil when no plugin subscribes, so the OnEvent hook
+	// stays unset in the common no-plugin case.
+	if n := plugin.NewEventNotifier(env.plugins, errOut); n != nil {
+		cfg.OnEvent = n.Handle
 	}
 	if err := runtime.RunHeadless(ctx, agentCtx, cfg); err != nil {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)

--- a/docs/issue#0133.html
+++ b/docs/issue#0133.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #133</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/133">#133</a> &mdash; 插件系统：生命周期事件订阅 (US-017) &mdash; 2026-07-17</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Subscription declared in the manifest, not per-event registration</h3>
+      <p><strong>Ambiguity:</strong> The spec says "插件握手时声明订阅的事件类型" but not the exact shape.</p>
+      <p><strong>Choice:</strong> Added <code>Events []string</code> to <code>Manifest</code>; the plugin lists the <code>agentcore.Event*</code> discriminants it wants at <code>initialize</code> time. pigo delivers only those via one-way <code>event</code> notifications.</p>
+      <p><strong>Rationale:</strong> Reuses the existing handshake — no new subscribe/unsubscribe RPC. pigo can gate payload construction on <code>Manager.Subscribers(type)</code>, so when nobody listens it does zero work.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Reuse the existing agentcore event stream as the source</h3>
+      <p><strong>Ambiguity:</strong> "复用现有 agentcore 事件流作事件源" — but the stream is consumed in three drivers (REPL, headless, sub-agent).</p>
+      <p><strong>Choice:</strong> A new <code>plugin.EventNotifier</code> maps each <code>AgentEvent</code> to a wire-safe payload and dispatches it. It is wired as the <code>DrainStream</code>/<code>RunHeadless</code> <code>OnEvent</code> callback — the single event-observation seam that already existed for stream-json.</p>
+      <p><strong>Rationale:</strong> No new event plumbing in the loop; the notifier is just another observer on the one drain path. Headless composes it with the stream-json serialiser (both observe every event).</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Payload mirrors the stream-json envelope's field selection</h3>
+      <p><strong>Ambiguity:</strong> The spec doesn't define the event payload.</p>
+      <p><strong>Choice:</strong> <code>eventPayload</code> emits only observable, non-secret fields (ids, tool names, counts, stop reasons, streamed text) — the same subset <code>headless.eventEnvelope</code> already sends over stream-json.</p>
+      <p><strong>Rationale:</strong> One consistent shape for plugin authors and stream consumers; no risk of leaking provider keys or raw internal structs to a subprocess.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Also bounded the shutdown notify, not just event delivery</h3>
+      <p><strong>Spec:</strong> requires the <em>event</em> notification to be timeout-isolated.</p>
+      <p><strong>Implemented:</strong> the same <code>eventTimeout</code> bound was added to <code>Plugin.Close</code>'s best-effort <code>shutdown</code> notify.</p>
+      <p><strong>Why:</strong> a plugin that stops reading stdin fills its write pipe; without the bound, a blocked <code>shutdown</code> write holds the transport write-mutex and made <code>Close</code> wait the full <code>closeGrace</code> (measured 58s → 7s after the fix). Same failure mode the spec flagged for events, so it got the same guard.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Timeout-per-event on the drain goroutine vs. a per-plugin outbound queue</h3>
+      <p><strong>Alternatives:</strong> (a) deliver inline with a short per-plugin timeout; (b) give each plugin a buffered queue + dedicated writer goroutine that drops on overflow.</p>
+      <p><strong>Chosen (a):</strong> <code>SendEvent</code> runs the write on a goroutine and selects against a 2s timer; a hung plugin costs at most 2s per event and is logged.</p>
+      <p><strong>Why:</strong> far simpler, no per-plugin lifecycle/backpressure state, and events are fire-and-forget by contract. Cost: a chronically slow (but not hung) plugin adds up to 2s of latency per delivered event. Acceptable for the low-priority audit use case; a queue can be added later without changing the manifest.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Real-subprocess event test vs. mock, and the 60s→9s timeout test</h3>
+      <p><strong>Alternatives:</strong> assert delivery against a mock client, or run a real plugin that logs received events to a file.</p>
+      <p><strong>Chosen:</strong> a real event-logging plugin (<code>eventPluginSrc</code>) proves subscribed-only delivery end-to-end; a real hung plugin proves the timeout bound. The hung-plugin test dropped from ~60s to ~9s once <code>Close</code> was also bounded — a bonus signal that the deviation above was correct.</p>
+      <p><strong>Why:</strong> the whole risk is the process boundary and the blocking-write failure mode; a mock would exercise neither.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Sub-agent driver does not deliver events to plugins</h3>
+      <p>Only the REPL and headless drivers wire the notifier. The sub-agent tool (<code>runtime/subagent.go</code>) consumes its own stream and currently has no plugin manager in scope. Confirm whether plugin events should fire for nested sub-agent runs, or only for the top-level run (current behavior).</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> No per-event ordering/delivery guarantee across a burst</h3>
+      <p>Events are delivered in stream order, but each is fire-and-forget; a plugin that is briefly slow may have a later event's write complete before... it won't, since delivery is synchronous per plugin in <code>DispatchEvent</code>. Ordering holds per plugin. Flagging only to confirm the synchronous-per-plugin model is the intended guarantee.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/plugin/events.go
+++ b/internal/plugin/events.go
@@ -1,0 +1,92 @@
+// This file bridges the agent's event stream to subscribed plugins (US-017,
+// #133). The agent loop emits agentcore.AgentEvent values; a plugin declares
+// which event types it wants in its manifest. EventNotifier maps each observed
+// event to a small, wire-safe payload and hands it to the Manager for
+// fire-and-forget delivery — the same "never secrets, only observable fields"
+// discipline the stream-json envelope uses.
+package plugin
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// EventNotifier forwards agent lifecycle events to the plugins that subscribed
+// to them. It is created once per run and its Handle method is wired as the
+// event-stream OnEvent callback. A nil *Manager (no plugins) makes NewNotifier
+// return nil, and calling Handle on a nil notifier is a safe no-op — callers can
+// wire it unconditionally.
+type EventNotifier struct {
+	mgr     *Manager
+	warnLog io.Writer
+}
+
+// NewEventNotifier returns a notifier over mgr, or nil when mgr is nil or has no
+// plugins — so the caller can skip the OnEvent wiring entirely in the common
+// no-plugin case. warnLog (when non-nil) receives per-plugin delivery failures.
+func NewEventNotifier(mgr *Manager, warnLog io.Writer) *EventNotifier {
+	if mgr == nil || len(mgr.plugins) == 0 {
+		return nil
+	}
+	return &EventNotifier{mgr: mgr, warnLog: warnLog}
+}
+
+// Handle maps ev to a wire payload and dispatches it to subscribed plugins. It
+// is a no-op on a nil notifier and when no plugin subscribes to ev's type, so it
+// builds a payload only when someone is listening. Delivery is bounded and
+// isolated by the Manager, so Handle never blocks the loop beyond the
+// per-plugin event timeout.
+func (n *EventNotifier) Handle(ev agentcore.AgentEvent) {
+	if n == nil {
+		return
+	}
+	t := ev.EventType()
+	if !n.mgr.Subscribers(t) {
+		return
+	}
+	data, err := json.Marshal(eventPayload(ev))
+	if err != nil {
+		data = nil // deliver the bare type rather than dropping the event
+	}
+	n.mgr.DispatchEvent(EventParams{Type: t, Data: data}, n.warnLog)
+}
+
+// eventPayload derives the wire-safe payload for an event: only observable,
+// non-secret fields (ids, names, counts, stop reasons, streamed text). It
+// mirrors the stream-json envelope's field selection so plugin authors and
+// stream consumers see the same shape.
+func eventPayload(ev agentcore.AgentEvent) map[string]any {
+	switch e := ev.(type) {
+	case agentcore.AgentEndEvent:
+		return map[string]any{"messageCount": len(e.Messages)}
+	case agentcore.TurnEndEvent:
+		p := map[string]any{"stopReason": e.Message.StopReason}
+		if text := agentcore.ContentToText(e.Message.Content); text != "" {
+			p["text"] = text
+		}
+		if calls := e.Message.ToolCalls(); len(calls) > 0 {
+			names := make([]string, len(calls))
+			for i, c := range calls {
+				names[i] = c.Name
+			}
+			p["toolCalls"] = names
+		}
+		return p
+	case agentcore.ToolExecutionStartEvent:
+		return map[string]any{"toolCallId": e.ToolCallID, "toolName": e.ToolName}
+	case agentcore.ToolExecutionEndEvent:
+		return map[string]any{"toolCallId": e.ToolCallID, "toolName": e.ToolName, "isError": e.IsError}
+	case agentcore.CompactionEvent:
+		return map[string]any{
+			"reason":          e.Reason,
+			"tokensBefore":    e.TokensBefore,
+			"tokensAfter":     e.TokensAfter,
+			"summarizedCount": e.SummarizedCount,
+			"keptCount":       e.KeptCount,
+		}
+	default:
+		return map[string]any{}
+	}
+}

--- a/internal/plugin/events_test.go
+++ b/internal/plugin/events_test.go
@@ -1,0 +1,262 @@
+// Tests for plugin lifecycle event subscription and delivery (US-017, #133):
+// a plugin declares subscribed event types in its manifest, pigo delivers only
+// those via one-way `event` notifications, and a slow/hung plugin is isolated by
+// the per-event timeout rather than blocking the caller.
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// eventPluginSrc declares a subscription to two event types and appends every
+// received `event` notification (as one JSON line: {"type":...,"data":...}) to a
+// file whose path is passed via the PIGO_EVENT_LOG env var. It lets the test
+// assert exactly which events were delivered, in order.
+const eventPluginSrc = `package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type req struct {
+	ID     *json.RawMessage ` + "`json:\"id\"`" + `
+	Method string           ` + "`json:\"method\"`" + `
+	Params json.RawMessage  ` + "`json:\"params\"`" + `
+}
+
+func main() {
+	logPath := os.Getenv("PIGO_EVENT_LOG")
+	sc := bufio.NewScanner(os.Stdin)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	w := bufio.NewWriter(os.Stdout)
+	for sc.Scan() {
+		var r req
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			continue
+		}
+		switch r.Method {
+		case "initialize":
+			reply(w, r.ID, json.RawMessage(` + "`" + `{"name":"watcher","version":"1.0","events":["agent_start","tool_execution_end"]}` + "`" + `))
+		case "event":
+			if logPath != "" {
+				f, _ := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+				if f != nil {
+					fmt.Fprintf(f, "%s\n", r.Params)
+					f.Close()
+				}
+			}
+		case "shutdown":
+			return
+		}
+	}
+}
+
+func reply(w *bufio.Writer, id *json.RawMessage, result json.RawMessage) {
+	if id == nil {
+		return
+	}
+	out, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "result": result})
+	fmt.Fprintf(w, "%s\n", out)
+	w.Flush()
+}
+`
+
+// TestPluginSubscribesReportsManifestEvents checks Subscribes reflects exactly
+// the manifest's declared event types.
+func TestPluginSubscribesReportsManifestEvents(t *testing.T) {
+	p := &Plugin{Manifest: Manifest{Name: "w", Events: []string{"agent_start", "tool_execution_end"}}}
+	if !p.Subscribes("agent_start") {
+		t.Error("should subscribe to agent_start")
+	}
+	if !p.Subscribes("tool_execution_end") {
+		t.Error("should subscribe to tool_execution_end")
+	}
+	if p.Subscribes("turn_end") {
+		t.Error("should NOT subscribe to unlisted turn_end")
+	}
+}
+
+// TestEventNotifierDeliversSubscribedOnly runs a real event-logging plugin and
+// verifies the notifier delivers a subscribed event but drops an unsubscribed
+// one — the full path: manifest events → Subscribers gate → payload → RPC.
+func TestEventNotifierDeliversSubscribedOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell/exec plugin test is unix-oriented")
+	}
+	logPath := filepath.Join(t.TempDir(), "events.log")
+	t.Setenv("PIGO_EVENT_LOG", logPath)
+
+	bin := buildTestPlugin(t, "watcher", eventPluginSrc)
+	p, err := Load(bin, nil, os.Stderr)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer p.Close()
+
+	m := &Manager{plugins: []*Plugin{p}}
+	if !m.Subscribers("agent_start") {
+		t.Fatal("manager should report a subscriber for agent_start")
+	}
+	if m.Subscribers("turn_end") {
+		t.Fatal("manager should report NO subscriber for turn_end")
+	}
+
+	n := NewEventNotifier(m, os.Stderr)
+	if n == nil {
+		t.Fatal("NewEventNotifier should be non-nil with a subscribing plugin")
+	}
+	// Subscribed → delivered.
+	n.Handle(agentcore.AgentStartEvent{})
+	// Unsubscribed → dropped (never written).
+	n.Handle(agentcore.TurnEndEvent{Message: agentcore.AssistantMessage{}})
+	// Subscribed → delivered with a payload.
+	n.Handle(agentcore.ToolExecutionEndEvent{ToolCallID: "c1", ToolName: "grep", IsError: false})
+
+	// The plugin writes asynchronously; poll briefly for the two expected lines.
+	var lines []string
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		data, _ := os.ReadFile(logPath)
+		lines = splitNonEmpty(string(data))
+		if len(lines) >= 2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("want 2 delivered events, got %d: %q", len(lines), lines)
+	}
+	var first EventParams
+	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
+		t.Fatalf("decode first event: %v", err)
+	}
+	if first.Type != "agent_start" {
+		t.Errorf("first event type = %q, want agent_start", first.Type)
+	}
+	var second EventParams
+	if err := json.Unmarshal([]byte(lines[1]), &second); err != nil {
+		t.Fatalf("decode second event: %v", err)
+	}
+	if second.Type != "tool_execution_end" {
+		t.Errorf("second event type = %q, want tool_execution_end", second.Type)
+	}
+	if !containsField(second.Data, "toolName", "grep") {
+		t.Errorf("second event data missing toolName=grep: %s", second.Data)
+	}
+}
+
+// TestNewEventNotifierNilWhenNoSubscribers checks the notifier is nil when there
+// are no plugins, so the caller can skip wiring OnEvent entirely.
+func TestNewEventNotifierNilWhenNoSubscribers(t *testing.T) {
+	if NewEventNotifier(nil, os.Stderr) != nil {
+		t.Error("nil manager should yield nil notifier")
+	}
+	if NewEventNotifier(&Manager{}, os.Stderr) != nil {
+		t.Error("empty manager should yield nil notifier")
+	}
+}
+
+// TestSendEventTimesOutOnHungPlugin verifies event delivery is bounded: a plugin
+// that initializes then stops reading stdin does not block SendEvent beyond the
+// timeout — it returns a timeout error instead of hanging.
+func TestSendEventTimesOutOnHungPlugin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell/exec plugin test is unix-oriented")
+	}
+	// hungPluginSrc initializes, then blocks forever without reading further
+	// stdin, so the OS pipe buffer fills and a Notify write eventually blocks.
+	const hungPluginSrc = `package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+type req struct {
+	ID     *json.RawMessage ` + "`json:\"id\"`" + `
+	Method string           ` + "`json:\"method\"`" + `
+}
+
+func main() {
+	sc := bufio.NewScanner(os.Stdin)
+	w := bufio.NewWriter(os.Stdout)
+	if sc.Scan() {
+		var r req
+		json.Unmarshal(sc.Bytes(), &r)
+		out, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": r.ID, "result": json.RawMessage(` + "`" + `{"name":"hung","events":["agent_start"]}` + "`" + `)})
+		fmt.Fprintf(w, "%s\n", out)
+		w.Flush()
+	}
+	time.Sleep(60 * time.Second) // never reads stdin again
+}
+`
+	bin := buildTestPlugin(t, "hung", hungPluginSrc)
+	p, err := Load(bin, nil, os.Stderr)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer p.Close()
+
+	// A single small event will not fill the pipe; force the write to block by
+	// sending a large payload many times until SendEvent reports the timeout. The
+	// key assertion is that SendEvent RETURNS (bounded) rather than hanging.
+	big := make([]byte, 256*1024)
+	for i := range big {
+		big[i] = 'x'
+	}
+	payload, _ := json.Marshal(map[string]any{"blob": string(big)})
+
+	start := time.Now()
+	var lastErr error
+	for range 50 {
+		lastErr = p.SendEvent(EventParams{Type: "agent_start", Data: payload})
+		if lastErr != nil {
+			break
+		}
+		if time.Since(start) > 10*time.Second {
+			t.Fatal("SendEvent never reported a timeout on a hung plugin")
+		}
+	}
+	if lastErr == nil {
+		t.Fatal("expected a timeout error from a hung plugin, got nil")
+	}
+	// The bounded return is the contract; the elapsed time per call is ~eventTimeout.
+	if elapsed := time.Since(start); elapsed > 12*time.Second {
+		t.Errorf("SendEvent took too long overall (%s) — not bounded", elapsed)
+	}
+}
+
+// splitNonEmpty splits s on newlines, dropping empty lines.
+func splitNonEmpty(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// containsField reports whether raw JSON object has key == value (string).
+func containsField(raw json.RawMessage, key, value string) bool {
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return false
+	}
+	s, ok := m[key].(string)
+	return ok && s == value
+}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -76,6 +76,34 @@ func (m *Manager) Tools() []agentcore.AgentTool {
 // Plugins returns the loaded plugins (for command aggregation and diagnostics).
 func (m *Manager) Plugins() []*Plugin { return m.plugins }
 
+// Subscribers reports whether any loaded plugin subscribes to the given event
+// type. It lets a caller skip building an event payload when nobody is listening
+// (US-017, #133).
+func (m *Manager) Subscribers(eventType string) bool {
+	for _, p := range m.plugins {
+		if p.Subscribes(eventType) {
+			return true
+		}
+	}
+	return false
+}
+
+// DispatchEvent delivers one lifecycle event to every plugin subscribed to its
+// type (US-017, #133). Delivery is best-effort and isolated: each plugin's send
+// is bounded by eventTimeout, and a delivery failure to one plugin (timeout,
+// dead process) is written to warnLog when non-nil and does not stop delivery to
+// the others. It never blocks the agent loop beyond the per-plugin timeout.
+func (m *Manager) DispatchEvent(params EventParams, warnLog io.Writer) {
+	for _, p := range m.plugins {
+		if !p.Subscribes(params.Type) {
+			continue
+		}
+		if err := p.SendEvent(params); err != nil && warnLog != nil {
+			fmt.Fprintf(warnLog, "pigo: plugin %q event %q: %v\n", p.Manifest.Name, params.Type, err)
+		}
+	}
+}
+
 // Close shuts down every loaded plugin, returning the first error encountered
 // (all plugins are attempted regardless).
 func (m *Manager) Close() error {

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -10,6 +10,9 @@
 //     The handshake. The plugin declares everything it offers up front.
 //   - tools/call {name, arguments} → CallResult {content, isError}
 //     pigo forwards a tool invocation; the plugin runs it and returns the text.
+//   - event {type, data} (notification)
+//     pigo pushes a subscribed agent lifecycle event (US-017, #133). One-way,
+//     fire-and-forget: the plugin never replies and a slow plugin is isolated.
 //   - shutdown (notification)
 //     Sent on Close so a well-behaved plugin can exit before stdin EOF.
 //
@@ -32,6 +35,11 @@ type Manifest struct {
 	Tools []ToolSpec `json:"tools,omitempty"`
 	// Commands are the slash commands this plugin registers.
 	Commands []CommandSpec `json:"commands,omitempty"`
+	// Events lists the agent lifecycle event types this plugin subscribes to
+	// (US-017, #133). pigo delivers only these via one-way `event` notifications;
+	// an empty list means the plugin observes no events. Valid values are the
+	// agentcore.Event* discriminants (e.g. "agent_start", "tool_execution_end").
+	Events []string `json:"events,omitempty"`
 }
 
 // ToolSpec declares one tool a plugin exposes. Schema is the JSON Schema for the
@@ -63,4 +71,12 @@ type CallParams struct {
 type CallResult struct {
 	Content string `json:"content"`
 	IsError bool   `json:"isError,omitempty"`
+}
+
+// EventParams is the parameter object for an `event` notification. Type is the
+// event discriminant (an agentcore.Event* value); Data carries a small,
+// wire-safe payload for that event (never secrets — see plugin.EventData).
+type EventParams struct {
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data,omitempty"`
 }

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"time"
 
 	"github.com/smallnest/pigo/internal/agentcore"
@@ -19,6 +20,12 @@ import (
 // initTimeout bounds the initialize handshake so a plugin that never replies
 // cannot hang plugin discovery.
 const initTimeout = 10 * time.Second
+
+// eventTimeout bounds one fire-and-forget lifecycle-event delivery (US-017,
+// #133). It is short so a slow or hung plugin adds only a small, bounded delay
+// per event rather than stalling the agent loop; the event is dropped on
+// timeout.
+const eventTimeout = 2 * time.Second
 
 // Plugin is a running plugin: its JSON-RPC client plus the manifest it declared
 // during initialize.
@@ -71,9 +78,17 @@ func (p *Plugin) Tools() []agentcore.AgentTool {
 }
 
 // Close shuts the plugin down: it sends a best-effort shutdown notification then
-// closes the transport (which closes stdin and, if needed, kills the child).
+// closes the transport (which closes stdin and, if needed, kills the child). The
+// shutdown notify is bounded by eventTimeout so a plugin that has stopped reading
+// its stdin (whose write pipe is full) cannot make Close block on the transport
+// write mutex — Close falls through to client.Close, which kills the child.
 func (p *Plugin) Close() error {
-	_ = p.client.Notify("shutdown", nil)
+	done := make(chan struct{})
+	go func() { _ = p.client.Notify("shutdown", nil); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(eventTimeout):
+	}
 	return p.client.Close()
 }
 
@@ -88,6 +103,30 @@ func (p *Plugin) call(ctx context.Context, name string, args json.RawMessage) (C
 		return CallResult{}, fmt.Errorf("plugin %q: decode result for %q: %w", p.Manifest.Name, name, err)
 	}
 	return res, nil
+}
+
+// Subscribes reports whether the plugin asked to receive the given event type in
+// its manifest (US-017, #133). pigo only delivers subscribed events.
+func (p *Plugin) Subscribes(eventType string) bool {
+	return slices.Contains(p.Manifest.Events, eventType)
+}
+
+// SendEvent delivers one lifecycle event to the plugin as a one-way `event`
+// notification (US-017, #133). Delivery is fire-and-forget and bounded by
+// eventTimeout: the underlying write runs on its own goroutine so a plugin that
+// has stopped reading its stdin (a hung or slow plugin) cannot block the agent
+// loop — the send is abandoned when the timeout elapses and its error returned.
+// The dropped write goroutine ends on its own when the plugin dies or Close
+// tears the pipe down.
+func (p *Plugin) SendEvent(params EventParams) error {
+	done := make(chan error, 1)
+	go func() { done <- p.client.Notify("event", params) }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(eventTimeout):
+		return fmt.Errorf("plugin %q: event %q delivery timed out after %s", p.Manifest.Name, params.Type, eventTimeout)
+	}
 }
 
 // pluginTool adapts one plugin-declared tool to the agentcore.AgentTool

--- a/internal/runtime/headless.go
+++ b/internal/runtime/headless.go
@@ -44,6 +44,10 @@ type HeadlessConfig struct {
 	Mode HeadlessMode
 	// Out receives the run output (final text or JSON lines). Required.
 	Out io.Writer
+	// OnEvent, when non-nil, is invoked for every AgentEvent before output
+	// handling. It is the seam plugin lifecycle-event delivery (US-017, #133)
+	// hooks into, independent of the output mode. It must not block.
+	OnEvent func(ev agentcore.AgentEvent)
 }
 
 // ErrRunFailed is the sentinel returned by RunHeadless when the agent run ended
@@ -78,12 +82,20 @@ func RunHeadless(ctx context.Context, agentCtx *agentcore.AgentContext, cfg Head
 	// the final message, which DrainStream returns.
 	var writeErr error
 	h := StreamHandler{}
-	if cfg.Mode == StreamJSONMode {
+	// Compose the output-mode serialiser (stream-json only) with the optional
+	// external OnEvent (plugin lifecycle delivery, US-017). Both observe every
+	// event; the serialiser runs first so a write failure is recorded even when a
+	// plugin observer is also wired.
+	streamJSON := cfg.Mode == StreamJSONMode
+	if streamJSON || cfg.OnEvent != nil {
 		h.OnEvent = func(ev agentcore.AgentEvent) {
-			if writeErr == nil {
+			if streamJSON && writeErr == nil {
 				if err := writeEventJSON(cfg.Out, ev); err != nil {
 					writeErr = err
 				}
+			}
+			if cfg.OnEvent != nil {
+				cfg.OnEvent(ev)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- 插件在 initialize 握手时通过 manifest 的 `events` 字段声明订阅的 agentcore 事件类型
- pigo 复用现有事件流作事件源，仅将订阅的事件以单向 `event` JSON-RPC 通知投递给对应插件（subscribed-only、fire-and-forget）
- 每次投递有 2s 超时隔离，挂死/慢插件不会阻塞 agent loop；`Close` 的 `shutdown` 通知同样加超时界
- `EventNotifier` 将 `AgentEvent` 映射为 wire-safe payload，字段选择对齐 headless stream-json envelope，不泄露密钥
- 接入 headless 驱动与 REPL 两条路径；无插件订阅时 `NewEventNotifier` 返回 nil，不挂载 OnEvent

Closes #133

## Test plan
- [x] `go build ./...` 通过
- [x] `go vet` 通过
- [x] `go test ./internal/plugin/` 通过（含真实子进程测试：订阅投递/非订阅丢弃/挂死插件超时有界）