### PR TITLE
子 agent process 隔离模式 (US-019, #135)

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -35,6 +35,7 @@ func main() {
 	flag.BoolVarP(&opts.listSessions, "list-sessions", "l", false, "list stored interactive sessions and exit")
 	flag.StringVarP(&opts.resumeID, "resume", "r", "", "resume the interactive session with this id")
 	flag.BoolVarP(&opts.continueLast, "continue", "c", false, "resume the most recent interactive session")
+	flag.BoolVar(&opts.subagentRPC, "subagent-rpc", false, "internal: run as a process-isolated sub-agent JSON-RPC server over stdio (US-019)")
 	flag.Parse()
 
 	// A prompt may also be supplied as positional args.

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -121,13 +121,24 @@ type cliOptions struct {
 	listSessions bool
 	resumeID     string
 	continueLast bool
+	// subagentRPC selects the process-isolated sub-agent server mode (US-019,
+	// #135): pigo reads JSON-RPC sub-agent run requests from stdin and writes
+	// results to stdout. Internal, used by SubAgentTool's process mode.
+	subagentRPC bool
 }
 
 // dispatch runs the resolved command and returns a process exit code, writing
 // diagnostics to errOut. It is the run-assembly seam: every path (list, REPL,
-// headless) is reached from here, so the CLI's behavior can be exercised without
-// re-parsing flags. A returned code of 0 is success.
+// headless, subagent-rpc) is reached from here, so the CLI's behavior can be
+// exercised without re-parsing flags. A returned code of 0 is success.
 func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
+	// --subagent-rpc is a fully separate mode: speak the sub-agent JSON-RPC
+	// protocol over stdio and exit. It is the subprocess end of process-isolated
+	// sub-agents and shares nothing with the interactive/headless paths.
+	if opts.subagentRPC {
+		return runSubAgentRPC(ctx, os.Stdin, out, errOut)
+	}
+
 	// --list-sessions is a standalone action: print and exit.
 	if opts.listSessions {
 		if err := printSessions(out); err != nil {

--- a/cmd/pigo/subagent_rpc.go
+++ b/cmd/pigo/subagent_rpc.go
@@ -1,0 +1,150 @@
+// This file implements the subprocess side of process-isolated sub-agents
+// (US-019, #135). Invoked as `pigo --subagent-rpc`, pigo speaks JSON-RPC 2.0
+// over stdio: for each "subagent/run" request on stdin it runs a child agent
+// loop and writes the result (or an error) to stdout, exiting when stdin
+// closes. The parent (SubAgentTool in process mode, internal/runtime) drives it
+// via internal/jsonrpc.
+//
+// It reuses internal/jsonrpc's message types (Request/Response/ID/Version) for
+// (de)serialization so the wire format matches the client exactly; the agent
+// execution itself is runtime.RunSubAgentOnce.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/jsonrpc"
+	"github.com/smallnest/pigo/internal/provider"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// runSubAgentRPC is the `pigo --subagent-rpc` entry point. It reads
+// newline-delimited JSON-RPC requests from in, runs each sub-agent request, and
+// writes one response per request to out. It returns 0 (success) when stdin
+// closes; a per-request failure is an RPC error response, not a non-zero exit,
+// so the parent can distinguish "the child answered with an error" from "the
+// child crashed" (the latter is detected by the parent's transport when stdout
+// closes without a response).
+func runSubAgentRPC(ctx context.Context, in io.Reader, out, errOut io.Writer) int {
+	scanner := bufio.NewScanner(in)
+	// A sub-agent prompt can be large; match the jsonrpc client's line cap.
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	enc := json.NewEncoder(out)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var req jsonrpc.Request
+		if err := json.Unmarshal(line, &req); err != nil {
+			// A parse error carries no id, so the response id is null. The
+			// jsonrpc client drops responses with a null id (it cannot correlate
+			// them), so this is only observable on the child's stderr; in
+			// practice the parent always sends well-formed requests.
+			writeSubAgentError(enc, nil, -32700, "parse error: "+err.Error())
+			continue
+		}
+		handleSubAgentRequest(ctx, enc, &req)
+	}
+	// A scanner error (e.g. a request line exceeding the 16 MiB cap) ends the
+	// stream abnormally: surface it on stderr and exit non-zero so the parent's
+	// transport sees a diagnostic rather than a silent clean exit.
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(errOut, "pigo: subagent-rpc stdin: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// handleSubAgentRequest dispatches one JSON-RPC request to the sub-agent runner
+// and writes the response. Unknown methods, bad params, provider-resolution
+// failures, and failed child runs are all RPC errors so the parent surfaces them
+// as tool errors; only a successful run yields a result with the child's text.
+func handleSubAgentRequest(ctx context.Context, enc *json.Encoder, req *jsonrpc.Request) {
+	if req.Method != runtime.SubAgentRPCMethod {
+		writeSubAgentError(enc, req.ID, -32601, "method not found: "+req.Method)
+		return
+	}
+	var params runtime.SubAgentRunParams
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			writeSubAgentError(enc, req.ID, -32602, "invalid params: "+err.Error())
+			return
+		}
+	}
+	if params.Prompt == "" || params.Model == "" {
+		writeSubAgentError(enc, req.ID, -32602, "invalid params: prompt and model are required")
+		return
+	}
+	// Resolve the provider the same way the CLI does, so the subprocess targets
+	// the same gateway the parent's NewRunConfig encoded. Credentials come from
+	// the inherited environment (the parent's env vars).
+	prov, providerName, err := resolveProvider(params.Model, params.BaseURL, params.Protocol)
+	if err != nil {
+		writeSubAgentError(enc, req.ID, -32603, "resolve provider: "+err.Error())
+		return
+	}
+	cwd, _ := os.Getwd()
+	tools := filterBuiltinTools(builtinTools(cwd, false), params.Tools)
+	reg := toolRegistry(tools)
+	creds := provider.NewCredentialStore(nil) // env-resolved
+	runCfg := runtime.RunConfig{
+		LoopConfig: runtime.LoopConfig{
+			Model:     params.Model,
+			Provider:  providerName,
+			Stream:    provider.StreamFnFromProvider(prov),
+			GetAPIKey: creds.GetAPIKey,
+		},
+		Batch: agenttool.BatchConfig{ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: reg}},
+	}
+	text, err := runtime.RunSubAgentOnce(ctx, params.SystemPrompt, params.Prompt, tools, runCfg)
+	if err != nil {
+		// A failed child run is an RPC error so the parent's defaultProcessCall
+		// returns a Go error and executeProcess marks the tool result IsError,
+		// matching goroutine mode's "failed run -> tool error" behavior.
+		writeSubAgentError(enc, req.ID, -32000, err.Error())
+		return
+	}
+	result, _ := json.Marshal(runtime.SubAgentRunResult{Text: text})
+	_ = enc.Encode(jsonrpc.Response{JSONRPC: jsonrpc.Version, ID: req.ID, Result: result})
+}
+
+// writeSubAgentError writes a JSON-RPC error response with the given id (which
+// may be nil for a parse error on an unidentifiable request) and code/message.
+func writeSubAgentError(enc *json.Encoder, id *jsonrpc.ID, code int, msg string) {
+	_ = enc.Encode(jsonrpc.Response{
+		JSONRPC: jsonrpc.Version,
+		ID:      id,
+		Error:   &jsonrpc.Error{Code: code, Message: msg},
+	})
+}
+
+// filterBuiltinTools returns the subset of tools whose Name is in names. An
+// empty names list keeps all tools. It lets a process-isolated sub-agent
+// restrict the child to a subset (e.g. a read-only researcher), matching
+// goroutine mode's Tools filtering, without serializing in-process tool objects
+// across the process boundary.
+func filterBuiltinTools(tools []agentcore.AgentTool, names []string) []agentcore.AgentTool {
+	if len(names) == 0 {
+		return tools
+	}
+	want := make(map[string]bool, len(names))
+	for _, n := range names {
+		want[n] = true
+	}
+	var out []agentcore.AgentTool
+	for _, t := range tools {
+		if want[t.Name()] {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/cmd/pigo/subagent_rpc_test.go
+++ b/cmd/pigo/subagent_rpc_test.go
@@ -1,0 +1,119 @@
+package main
+
+// Tests for the sub-agent RPC subprocess mode (US-019, #135): the pure
+// filterBuiltinTools helper and the runSubAgentRPC validation branches
+// (method-not-found, invalid params, parse error) that return RPC errors before
+// any provider is resolved. The happy-path transport is covered in
+// internal/runtime via a compiled helper binary; RunSubAgentOnce (the agent
+// core) is covered there with a faux provider.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/jsonrpc"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// TestFilterBuiltinTools verifies the subprocess tool filter: an empty name
+// list keeps all builtins, a subset keeps only the named tools, and unknown
+// names are silently ignored.
+func TestFilterBuiltinTools(t *testing.T) {
+	all := builtinTools(t.TempDir(), false)
+	if len(all) == 0 {
+		t.Fatal("builtinTools returned no tools")
+	}
+	namesOf := func(ts []agentcore.AgentTool) []string {
+		out := make([]string, len(ts))
+		for i, tl := range ts {
+			out[i] = tl.Name()
+		}
+		return out
+	}
+
+	if got := filterBuiltinTools(all, nil); len(got) != len(all) {
+		t.Errorf("nil names kept %d, want all %d", len(got), len(all))
+	}
+	if got := filterBuiltinTools(all, []string{}); len(got) != len(all) {
+		t.Errorf("empty names kept %d, want all %d", len(got), len(all))
+	}
+
+	got := filterBuiltinTools(all, []string{"read", "grep"})
+	if len(got) != 2 {
+		t.Fatalf("subset kept %d, want 2: %v", len(got), namesOf(got))
+	}
+	gotNames := namesOf(got)
+	if gotNames[0] != "read" || gotNames[1] != "grep" {
+		t.Errorf("subset names = %v, want [read grep]", gotNames)
+	}
+
+	// Unknown names are ignored, known ones kept.
+	got = filterBuiltinTools(all, []string{"read", "does-not-exist"})
+	if len(got) != 1 || got[0].Name() != "read" {
+		t.Errorf("unknown-name filter kept %v, want [read]", namesOf(got))
+	}
+}
+
+// TestRunSubAgentRPCValidation verifies the subprocess returns JSON-RPC errors
+// for malformed requests without reaching provider resolution: a parse error,
+// an unknown method, and missing prompt/model params. These branches are the
+// server's contract for bad input and need not involve a provider.
+func TestRunSubAgentRPCValidation(t *testing.T) {
+	cases := []struct {
+		name     string
+		line     string
+		wantCode int
+		wantMsg  string
+	}{
+		{"parse error", "not-json", -32700, "parse error"},
+		{"method not found", `{"jsonrpc":"2.0","id":1,"method":"other","params":{}}`, -32601, "method not found"},
+		{"missing prompt", `{"jsonrpc":"2.0","id":2,"method":"` + runtime.SubAgentRPCMethod + `","params":{"model":"x"}}`, -32602, "prompt and model are required"},
+		{"missing model", `{"jsonrpc":"2.0","id":3,"method":"` + runtime.SubAgentRPCMethod + `","params":{"prompt":"x"}}`, -32602, "prompt and model are required"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var out, errOut bytes.Buffer
+			code := runSubAgentRPC(context.Background(), strings.NewReader(c.line+"\n"), &out, &errOut)
+			if code != 0 {
+				t.Errorf("exit code = %d, want 0 (validation errors are RPC responses, not non-zero exits)", code)
+			}
+			line, _ := out.ReadString('\n')
+			if line == "" {
+				t.Fatal("no response written")
+			}
+			var resp jsonrpc.Response
+			if err := json.Unmarshal([]byte(line), &resp); err != nil {
+				t.Fatalf("unmarshal response %q: %v", line, err)
+			}
+			if resp.Error == nil {
+				t.Fatalf("response has no error: %s", line)
+			}
+			if resp.Error.Code != c.wantCode {
+				t.Errorf("error code = %d, want %d (msg=%q)", resp.Error.Code, c.wantCode, resp.Error.Message)
+			}
+			if !strings.Contains(resp.Error.Message, c.wantMsg) {
+				t.Errorf("error msg = %q, want it to contain %q", resp.Error.Message, c.wantMsg)
+			}
+		})
+	}
+}
+
+// TestRunSubAgentRPCScannerError verifies a stdin read error (a line exceeding
+// the scanner cap) is surfaced on stderr and yields a non-zero exit, rather
+// than a silent clean exit.
+func TestRunSubAgentRPCScannerError(t *testing.T) {
+	// A line longer than the 16 MiB scanner cap triggers a scanner error.
+	huge := strings.Repeat("a", 17*1024*1024)
+	var out, errOut bytes.Buffer
+	code := runSubAgentRPC(context.Background(), strings.NewReader(huge), &out, &errOut)
+	if code == 0 {
+		t.Error("exit code = 0 on scanner error, want non-zero")
+	}
+	if !strings.Contains(errOut.String(), "subagent-rpc stdin") {
+		t.Errorf("stderr = %q, want it to mention 'subagent-rpc stdin'", errOut.String())
+	}
+}

--- a/docs/issue#0135.html
+++ b/docs/issue#0135.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes - Issue #0135</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .item p:last-child { margin-bottom: 0; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    code { font-family: 'SF Mono', Menlo, Consolas, monospace; font-size: 0.8em; background: #F3F1ED; padding: 0.05em 0.3em; border-radius: 3px; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/135">#135</a> &mdash; 子 agent process 隔离模式 (US-019) &mdash; 2026-07-19</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>Isolation</code> field on <code>SubAgentSpec</code>, zero-value = goroutine</h3>
+      <p><strong>Ambiguity:</strong> The spec said add <code>Isolation: goroutine | process</code> but did not say how the default preserves existing behavior.</p>
+      <p><strong>Choice:</strong> A new <code>SubAgentIsolation</code> enum (<code>SubAgentIsolationGoroutine = iota</code> default, <code>SubAgentIsolationProcess</code>). <code>Execute</code> dispatches on it; the goroutine branch is the original code verbatim.</p>
+      <p><strong>Rationale:</strong> The zero value is goroutine, so every existing <code>SubAgentSpec</code> (built by <code>Skill.SubAgentSpec</code> and tests) keeps running in-process with no behavior change - satisfying "默认 goroutine 模式无行为变化".</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Subprocess = the pigo binary itself over stdio JSON-RPC, reusing <code>internal/jsonrpc</code></h3>
+      <p><strong>Ambiguity:</strong> The spec said "pigo 以子进程启动自身 headless/rpc...复用 internal/jsonrpc" without specifying the wire shape.</p>
+      <p><strong>Choice:</strong> The parent (<code>defaultProcessCall</code>) launches <code>os.Executable()</code> with <code>--subagent-rpc</code> via <code>jsonrpc.NewClient</code>, sends one <code>subagent/run</code> request, and decodes the <code>{text}</code> response. The subprocess side is a new <code>pigo --subagent-rpc</code> mode that reads JSON-RPC requests, resolves the provider, runs <code>RunSubAgentOnce</code>, and writes responses.</p>
+      <p><strong>Rationale:</strong> Spawning pigo itself (not a separate helper) matches "启动自身"; <code>internal/jsonrpc.Client</code> already handles exec, line-delimited framing, id correlation, EOF/crash detection, and Close-with-grace-kill, so the parent transport is reuse, not reinvention.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Serializable provider config (<code>Model</code>/<code>BaseURL</code>/<code>Protocol</code>) + env-inherited credentials</h3>
+      <p><strong>Ambiguity:</strong> Goroutine mode passes a <code>RunConfig</code> with in-process <code>Stream</code>/<code>GetAPIKey</code> funcs; the spec did not say how a subprocess gets its provider.</p>
+      <p><strong>Choice:</strong> <code>SubAgentProcessConfig</code> carries <code>Model</code>/<code>BaseURL</code>/<code>Protocol</code> (strings). The subprocess calls <code>resolveProvider</code> (the same resolution the CLI uses) and inherits the parent environment, so API keys resolve via the same env vars.</p>
+      <p><strong>Rationale:</strong> Funcs cannot cross a process boundary. Forwarding the model id + endpoint overrides lets the subprocess reconstruct the identical provider; env inheritance is the natural credential channel and needs no key marshaling over the wire.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Crash and failed-run both surface as a tool error</h3>
+      <p><strong>Ambiguity:</strong> The spec required "子进程崩溃被父捕获为工具错误" but did not define failed-run handling.</p>
+      <p><strong>Choice:</strong> A subprocess crash (exit without responding) is caught by <code>jsonrpc.Client</code>'s readLoop EOF &rarr; <code>failAll</code> &rarr; <code>Call</code> returns an error &rarr; <code>executeProcess</code> wraps it as a tool error. A failed child run (<code>StopReasonError</code>/<code>Aborted</code>) is returned by <code>RunSubAgentOnce</code> as an error &rarr; the subprocess emits it as a JSON-RPC error &rarr; same parent path. The parent loop is never affected.</p>
+      <p><strong>Rationale:</strong> Treating both as tool errors matches goroutine mode's "failed run &rarr; IsError" contract and gives the parent model a clear signal the delegation failed, whether the child crashed or merely errored.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Injectable <code>processCall</code> seam for testing</h3>
+      <p><strong>Ambiguity:</strong> The spec's test gate is <code>go test ./internal/runtime/...</code>, but the real transport needs a subprocess + provider.</p>
+      <p><strong>Choice:</strong> <code>SubAgentTool</code> has an unexported <code>processCall</code> field; when nil, <code>Execute</code> uses <code>defaultProcessCall</code> (real transport). Tests in <code>package runtime</code> inject a fake to verify params shaping and crash-as-error without a binary. The real transport is covered separately by compiling a tiny JSON-RPC helper binary (mirroring the plugin tests).</p>
+      <p><strong>Rationale:</strong> Fast, hermetic unit tests for the process-mode logic plus a real exec+pipe+JSON-RPC round-trip (and crash) test - without needing a live provider. The seam is set only at construction (safe by convention).</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Process mode does not stream partial updates</h3>
+      <p><strong>Spec:</strong> Goroutine mode forwards streamed child text deltas via <code>onUpdate</code>.</p>
+      <p><strong>Implemented:</strong> Process mode returns only the child's final text; <code>onUpdate</code> is intentionally not forwarded (documented at the dispatch site).</p>
+      <p><strong>Why:</strong> The JSON-RPC protocol is a single request/response carrying the final result; streaming deltas would require server-&gt;client notifications, which is out of scope for #135. The parent still receives the complete result when the child settles.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Process-mode tools are builtins-only, rebuilt by name</h3>
+      <p><strong>Spec:</strong> <code>SubAgentSpec.Tools</code> is an arbitrary <code>[]agentcore.AgentTool</code>.</p>
+      <p><strong>Implemented:</strong> Process mode forwards only the tool <em>names</em>; the subprocess rebuilds its builtin set (<code>builtinTools</code>) filtered by those names. Custom/plugin/MCP tools in <code>spec.Tools</code> are silently dropped.</p>
+      <p><strong>Why:</strong> In-process tool objects (closures, registries) cannot be serialized across a process boundary. Builtins are reconstructable; non-builtins are not. This preserves the common "read-only researcher" pattern (filtering builtins by name) while documenting the limitation for custom tools.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Removed a <code>Provider</code> name field after review</h3>
+      <p><strong>Spec:</strong> The spec did not mandate a provider-name field.</p>
+      <p><strong>Implemented:</strong> An initial draft forwarded a <code>Provider</code> name hint, but <code>resolveProvider</code> derives the provider from model/baseURL/protocol and never read it - so a developer setting <code>Provider: "anthropic"</code> on a non-preset model would silently get OpenRouter. The field was removed from <code>SubAgentProcessConfig</code> and the wire payload.</p>
+      <p><strong>Why:</strong> A dead, misleading field is worse than none. Forcing a wire format is done via <code>Protocol</code> ("anthropic"/"openai"); preset ids encode their provider. (Caught in code review, M1.)</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Per-call subprocess spawn vs. a long-lived worker pool</h3>
+      <p><strong>Alternatives:</strong> (a) spawn a fresh pigo per sub-agent call (chosen); (b) keep a pool of long-lived subprocesses reused across calls.</p>
+      <p><strong>Pros/cons:</strong> (a) is simplest and gives strongest isolation (each child is fresh; a crash corrupts nothing shared), at the cost of an exec + JSON-RPC handshake per call. (b) amortizes spawn cost but adds pool lifecycle, worker health checks, and state-leak risk.</p>
+      <p><strong>Chose:</strong> Per-call spawn. The AC accepts subprocess execution and prioritizes isolation; spawn cost is acceptable for an "optional enhancement, low priority" feature. A pool is a possible follow-up if delegation becomes frequent.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Duplicate drain+classify logic in <code>executeGoroutine</code> and <code>RunSubAgentOnce</code></h3>
+      <p><strong>Alternatives:</strong> (a) extract a shared "drain + classify failed run" core used by both (chosen NOT to); (b) leave them duplicated.</p>
+      <p><strong>Pros/cons:</strong> (a) removes duplication but touches the goroutine path, risking the "no behavior change" regression guarantee. (b) keeps the goroutine path byte-identical to master (verified by <code>git show master</code> in review) at the cost of two ~similar blocks.</p>
+      <p><strong>Chose:</strong> Duplication (b). The two differ deliberately anyway (goroutine forwards <code>onUpdate</code>, uses a placeholder for empty text; <code>RunSubAgentOnce</code> falls back to <code>ErrorMessage</code> and returns the raw text). A future change to one must be mirrored in the other - noted as an open item.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Cancellation via stdin close rather than a context-aware reader</h3>
+      <p><strong>Alternatives:</strong> (a) make <code>runSubAgentRPC</code>'s stdin scanner select on <code>ctx.Done()</code>; (b) rely on the parent's <code>Client.Close()</code> closing the child's stdin to unblock the scanner.</p>
+      <p><strong>Pros/cons:</strong> (a) is more obviously correct but needs a custom reader/goroutine. (b) is simpler and already correct: the parent owns the child's lifetime, and closing stdin on cancel/Close makes <code>scanner.Scan</code> return false.</p>
+      <p><strong>Chose:</strong> (b). The <code>ctx</code> still flows into <code>RunSubAgentOnce</code> so an in-flight child run is cancelled; the scanner unblocks via stdin EOF. Documented as a known minor asymmetry.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Child stderr discarded by default</h3>
+      <p><strong>Alternatives:</strong> (a) <code>SubAgentProcessConfig.Stderr</code> defaults to nil (discarded) - chosen; (b) always capture and surface child stderr.</p>
+      <p><strong>Pros/cons:</strong> (a) avoids noisy output when a caller does not care; diagnostics are instead surfaced through the RPC error path (<code>RunSubAgentOnce</code> falls back to <code>ErrorMessage</code>). (b) gives full child logs but at the cost of wiring/buffering.</p>
+      <p><strong>Chose:</strong> (a) with opt-in <code>Stderr</code>. The key failure diagnostics (the cause of an error stop) reach the parent as the RPC error message, so stderr is not needed for correctness - only for deep debugging, which a caller can opt into.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should process mode stream partial child updates?</h3>
+      <p><strong>Assumption:</strong> Process mode returns only the final result; goroutine mode streams text deltas via <code>onUpdate</code>. This is an intentional parity gap.</p>
+      <p><strong>Verify/Follow-up:</strong> Is streaming parity wanted? It would require server-&gt;client JSON-RPC notifications (the current <code>jsonrpc.Client</code> drops notifications), so it is a non-trivial protocol extension deferred from #135.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Is per-call spawn acceptable, or do we need a subprocess pool?</h3>
+      <p><strong>Assumption:</strong> Each sub-agent call execs a fresh pigo. Fine for occasional delegation; costly for frequent delegation.</p>
+      <p><strong>Verify:</strong> If sub-agents become a hot path, revisit a worker pool with health checks. Not needed for #135's "optional enhancement" scope.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Are builtins-only tools acceptable, or should the subprocess support a tool protocol?</h3>
+      <p><strong>Assumption:</strong> A process-isolated child runs with builtins (filtered by name); custom/plugin/MCP tools are silently dropped.</p>
+      <p><strong>Verify:</strong> If a process-isolated sub-agent needs plugin/MCP tools, the subprocess would need a tool-registration RPC or to load the same plugins. Currently out of scope; confirm this limitation is acceptable.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should <code>--subagent-rpc</code> be documented or stay hidden?</h3>
+      <p><strong>Assumption:</strong> The flag is internal (an implementation detail of process-isolated sub-agents) and not advertised in <code>--help</code>-style usage beyond its flag description.</p>
+      <p><strong>Verify:</strong> Keep it hidden, or surface it for power users who want to drive the sub-agent protocol directly?</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Sub-agents are library-level only - how should isolation be chosen in the REPL?</h3>
+      <p><strong>Assumption:</strong> <code>SubAgentSpec</code> is built by <code>Skill.SubAgentSpec</code> but no CLI/REPL path currently spawns sub-agents, so process mode is exercised by tests only. The default is goroutine.</p>
+      <p><strong>Verify/Follow-up:</strong> When sub-agents are wired into the REPL (e.g. via skills), should there be a per-skill or global switch for process isolation, or should it be automatic for certain tool sets? This is a product decision deferred until sub-agents ship in the CLI.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Pre-existing environment-fragile test (unrelated, carried from #134)</h3>
+      <p><strong>Observation:</strong> <code>internal/provider.TestCredentialStoreOAuthRefreshFallback</code> fails locally because the user's shell has <code>ANTHROPIC_API_KEY</code> set; it passes in a clean env (CI). Not in this diff.</p>
+      <p><strong>Follow-up:</strong> Isolate it with <code>t.Setenv</code> in a separate change so local <code>go test ./...</code> is green regardless of the shell environment.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/runtime/subagent.go
+++ b/internal/runtime/subagent.go
@@ -1,32 +1,123 @@
-// This file implements single-process sub-agent orchestration (US-027, #45).
+// This file implements sub-agent orchestration (US-027, #45) with an optional
+// process-isolation mode (US-019, #135).
 //
-// A sub-agent is a full agent loop run in a child goroutine with its own
-// AgentContext (independent system prompt, message history and tool set),
-// launched by the parent through a normal tool call. The child runs to
-// completion via StartRun, and its final assistant text is fed back to the
-// parent as the tool result — so from the parent loop's perspective a sub-agent
-// is just another tool. Because each Execute call spins up an independent
-// StartRun with a fresh context, multiple sub-agents can run concurrently (the
-// batch executor already runs parallel tool calls in separate goroutines).
+// A sub-agent is a full agent loop with its own AgentContext (independent system
+// prompt, message history and tool set), launched by the parent through a normal
+// tool call. The child runs to completion and its final assistant text is fed
+// back to the parent as the tool result - so from the parent loop's perspective
+// a sub-agent is just another tool.
 //
-// There is deliberately NO cross-process RPC: sub-agents are goroutines sharing
-// the parent process, matching the spec's "单进程 goroutine" decision.
+// Two isolation modes are supported, selected by SubAgentSpec.Isolation:
+//
+//   - Goroutine (default): the child loop runs in-process in a goroutine sharing
+//     the parent process, matching the original "单进程 goroutine" decision.
+//   - Process: the parent spawns a fresh pigo subprocess (pigo --subagent-rpc)
+//     and delegates the run over stdio JSON-RPC (reusing internal/jsonrpc). The
+//     child runs in a separate process, so a crash or resource leak in the child
+//     cannot affect the parent loop; a crash is surfaced as a tool error. The
+//     subprocess resolves its own provider from the model/provider passed in the
+//     request and inherits the parent environment for credentials.
+//
+// Because each Execute call spins up an independent run, multiple sub-agents can
+// run concurrently (the batch executor already runs parallel tool calls in
+// separate goroutines/processes).
 package runtime
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/jsonrpc"
 )
+
+// SubAgentIsolation selects how a sub-agent runs relative to its parent.
+type SubAgentIsolation int
+
+const (
+	// SubAgentIsolationGoroutine runs the child agent loop in-process in a
+	// goroutine. This is the default and the original behavior; it changes
+	// nothing about how sub-agents previously ran.
+	SubAgentIsolationGoroutine SubAgentIsolation = iota
+	// SubAgentIsolationProcess runs the child in a fresh pigo subprocess,
+	// delegating the run over stdio JSON-RPC. A subprocess crash is surfaced to
+	// the parent as a tool error and never affects the parent loop.
+	SubAgentIsolationProcess
+)
+
+// SubAgentProcessConfig configures process-isolated sub-agent execution. It
+// carries the serializable provider config the subprocess needs to reconstruct
+// the run: the in-process Stream/GetAPIKey functions a goroutine-mode
+// NewRunConfig returns cannot cross a process boundary, so the parent forwards
+// the model (and optional base URL/protocol) and the subprocess resolves the
+// provider itself, inheriting the parent environment for API keys.
+type SubAgentProcessConfig struct {
+	// Command is the executable to spawn. When empty, os.Executable() (the pigo
+	// binary itself) is used so a pigo process spawns another pigo.
+	Command string
+	// Args are appended to the command after the subagent-rpc flag. Rarely
+	// needed; reserved for test doubles or non-standard layouts.
+	Args []string
+	// Model is the model id the subprocess runs against. Required. A preset id
+	// (e.g. "openrouter/free", "anthropic/claude-...") or ollama/nvidia-prefixed
+	// id resolves its own provider; a custom gateway needs BaseURL/Protocol.
+	Model string
+	// BaseURL and Protocol override the provider endpoint and wire protocol for
+	// custom gateways (Protocol "anthropic"/"openai" forces that wire format).
+	// Empty falls back to the same resolution the CLI uses.
+	BaseURL  string
+	Protocol string
+	// ToolNames restricts the subprocess's builtin tool set to the named tools
+	// (e.g. a read-only researcher). Empty keeps all builtins. Non-builtin names
+	// are ignored: custom/plugin tools cannot cross a process boundary, so a
+	// process-isolated child runs with builtins only.
+	ToolNames []string
+	// Env is the child's environment (os/exec form). When nil the child inherits
+	// the parent environment, which is how it picks up provider API keys.
+	Env []string
+	// Dir is the child's working directory; empty means the parent's.
+	Dir string
+	// Stderr optionally receives the child's stderr. When nil it is discarded.
+	Stderr io.Writer
+}
+
+// SubAgentRunParams is the JSON-RPC request payload for a process-isolated
+// sub-agent run (the "subagent/run" method). It is the wire contract between
+// the parent (SubAgentTool in process mode) and the pigo subprocess
+// (cmd/pigo --subagent-rpc).
+type SubAgentRunParams struct {
+	Prompt       string   `json:"prompt"`
+	SystemPrompt string   `json:"systemPrompt,omitempty"`
+	Model        string   `json:"model"`
+	BaseURL      string   `json:"baseUrl,omitempty"`
+	Protocol     string   `json:"protocol,omitempty"`
+	Tools        []string `json:"tools,omitempty"`
+}
+
+// SubAgentRunResult is the JSON-RPC response payload carrying the child's final
+// assistant text.
+type SubAgentRunResult struct {
+	Text string `json:"text"`
+}
+
+// SubAgentRPCMethod is the JSON-RPC method name the parent calls on the
+// subprocess: "subagent/run".
+const SubAgentRPCMethod = "subagent/run"
+
+// SubAgentRPCFlag is the command-line flag the parent launches the pigo
+// subprocess with so it enters the sub-agent RPC server mode: "--subagent-rpc".
+const SubAgentRPCFlag = "--subagent-rpc"
 
 // SubAgentSpec declares a spawnable sub-agent: its identity (surfaced to the
 // model as a tool), the system prompt and tools its child context runs with,
 // and a factory for the child's run configuration (provider stream, batch
 // registry, hooks). The factory is called once per spawn so each child gets an
 // independent RunConfig; NewRunConfig must wire a ToolRegistry consistent with
-// Tools.
+// Tools. It is used by goroutine mode; process mode uses Process instead (the
+// subprocess builds its own RunConfig from the serializable provider config).
 type SubAgentSpec struct {
 	// Name is the tool name the parent invokes to spawn this sub-agent.
 	Name string
@@ -37,11 +128,20 @@ type SubAgentSpec struct {
 	// runs with no system prompt.
 	SystemPrompt string
 	// Tools is the child's independent tool set. It may differ from the parent's
-	// (e.g. a read-only researcher sub-agent) and may be empty.
+	// (e.g. a read-only researcher sub-agent) and may be empty. In goroutine
+	// mode these exact tools run in-process; in process mode only the tools'
+	// NAMES are forwarded (the subprocess rebuilds builtins by name).
 	Tools []agentcore.AgentTool
-	// NewRunConfig builds the loop configuration for one child run. It is called
-	// per spawn; the returned config's Batch registry should contain Tools.
+	// NewRunConfig builds the loop configuration for one child run in goroutine
+	// mode. It is called per spawn; the returned config's Batch registry should
+	// contain Tools. Ignored in process mode (the subprocess resolves its own).
 	NewRunConfig func() RunConfig
+	// Isolation selects goroutine (default) vs process execution. Zero value is
+	// goroutine, preserving the original behavior.
+	Isolation SubAgentIsolation
+	// Process configures process-isolated execution. Required when Isolation is
+	// SubAgentIsolationProcess; ignored otherwise.
+	Process SubAgentProcessConfig
 }
 
 // subAgentArgs is the JSON argument shape for a sub-agent tool call: a single
@@ -64,14 +164,20 @@ var subAgentSchema = json.RawMessage(`{
 }`)
 
 // SubAgentTool adapts a SubAgentSpec into an AgentTool. Executing it spawns a
-// child agent loop over the spec's context and returns the child's final text.
+// child agent run (in a goroutine or a subprocess, per Isolation) and returns
+// the child's final text.
 type SubAgentTool struct {
 	spec SubAgentSpec
+	// processCall, when non-nil, overrides the default subprocess transport for
+	// process-isolated mode. Tests inject a fake to exercise the process-mode
+	// logic (params shaping, crash-as-error, result forwarding) without building
+	// a real binary; production leaves it nil so Execute uses defaultProcessCall.
+	processCall func(ctx context.Context, cfg SubAgentProcessConfig, params SubAgentRunParams) (string, error)
 }
 
-// NewSubAgentTool builds a sub-agent tool from a spec. NewRunConfig is required
-// (it supplies the provider stream that drives the child); a spec without it
-// yields a tool whose Execute fails cleanly.
+// NewSubAgentTool builds a sub-agent tool from a spec. In goroutine mode
+// NewRunConfig is required (it supplies the provider stream that drives the
+// child); in process mode Process.Model is required instead.
 func NewSubAgentTool(spec SubAgentSpec) *SubAgentTool {
 	return &SubAgentTool{spec: spec}
 }
@@ -83,17 +189,24 @@ func (t *SubAgentTool) Description() string { return t.spec.Description }
 func (t *SubAgentTool) Schema() json.RawMessage { return subAgentSchema }
 
 // ExecutionMode is parallel: independent sub-agents may run concurrently, since
-// each spawns its own context and StartRun goroutine with no shared mutable
-// state.
+// each spawns its own context and run (goroutine or process) with no shared
+// mutable state.
 func (t *SubAgentTool) ExecutionMode() agentcore.ToolExecutionMode {
 	return agentcore.ToolExecutionParallel
 }
 
-// Execute spawns the child agent loop and blocks until it settles, then returns
+// Execute spawns the child agent run and blocks until it settles, then returns
 // the child's final assistant text as the tool result. The parent's ctx governs
-// the child, so cancelling the parent run cancels in-flight sub-agents.
+// the child, so cancelling the parent run cancels in-flight sub-agents (in
+// goroutine mode via ctx; in process mode via ctx cancelling the JSON-RPC call
+// and Close killing the child).
 func (t *SubAgentTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
-	if t.spec.NewRunConfig == nil {
+	// Goroutine mode requires NewRunConfig (it supplies the in-process provider
+	// stream). Process mode does not - the subprocess resolves its own provider
+	// from Process.Model - so the check is guarded to goroutine mode. This
+	// preserves the original precedence (nil NewRunConfig reported before an
+	// empty prompt) for the unchanged goroutine path.
+	if t.spec.Isolation != SubAgentIsolationProcess && t.spec.NewRunConfig == nil {
 		return agentcore.AgentToolResult{}, fmt.Errorf("sub-agent %q: no run configuration", t.spec.Name)
 	}
 	var a subAgentArgs
@@ -106,10 +219,22 @@ func (t *SubAgentTool) Execute(ctx context.Context, id string, args json.RawMess
 		return agentcore.AgentToolResult{}, fmt.Errorf("sub-agent %q: empty prompt", t.spec.Name)
 	}
 
+	if t.spec.Isolation == SubAgentIsolationProcess {
+		// Process mode returns only the child's final text (the JSON-RPC protocol
+		// does not stream partial updates), so onUpdate is intentionally not
+		// forwarded here; a caller supplying a sink gets no deltas in this mode.
+		return t.executeProcess(ctx, a.Prompt)
+	}
+	return t.executeGoroutine(ctx, a.Prompt, onUpdate)
+}
+
+// executeGoroutine runs the child agent loop in-process and returns its final
+// text. This is the default mode and the original sub-agent behavior.
+func (t *SubAgentTool) executeGoroutine(ctx context.Context, prompt string, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
 	childCtx := &agentcore.AgentContext{
 		SystemPrompt: t.spec.SystemPrompt,
 		Messages: agentcore.MessageList{
-			agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent(a.Prompt)}},
+			agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent(prompt)}},
 		},
 		Tools: t.spec.Tools,
 	}
@@ -143,4 +268,123 @@ func (t *SubAgentTool) Execute(ctx context.Context, id string, args json.RawMess
 		return agentcore.AgentToolResult{}, fmt.Errorf("sub-agent %q failed (%s): %s", t.spec.Name, final.StopReason, text)
 	}
 	return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent(text)}}, nil
+}
+
+// executeProcess runs the child agent loop in a fresh pigo subprocess over stdio
+// JSON-RPC and returns its final text. A subprocess crash, transport error, or
+// failed child run is surfaced as a tool error; the parent loop is unaffected.
+// Streamed child text is not forwarded (the process protocol returns only the
+// final result); the parent sees the complete result when the child settles.
+func (t *SubAgentTool) executeProcess(ctx context.Context, prompt string) (agentcore.AgentToolResult, error) {
+	cfg := t.spec.Process
+	if cfg.Model == "" {
+		return agentcore.AgentToolResult{}, fmt.Errorf("sub-agent %q: process mode requires Process.Model", t.spec.Name)
+	}
+	// Forward the child's tool names so the subprocess can rebuild a matching
+	// builtin set; an explicit ToolNames list wins over deriving from Tools.
+	toolNames := cfg.ToolNames
+	if len(toolNames) == 0 {
+		for _, tl := range t.spec.Tools {
+			toolNames = append(toolNames, tl.Name())
+		}
+	}
+	params := SubAgentRunParams{
+		Prompt:       prompt,
+		SystemPrompt: t.spec.SystemPrompt,
+		Model:        cfg.Model,
+		BaseURL:      cfg.BaseURL,
+		Protocol:     cfg.Protocol,
+		Tools:        toolNames,
+	}
+	call := t.processCall
+	if call == nil {
+		call = defaultProcessCall
+	}
+	text, err := call(ctx, cfg, params)
+	if err != nil {
+		return agentcore.AgentToolResult{}, fmt.Errorf("sub-agent %q (process): %w", t.spec.Name, err)
+	}
+	if text == "" {
+		text = fmt.Sprintf("(sub-agent %q produced no text output)", t.spec.Name)
+	}
+	return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent(text)}}, nil
+}
+
+// defaultProcessCall is the production subprocess transport: it launches the
+// pigo binary (or cfg.Command) with the subagent-rpc flag, sends a single
+// "subagent/run" JSON-RPC request over the child's stdin, and returns the
+// child's final text from the response. The child is closed (killed if it does
+// not exit on its own) before returning. A crash, transport error, or RPC error
+// is returned as a Go error so executeProcess surfaces it as a tool error.
+func defaultProcessCall(ctx context.Context, cfg SubAgentProcessConfig, params SubAgentRunParams) (string, error) {
+	command := cfg.Command
+	if command == "" {
+		exe, err := os.Executable()
+		if err != nil {
+			return "", fmt.Errorf("resolve pigo executable: %w", err)
+		}
+		command = exe
+	}
+	args := append([]string{SubAgentRPCFlag}, cfg.Args...)
+	client, err := jsonrpc.NewClient(jsonrpc.Config{
+		Command: command,
+		Args:    args,
+		Env:     cfg.Env,
+		Dir:     cfg.Dir,
+		Stderr:  cfg.Stderr,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer client.Close()
+	raw, err := client.Call(ctx, SubAgentRPCMethod, params)
+	if err != nil {
+		return "", err
+	}
+	var res SubAgentRunResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return "", fmt.Errorf("decode sub-agent result: %w", err)
+	}
+	return res.Text, nil
+}
+
+// RunSubAgentOnce runs one sub-agent loop to completion and returns the child's
+// final assistant text. It is the execution core shared by the process-isolated
+// subprocess (cmd/pigo --subagent-rpc): given a resolved RunConfig (provider
+// stream, tool registry) and the prompt/system prompt, it builds a fresh child
+// context and drains the run. A run whose final turn stopped on error/aborted
+// is reported as an error so the subprocess surfaces failure (as an RPC error)
+// rather than returning empty text. It does not stream partial updates: the
+// process protocol returns only the final result.
+func RunSubAgentOnce(ctx context.Context, systemPrompt, prompt string, tools []agentcore.AgentTool, runCfg RunConfig) (string, error) {
+	childCtx := &agentcore.AgentContext{
+		SystemPrompt: systemPrompt,
+		Messages: agentcore.MessageList{
+			agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent(prompt)}},
+		},
+		Tools: tools,
+	}
+	stream := StartRun(ctx, childCtx, runCfg)
+	final, err := DrainStream(ctx, stream, StreamHandler{})
+	if err != nil {
+		return "", err
+	}
+	text := ""
+	if final != nil {
+		text = agentcore.ContentToText(final.Content)
+	}
+	if final != nil && (final.StopReason == agentcore.StopReasonError || final.StopReason == agentcore.StopReasonAborted) {
+		// When the loop synthesizes an error turn (e.g. a provider connection
+		// failure) the diagnostic lands in ErrorMessage, not Content; fall back
+		// to it so the subprocess surfaces the real cause rather than a bare
+		// "error" stop reason.
+		if text == "" && final.ErrorMessage != "" {
+			text = final.ErrorMessage
+		}
+		if text == "" {
+			text = string(final.StopReason)
+		}
+		return text, fmt.Errorf("sub-agent failed (%s): %s", final.StopReason, text)
+	}
+	return text, nil
 }

