### PR TITLE
项目信任 Project Trust (US-018, #134)

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -6,11 +6,13 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/smallnest/pigo/internal/agentcore"
@@ -18,6 +20,7 @@ import (
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 	"github.com/smallnest/pigo/internal/session"
+	"github.com/smallnest/pigo/internal/trust"
 )
 
 // sessionStore returns the session store rooted at ~/.pigo/sessions (or under
@@ -123,6 +126,27 @@ func runInteractive(opts interactiveOptions) error {
 		contextWindow: defaultContextWindow,
 	}
 
+	// Project trust (US-018, #134): load the persisted trust store for the
+	// launch directory. A load failure (e.g. a corrupted trust.json) is
+	// non-fatal: trust is disabled (mgr stays nil) and the REPL still runs -
+	// the store is surfaced rather than silently overwritten. cwd is captured
+	// once since pigo does not cd during a session; if it cannot be resolved
+	// trust is disabled too, since an empty cwd would silently never match.
+	cwd, cwdErr := os.Getwd()
+	mgr, mgrErr := trust.NewManager(trust.DefaultPath())
+	if mgrErr != nil {
+		fmt.Fprintf(os.Stderr, "pigo: trust store unavailable, trust disabled: %v\n", mgrErr)
+		mgr = nil
+	}
+	if cwdErr != nil && mgr != nil {
+		fmt.Fprintf(os.Stderr, "pigo: cannot resolve working directory, trust disabled: %v\n", cwdErr)
+		mgr = nil
+	}
+	// in is the shared input reader for the main loop and the tool-call
+	// confirmation prompt (see repl.go). Wrapping os.Stdin once here means both
+	// read from the same buffer.
+	reader := bufio.NewReaderSize(os.Stdin, replScanBufInit)
+
 	// Wire slash-commands: built-ins (compile-time) plus any user templates under
 	// ~/.pigo/commands (对标 the commands/*.md convention) plus skills under
 	// ~/.agents/skills. A load error is non-fatal — the REPL still runs with the
@@ -132,6 +156,12 @@ func runInteractive(opts interactiveOptions) error {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "pigo: slash-commands: %v\n", err)
 	}