--- a/internal/runtime/subagent_process_test.go
+++ b/internal/runtime/subagent_process_test.go
@@ -1,0 +1,328 @@
+package runtime
+
+// Tests for process-isolated sub-agents (US-019, #135): the Isolation field,
+// the process-mode Execute path (params shaping, crash-as-tool-error), the
+// shared RunSubAgentOnce core, and the real defaultProcessCall transport
+// (exec + stdio JSON-RPC + crash handling) driven through a tiny compiled
+// helper binary - no provider or network, mirroring the plugin tests.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	goruntime "runtime"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+// errorTurn scripts a turn whose final message stops on StopReasonError, so a
+// RunSubAgentOnce run surfaces as a failure (matching the goroutine-mode
+// "failed run -> tool error" contract).
+func errorTurn(msg string) fauxTurn {
+	partial := agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant}
+	final := partial
+	final.StopReason = agentcore.StopReasonError
+	final.ErrorMessage = msg
+	return fauxTurn{
+		provider.StreamStartEvent{Partial: partial},
+		provider.StreamDoneEvent{Message: final},
+	}
+}
+
+// TestSubAgentGoroutineModeUnchanged verifies the default (zero-value) isolation
+// still runs in-process: the existing parent->child->parent tests cover the
+// full path, but this pins that Isolation==goroutine is the default and reaches
+// NewRunConfig (not the process path) so the regression is caught locally too.
+func TestSubAgentGoroutineModeUnchanged(t *testing.T) {
+	child := &fauxProvider{
+		name:   "faux-child",
+		models: []provider.Model{{Provider: "faux-child", ID: "child"}},
+		turns:  []fauxTurn{textTurn("child answer")},
+	}
+	sub := NewSubAgentTool(SubAgentSpec{
+		Name:         "researcher",
+		SystemPrompt: "you are a researcher",
+		NewRunConfig: func() RunConfig { return newFauxRunCfg(child) },
+	})
+	if sub.spec.Isolation != SubAgentIsolationGoroutine {
+		t.Errorf("default Isolation = %v, want goroutine", sub.spec.Isolation)
+	}
+	res, err := sub.Execute(context.Background(), "id", json.RawMessage(`{"prompt":"go"}`), nil)
+	if err != nil {
+		t.Fatalf("goroutine Execute err = %v", err)
+	}
+	if got := agentcore.ContentToText(res.Content); got != "child answer" {
+		t.Errorf("goroutine result = %q, want 'child answer'", got)
+	}
+	if child.callCount() != 1 {
+		t.Errorf("child provider calls = %d, want 1", child.callCount())
+	}
+}
+
+// TestSubAgentGoroutineNilRunConfigErrors verifies goroutine mode reports a
+// missing NewRunConfig, and - preserving the original precedence - reports it
+// even when the prompt is empty (so a nil config is not masked by "empty
+// prompt"). This pins the L3 regression: the NewRunConfig check stays before
+// the empty-prompt check on the goroutine path.
+func TestSubAgentGoroutineNilRunConfigErrors(t *testing.T) {
+	sub := NewSubAgentTool(SubAgentSpec{Name: "x"}) // no NewRunConfig, default goroutine
+	_, err := sub.Execute(context.Background(), "id", json.RawMessage(`{"prompt":"go"}`), nil)
+	if err == nil || !strings.Contains(err.Error(), "no run configuration") {
+		t.Errorf("err = %v, want 'no run configuration'", err)
+	}
+	// Precedence: nil NewRunConfig is reported even when the prompt is empty.
+	_, err = sub.Execute(context.Background(), "id", json.RawMessage(`{"prompt":""}`), nil)
+	if err == nil || !strings.Contains(err.Error(), "no run configuration") {
+		t.Errorf("empty-prompt err = %v, want 'no run configuration' (nil config takes precedence)", err)
+	}
+}
+
+// TestSubAgentProcessModeFake drives process mode through an injectable
+// processCall (the test seam) to verify params shaping and crash-as-tool-error
+// without a real subprocess. The real transport is covered separately by
+// TestSubAgentProcessDefaultCall.
+func TestSubAgentProcessModeFake(t *testing.T) {
+	t.Run("happy", func(t *testing.T) {
+		sub := NewSubAgentTool(SubAgentSpec{
+			Name:         "proc",
+			Isolation:    SubAgentIsolationProcess,
+			Process:      SubAgentProcessConfig{Model: "faux"},
+			SystemPrompt: "you are a subprocess child",
+		})
+		var got SubAgentRunParams
+		sub.processCall = func(ctx context.Context, cfg SubAgentProcessConfig, params SubAgentRunParams) (string, error) {
+			got = params
+			return "process result: 99", nil
+		}
+		res, err := sub.Execute(context.Background(), "id", json.RawMessage(`{"prompt":"find it"}`), nil)
+		if err != nil {
+			t.Fatalf("Execute err = %v", err)
+		}
+		if got := agentcore.ContentToText(res.Content); got != "process result: 99" {
+			t.Errorf("result = %q, want 'process result: 99'", got)
+		}
+		// The prompt, system prompt, and model are forwarded to the subprocess;
+		// NewRunConfig is NOT called (the subprocess resolves its own provider).
+		if got.Prompt != "find it" || got.Model != "faux" || got.SystemPrompt != "you are a subprocess child" {
+			t.Errorf("forwarded params = %+v", got)
+		}
+	})
+
+	t.Run("crash is tool error", func(t *testing.T) {
+		sub := NewSubAgentTool(SubAgentSpec{
+			Name:      "proc",
+			Isolation: SubAgentIsolationProcess,
+			Process:   SubAgentProcessConfig{Model: "faux"},
+		})
+		sub.processCall = func(context.Context, SubAgentProcessConfig, SubAgentRunParams) (string, error) {
+			return "", errors.New("subprocess exited: signal: killed")
+		}
+		_, err := sub.Execute(context.Background(), "id", json.RawMessage(`{"prompt":"x"}`), nil)
+		if err == nil {
+			t.Fatal("expected tool error on subprocess crash, got nil")
+		}
+	})
+
+	t.Run("missing model errors", func(t *testing.T) {
+		sub := NewSubAgentTool(SubAgentSpec{
+			Name:      "proc",
+			Isolation: SubAgentIsolationProcess,
+			// Process.Model intentionally empty.
+		})
+		_, err := sub.Execute(context.Background(), "id", json.RawMessage(`{"prompt":"x"}`), nil)
+		if err == nil {
+			t.Fatal("expected error when Process.Model is missing")
+		}
+	})
+
+	t.Run("forwards tool names", func(t *testing.T) {
+		// spec.Tools is in-process; process mode forwards only their names so
+		// the subprocess can rebuild builtins by name.
+		sub := NewSubAgentTool(SubAgentSpec{
+			Name:      "proc",
+			Isolation: SubAgentIsolationProcess,
+			Process:   SubAgentProcessConfig{Model: "faux"},
+			Tools:     []agentcore.AgentTool{nameOnlyTool("read"), nameOnlyTool("grep")},
+		})
+		var got SubAgentRunParams
+		sub.processCall = func(_ context.Context, _ SubAgentProcessConfig, params SubAgentRunParams) (string, error) {
+			got = params
+			return "ok", nil
+		}
+		if _, err := sub.Execute(context.Background(), "id", json.RawMessage(`{"prompt":"x"}`), nil); err != nil {
+			t.Fatalf("Execute err = %v", err)
+		}
+		if len(got.Tools) != 2 || got.Tools[0] != "read" || got.Tools[1] != "grep" {
+			t.Errorf("forwarded tool names = %v, want [read grep]", got.Tools)
+		}
+	})
+}
+
+// nameOnlyTool is a minimal AgentTool whose only meaningful attribute is its
+// Name, used to verify process mode forwards tool names without needing real
+// tool implementations.
+func nameOnlyTool(name string) agentcore.AgentTool { return nameOnly{name: name} }
+
+type nameOnly struct{ name string }
+
+func (t nameOnly) Name() string            { return t.name }
+func (t nameOnly) Description() string     { return "" }
+func (t nameOnly) Schema() json.RawMessage { return json.RawMessage(`{}`) }
+func (t nameOnly) ExecutionMode() agentcore.ToolExecutionMode {
+	return agentcore.ToolExecutionParallel
+}
+func (t nameOnly) Execute(context.Context, string, json.RawMessage, agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+	return agentcore.AgentToolResult{}, nil
+}
+
+// TestRunSubAgentOnce verifies the shared subprocess-side agent core: a normal
+// run returns the child's final text, and a run whose final turn stopped on
+// error is reported as an error (so the subprocess surfaces it as an RPC error
+// and the parent marks the tool result IsError).
+func TestRunSubAgentOnce(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		p := &fauxProvider{
+			name:   "faux",
+			models: []provider.Model{{Provider: "faux", ID: "faux"}},
+			turns:  []fauxTurn{textTurn("hello from child")},
+		}
+		text, err := RunSubAgentOnce(context.Background(), "sys", "do it", nil, newFauxRunCfg(p))
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if text != "hello from child" {
+			t.Errorf("text = %q, want 'hello from child'", text)
+		}
+		if p.callCount() != 1 {
+			t.Errorf("provider calls = %d, want 1", p.callCount())
+		}
+	})
+
+	t.Run("failed run errors", func(t *testing.T) {
+		p := &fauxProvider{
+			name:   "faux",
+			models: []provider.Model{{Provider: "faux", ID: "faux"}},
+			turns:  []fauxTurn{errorTurn("boom")},
+		}
+		_, err := RunSubAgentOnce(context.Background(), "sys", "do it", nil, newFauxRunCfg(p))
+		if err == nil {
+			t.Fatal("expected error for failed child run, got nil")
+		}
+		// The diagnostic is in ErrorMessage (errorTurn sets no Content); the
+		// subprocess must surface it rather than a bare "error" stop reason.
+		if !strings.Contains(err.Error(), "boom") {
+			t.Errorf("error %q does not contain the 'boom' diagnostic", err.Error())
+		}
+	})
+}
+
+// TestSubAgentProcessDefaultCall exercises the real defaultProcessCall transport
+// (exec + stdio JSON-RPC) against a tiny compiled helper binary. It verifies the
+// happy round-trip (prompt forwarded, result decoded) and that a crashing
+// subprocess is surfaced as a Go error (the AC: "子进程崩溃被父捕获为工具错误").
+func TestSubAgentProcessDefaultCall(t *testing.T) {
+	bin := buildSubAgentHelper(t)
+	cfg := SubAgentProcessConfig{Command: bin}
+
+	t.Run("happy round-trip", func(t *testing.T) {
+		text, err := defaultProcessCall(context.Background(), cfg, SubAgentRunParams{
+			Prompt: "hello", Model: "faux", SystemPrompt: "sys",
+		})
+		if err != nil {
+			t.Fatalf("defaultProcessCall err = %v", err)
+		}
+		if text != "echo: hello" {
+			t.Errorf("text = %q, want 'echo: hello'", text)
+		}
+	})
+
+	t.Run("crash is error", func(t *testing.T) {
+		_, err := defaultProcessCall(context.Background(), cfg, SubAgentRunParams{
+			Prompt: "CRASH", Model: "faux",
+		})
+		if err == nil {
+			t.Fatal("expected error for crashing subprocess, got nil")
+		}
+	})
+}
+
+// buildSubAgentHelper compiles the sub-agent helper binary into a temp dir and
+// returns its path. The helper speaks the same JSON-RPC "subagent/run" wire
+// format as pigo --subagent-rpc (decoded with plain encoding/json, no internal
+// imports, so it stays a standalone main package).
+func buildSubAgentHelper(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "subagent_helper.go")
+	if err := os.WriteFile(srcPath, []byte(subAgentHelperSrc), 0o644); err != nil {
+		t.Fatalf("write helper source: %v", err)
+	}
+	bin := filepath.Join(dir, "subagent_helper")
+	if goruntime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", bin, srcPath)
+	cmd.Env = os.Environ()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build sub-agent helper: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// subAgentHelperSrc is a tiny JSON-RPC server mirroring pigo --subagent-rpc:
+// read a "subagent/run" request per line, and either respond with
+// {text:"echo: <prompt>"} or, when the prompt is "CRASH", exit without
+// responding to simulate a subprocess crash.
+const subAgentHelperSrc = `package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+)
+
+type params struct {
+	Prompt string ` + "`json:\"prompt\"`" + `
+}
+
+type request struct {
+	ID     *json.RawMessage ` + "`json:\"id\"`" + `
+	Method string           ` + "`json:\"method\"`" + `
+	Params params           ` + "`json:\"params\"`" + `
+}
+
+func main() {
+	sc := bufio.NewScanner(os.Stdin)
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	enc := json.NewEncoder(os.Stdout)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var r request
+		if err := json.Unmarshal(line, &r); err != nil {
+			continue
+		}
+		if r.Params.Prompt == "CRASH" {
+			// Simulate a subprocess crash: exit without writing a response so
+			// the parent's JSON-RPC reader sees EOF and fails the call.
+			os.Exit(1)
+		}
+		result, _ := json.Marshal(map[string]string{"text": "echo: " + r.Params.Prompt})
+		resp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      r.ID,
+			"result":  json.RawMessage(result),
+		}
+		_ = enc.Encode(resp)
+	}
+}
+`


### PR DESCRIPTION
## Summary
- `SubAgentSpec` gains an `Isolation` field (`goroutine` default | `process`); the goroutine path is unchanged (verified verbatim against master).
- In process mode the parent spawns the pigo binary itself (`--subagent-rpc`) and delegates the run over stdio JSON-RPC, reusing `internal/jsonrpc`. A subprocess crash, transport error, or failed child run is surfaced as a tool error; the parent loop is unaffected.
- New `cmd/pigo subagent-rpc` mode (hidden `--subagent-rpc` flag) reads `subagent/run` JSON-RPC requests, resolves the provider, builds filtered builtins, runs `runtime.RunSubAgentOnce`, and writes responses.
- Subprocess-side `RunSubAgentOnce` is the shared agent core; falls back to `ErrorMessage` on a synthesized error turn so the real cause reaches the parent.
- Implementation notes: `docs/issue#0135.html`.

Closes #135

## Test plan
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] `go test -race ./internal/runtime/ ./cmd/pigo/` passes
- [x] Goroutine-mode regression: existing `TestSubAgentParentChildParent`/`Concurrent`/`EmptyPromptErrors`/`FailedChildErrors` + new `TestSubAgentGoroutineModeUnchanged` / `TestSubAgentGoroutineNilRunConfigErrors`
- [x] Process mode via injectable fake: happy / crash-as-tool-error / missing-model / tool-name forwarding
- [x] `RunSubAgentOnce` with faux provider: success + failed run (asserts `ErrorMessage` surfaces)
- [x] Real `defaultProcessCall` transport: compiled helper binary round-trip + crash-as-error
- [x] `cmd/pigo` server tests: `filterBuiltinTools`, `runSubAgentRPC` validation branches (parse/method/params), scanner-error non-zero exit