+	registerTrustCommand(slash, mgr, cwd)
+
+	// On the first launch in an undecided directory, ask the user how much to
+	// trust it before any tool runs. This happens before replay so the trust
+	// question is the first thing the user sees, not their prior history.
+	ensureTrustPrompt(os.Stdout, reader, mgr, cwd)
 
 	// Replay the resumed conversation so the user sees history before re-prompting.
 	if len(history) > 0 {
@@ -146,6 +176,10 @@ func runInteractive(opts interactiveOptions) error {
 		reg:       reg,
 		slash:     slash,
 		creds:     creds,
+		trust:     mgr,
+		cwd:       cwd,
+		in:        reader,
+		confirmMu: &sync.Mutex{},
 		curLeaf:   curLeaf,
 		persisted: len(history),
 		notifier:  plugin.NewEventNotifier(opts.plugins, os.Stderr),

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -32,6 +32,7 @@ import (
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 	"github.com/smallnest/pigo/internal/session"
+	"github.com/smallnest/pigo/internal/trust"
 )
 
 // replDeps bundles the collaborators a REPL run needs. They are assembled once
@@ -50,6 +51,25 @@ type replDeps struct {
 	// unset in that case.
 	notifier *plugin.EventNotifier
 
+	// trust persists project-trust decisions (US-018, #134). It is nil when
+	// trust is disabled (e.g. the store could not be loaded); when nil the
+	// BeforeToolCall hook is not installed and the first-run prompt is skipped.
+	trust *trust.Manager
+	// cwd is the directory pigo was launched in, used as the trust key and as
+	// the directory side-effect tools are gated against. It does not change
+	// during a session (pigo does not cd).
+	cwd string
+	// in is the shared buffered input reader. The main loop and the tool-call
+	// confirmation prompt both read from it so input typed ahead is never split
+	// between them. It is created by runInteractive (wrapping os.Stdin) or, for
+	// direct test callers, lazily from the in argument at the top of runREPL.
+	in *bufio.Reader
+	// confirmMu serializes tool-call confirmation prompts so concurrent
+	// parallel side-effect tool calls do not interleave on the shared
+	// stdin/stdout. It is a pointer so every value copy of replDeps (passed to
+	// streamRun per prompt) shares one mutex.
+	confirmMu *sync.Mutex
+
 	// curLeaf is the id of the entry the conversation currently descends from —
 	// the active leaf of the on-disk session tree (US-007, #123). A fresh session
 	// starts empty (""); each persisted turn advances it to the newly written
@@ -63,14 +83,15 @@ type replDeps struct {
 	persisted int
 }
 
-// replScanBufInit / replScanBufMax bound the line scanner. bufio.Scanner caps
-// lines at 64KiB by default; a REPL user may paste a long single line (a big
-// prompt or a pasted file), so the max is raised to 4MiB. The initial buffer
-// stays at 64KiB and grows on demand.
-const (
-	replScanBufInit = 64 * 1024
-	replScanBufMax  = 4 * 1024 * 1024
-)
+// replScanBufInit is the initial size of the shared input reader. A REPL user
+// may paste a long single line (a big prompt or a pasted file); bufio.Reader
+// grows its returned string beyond this buffer on demand, so a long line is
+// still read whole (just accumulated rather than capped). This drops the hard
+// 4MiB cap the previous bufio.Scanner had: ReadString is unbounded, so a
+// pathological paste can grow the line buffer. That is an acceptable tradeoff
+// for a terminal REPL (where OS line buffering bounds normal input) in exchange
+// for correct buffer sharing with the tool-call confirmation prompt.
+const replScanBufInit = 64 * 1024
 
 // notifierHandle returns the plugin event-delivery callback for this session's
 // runs, or nil when no plugin subscribed. Returning nil (rather than a func that
@@ -88,9 +109,17 @@ func (deps replDeps) notifierHandle() func(agentcore.AgentEvent) {
 // and status lines to out (os.Stdout). It is the interactive replacement for the
 // bubbletea program.
 func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
-	scanner := bufio.NewScanner(in)
-	// Allow long pasted lines (default bufio.Scanner caps at 64KiB).
-	scanner.Buffer(make([]byte, 0, replScanBufInit), replScanBufMax)
+	// Use the shared buffered reader so the main loop and the tool-call
+	// confirmation prompt read from the same buffer: input is never split
+	// between them the way it would be if the loop used a bufio.Scanner with
+	// its own private buffer (a Scanner can read past the current line into its
+	// internal buffer, trapping bytes the confirmation prompt would then never
+	// see). deps.in is set by runInteractive (wrapping os.Stdin); the in
+	// parameter is only a fallback for direct callers (tests) that do not set
+	// deps.in, and is ignored once deps.in is populated.
+	if deps.in == nil {
+		deps.in = bufio.NewReaderSize(in, replScanBufInit)
+	}
 
 	// A SIGINT during a run cancels only that run; the handler is installed for
 	// the whole REPL and targets whichever run is active via runCancel. runCancel
@@ -121,13 +150,22 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 
 	for {
 		fmt.Fprintf(out, "\npigo(%s)> ", deps.live.model)
-		if !scanner.Scan() {
-			// EOF (Ctrl+D) or read error: exit cleanly.
+		raw, err := deps.in.ReadString('\n')
+		if err != nil && raw == "" {
+			// EOF (Ctrl+D) or read error with no partial line: exit cleanly.
 			fmt.Fprintln(out)
-			return scanner.Err()
+			if err == io.EOF {
+				return nil
+			}
+			return err
 		}
-		line := strings.TrimSpace(scanner.Text())
+		line := strings.TrimSpace(raw)
 		if line == "" {
+			if err != nil {
+				// A trailing partial line at EOF that trims to empty: exit.
+				fmt.Fprintln(out)
+				return nil
+			}
 			continue
 		}
 		if line == "/exit" || line == "/quit" {
@@ -285,7 +323,10 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 			Compaction:    compaction.DefaultCompactionSettings,
 		},
 		Batch: agenttool.BatchConfig{
-			ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: deps.reg},
+			ToolExecutorConfig: agenttool.ToolExecutorConfig{
+				Registry:       deps.reg,
+				BeforeToolCall: trustBeforeToolCall(deps.trust, deps.cwd, deps.in, out, deps.confirmMu),
+			},
 		},
 	}
 	stream := runtime.StartRun(ctx, deps.agentCtx, cfg)

--- a/cmd/pigo/repl_test.go
+++ b/cmd/pigo/repl_test.go
@@ -126,6 +126,22 @@ func TestREPLEOFExits(t *testing.T) {
 	}
 }
 
+// TestREPLFinalLineNoNewline verifies the ReadString-based loop handles a final
+// input line without a trailing newline: the line is still run as a prompt and
+// the loop then exits cleanly on EOF. (The previous bufio.Scanner had the same
+// behavior; this pins it for the reader-based loop.)
+func TestREPLFinalLineNoNewline(t *testing.T) {
+	p := &replProvider{reply: "hi"}
+	deps, _ := newTestDeps(t, p)
+	var out bytes.Buffer
+	if err := runREPL(strings.NewReader("hello"), &out, deps); err != nil {
+		t.Fatalf("runREPL on no-trailing-newline input: %v", err)
+	}
+	if p.calls != 1 {
+		t.Errorf("runs fired = %d, want 1 (the final line should run once)", p.calls)
+	}
+}
+
 // TestREPLEmptyLineIgnored verifies blank lines are skipped without running.
 func TestREPLEmptyLineIgnored(t *testing.T) {
 	p := &replProvider{reply: "hi"}

--- a/cmd/pigo/trust.go
+++ b/cmd/pigo/trust.go
@@ -1,0 +1,284 @@
+// This file holds the interactive pieces of project trust (US-018, #134). The
+// trust store itself lives in internal/trust; here we have the REPL-only parts:
+//
+//   - the first-run trust dialog (ensureTrustPrompt), shown when the cwd has no
+//     saved decision;
+//   - the /trust command (registerTrustCommand), which saves or reports the
+//     current project's decision;
+//   - the BeforeToolCall hook (trustBeforeToolCall) that asks before side-effect
+//     tools (bash/write/edit) run in an untrusted directory.
+//
+// All prompts share the REPL's single *bufio.Reader so input typed ahead is
+// never split between the main loop and a confirmation. Headless mode is
+// unaffected: trust is a REPL safety feature and headless is an explicit,
+// non-interactive invocation.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/runtime"
+	"github.com/smallnest/pigo/internal/trust"
+)
+
+// sideEffectTools are the built-in tools with filesystem or process side
+// effects that trust gates. Read-only tools (read/grep/find), in-memory tools
+// (todo), and network-read tools (webfetch) are never gated.
+var sideEffectTools = map[string]bool{
+	"bash":  true,
+	"write": true,
+	"edit":  true,
+}
+
+// ensureTrustPrompt runs the first-run trust dialog when cwd has no saved
+// decision (NearestTrustDecision reports Found=false). When a decision already
+// exists (trusted/untrusted/null) it is a no-op: the user already answered, so
+// pigo does not re-ask on every launch. mgr==nil disables trust entirely.
+func ensureTrustPrompt(out io.Writer, in *bufio.Reader, mgr *trust.Manager, cwd string) {
+	if mgr == nil {
+		return
+	}
+	if res := mgr.NearestTrustDecision(cwd); res.Found {
+		return
+	}
+	fmt.Fprintf(out, "\nFirst time in this directory: %s\n", cwd)
+	fmt.Fprintln(out, "pigo runs side-effect tools (bash, write, edit) here. Choose a trust level:")
+	fmt.Fprintln(out, "  1) Trust     - remember as trusted (tools run without asking)")
+	fmt.Fprintln(out, "  2) Just once - trust only for this session (default)")
+	fmt.Fprintln(out, "  3) Reject    - do not trust (tools ask each time)")
+
+	// Default to "just once" (2): it keeps the REPL usable without persisting
+	// a trust grant the user did not explicitly confirm.
+	choice := readMenuChoice(out, in, "Enter choice [1-3]: ", 3, 2)
+	switch choice {
+	case 1:
+		target := chooseScope(out, in, cwd)
+		if err := mgr.SetDecision(target, trust.Trusted); err != nil {
+			fmt.Fprintf(out, "pigo: could not save trust decision: %v\n", err)
+			return
+		}
+		fmt.Fprintf(out, "Trusted %s (saved to %s).\n", cwd, target)
+	case 3:
+		target := chooseScope(out, in, cwd)
+		if err := mgr.SetDecision(target, trust.Untrusted); err != nil {
+			fmt.Fprintf(out, "pigo: could not save trust decision: %v\n", err)
+			return
+		}
+		fmt.Fprintf(out, "Marked %s untrusted (saved to %s). Side-effect tools will ask.\n", cwd, target)
+	default: // 2 = just once
+		mgr.SetSessionTrust(cwd)
+		fmt.Fprintf(out, "Trusted %s for this session only (not saved).\n", cwd)
+	}
+}
+
+// chooseScope asks whether to save the decision for the current directory or
+// its parent, returning the chosen path. On empty/EOF it defaults to the
+// current directory.
+func chooseScope(out io.Writer, in *bufio.Reader, cwd string) string {
+	parent := filepath.Dir(filepath.Clean(cwd))
+	if parent == filepath.Clean(cwd) {
+		// cwd is the filesystem root: there is no parent, so do not offer one.
+		return cwd
+	}
+	fmt.Fprintln(out, "Save for:")
+	fmt.Fprintf(out, "  1) This directory (%s)\n", cwd)
+	fmt.Fprintf(out, "  2) Parent directory (%s)\n", parent)
+	if readMenuChoice(out, in, "Enter [1-2]: ", 2, 1) == 2 {
+		return parent
+	}
+	return cwd
+}
+
+// readMenuChoice prompts and reads a 1..max integer, re-prompting on invalid
+// input. An empty line or EOF returns def so the dialog never deadlocks on
+// missing input.
+func readMenuChoice(out io.Writer, in *bufio.Reader, prompt string, max, def int) int {
+	for {
+		fmt.Fprint(out, prompt)
+		line, err := in.ReadString('\n')
+		if err != nil && line == "" {
+			return def
+		}
+		s := strings.TrimSpace(line)
+		if s == "" {
+			return def
+		}
+		if n, parseErr := strconv.Atoi(s); parseErr == nil && n >= 1 && n <= max {
+			return n
+		}
+		fmt.Fprintf(out, "  (enter a number 1-%d)\n", max)
+		if err != nil {
+			return def
+		}
+	}
+}
+
+// registerTrustCommand installs the /trust action command, which saves or
+// reports the current project's trust decision. It is an instance built-in
+// (AddBuiltin) because its closure captures the trust manager and cwd - state
+// out of reach of an init()-time global registration. mgr==nil is a no-op: the
+// command is not installed, so /trust reports unknown when trust is disabled.
+func registerTrustCommand(reg *runtime.SlashRegistry, mgr *trust.Manager, cwd string) {
+	if mgr == nil {
+		return
+	}
+	reg.AddBuiltin(runtime.SlashCommand{
+		Name:        "trust",
+		Description: "view or set this project's trust: /trust [on|off|once|status]",
+		Action: func(args string) string {
+			switch strings.TrimSpace(strings.ToLower(args)) {
+			case "", "on":
+				if err := mgr.SetDecision(cwd, trust.Trusted); err != nil {
+					return fmt.Sprintf("pigo: could not save trust: %v", err)
+				}
+				return fmt.Sprintf("trusted %s (saved)", cwd)
+			case "off":
+				// Clear any active session grant first: IsTrusted checks
+				// session before the persisted decision, so without this an
+				// "always" granted earlier in the session would keep the dir
+				// trusted until restart and the message below would be a lie.
+				mgr.ClearSessionTrust(cwd)
+				if err := mgr.SetDecision(cwd, trust.Untrusted); err != nil {
+					return fmt.Sprintf("pigo: could not save trust: %v", err)
+				}
+				return fmt.Sprintf("marked %s untrusted (saved); side-effect tools will ask", cwd)
+			case "once":
+				mgr.SetSessionTrust(cwd)
+				return fmt.Sprintf("trusted %s for this session only (not saved)", cwd)
+			case "status":
+				res := mgr.NearestTrustDecision(cwd)
+				if !res.Found {
+					return fmt.Sprintf("%s: undecided (no saved decision)", cwd)
+				}
+				return fmt.Sprintf("%s: %s (decision saved for %s)", cwd, res.Decision, res.Path)
+			default:
+				return "usage: /trust [on|off|once|status]  (default: on)"
+			}
+		},
+	})
+}
+
+// trustBeforeToolCall builds the permission hook that gates side-effect tools
+// (bash/write/edit) on the cwd's trust decision. In a trusted directory the
+// call is allowed (nil). Otherwise the user is prompted; "always" grants
+// session trust so subsequent side-effect calls skip the prompt. mgr==nil
+// returns nil (trust disabled, no gating).
+//
+// Concurrency: bash/write/edit are all ToolExecutionSequential, so the batch
+// runs serially and this hook fires on the run-loop producer goroutine - never
+// concurrently with itself. mu serializes prompts anyway as cheap insurance
+// should a side-effect tool ever become parallel; it is nil-safe (callers that
+// wire trust without a mutex simply get no serialization). The prompt writes to
+// out from the producer goroutine; this is safe because streamRun uses an
+// unbuffered event stream (EventBuffer=0, the default), so by the time the hook
+// runs the main goroutine has already drained the assistant's streamed text and
+// is idle in DrainStream. Do not raise EventBuffer above 0 while trust gating
+// is wired without routing the prompt through the main goroutine.
+//
+// SIGINT caveat: a Ctrl+C that arrives while the prompt is blocked reading
+// stdin cancels the run context but does NOT unblock the read, so the
+// interrupt takes effect only after the user answers the prompt. This is safe -
+// a post-cancel "yes" still aborts: executeToolCall's emit of
+// ToolExecutionStartEvent returns ctx.Err() and the tool never runs. A fix that
+// unblocks the read on signal would require injecting input on SIGINT, which is
+// out of scope for this change.
+func trustBeforeToolCall(mgr *trust.Manager, cwd string, in *bufio.Reader, out io.Writer, mu *sync.Mutex) agentcore.BeforeToolCallFunc {
+	if mgr == nil {
+		return nil
+	}
+	return func(ctx context.Context, call agentcore.AgentToolCall) *agentcore.BeforeToolCallDecision {
+		if !sideEffectTools[call.Name] {
+			return nil
+		}
+		if mu != nil {
+			mu.Lock()
+			defer mu.Unlock()
+		}
+		// Check under the lock: a prior call's "always" in the same batch may
+		// have granted session trust, in which case this call skips the prompt.
+		// (Today batches with side-effect tools run serially, so this is
+		// belt-and-suspenders.)
+		if mgr.IsTrusted(cwd) {
+			return nil
+		}
+		allow, always := confirmToolCall(out, in, call)
+		if always {
+			mgr.SetSessionTrust(cwd)
+		}
+		if !allow {
+			msg := fmt.Sprintf("tool %q blocked: %s is not trusted (use /trust to trust this project)", call.Name, cwd)
+			return &agentcore.BeforeToolCallDecision{
+				Block:   true,
+				Content: &agentcore.ContentList{agentcore.NewTextContent(msg)},
+			}
+		}
+		return nil
+	}
+}
+
+// confirmToolCall asks whether a side-effect tool call may run in an untrusted
+// directory. It returns (allow, always): allow runs the call this once; always
+// runs it AND grants session trust so subsequent side-effect calls skip the
+// prompt. Denial (no/empty/EOF) returns (false, false).
+func confirmToolCall(out io.Writer, in *bufio.Reader, call agentcore.AgentToolCall) (allow bool, always bool) {
+	fmt.Fprintf(out, "\npigo wants to run %q in an untrusted directory.\n", call.Name)
+	if summary := toolCallSummary(call); summary != "" {
+		fmt.Fprintf(out, "  %s\n", summary)
+	}
+	fmt.Fprint(out, "Allow? [y]es / [n]o / [a]lways (trust for this session) [y/N/a]: ")
+	line, _ := in.ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true, false
+	case "a", "always":
+		return true, true
+	default:
+		return false, false
+	}
+}
+
+// toolCallSummary renders a one-line preview of what a side-effect tool will
+// do, so the user can make an informed allow/deny choice. It best-effort
+// extracts the bash command or the write/edit path from the arguments; if the
+// arguments do not parse it falls back to a truncated raw view.
+func toolCallSummary(call agentcore.AgentToolCall) string {
+	raw := strings.TrimSpace(string(call.Arguments))
+	if raw == "" || raw == "{}" {
+		return ""
+	}
+	var args map[string]any
+	if err := json.Unmarshal(call.Arguments, &args); err != nil {
+		return truncateForPrompt(raw)
+	}
+	switch call.Name {
+	case "bash":
+		if cmd, ok := args["command"].(string); ok && cmd != "" {
+			return "command: " + truncateForPrompt(cmd)
+		}
+	case "write", "edit":
+		if p, ok := args["path"].(string); ok && p != "" {
+			return "path: " + truncateForPrompt(p)
+		}
+	}
+	return truncateForPrompt(raw)
+}
+
+// truncateForPrompt caps a string at maxPromptPreview runes so a confirmation
+// prompt stays readable even for large write/edit payloads.
+func truncateForPrompt(s string) string {
+	const maxPromptPreview = 200
+	r := []rune(s)
+	if len(r) <= maxPromptPreview {
+		return s
+	}
+	return string(r[:maxPromptPreview]) + " …"
+}

--- a/cmd/pigo/trust_test.go
+++ b/cmd/pigo/trust_test.go
@@ -1,0 +1,280 @@
+package main
+
+// Tests for the project-trust REPL integration (US-018, #134): the first-run
+// prompt, the tool-call confirmation, the summary preview, and the
+// BeforeToolCall gating hook. The trust store itself is covered in
+// internal/trust; here we exercise the interactive glue.
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/runtime"
+	"github.com/smallnest/pigo/internal/trust"
+)
+
+// newTrustManagerAt builds a Manager backed by path.
+func newTrustManagerAt(t *testing.T, path string) *trust.Manager {
+	t.Helper()
+	m, err := trust.NewManager(path)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	return m
+}
+
+// newTrustManager builds a Manager backed by a fresh temp file and returns the
+// manager plus its path (so a test can reload to verify persistence).
+func newTrustManager(t *testing.T) (*trust.Manager, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "trust.json")
+	return newTrustManagerAt(t, path), path
+}
+
+// readerOf wraps a string in the *bufio.Reader the trust prompts expect.
+func readerOf(s string) *bufio.Reader { return bufio.NewReader(strings.NewReader(s)) }
+
+// TestEnsureTrustPromptTrustedThisDir verifies choice 1 + scope 1 (this
+// directory) persists a Trusted decision for cwd.
+func TestEnsureTrustPromptTrustedThisDir(t *testing.T) {
+	mgr, _ := newTrustManager(t)
+	cwd := t.TempDir()
+	var out bytes.Buffer
+	ensureTrustPrompt(&out, readerOf("1\n1\n"), mgr, cwd)
+
+	if got := mgr.NearestTrustDecision(cwd); !got.Found || got.Decision != trust.Trusted || got.Path != cwd {
+		t.Errorf("after prompt, NearestTrustDecision(%q) = %+v, want Trusted/@cwd", cwd, got)
+	}
+	if !strings.Contains(out.String(), "First time in this directory") {
+		t.Errorf("output missing prompt: %q", out.String())
+	}
+}
+
+// TestEnsureTrustPromptRejectParent verifies choice 3 (reject) + scope 2
+// (parent) persists an Untrusted decision for the parent directory.
+func TestEnsureTrustPromptRejectParent(t *testing.T) {
+	mgr, _ := newTrustManager(t)
+	cwd := t.TempDir()
+	parent := filepath.Dir(cwd)
+	ensureTrustPrompt(&bytes.Buffer{}, readerOf("3\n2\n"), mgr, cwd)
+
+	if got := mgr.NearestTrustDecision(cwd); !got.Found || got.Decision != trust.Untrusted || got.Path != parent {
+		t.Errorf("after reject-parent, NearestTrustDecision(%q) = %+v, want Untrusted/@parent", cwd, got)
+	}
+}
+
+// TestEnsureTrustPromptJustOnce verifies choice 2 (just once) grants session
+// trust without persisting: IsTrusted is true now but false after a reload.
+func TestEnsureTrustPromptJustOnce(t *testing.T) {
+	mgr, path := newTrustManager(t)
+	cwd := t.TempDir()
+	ensureTrustPrompt(&bytes.Buffer{}, readerOf("2\n"), mgr, cwd)
+
+	if !mgr.IsTrusted(cwd) {
+		t.Error("IsTrusted(cwd) = false after just-once, want true")
+	}
+	// Reload from the same file: session trust must not survive.
+	m2 := newTrustManagerAt(t, path)
+	if m2.IsTrusted(cwd) {
+		t.Error("reload IsTrusted(cwd) = true, want false (session trust must not persist)")
+	}
+}
+
+// TestEnsureTrustPromptSkipsWhenDecided verifies that when a decision already
+// exists, ensureTrustPrompt is a no-op: it writes nothing and reads nothing.
+func TestEnsureTrustPromptSkipsWhenDecided(t *testing.T) {
+	mgr, _ := newTrustManager(t)
+	cwd := t.TempDir()
+	if err := mgr.SetDecision(cwd, trust.Trusted); err != nil {
+		t.Fatalf("SetDecision: %v", err)
+	}
+	var out bytes.Buffer
+	// Empty reader: if the prompt tried to read it would block/EOF; it must not.
+	ensureTrustPrompt(&out, readerOf(""), mgr, cwd)
+	if out.Len() != 0 {
+		t.Errorf("ensureTrustPrompt wrote %q when a decision existed, want no output", out.String())
+	}
+}
+
+// TestConfirmToolCall verifies the y/n/a responses.
+func TestConfirmToolCall(t *testing.T) {
+	call := agentcore.AgentToolCall{Name: "bash", Arguments: []byte(`{"command":"ls"}`)}
+	cases := []struct {
+		in     string
+		allow  bool
+		always bool
+	}{
+		{"y\n", true, false},
+		{"yes\n", true, false},
+		{"a\n", true, true},
+		{"always\n", true, true},
+		{"n\n", false, false},
+		{"\n", false, false},
+		{"garbage\n", false, false},
+	}
+	for _, c := range cases {
+		var out bytes.Buffer
+		allow, always := confirmToolCall(&out, readerOf(c.in), call)
+		if allow != c.allow || always != c.always {
+			t.Errorf("confirmToolCall(%q) = (%v,%v), want (%v,%v)", c.in, allow, always, c.allow, c.always)
+		}
+	}
+}
+
+// TestToolCallSummary verifies the one-line preview for each side-effect tool.
+func TestToolCallSummary(t *testing.T) {
+	cases := []struct {
+		name string
+		args string
+		want string
+	}{
+		{"bash", `{"command":"rm -rf /tmp/x"}`, "command: rm -rf /tmp/x"},
+		{"write", `{"path":"/a/b.txt","content":"..."}`, "path: /a/b.txt"},
+		{"edit", `{"path":"/a/b.txt","old_string":"x"}`, "path: /a/b.txt"},
+		{"bash", `{}`, ""},
+		{"bash", ``, ""},
+		{"bash", `not-json`, "not-json"},
+	}
+	for _, c := range cases {
+		got := toolCallSummary(agentcore.AgentToolCall{Name: c.name, Arguments: []byte(c.args)})
+		if got != c.want {
+			t.Errorf("toolCallSummary(%s,%s) = %q, want %q", c.name, c.args, got, c.want)
+		}
+	}
+}
+
+// TestToolCallSummaryTruncates verifies a very long command is truncated.
+func TestToolCallSummaryTruncates(t *testing.T) {
+	long := strings.Repeat("x", 500)
+	got := toolCallSummary(agentcore.AgentToolCall{Name: "bash", Arguments: []byte(`{"command":"` + long + `"}`)})
+	if !strings.HasSuffix(got, " …") {
+		t.Errorf("expected truncated output ending with ' …', got %q", got)
+	}
+	if len([]rune(got)) > 250 {
+		t.Errorf("output not truncated: len=%d", len([]rune(got)))
+	}
+}
+
+// TestTrustBeforeToolCallGating verifies the hook: nil manager -> nil hook;
+// trusted dir -> allow; untrusted + deny -> block; untrusted + always -> allow
+// and grant session trust so the next call is allowed without a prompt.
+func TestTrustBeforeToolCallGating(t *testing.T) {
+	cwd := t.TempDir()
+	mu := &sync.Mutex{}
+	call := agentcore.AgentToolCall{Name: "write", Arguments: []byte(`{"path":"/tmp/x"}`)}
+
+	// nil manager -> no hook.
+	if h := trustBeforeToolCall(nil, cwd, nil, nil, mu); h != nil {
+		t.Error("nil manager should yield nil hook")
+	}
+
+	// Trusted dir: hook returns nil (allow) without prompting.
+	mgr, _ := newTrustManager(t)
+	if err := mgr.SetDecision(cwd, trust.Trusted); err != nil {
+		t.Fatalf("SetDecision: %v", err)
+	}
+	hook := trustBeforeToolCall(mgr, cwd, readerOf(""), &bytes.Buffer{}, mu)
+	if dec := hook(context.Background(), call); dec != nil {
+		t.Errorf("trusted dir: hook returned %+v, want nil", dec)
+	}
+
+	// Untrusted dir, user denies: hook blocks with an error result.
+	mgr2, _ := newTrustManager(t)
+	var out bytes.Buffer
+	hook2 := trustBeforeToolCall(mgr2, cwd, readerOf("n\n"), &out, mu)
+	dec := hook2(context.Background(), call)
+	if dec == nil || !dec.Block {
+		t.Errorf("untrusted + deny: hook returned %+v, want a Block decision", dec)
+	}
+
+	// Untrusted dir, user says "always": hook allows and grants session trust,
+	// so a second call is allowed WITHOUT reading any more input.
+	mgr3, _ := newTrustManager(t)
+	var out3 bytes.Buffer
+	// Only one line of input ("a\n"); a second prompt would block on EOF.
+	hook3 := trustBeforeToolCall(mgr3, cwd, readerOf("a\n"), &out3, mu)
+	if dec := hook3(context.Background(), call); dec != nil {
+		t.Errorf("untrusted + always: hook returned %+v, want nil (allow)", dec)
+	}
+	if !mgr3.IsTrusted(cwd) {
+		t.Error("after 'always', IsTrusted(cwd) = false, want true (session trust granted)")
+	}
+	// Second call: no input left, but session trust means no prompt.
+	if dec := hook3(context.Background(), call); dec != nil {
+		t.Errorf("second call after 'always': hook returned %+v, want nil (no re-prompt)", dec)
+	}
+}
+
+// TestTrustBeforeToolCallSkipsNonSideEffect verifies read-only tools are never
+// gated, even in an untrusted directory.
+func TestTrustBeforeToolCallSkipsNonSideEffect(t *testing.T) {
+	cwd := t.TempDir()
+	mgr, _ := newTrustManager(t)
+	mu := &sync.Mutex{}
+	hook := trustBeforeToolCall(mgr, cwd, readerOf(""), &bytes.Buffer{}, mu)
+	for _, name := range []string{"read", "grep", "find", "todo", "webfetch"} {
+		if dec := hook(context.Background(), agentcore.AgentToolCall{Name: name}); dec != nil {
+			t.Errorf("non-side-effect tool %q was gated (%+v), want nil", name, dec)
+		}
+	}
+}
+
+// TestRegisterTrustCommand exercises the /trust action closure: status on an
+// undecided dir, on (default) persists Trusted, once grants session trust, off
+// revokes session trust AND persists Untrusted (the M2 regression - without
+// ClearSessionTrust, an active "always"/once grant would keep IsTrusted true
+// until restart), and an unknown arg yields usage.
+func TestRegisterTrustCommand(t *testing.T) {
+	cwd := t.TempDir()
+	mgr, _ := newTrustManager(t)
+	reg := runtime.NewSlashRegistry()
+	registerTrustCommand(reg, mgr, cwd)
+	cmd, ok := reg.Lookup("trust")
+	if !ok {
+		t.Fatal("/trust command not registered")
+	}
+
+	if got := cmd.Action("status"); !strings.Contains(got, "undecided") {
+		t.Errorf("status on undecided dir = %q, want 'undecided'", got)
+	}
+
+	// on (default arg) persists Trusted for cwd.
+	if got := cmd.Action(""); !strings.Contains(got, "trusted") {
+		t.Errorf("on = %q, want 'trusted'", got)
+	}
+	if res := mgr.NearestTrustDecision(cwd); !res.Found || res.Decision != trust.Trusted {
+		t.Errorf("after on, nearest = %+v, want Trusted/@cwd", res)
+	}
+
+	// Fresh dir: once grants session trust (in-memory), off must revoke it and
+	// persist Untrusted so IsTrusted is false immediately.
+	cwd2 := t.TempDir()
+	mgr2, _ := newTrustManager(t)
+	reg2 := runtime.NewSlashRegistry()
+	registerTrustCommand(reg2, mgr2, cwd2)
+	cmd2, _ := reg2.Lookup("trust")
+	cmd2.Action("once")
+	if !mgr2.IsTrusted(cwd2) {
+		t.Error("after once, IsTrusted = false, want true")
+	}
+	if got := cmd2.Action("off"); !strings.Contains(got, "untrusted") {
+		t.Errorf("off = %q, want 'untrusted'", got)
+	}
+	if mgr2.IsTrusted(cwd2) {
+		t.Error("after off, IsTrusted = true, want false (session grant must be revoked)")
+	}
+	if res := mgr2.NearestTrustDecision(cwd2); !res.Found || res.Decision != trust.Untrusted {
+		t.Errorf("after off, nearest = %+v, want Untrusted/@cwd", res)
+	}
+
+	// Unknown arg yields usage text.
+	if got := cmd.Action("bogus"); !strings.Contains(got, "usage") {
+		t.Errorf("unknown arg = %q, want 'usage'", got)
+	}
+}

--- a/docs/issue#0134.html
+++ b/docs/issue#0134.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes - Issue #0134</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .item p:last-child { margin-bottom: 0; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    code { font-family: 'SF Mono', Menlo, Consolas, monospace; font-size: 0.8em; background: #F3F1ED; padding: 0.05em 0.3em; border-radius: 3px; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/134">#134</a> &mdash; 项目信任 Project Trust (US-018) &mdash; 2026-07-19</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Tri-state trust via nullable <code>*bool</code> (true / false / null)</h3>
+      <p><strong>Ambiguity:</strong> The spec said trust is stored as <code>path -&gt; bool|null</code> but did not define what <code>null</code> means versus an absent entry, nor how "just once" is represented.</p>
+      <p><strong>Choice:</strong> <code>internal/trust</code> uses a <code>Decision</code> enum (Trusted / Untrusted / Undecided) backed by <code>*bool</code>: <code>true</code>=trusted, <code>false</code>=untrusted, <code>nil</code>=undecided. "Just once" is NOT persisted &mdash; it is an in-memory session grant (<code>SetSessionTrust</code>).</p>
+      <p><strong>Rationale:</strong> A nullable boolean preserves the literal <code>bool|null</code> schema with full round-trip fidelity (tested by <code>TestNullEntryRoundTrip</code>), while a separate session map keeps "just once" genuinely per-process &mdash; persisting it would contradict "just this once". <code>NearestTrustDecision</code> returns a <code>Found</code> flag so the REPL can distinguish "no entry anywhere" (prompt) from "entry exists, even null" (don't re-prompt).</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Side-effect tool set = {bash, write, edit}; read-only tools never gated</h3>
+      <p><strong>Ambiguity:</strong> The spec said "具有副作用的工具（bash/write/edit）" but did not say how to classify the rest.</p>
+      <p><strong>Choice:</strong> Only <code>bash</code>, <code>write</code>, <code>edit</code> are gated. <code>read</code>, <code>grep</code>, <code>find</code>, <code>webfetch</code> (read-only) and <code>todo</code> (in-memory) always run.</p>
+      <p><strong>Rationale:</strong> Trust protects against unwanted filesystem/process mutation. Read-only inspection does not need a trust gate, and gating it would make the agent useless in untrusted dirs. Notably all three gated tools are <code>ToolExecutionSequential</code>, so the <code>BeforeToolCall</code> hook fires on the run-loop producer goroutine, never concurrently with itself.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Trust gating is REPL-only; headless mode unchanged</h3>
+      <p><strong>Ambiguity:</strong> AC 5 ("未信任目录下 bash/write/edit 默认需确认") did not specify whether it applies to the headless (<code>-p</code>) path.</p>
+      <p><strong>Choice:</strong> The <code>BeforeToolCall</code> hook is wired only into <code>streamRun</code> (the REPL). Headless (<code>runtime.RunHeadless</code>) keeps no hook and runs tools as before.</p>
+      <p><strong>Rationale:</strong> Headless is non-interactive (CI/scripts); it cannot prompt. AC 3 ("REPL 询问") and the confirmation flow are inherently interactive. Applying trust to headless would either block tools silently (breaking scripts) or require a non-interactive policy the spec does not define.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Confirmation prompt offers y / N / a (a = "always this session")</h3>
+      <p><strong>Ambiguity:</strong> The spec said "默认需确认" without specifying the prompt's choices.</p>
+      <p><strong>Choice:</strong> The per-tool prompt is <code>[y]es / [n]o / [a]lways (trust for this session) [y/N/a]</code>, default <code>N</code> (deny). <code>a</code> grants session trust via <code>SetSessionTrust</code> so subsequent side-effect calls skip the prompt.</p>
+      <p><strong>Rationale:</strong> Default-deny keeps the safety property; <code>a</code> avoids prompt fatigue when the user has already decided to trust for the session, without persisting a grant they did not explicitly confirm via <code>/trust</code> or the startup dialog.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> <code>/trust off</code> clears session trust before persisting Untrusted</h3>
+      <p><strong>Spec:</strong> AC 4 said "/trust 命令保存当前项目信任决策" with no mention of session trust.</p>
+      <p><strong>Implemented:</strong> <code>/trust off</code> calls <code>Manager.ClearSessionTrust(cwd)</code> before <code>SetDecision(cwd, Untrusted)</code>.</p>
+      <p><strong>Why:</strong> <code>IsTrusted</code> checks the in-memory session map before the persisted decision, so an "always" granted earlier in the session would keep the dir trusted until restart &mdash; making <code>/trust off</code> ineffective and its "side-effect tools will ask" message false. Clearing first makes <code>off</code> take effect immediately. Caught in code review (M2).</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> REPL main loop switched from <code>bufio.Scanner</code> to a shared <code>*bufio.Reader.ReadString</code></h3>
+      <p><strong>Spec:</strong> Not specified; the REPL previously used <code>bufio.Scanner</code>.</p>
+      <p><strong>Implemented:</strong> <code>runREPL</code> now reads lines via <code>deps.in.ReadString('\n')</code> on a single shared <code>*bufio.Reader</code> that both the main loop and the tool-call confirmation prompt read from.</p>
+      <p><strong>Why:</strong> A <code>Scanner</code> has its own private buffer and can read past the current line, trapping bytes the confirmation prompt would then never see (it reads from the same underlying reader). Sharing one <code>*bufio.Reader</code> guarantees typed-ahead input is never split between the loop and a confirmation. This was required for correct trust-prompt behavior.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Trust file honors <code>$PIGO_HOME</code> in addition to <code>~/.pigo</code></h3>
+      <p><strong>Spec:</strong> AC 1 said the store is at <code>~/.pigo/trust.json</code>.</p>
+      <p><strong>Implemented:</strong> <code>trust.DefaultPath()</code> returns <code>$PIGO_HOME/trust.json</code> when <code>PIGO_HOME</code> is set, else <code>~/.pigo/trust.json</code>.</p>
+      <p><strong>Why:</strong> Every other pigo home-dir path (sessions, plugins, commands) already honors <code>PIGO_HOME</code>. Matching that keeps the trust store in the same place as the rest of the user's pigo state when the override is used.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> SIGINT during a trust confirmation does not instantly interrupt</h3>
+      <p><strong>Alternatives:</strong> (a) ctx-aware prompt with a reader goroutine + <code>select</code> on <code>ctx.Done()</code>; (b) have the SIGINT handler inject a line into stdin.</p>
+      <p><strong>Pros/cons:</strong> (a) leaks a goroutine blocked on the shared reader, which would then race with the next prompt's read &mdash; unsafe. (b) is platform-specific and hacky.</p>
+      <p><strong>Chose:</strong> Document the limitation. It is safe: a post-Ctrl+C "yes" still aborts the tool because <code>executeToolCall</code>'s <code>emit(ToolExecutionStartEvent)</code> returns <code>ctx.Err()</code> and the tool never runs. The cost is purely that the user must answer the prompt before the interrupt takes effect &mdash; a UX wart in a narrow scenario, not a safety issue.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Unbounded <code>ReadString</code> replaces the old 4 MiB Scanner cap</h3>
+      <p><strong>Alternatives:</strong> Keep <code>Scanner</code> with its 4 MiB cap; or write a bounded line reader on top of <code>ReadSlice</code>.</p>
+      <p><strong>Pros/cons:</strong> <code>Scanner</code> reintroduces the buffer-trapping problem. A bounded reader adds ~15 lines of fiddly code for a pathological-paste OOM that does not occur on a terminal.</p>
+      <p><strong>Chose:</strong> <code>ReadString</code> (unbounded) for correct buffer sharing, documented as an acceptable tradeoff for a terminal REPL where OS line-buffering bounds normal input. The cap loss is acknowledged in the <code>replScanBufInit</code> comment.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Confirmation writes to stdout from the run-loop goroutine</h3>
+      <p><strong>Alternatives:</strong> Route the confirmation through a custom event that the main goroutine renders in <code>DrainStream</code>.</p>
+      <p><strong>Pros/cons:</strong> The event approach is cleaner (single writer) but a much larger change touching the event stream and <code>StreamHandler</code>.</p>
+      <p><strong>Chose:</strong> Direct write from the hook. It is safe because <code>streamRun</code> uses an unbuffered event stream (<code>EventBuffer=0</code>, the default): by the time the hook runs, the main goroutine has finished draining the assistant's streamed text and is idle in <code>DrainStream</code>. The invariant is documented in <code>trustBeforeToolCall</code>; raising <code>EventBuffer</code> would require the event-routing approach.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> <code>confirmMu</code> kept despite side-effect tools being Sequential today</h3>
+      <p><strong>Alternatives:</strong> Remove the mutex entirely, since bash/write/edit are <code>ToolExecutionSequential</code> and the hook never runs in parallel today.</p>
+      <p><strong>Chose:</strong> Keep the mutex (nil-safe) as cheap future-proofing: if a side-effect tool ever becomes <code>Parallel</code>, concurrent confirmations would interleave on the shared stdin/stdout without it. The cost is one lock per gated call; the benefit is correctness under a plausible future change.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should <code>/trust forget</code> be exposed?</h3>
+      <p><strong>Assumption:</strong> <code>Manager.Forget</code> exists and is tested, but the <code>/trust</code> command does not surface it. Once a decision is saved, the only way to clear it is editing <code>~/.pigo/trust.json</code>.</p>
+      <p><strong>Verify/Follow-up:</strong> Is a <code>/trust forget</code> (or <code>/trust reset</code>) wanted? It was left out as out-of-scope for #134's acceptance criteria, but it is a natural companion to <code>/trust status</code>.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Is "just once" the right default for empty/EOF input at the startup prompt?</h3>
+      <p><strong>Assumption:</strong> <code>readMenuChoice</code> defaults to option 2 ("just once" = session trust) on an empty line or EOF, so the dialog never deadlocks and the REPL stays usable.</p>
+      <p><strong>Verify:</strong> Does the user prefer defaulting to "Reject" (safer: every tool prompts) instead of "just once" (permissive for the session) when input is empty? This is a UX policy call.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Pre-existing environment-fragile test (unrelated to this change)</h3>
+      <p><strong>Observation:</strong> <code>internal/provider.TestCredentialStoreOAuthRefreshFallback</code> fails locally because the user's environment has <code>ANTHROPIC_API_KEY</code> set, and <code>GetAPIKey</code> reads env before the config fallback. It passes in a clean env (CI). It is NOT in this diff.</p>
+      <p><strong>Follow-up:</strong> Consider isolating it with <code>t.Setenv("ANTHROPIC_API_KEY", "")</code> in a separate change so local dev <code>go test ./...</code> is green regardless of the shell environment.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should trust gating extend to headless mode?</h3>
+      <p><strong>Assumption:</strong> Trust is REPL-only; headless (<code>pigo -p</code>) runs side-effect tools without any trust check.</p>
+      <p><strong>Verify:</strong> Is that intended, or should headless block side-effect tools in untrusted dirs (without prompting) as a defense-in-depth measure for CI? The current behavior keeps headless permissive per the interactive-only reading of the AC.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Is the persisted <code>null</code> ("deferred") state actually useful?</h3>
+      <p><strong>Assumption:</strong> The store supports <code>SetDecision(dir, Undecided)</code> writing an explicit JSON <code>null</code> for schema completeness, but the REPL never writes it.</p>
+      <p><strong>Verify:</strong> If there is no use case for an explicitly-recorded undecided entry, the <code>null</code> write path could be removed to simplify the model &mdash; or kept if a future "ask once, remember not to re-ask" flow is wanted.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/trust/manager.go
+++ b/internal/trust/manager.go
@@ -1,0 +1,303 @@
+// Package trust persists per-directory trust decisions so pigo can avoid running
+// side-effect tools (bash/write/edit) in directories the user has not trusted
+// (US-018, #134). Decisions are stored as a JSON map of directory path to a
+// nullable boolean: true = trusted, false = untrusted, null/absent = undecided.
+//
+// The package is intentionally free of any REPL or tool-execution concerns: it
+// only loads, queries, and persists decisions. The interactive prompt and the
+// permission-hook integration live in cmd/pigo.
+package trust
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Decision is the tri-state trust value for a directory.
+type Decision int
+
+const (
+	// Undecided means no decision is saved for the directory (or an explicit
+	// null entry). The caller should prompt the user and treat side-effect
+	// tools as requiring confirmation.
+	Undecided Decision = iota
+	// Trusted means side-effect tools may run without confirmation.
+	Trusted
+	// Untrusted means side-effect tools require confirmation.
+	Untrusted
+)
+
+// String returns a human-readable label for the decision.
+func (d Decision) String() string {
+	switch d {
+	case Trusted:
+		return "trusted"
+	case Untrusted:
+		return "untrusted"
+	default:
+		return "undecided"
+	}
+}
+
+// decisionFromBool maps a saved nullable boolean to a Decision. A nil pointer
+// (JSON null, or an absent entry) is Undecided.
+func decisionFromBool(b *bool) Decision {
+	if b == nil {
+		return Undecided
+	}
+	if *b {
+		return Trusted
+	}
+	return Untrusted
+}
+
+// boolFromDecision maps a Decision to the nullable boolean persisted to disk.
+// Undecided maps to nil so the JSON value is null, preserving the
+// "path -> bool|null" schema even for an explicitly-recorded undecided entry.
+func boolFromDecision(d Decision) *bool {
+	switch d {
+	case Trusted:
+		v := true
+		return &v
+	case Untrusted:
+		v := false
+		return &v
+	default:
+		return nil
+	}
+}
+
+// Result is the outcome of a nearest-decision lookup.
+type Result struct {
+	// Decision is the nearest saved decision, or Undecided when none is found.
+	Decision Decision
+	// Path is the directory whose saved decision applies (the nearest ancestor
+	// of cwd with an entry, inclusive of cwd itself). Empty when no entry was
+	// found anywhere up the tree.
+	Path string
+	// Found reports whether any entry (true/false/null) existed for cwd or an
+	// ancestor. When false, Decision is Undecided and the caller should prompt
+	// the user for a fresh decision.
+	Found bool
+}
+
+// Manager loads and persists trust decisions to a JSON file (path -> *bool).
+// The zero value is not usable; construct with NewManager. It is safe for
+// concurrent use: every method takes the manager mutex.
+type Manager struct {
+	path string
+	mu   sync.Mutex
+	data map[string]*bool
+	// session marks directories trusted for the current process only ("just
+	// once"). It is never persisted and is consulted by IsTrusted before the
+	// on-disk data, so a one-shot grant takes effect immediately.
+	session map[string]bool
+}
+
+// DefaultPath returns the trust file location: $PIGO_HOME/trust.json, or
+// ~/.pigo/trust.json when PIGO_HOME is unset. It returns "" when the home
+// directory cannot be resolved and no override is set, so a caller can treat
+// trust as disabled rather than guessing a path.
+func DefaultPath() string {
+	if dir := os.Getenv("PIGO_HOME"); dir != "" {
+		return filepath.Join(dir, "trust.json")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".pigo", "trust.json")
+}
+
+// NewManager loads the trust file at path. A missing file is not an error: the
+// manager starts empty and the file is created lazily on the first SetDecision
+// / Forget. A present-but-malformed file is a hard error so a corrupted trust
+// store is surfaced rather than silently overwritten.
+func NewManager(path string) (*Manager, error) {
+	m := &Manager{
+		path:    path,
+		data:    make(map[string]*bool),
+		session: make(map[string]bool),
+	}
+	if path == "" {
+		return m, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return m, nil
+		}
+		return nil, fmt.Errorf("trust: read %s: %w", path, err)
+	}
+	if len(data) == 0 {
+		return m, nil
+	}
+	if err := json.Unmarshal(data, &m.data); err != nil {
+		return nil, fmt.Errorf("trust: parse %s: %w", path, err)
+	}
+	if m.data == nil {
+		m.data = make(map[string]*bool)
+	}
+	return m, nil
+}
+
+// walkUp returns the directory chain from cwd (inclusive) up to the filesystem
+// root, in nearest-first order. Paths are cleaned. An empty cwd yields no
+// entries.
+func walkUp(cwd string) []string {
+	cwd = filepath.Clean(cwd)
+	if cwd == "" || cwd == "." {
+		return nil
+	}
+	var dirs []string
+	cur := cwd
+	for {
+		dirs = append(dirs, cur)
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			break
+		}
+		cur = parent
+	}
+	return dirs
+}
+
+// nearestLocked computes the nearest saved decision for cwd without taking the
+// mutex, so it can be reused inside already-locked methods.
+func (m *Manager) nearestLocked(cwd string) Result {
+	for _, dir := range walkUp(cwd) {
+		if v, ok := m.data[dir]; ok {
+			return Result{Decision: decisionFromBool(v), Path: dir, Found: true}
+		}
+	}
+	return Result{Decision: Undecided, Found: false}
+}
+
+// NearestTrustDecision walks up from cwd (inclusive) to the filesystem root and
+// returns the nearest saved decision. When no entry is found anywhere up the
+// tree it returns {Decision: Undecided, Found: false} so the caller knows to
+// prompt the user.
+func (m *Manager) NearestTrustDecision(cwd string) Result {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.nearestLocked(cwd)
+}
+
+// IsTrusted reports whether cwd is trusted for side-effect execution. It
+// returns true when the nearest persisted decision is Trusted, or when cwd (or
+// an ancestor) was granted session trust via SetSessionTrust. Everything else
+// (Untrusted, Undecided, or no entry) returns false, meaning side-effect tools
+// require confirmation.
+func (m *Manager) IsTrusted(cwd string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, dir := range walkUp(cwd) {
+		if m.session[dir] {
+			return true
+		}
+	}
+	return m.nearestLocked(cwd).Decision == Trusted
+}
+
+// SetDecision persists a decision for dir. Trusted and Untrusted write true and
+// false respectively; Undecided writes an explicit null entry (recorded but
+// undecided, distinct from a forgotten/absent entry). The directory is created
+// lazily when the trust file is first written.
+func (m *Manager) SetDecision(dir string, dec Decision) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	dir = filepath.Clean(dir)
+	m.data[dir] = boolFromDecision(dec)
+	return m.saveLocked()
+}
+
+// SetSessionTrust grants trust for dir for the current process only. It is not
+// persisted: a future pigo launch re-prompts. Used by the "just once" REPL
+// choice and by the confirmation prompt's "always" response.
+func (m *Manager) SetSessionTrust(dir string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.session[filepath.Clean(dir)] = true
+}
+
+// ClearSessionTrust revokes any session trust granted for dir or an ancestor,
+// so a subsequent IsTrusted reflects only the persisted decision. It does not
+// touch the on-disk store. Used by "/trust off" so an active session grant
+// (from a prior "always") does not override a freshly-persisted Untrusted
+// entry - IsTrusted checks session before persisted, so without this clear the
+// "off" command would be ineffective until restart.
+func (m *Manager) ClearSessionTrust(dir string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, d := range walkUp(dir) {
+		delete(m.session, d)
+	}
+}
+
+// Forget removes any saved decision for dir (both true/false and an explicit
+// null entry), so the directory is treated as undecided on the next lookup.
+func (m *Manager) Forget(dir string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	dir = filepath.Clean(dir)
+	delete(m.data, dir)
+	return m.saveLocked()
+}
+
+// DecisionFor returns the raw saved value for a single path (nil when absent or
+// null). It is the exact-path lookup (no walk), used by /trust status to show
+// what is stored for the current directory itself.
+func (m *Manager) DecisionFor(dir string) (Decision, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.data[filepath.Clean(dir)]
+	if !ok {
+		return Undecided, false
+	}
+	return decisionFromBool(v), true
+}
+
+// saveLocked writes the trust map to disk atomically so a crash mid-write
+// cannot leave a truncated store. json.Marshal sorts map keys, so the output is
+// stable and diff-friendly; a nil *bool marshals as JSON null, preserving the
+// "path -> bool|null" schema. The temp file is created with os.CreateTemp
+// (mode 0o600, process-unique name) so two concurrent pigo processes writing
+// the shared store cannot clobber each other's temp file before the rename.
+// The caller must hold m.mu.
+func (m *Manager) saveLocked() error {
+	if m.path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(m.path), 0o700); err != nil {
+		return fmt.Errorf("trust: create dir: %w", err)
+	}
+	b, err := json.Marshal(m.data)
+	if err != nil {
+		return fmt.Errorf("trust: marshal: %w", err)
+	}
+	b = append(b, '\n')
+	dir := filepath.Dir(m.path)
+	f, err := os.CreateTemp(dir, filepath.Base(m.path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("trust: create temp file: %w", err)
+	}
+	tmpPath := f.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if _, err := f.Write(b); err != nil {
+		f.Close()
+		cleanup()
+		return fmt.Errorf("trust: write %s: %w", tmpPath, err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("trust: close %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, m.path); err != nil {
+		cleanup()
+		return fmt.Errorf("trust: rename %s: %w", m.path, err)
+	}
+	return nil
+}

--- a/internal/trust/manager_test.go
+++ b/internal/trust/manager_test.go
@@ -1,0 +1,338 @@
+package trust
+
+// Tests for the trust store (US-018, #134). The store is a JSON map of
+// directory path to a nullable boolean (true/false/null); these tests pin the
+// tri-state semantics, the nearest-ancestor walk, session-vs-persisted trust,
+// and the on-disk round-trip including the null value.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// newTestManager builds a Manager backed by a temp file, failing the test if
+// construction fails. Every test starts from an empty store.
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	m, err := NewManager(filepath.Join(t.TempDir(), "trust.json"))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	return m
+}
+
+// reload reopens the manager at the same path, asserting no error, so a test
+// can verify a decision survived a write.
+func reload(t *testing.T, m *Manager) *Manager {
+	t.Helper()
+	m2, err := NewManager(m.path)
+	if err != nil {
+		t.Fatalf("reload NewManager: %v", err)
+	}
+	return m2
+}
+
+// TestNewManagerMissingFile verifies a missing trust file is not an error: the
+// manager starts empty and the nearest lookup reports nothing found.
+func TestNewManagerMissingFile(t *testing.T) {
+	m := newTestManager(t)
+	if res := m.NearestTrustDecision("/some/dir"); res.Found {
+		t.Errorf("NearestTrustDecision on empty store: Found=true, want false")
+	}
+}
+
+// TestNewManagerEmptyPath verifies an empty path disables persistence: Set and
+// Forget are no-ops on disk and never error, and lookups still work in-memory.
+func TestNewManagerEmptyPath(t *testing.T) {
+	m, err := NewManager("")
+	if err != nil {
+		t.Fatalf("NewManager(\"\"): %v", err)
+	}
+	if err := m.SetDecision("/a", Trusted); err != nil {
+		t.Fatalf("SetDecision on empty-path manager: %v", err)
+	}
+	if !m.IsTrusted("/a") {
+		t.Error("IsTrusted(/a) = false after in-memory SetDecision, want true")
+	}
+}
+
+// TestSetDecisionPersists verifies Trusted/Untrusted round-trip through disk:
+// after SetDecision + reload, the nearest decision matches what was written.
+func TestSetDecisionPersists(t *testing.T) {
+	m := newTestManager(t)
+	if err := m.SetDecision("/a", Trusted); err != nil {
+		t.Fatalf("SetDecision Trusted: %v", err)
+	}
+	if err := m.SetDecision("/b", Untrusted); err != nil {
+		t.Fatalf("SetDecision Untrusted: %v", err)
+	}
+	m2 := reload(t, m)
+	if got := m2.NearestTrustDecision("/a"); !got.Found || got.Decision != Trusted || got.Path != "/a" {
+		t.Errorf("reload NearestTrustDecision(/a) = %+v, want Found/Trusted//a", got)
+	}
+	if got := m2.NearestTrustDecision("/b"); !got.Found || got.Decision != Untrusted || got.Path != "/b" {
+		t.Errorf("reload NearestTrustDecision(/b) = %+v, want Found/Untrusted//b", got)
+	}
+}
+
+// TestNearestAncestorWalk verifies the lookup walks up from cwd to root and
+// returns the nearest ancestor (inclusive) with an entry: a decision saved for
+// /a applies to /a/b/c, and the returned Path is the directory it was saved
+// for, not the query directory.
+func TestNearestAncestorWalk(t *testing.T) {
+	m := newTestManager(t)
+	if err := m.SetDecision("/a", Trusted); err != nil {
+		t.Fatalf("SetDecision: %v", err)
+	}
+	got := m.NearestTrustDecision("/a/b/c")
+	if !got.Found || got.Decision != Trusted || got.Path != "/a" {
+		t.Errorf("NearestTrustDecision(/a/b/c) = %+v, want Found/Trusted/Path=/a", got)
+	}
+	// A more specific entry shadows a broader one: /a/b/untrusted wins over
+	// /a/trusted for anything under /a/b.
+	if err := m.SetDecision("/a/b", Untrusted); err != nil {
+		t.Fatalf("SetDecision /a/b: %v", err)
+	}
+	got = m.NearestTrustDecision("/a/b/c")
+	if !got.Found || got.Decision != Untrusted || got.Path != "/a/b" {
+		t.Errorf("NearestTrustDecision(/a/b/c) after shadow = %+v, want Found/Untrusted/Path=/a/b", got)
+	}
+	// /a/d is under /a but not /a/b, so it still sees /a/trusted.
+	got = m.NearestTrustDecision("/a/d")
+	if !got.Found || got.Decision != Trusted || got.Path != "/a" {
+		t.Errorf("NearestTrustDecision(/a/d) = %+v, want Found/Trusted/Path=/a", got)
+	}
+}
+
+// TestNearestNotFound verifies a query with no entry on the path returns
+// Found=false and Undecided.
+func TestNearestNotFound(t *testing.T) {
+	m := newTestManager(t)
+	if err := m.SetDecision("/a", Trusted); err != nil {
+		t.Fatalf("SetDecision: %v", err)
+	}
+	if got := m.NearestTrustDecision("/completely/unrelated"); got.Found {
+		t.Errorf("NearestTrustDecision(unrelated) = %+v, want Found=false", got)
+	}
+}
+
+// TestNullEntryRoundTrip verifies the "null" half of the "path -> bool|null"
+// schema: SetDecision(Undecided) writes an explicit JSON null, which reloads as
+// Found=true with Decision Undecided (recorded but not trusted).
+func TestNullEntryRoundTrip(t *testing.T) {
+	m := newTestManager(t)
+	if err := m.SetDecision("/a", Undecided); err != nil {
+		t.Fatalf("SetDecision Undecided: %v", err)
+	}
+	// The on-disk value really is null, not omitted.
+	raw, err := os.ReadFile(m.path)
+	if err != nil {
+		t.Fatalf("read trust file: %v", err)
+	}
+	var got map[string]*bool
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("parse trust file: %v", err)
+	}
+	v, ok := got["/a"]
+	if !ok {
+		t.Fatal("entry /a missing from trust file")
+	}
+	if v != nil {
+		t.Errorf("stored value = %v, want nil (JSON null)", *v)
+	}
+	// Reload: Found=true (an entry exists), Decision=Undecided (it is null).
+	m2 := reload(t, m)
+	res := m2.NearestTrustDecision("/a")
+	if !res.Found || res.Decision != Undecided {
+		t.Errorf("reload NearestTrustDecision(/a) = %+v, want Found=true/Undecided", res)
+	}
+}
+
+// TestIsTrusted verifies the gating predicate: true only for Trusted (persisted
+// or session), false for Untrusted/Undecided/absent, and that an ancestor
+// Trusted decision covers a descendant.
+func TestIsTrusted(t *testing.T) {
+	m := newTestManager(t)
+	if err := m.SetDecision("/trusted", Trusted); err != nil {
+		t.Fatalf("SetDecision Trusted: %v", err)
+	}
+	if err := m.SetDecision("/untrusted", Untrusted); err != nil {
+		t.Fatalf("SetDecision Untrusted: %v", err)
+	}
+	cases := []struct {
+		cwd  string
+		want bool
+	}{
+		{"/trusted", true},          // exact trusted
+		{"/trusted/sub/deep", true}, // ancestor trusted
+		{"/untrusted", false},       // exact untrusted
+		{"/untrusted/sub", false},   // ancestor untrusted
+		{"/undecided", false},       // no entry
+		{"/", false},                // root, no entry
+	}
+	for _, c := range cases {
+		if got := m.IsTrusted(c.cwd); got != c.want {
+			t.Errorf("IsTrusted(%q) = %v, want %v", c.cwd, got, c.want)
+		}
+	}
+}
+
+// TestSessionTrustNotPersisted verifies SetSessionTrust grants trust for the
+// current process but does not survive a reload (matching the "just once" REPL
+// choice): a fresh manager over the same file does not see the grant.
+func TestSessionTrustNotPersisted(t *testing.T) {
+	m := newTestManager(t)
+	m.SetSessionTrust("/proj")
+	if !m.IsTrusted("/proj") {
+		t.Error("IsTrusted(/proj) = false after SetSessionTrust, want true")
+	}
+	if !m.IsTrusted("/proj/sub") {
+		t.Error("IsTrusted(/proj/sub) = false, want true (session trust covers descendants)")
+	}
+	m2 := reload(t, m)
+	if m2.IsTrusted("/proj") {
+		t.Error("reload IsTrusted(/proj) = true, want false (session trust must not persist)")
+	}
+}
+
+// TestClearSessionTrust verifies ClearSessionTrust revokes a session grant so
+// IsTrusted reflects only the persisted decision, including grants on an
+// ancestor (walkUp). This is the contract "/trust off" relies on to take effect
+// immediately rather than only after a restart.
+func TestClearSessionTrust(t *testing.T) {
+	m := newTestManager(t)
+	m.SetSessionTrust("/proj")
+	if !m.IsTrusted("/proj") {
+		t.Fatal("IsTrusted = false after SetSessionTrust, want true")
+	}
+	m.ClearSessionTrust("/proj")
+	if m.IsTrusted("/proj") {
+		t.Error("IsTrusted = true after ClearSessionTrust, want false")
+	}
+	// Clearing a descendant also revokes an ancestor's session grant, since
+	// ClearSessionTrust walks up (matching IsTrusted's walkUp check).
+	m.SetSessionTrust("/a")
+	m.ClearSessionTrust("/a/b")
+	if m.IsTrusted("/a/b") {
+		t.Error("IsTrusted(/a/b) = true after ClearSessionTrust(/a/b), want false (ancestor /a grant revoked)")
+	}
+}
+
+// TestForget verifies Forget removes an entry so the directory becomes
+// undecided again, both in-memory and after reload.
+func TestForget(t *testing.T) {
+	m := newTestManager(t)
+	if err := m.SetDecision("/a", Trusted); err != nil {
+		t.Fatalf("SetDecision: %v", err)
+	}
+	if err := m.Forget("/a"); err != nil {
+		t.Fatalf("Forget: %v", err)
+	}
+	if got := m.NearestTrustDecision("/a"); got.Found {
+		t.Errorf("NearestTrustDecision after Forget = %+v, want Found=false", got)
+	}
+	// Forget is idempotent: forgetting a path with no entry is not an error.
+	if err := m.Forget("/a"); err != nil {
+		t.Errorf("Forget missing entry: %v", err)
+	}
+}
+
+// TestDecisionForExactPath verifies the exact-path lookup (no walk) returns the
+// stored decision and a Found flag, distinct from the walk-based nearest.
+func TestDecisionForExactPath(t *testing.T) {
+	m := newTestManager(t)
+	if err := m.SetDecision("/a", Trusted); err != nil {
+		t.Fatalf("SetDecision: %v", err)
+	}
+	if dec, found := m.DecisionFor("/a"); !found || dec != Trusted {
+		t.Errorf("DecisionFor(/a) = %v,%v, want Trusted,true", dec, found)
+	}
+	if dec, found := m.DecisionFor("/a/b"); found {
+		t.Errorf("DecisionFor(/a/b) = %v,%v, want _,false (no exact entry)", dec, found)
+	}
+}
+
+// TestDefaultPath verifies DefaultPath honors PIGO_HOME and falls back to
+// ~/.pigo/trust.json.
+func TestDefaultPath(t *testing.T) {
+	t.Setenv("PIGO_HOME", "/custom/pigo")
+	if got := DefaultPath(); got != "/custom/pigo/trust.json" {
+		t.Errorf("DefaultPath with PIGO_HOME = %q, want /custom/pigo/trust.json", got)
+	}
+	t.Setenv("PIGO_HOME", "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("home dir unavailable")
+	}
+	want := filepath.Join(home, ".pigo", "trust.json")
+	if got := DefaultPath(); got != want {
+		t.Errorf("DefaultPath default = %q, want %q", got, want)
+	}
+}
+
+// TestSaveIsSorted verifies the written file has sorted keys (stable, diffable
+// output) and is a valid JSON object.
+func TestSaveIsSorted(t *testing.T) {
+	m := newTestManager(t)
+	for _, p := range []string{"/zeta", "/alpha", "/mid"} {
+		if err := m.SetDecision(p, Trusted); err != nil {
+			t.Fatalf("SetDecision %s: %v", p, err)
+		}
+	}
+	raw, err := os.ReadFile(m.path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	s := string(raw)
+	i := strings.Index(s, "/alpha")
+	j := strings.Index(s, "/mid")
+	k := strings.Index(s, "/zeta")
+	if i < 0 || j < 0 || k < 0 {
+		t.Fatalf("expected /alpha, /mid, /zeta in output; got indices %d/%d/%d", i, j, k)
+	}
+	if !(i < j && j < k) {
+		t.Errorf("keys not sorted in output: alpha@%d mid@%d zeta@%d", i, j, k)
+	}
+	var got map[string]*bool
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Errorf("output is not valid JSON: %v", err)
+	}
+}
+
+// TestMalformedFileIsError verifies a corrupted trust file is a hard error
+// rather than being silently overwritten, so the user's data is surfaced.
+func TestMalformedFileIsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trust.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write malformed file: %v", err)
+	}
+	if _, err := NewManager(path); err == nil {
+		t.Error("NewManager on malformed file returned nil error, want a parse error")
+	}
+}
+
+// TestConcurrentAccess exercises the mutex under -race: many goroutines reading
+// and writing concurrently must not trip the race detector.
+func TestConcurrentAccess(t *testing.T) {
+	m := newTestManager(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			dir := filepath.Join("/p", "d"+strconv.Itoa(i))
+			_ = m.SetDecision(dir, Trusted)
+			_ = m.IsTrusted(dir)
+			_ = m.NearestTrustDecision(dir)
+			m.SetSessionTrust(dir)
+			_, _ = m.DecisionFor(dir)
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- New `internal/trust` package: per-directory trust store persisted as `path -> *bool` (true/false/null) JSON at `~/.pigo/trust.json` (or `$PIGO_HOME`), with `NearestTrustDecision(cwd)` walk-up and `IsTrusted` (session grant + persisted decision).
- REPL first-run dialog (trust / just-once / reject, with save-to-this-dir-or-parent scope) when the cwd has no saved decision; `/trust` command (`on|off|once|status`).
- `BeforeToolCall` hook gates the side-effect tools `bash`/`write`/`edit` on the cwd's trust decision; untrusted dirs prompt `y/N/a` before each call (`a` grants session trust). Read-only tools and headless mode are unaffected.
- REPL read loop switches from `bufio.Scanner` to a shared `*bufio.Reader` so the main loop and the confirmation prompt share one input buffer.
- Implementation notes: `docs/issue#0134.html`.

Closes #134

## Test plan
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] `go test -race ./internal/trust/ ./cmd/pigo/` passes
- [x] `internal/trust` unit tests cover tri-state, nearest-ancestor walk, session-vs-persisted, null round-trip, concurrency, `ClearSessionTrust`
- [x] `cmd/pigo` tests cover `/trust` action, the gating hook (trusted/untrusted/deny/always), the first-run dialog, and the no-trailing-newline read path