### PR TITLE
定义 pi 包清单 lockfile 与安装目录约定 (#154)

### DIFF
--- a/docs/issue#0154.html
+++ b/docs/issue#0154.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0154</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEEA; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/154">#154</a> &mdash; 定义包清单 lockfile 与安装目录约定 &mdash; 2026-07-20</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 新建 internal/pkgmgr package，镜像 internal/trust 的约定</h3>
+      <p><strong>Ambiguity:</strong> PRD/Issue 未指定 lockfile 模块放哪、用什么加载语义。</p>
+      <p><strong>Choice:</strong> 新建 <code>internal/pkgmgr</code>，lockfile 的 load/save 语义完全对齐既有的 <code>internal/trust.Manager</code>：文件缺失 = 空清单（非错误），文件存在但损坏 = 硬错误。</p>
+      <p><strong>Rationale:</strong> 项目已有一套成熟的「$PIGO_HOME + 缺失非错/损坏报错」范式，复用它让读者零学习成本，也满足验收条件里的「不存在时视为空清单」「损坏文件容错」。</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> lockfile 按包名 map 存储，List/Save 排序输出</h3>
+      <p><strong>Ambiguity:</strong> Issue 只要求「记录每个已安装包」，未规定内部结构与顺序。</p>
+      <p><strong>Choice:</strong> <code>Packages map[string]InstalledPackage</code>（按名查找 O(1)，卸载/更新友好）；<code>Save</code> 用 <code>MarshalIndent</code> 且 map 天然由 encoding/json 按 key 排序，<code>List()</code> 显式按 name 排序。</p>
+      <p><strong>Rationale:</strong> uninstall/update 都按包名操作，map 是最自然的主键结构；排序输出保证 lockfile diff 稳定、list 输出确定。</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> skills 目录不挂在 $PIGO_HOME 下</h3>
+      <p><strong>Ambiguity:</strong> PRD 映射表把 skill 落到「skills 目录」，但 pigo 的 skill 加载器读的是 <code>~/.agents/skills</code>（<code>PIGO_SKILLS_DIR</code> 可覆盖），而非 $PIGO_HOME/skills。</p>
+      <p><strong>Choice:</strong> <code>SkillsDir()</code> 遵循现有 skill 加载器的路径约定，是唯一不挂在 $PIGO_HOME 下的类型；plugins/commands/themes 都在 $PIGO_HOME 下。</p>
+      <p><strong>Rationale:</strong> 分发的唯一目的是让文件被现有发现机制加载。若装到 $PIGO_HOME/skills，skill 加载器根本不会去读，安装等于无效。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> lockfile 字段用 <code>types[]</code> 而非 PRD 文字里的 <code>type[]</code></h3>
+      <p><strong>Spec:</strong> PRD 正文写「<code>type[]</code>」。</p>
+      <p><strong>Implemented:</strong> JSON 字段名用 <code>types</code>（Go 字段 <code>Types []PackageType</code>）。</p>
+      <p><strong>Why:</strong> 复数名更符合 Go/JSON 惯例（切片用复数），语义完全一致。这是纯命名，不影响契约。若后续 Issue 依赖精确字段名，以本实现为准。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> lockfile 记录绝对文件路径</h3>
+      <p><strong>Alternatives:</strong> (A) 记录相对 $PIGO_HOME 的相对路径；(B) 记录落地文件的绝对路径。</p>
+      <p><strong>Pros/Cons:</strong> 相对路径更可移植（$PIGO_HOME 搬家不失效），但 uninstall 需要重新拼接根路径、且 skills 不在 $PIGO_HOME 下、相对基准不统一；绝对路径 uninstall 直接删、逻辑最简，代价是 $PIGO_HOME 迁移后失效。</p>
+      <p><strong>Winner:</strong> 绝对路径。安装是本机行为、$PIGO_HOME 迁移极少见，而 skills/commands/plugins 分属不同根，统一绝对路径避免「相对谁」的歧义，uninstall 实现最直接。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Home() 返回空字符串时的上层处理</h3>
+      <p><strong>Assumption:</strong> 当无法解析 home 目录且未设 PIGO_HOME 时，<code>Home()</code>/<code>DirForType()</code> 返回 <code>""</code>（对齐 trust.DefaultPath 的「不可用」契约）。</p>
+      <p><strong>Verify:</strong> 后续分发/安装 Issue（#158–#161、#162）需在拿到空目录时报清晰错误，而非用空路径写文件。此边界留给消费方处理，本 Issue 只提供契约。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> lockfile 版本迁移策略</h3>
+      <p><strong>Assumption:</strong> 预留了 <code>Version</code> 字段（当前恒为 1），但未实现任何版本迁移逻辑。</p>
+      <p><strong>Verify:</strong> 本期只有 v1，无需迁移；确认未来 schema 变更时再补迁移即可，符合当前范围。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/pkgmgr/layout.go
+++ b/internal/pkgmgr/layout.go
@@ -1,0 +1,97 @@
+// This file defines pigo's install directory layout (#154): where each pi
+// package type is placed so pigo's existing discovery mechanisms load it with
+// no extra configuration. The paths intentionally match the conventions already
+// used elsewhere in cmd/pigo and internal/*:
+//
+//   - extensions → $PIGO_HOME/plugins   (internal/plugin.Discover)
+//   - prompts    → $PIGO_HOME/commands  (runtime.LoadUserCommandsDir)
+//   - themes     → $PIGO_HOME/themes    (no runtime consumer yet)
+//   - skills     → skills dir           (~/.agents/skills, PIGO_SKILLS_DIR override)
+//
+// Skills are the one exception to the $PIGO_HOME root: pigo loads skills from
+// ~/.agents/skills (overridable with PIGO_SKILLS_DIR), so SkillsDir honors that
+// rather than nesting under $PIGO_HOME.
+package pkgmgr
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Home returns the pigo home directory: $PIGO_HOME, or ~/.pigo when unset. It
+// returns "" when the home directory cannot be resolved and no override is set,
+// matching trust.DefaultPath's "unavailable" contract.
+func Home() string {
+	if dir := os.Getenv("PIGO_HOME"); dir != "" {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".pigo")
+}
+
+// PluginsDir returns $PIGO_HOME/plugins, where installed extensions (including
+// MCP adapters) are laid down for internal/plugin.Discover. It returns "" when
+// Home is unavailable.
+func PluginsDir() string {
+	h := Home()
+	if h == "" {
+		return ""
+	}
+	return filepath.Join(h, "plugins")
+}
+
+// CommandsDir returns $PIGO_HOME/commands, where installed prompt/command
+// templates are laid down for runtime.LoadUserCommandsDir. It returns "" when
+// Home is unavailable.
+func CommandsDir() string {
+	h := Home()
+	if h == "" {
+		return ""
+	}
+	return filepath.Join(h, "commands")
+}
+
+// ThemesDir returns $PIGO_HOME/themes, where installed themes are stored. pigo
+// has no theme runtime yet, so this is a holding location for a future consumer.
+// It returns "" when Home is unavailable.
+func ThemesDir() string {
+	h := Home()
+	if h == "" {
+		return ""
+	}
+	return filepath.Join(h, "themes")
+}
+
+// SkillsDir returns the directory installed skills are placed in: PIGO_SKILLS_DIR
+// when set, else ~/.agents/skills — matching cmd/pigo's skill loader. It returns
+// "" when the home directory cannot be resolved and no override is set.
+func SkillsDir() string {
+	if dir := os.Getenv("PIGO_SKILLS_DIR"); dir != "" {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".agents", "skills")
+}
+
+// DirForType returns the install directory for a package type, or "" when the
+// type is unknown or the underlying home directory is unavailable.
+func DirForType(t PackageType) string {
+	switch t {
+	case TypeExtension:
+		return PluginsDir()
+	case TypePrompt:
+		return CommandsDir()
+	case TypeTheme:
+		return ThemesDir()
+	case TypeSkill:
+		return SkillsDir()
+	default:
+		return ""
+	}
+}

--- a/internal/pkgmgr/layout_test.go
+++ b/internal/pkgmgr/layout_test.go
@@ -1,0 +1,58 @@
+package pkgmgr
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestHomeHonorsPIGOHOME verifies Home prefers PIGO_HOME over the default.
+func TestHomeHonorsPIGOHOME(t *testing.T) {
+	t.Setenv("PIGO_HOME", "/custom/pigo")
+	if got := Home(); got != "/custom/pigo" {
+		t.Errorf("Home() = %q, want /custom/pigo", got)
+	}
+}
+
+// TestTypeDirsUnderHome verifies the plugins/commands/themes dirs nest under
+// $PIGO_HOME.
+func TestTypeDirsUnderHome(t *testing.T) {
+	t.Setenv("PIGO_HOME", "/custom/pigo")
+	cases := map[PackageType]string{
+		TypeExtension: "/custom/pigo/plugins",
+		TypePrompt:    "/custom/pigo/commands",
+		TypeTheme:     "/custom/pigo/themes",
+	}
+	for typ, want := range cases {
+		if got := DirForType(typ); got != want {
+			t.Errorf("DirForType(%s) = %q, want %q", typ, got, want)
+		}
+	}
+}
+
+// TestSkillsDirHonorsOverride verifies skills use PIGO_SKILLS_DIR, not $PIGO_HOME.
+func TestSkillsDirHonorsOverride(t *testing.T) {
+	t.Setenv("PIGO_SKILLS_DIR", "/custom/skills")
+	if got := SkillsDir(); got != "/custom/skills" {
+		t.Errorf("SkillsDir() = %q, want /custom/skills", got)
+	}
+	if got := DirForType(TypeSkill); got != "/custom/skills" {
+		t.Errorf("DirForType(skill) = %q, want /custom/skills", got)
+	}
+}
+
+// TestSkillsDirDefault verifies skills default to ~/.agents/skills.
+func TestSkillsDirDefault(t *testing.T) {
+	t.Setenv("PIGO_SKILLS_DIR", "")
+	t.Setenv("HOME", "/home/tester")
+	want := filepath.Join("/home/tester", ".agents", "skills")
+	if got := SkillsDir(); got != want {
+		t.Errorf("SkillsDir() = %q, want %q", got, want)
+	}
+}
+
+// TestDirForUnknownType verifies an unknown type yields "".
+func TestDirForUnknownType(t *testing.T) {
+	if got := DirForType(PackageType("bogus")); got != "" {
+		t.Errorf("DirForType(bogus) = %q, want empty", got)
+	}
+}

--- a/internal/pkgmgr/lockfile.go
+++ b/internal/pkgmgr/lockfile.go
@@ -1,0 +1,183 @@
+// Package pkgmgr implements pigo's pi-package installer state and layout
+// (#154). A pi package is an add-on published to npm — an extension (often an
+// MCP adapter), a skill, a prompt/command template, or a theme — installed with
+// `pigo install npm:<name>`. This package owns two concerns that the install /
+// list / uninstall / update commands all build on:
+//
+//   - The lockfile: a JSON record at $PIGO_HOME/packages.json of every installed
+//     package (name, source, version, types, and the exact files laid down on
+//     disk). It is the source of truth for list/uninstall/update, so removal and
+//     upgrade can find and clean up precisely what an install created.
+//   - The directory layout: where each package type is placed so pigo's existing
+//     discovery mechanisms pick it up without extra configuration — extensions
+//     under $PIGO_HOME/plugins, skills under the skills dir, prompts under
+//     $PIGO_HOME/commands, themes under $PIGO_HOME/themes.
+//
+// This file defines the lockfile wire types and their load/save, mirroring the
+// conventions already used by internal/trust: a missing file is an empty
+// lockfile (not an error), while a present-but-malformed file is a hard error so
+// a corrupted store is surfaced rather than silently overwritten.
+package pkgmgr
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// PackageType is one of the pi package kinds pigo can install. A single package
+// may declare several (the npm catalog has combined "extensionskill" entries),
+// so an InstalledPackage carries a slice of these.
+type PackageType string
+
+const (
+	// TypeExtension is an executable extension (including MCP adapters); it is
+	// laid down under $PIGO_HOME/plugins and discovered by internal/plugin.
+	TypeExtension PackageType = "extension"
+	// TypeSkill is a skill bundle placed under the skills directory.
+	TypeSkill PackageType = "skill"
+	// TypePrompt is a prompt/command template placed under $PIGO_HOME/commands.
+	TypePrompt PackageType = "prompt"
+	// TypeTheme is a theme; pigo has no theme runtime yet, so it is only stored
+	// under $PIGO_HOME/themes for a future consumer.
+	TypeTheme PackageType = "theme"
+)
+
+// InstalledPackage is one entry in the lockfile: everything needed to describe,
+// upgrade, or remove a package that was installed.
+type InstalledPackage struct {
+	// Name is the package's identifier (the npm package name).
+	Name string `json:"name"`
+	// Source is the original install reference, e.g. "npm:pi-mcp-adapter".
+	Source string `json:"source"`
+	// Version is the resolved, installed version string.
+	Version string `json:"version"`
+	// Types are the pi package kinds this package was classified as (one or more).
+	Types []PackageType `json:"types"`
+	// Files are the absolute paths of every file laid down on disk for this
+	// package, so uninstall/update can remove exactly what was created.
+	Files []string `json:"files"`
+}
+
+// Lockfile is the on-disk record of all installed packages, keyed by package
+// name. The zero value is not usable; obtain one via Load.
+type Lockfile struct {
+	// Version is the lockfile schema version, for forward migration.
+	Version int `json:"version"`
+	// Packages maps package name to its installed record.
+	Packages map[string]InstalledPackage `json:"packages"`
+
+	// path is where Save writes; not serialized.
+	path string `json:"-"`
+}
+
+// lockfileVersion is the current schema version written by Save.
+const lockfileVersion = 1
+
+// DefaultLockfilePath returns the lockfile location: $PIGO_HOME/packages.json,
+// or ~/.pigo/packages.json when PIGO_HOME is unset. It returns "" when the home
+// directory cannot be resolved and no override is set, mirroring
+// trust.DefaultPath so the caller can treat the store as unavailable rather than
+// guessing a path.
+func DefaultLockfilePath() string {
+	if dir := os.Getenv("PIGO_HOME"); dir != "" {
+		return filepath.Join(dir, "packages.json")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".pigo", "packages.json")
+}
+
+// Load reads the lockfile at path. A missing file is not an error: it yields an
+// empty lockfile whose Save will create the file. A present-but-malformed file
+// is a hard error so a corrupted store is surfaced rather than silently
+// overwritten. An empty path yields an in-memory-only lockfile (Save is a no-op).
+func Load(path string) (*Lockfile, error) {
+	lf := &Lockfile{
+		Version:  lockfileVersion,
+		Packages: make(map[string]InstalledPackage),
+		path:     path,
+	}
+	if path == "" {
+		return lf, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return lf, nil // no lockfile yet → empty
+		}
+		return nil, fmt.Errorf("pkgmgr: read lockfile %q: %w", path, err)
+	}
+	if err := json.Unmarshal(data, lf); err != nil {
+		return nil, fmt.Errorf("pkgmgr: parse lockfile %q: %w", path, err)
+	}
+	if lf.Packages == nil {
+		lf.Packages = make(map[string]InstalledPackage)
+	}
+	lf.path = path
+	return lf, nil
+}
+
+// Save writes the lockfile to its path as human-readable, indented JSON, with
+// package keys in sorted order for a stable diff. Save creates the parent
+// directory if needed. It is a no-op when the lockfile has no path (empty-path
+// Load), so in-memory use never touches disk.
+func (lf *Lockfile) Save() error {
+	if lf.path == "" {
+		return nil
+	}
+	if lf.Version == 0 {
+		lf.Version = lockfileVersion
+	}
+	if err := os.MkdirAll(filepath.Dir(lf.path), 0o755); err != nil {
+		return fmt.Errorf("pkgmgr: create lockfile dir: %w", err)
+	}
+	data, err := json.MarshalIndent(lf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("pkgmgr: encode lockfile: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(lf.path, data, 0o644); err != nil {
+		return fmt.Errorf("pkgmgr: write lockfile %q: %w", lf.path, err)
+	}
+	return nil
+}
+
+// Get returns the installed record for name and whether it exists.
+func (lf *Lockfile) Get(name string) (InstalledPackage, bool) {
+	p, ok := lf.Packages[name]
+	return p, ok
+}
+
+// Set records (or replaces) a package entry in memory. Call Save to persist.
+func (lf *Lockfile) Set(p InstalledPackage) {
+	if lf.Packages == nil {
+		lf.Packages = make(map[string]InstalledPackage)
+	}
+	lf.Packages[p.Name] = p
+}
+
+// Remove deletes the entry for name in memory, reporting whether it existed.
+// Call Save to persist.
+func (lf *Lockfile) Remove(name string) bool {
+	if _, ok := lf.Packages[name]; !ok {
+		return false
+	}
+	delete(lf.Packages, name)
+	return true
+}
+
+// List returns all installed packages sorted by name, for stable `pigo list`
+// output.
+func (lf *Lockfile) List() []InstalledPackage {
+	out := make([]InstalledPackage, 0, len(lf.Packages))
+	for _, p := range lf.Packages {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/internal/pkgmgr/lockfile_test.go
+++ b/internal/pkgmgr/lockfile_test.go
@@ -1,0 +1,141 @@
+package pkgmgr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadMissingFileIsEmpty verifies a missing lockfile yields an empty,
+// usable lockfile rather than an error.
+func TestLoadMissingFileIsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "packages.json")
+	lf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load missing file: %v", err)
+	}
+	if len(lf.Packages) != 0 {
+		t.Errorf("expected empty lockfile, got %d packages", len(lf.Packages))
+	}
+	if lf.Version != lockfileVersion {
+		t.Errorf("version = %d, want %d", lf.Version, lockfileVersion)
+	}
+}
+
+// TestSaveThenLoadRoundTrips verifies a written lockfile reads back identically.
+func TestSaveThenLoadRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "packages.json") // sub dir must be created
+	lf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	lf.Set(InstalledPackage{
+		Name:    "pi-mcp-adapter",
+		Source:  "npm:pi-mcp-adapter",
+		Version: "1.2.3",
+		Types:   []PackageType{TypeExtension},
+		Files:   []string{"/home/u/.pigo/plugins/pi-mcp-adapter"},
+	})
+	lf.Set(InstalledPackage{
+		Name:    "pi-web-access",
+		Source:  "npm:pi-web-access",
+		Version: "0.1.0",
+		Types:   []PackageType{TypeExtension, TypeSkill},
+		Files:   []string{"/home/u/.pigo/plugins/pi-web-access"},
+	})
+	if err := lf.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(got.Packages) != 2 {
+		t.Fatalf("reloaded %d packages, want 2", len(got.Packages))
+	}
+	p, ok := got.Get("pi-web-access")
+	if !ok {
+		t.Fatal("pi-web-access missing after reload")
+	}
+	if p.Version != "0.1.0" || len(p.Types) != 2 {
+		t.Errorf("pi-web-access = %+v, unexpected", p)
+	}
+}
+
+// TestSaveIsIndentedJSON verifies the on-disk format is human-readable.
+func TestSaveIsIndentedJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "packages.json")
+	lf, _ := Load(path)
+	lf.Set(InstalledPackage{Name: "x", Source: "npm:x", Version: "1", Types: []PackageType{TypeSkill}})
+	if err := lf.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !contains(string(data), "\n  ") {
+		t.Errorf("expected indented JSON, got:\n%s", data)
+	}
+}
+
+// TestLoadCorruptFileIsError verifies a malformed lockfile is surfaced, never
+// silently overwritten.
+func TestLoadCorruptFileIsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "packages.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected error for corrupt lockfile, got nil")
+	}
+}
+
+// TestRemove verifies Remove reports existence and deletes the entry.
+func TestRemove(t *testing.T) {
+	lf, _ := Load("") // in-memory
+	lf.Set(InstalledPackage{Name: "a", Source: "npm:a", Version: "1"})
+	if !lf.Remove("a") {
+		t.Error("Remove(a) = false, want true")
+	}
+	if lf.Remove("a") {
+		t.Error("Remove(a) second time = true, want false")
+	}
+	if _, ok := lf.Get("a"); ok {
+		t.Error("a still present after Remove")
+	}
+}
+
+// TestListSorted verifies List returns packages ordered by name.
+func TestListSorted(t *testing.T) {
+	lf, _ := Load("")
+	lf.Set(InstalledPackage{Name: "zebra", Source: "npm:zebra"})
+	lf.Set(InstalledPackage{Name: "alpha", Source: "npm:alpha"})
+	lf.Set(InstalledPackage{Name: "mango", Source: "npm:mango"})
+	got := lf.List()
+	want := []string{"alpha", "mango", "zebra"}
+	for i, p := range got {
+		if p.Name != want[i] {
+			t.Errorf("List()[%d] = %q, want %q", i, p.Name, want[i])
+		}
+	}
+}
+
+// TestEmptyPathSaveIsNoop verifies an in-memory lockfile never touches disk.
+func TestEmptyPathSaveIsNoop(t *testing.T) {
+	lf, _ := Load("")
+	lf.Set(InstalledPackage{Name: "a"})
+	if err := lf.Save(); err != nil {
+		t.Errorf("Save on empty-path lockfile: %v", err)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/tasks/prd-install-pi-packages.md
+++ b/tasks/prd-install-pi-packages.md
@@ -1,0 +1,213 @@
+# PRD: 安装 pi Agent 包（pigo install）
+
+## Introduction
+
+pi 生态在 npm 上发布了大量 agent 扩展包（catalog: https://pi.dev/packages），涵盖 **extension（可执行扩展/插件）、skill（技能）、prompt（提示词/命令模板）、theme（主题）** 四类，其中不少扩展本质是 MCP adapter（如 `pi-mcp-adapter`）。pi 用户通过 `pi install npm:<package>` 一行命令即可安装。
+
+pigo 是 pi agent 的 Go 复刻版，已具备自己的 **plugin 系统**（`$PIGO_HOME/plugins` 下的可执行文件，走 JSON-RPC）、**命令系统**（`$PIGO_HOME/commands/*.md`）和 **skill 系统**（`~/.agents/skills`）。目前用户无法直接复用 pi 生态里的现成包。
+
+本功能给 pigo 增加一个 `pigo install` 子命令，从 npm 拉取 pi 包，识别其类型，并把内容分发到 pigo 对应的目录，使其被现有的发现机制自动加载。同时提供 `list` 与 `uninstall` 管理已安装的包。
+
+**读者假设**：面向初级开发者或 AI agent，涉及的概念（npm 包结构、pi 包类型、pigo 目录约定）首次出现时给出解释。
+
+**关键决策（来自澄清问答）**：
+- **获取方式（1B）**：调用本机已安装的 `npm`（`npm pack` / `npm install`）拉取包，不自己实现 npm registry 客户端。未检测到 npm 时给出清晰报错与安装指引。
+- **包类型（2A）**：尽力映射全部 pi 包类型到 pigo 对应机制。
+- **命令范围（3C）**：`install` + `list` + `uninstall` + `update`。
+- **来源前缀（4A）**：仅 `npm:<name>`，含 scoped 形式 `npm:@scope/name`。
+- **安装位置（5B）**：按类型分发到各自专用目录（`plugins/`、`commands/`、skills 目录），而非集中目录。
+
+## Goals
+
+- 用户可通过 `pigo install npm:<package>` 一行命令安装 pi 生态的 npm 包。
+- 安装时自动识别包类型并分发到 pigo 对应目录，安装后无需额外配置即可被发现机制加载。
+- 支持 `list` 查看已安装包、`uninstall` 卸载、`update` 更新到最新版本。
+- 维护一份已安装包的清单（lockfile），记录包名、版本、类型、安装的文件，使 `list`/`uninstall`/`update` 可靠工作。
+- 依赖本机 `npm`；缺失时报错清晰，不静默失败。
+- 全流程 `go build ./... && go vet ./... && go test ./...` 全绿。
+
+## pi 包类型 → pigo 目标目录映射
+
+| pi 包类型 | 识别依据（package.json 字段/约定） | pigo 目标目录 | 说明 |
+|-----------|-----------------------------------|--------------|------|
+| extension（含 MCP adapter） | 声明可执行入口（`bin`/`pi.extension`） | `$PIGO_HOME/plugins/` | 落地为可执行文件，走现有 JSON-RPC 插件协议 |
+| skill | 含 `SKILL.md`/skill 元数据（`pi.skill`） | skills 目录（`~/.agents/skills` 或 `PIGO_SKILLS_DIR`） | 复用现有 skill 加载 |
+| prompt / command | 含命令模板（`pi.prompt` / `commands/*.md`） | `$PIGO_HOME/commands/` | 复用现有命令加载 |
+| theme | `pi.theme` | `$PIGO_HOME/themes/`（暂存） | [Assumption] pigo 尚无主题系统，先落盘保存，运行时消费留待后续（见 Open Questions） |
+
+> 类型识别以包 `package.json` 中的 pi 元数据字段为准；一个包可同时声明多种类型（catalog 中存在 `extensionskill` 组合），按声明的每种类型分别分发。识别不出任何已知类型时，安装失败并提示。
+
+## User Stories
+
+### US-001: 定义包清单（lockfile）与安装目录约定
+**Description:** 作为开发者，我需要一份记录已安装包的清单文件，以便 `list`/`uninstall`/`update` 能准确知道装了什么、装了哪些文件。
+
+**Acceptance Criteria:**
+- [ ] 在 `$PIGO_HOME/packages.json`（或等价 lockfile）中记录每个已安装包：`name`、`source`（如 `npm:pi-mcp-adapter`）、`version`、`type[]`、安装落地的文件路径列表
+- [ ] 定义并实现读写该 lockfile 的函数（不存在时视为空清单，不报错）
+- [ ] lockfile 为格式化 JSON，可人工阅读
+- [ ] 该模块有单元测试覆盖读、写、空文件、损坏文件容错
+- [ ] Typecheck/lint passes（`go build ./... && go vet ./...`）
+
+### US-002: 解析并校验 `npm:<name>` 包引用
+**Description:** 作为用户，我输入 `npm:pi-mcp-adapter` 或 `npm:@scope/name`，系统需正确解析出 registry 与包名。
+
+**Acceptance Criteria:**
+- [ ] 输入 `npm:pi-mcp-adapter` 解析为 `{registry: npm, name: pi-mcp-adapter}`
+- [ ] 输入 `npm:@scope/name` 正确解析 scoped 包名
+- [ ] 缺少 `npm:` 前缀或前缀不受支持时，返回明确错误：`unsupported package source, expected npm:<name>`
+- [ ] 非法 npm 包名（含空格/非法字符）被拒绝并报错
+- [ ] 解析逻辑有单元测试覆盖上述各分支
+- [ ] Typecheck/lint passes
+
+### US-003: 检测本机 npm 并从 npm 拉取包内容
+**Description:** 作为用户，我希望 `pigo install` 用本机 npm 把包下载并解包到临时目录，供后续分发。
+
+**Acceptance Criteria:**
+- [ ] 安装前检测 `npm` 是否在 PATH；缺失时报错 `npm not found; install Node.js/npm to use pigo install` 并退出非零
+- [ ] 通过 npm（如 `npm pack <name>` 后解包，或 `npm install` 到临时目录）获取包内容到一个临时目录
+- [ ] 支持指定版本（`npm:name@1.2.3`）；未指定时取最新版
+- [ ] npm 命令失败（包不存在、网络错误）时，透传 npm 的错误信息并退出非零，不留下半安装状态
+- [ ] 拉取结束后清理临时目录
+- [ ] Typecheck/lint passes
+
+### US-004: 识别 pi 包类型
+**Description:** 作为系统，我需要读取包内 `package.json` 的 pi 元数据，判断这是 extension/skill/prompt/theme 中的哪一种（或多种）。
+
+**Acceptance Criteria:**
+- [ ] 读取包 `package.json`，根据映射表列出的字段/约定判定类型，返回类型集合
+- [ ] 一个包声明多种类型时，返回全部类型
+- [ ] 无法识别任何已知 pi 类型时，返回错误 `unrecognized pi package: no known pi metadata`
+- [ ] 识别逻辑有单元测试，覆盖单类型、多类型（如 extension+skill）、未知类型三种输入
+- [ ] Typecheck/lint passes
+
+### US-005: 分发 extension/MCP-adapter 类型到 plugins 目录
+**Description:** 作为用户，安装一个 extension（如 MCP adapter）后，它应作为 pigo 插件被自动发现。
+
+**Acceptance Criteria:**
+- [ ] extension 包的可执行入口被落地到 `$PIGO_HOME/plugins/`，且带可执行权限（chmod +x）
+- [ ] 落地的文件路径写入 US-001 的 lockfile
+- [ ] 安装后启动 pigo，该插件出现在已加载插件中（现有 `plugin.Discover` 能发现它）
+- [ ] 若包声明的入口需运行时（如 node 脚本），安装时验证运行时存在或在 lockfile 记录其运行方式（见 Open Questions）
+- [ ] 有测试验证：给定一个 mock extension 包，分发后文件出现在 plugins 目录且可执行位已设置
+- [ ] Typecheck/lint passes
+
+### US-006: 分发 skill 类型到 skills 目录
+**Description:** 作为用户，安装一个 skill 包后，它应被 pigo 的 skill 加载机制发现。
+
+**Acceptance Criteria:**
+- [ ] skill 包内容被落地到 skills 目录（`~/.agents/skills/<name>/`，遵循 `PIGO_SKILLS_DIR` 覆盖）
+- [ ] 落地文件路径写入 lockfile
+- [ ] 安装后 skill 以 `/skill-name` 形式出现在可用命令中（现有 skill 加载能发现它）
+- [ ] 有测试验证 mock skill 包分发后出现在 skills 目录
+- [ ] Typecheck/lint passes
+
+### US-007: 分发 prompt/command 类型到 commands 目录
+**Description:** 作为用户，安装一个 prompt/command 包后，它应作为斜杠命令可用。
+
+**Acceptance Criteria:**
+- [ ] command 模板被落地到 `$PIGO_HOME/commands/`（遵循现有 `commands/*.md` 约定）
+- [ ] 落地文件路径写入 lockfile
+- [ ] 与内置命令重名时，沿用现有「用户命令被内置命令 shadow」的行为并在安装时警告
+- [ ] 有测试验证 mock prompt 包分发后出现在 commands 目录
+- [ ] Typecheck/lint passes
+
+### US-008: 分发 theme 类型（暂存落盘）
+**Description:** 作为用户，安装 theme 包不应报错；即便 pigo 暂无主题系统，也先把主题文件保存下来。
+
+**Acceptance Criteria:**
+- [ ] theme 包内容落地到 `$PIGO_HOME/themes/<name>/`
+- [ ] 落地文件路径写入 lockfile
+- [ ] 安装成功输出提示：`theme installed but not yet consumed by pigo runtime`（`[Assumption]`，见 Open Questions）
+- [ ] 有测试验证 mock theme 包分发后出现在 themes 目录
+- [ ] Typecheck/lint passes
+
+### US-009: `pigo install` 端到端命令
+**Description:** 作为用户，我运行 `pigo install npm:pi-mcp-adapter` 即可完成解析→拉取→识别→分发→写清单的全流程。
+
+**Acceptance Criteria:**
+- [ ] `pigo install npm:<name>` 串联 US-002~US-008，成功后打印安装摘要（包名、版本、类型、落地目录）
+- [ ] 任一步骤失败时报错清晰、退出非零，且不写入部分 lockfile 记录（要么全成功要么不留记录）
+- [ ] 重复安装同一包时，先卸载旧版本文件再装新的（幂等，不残留旧文件）
+- [ ] 有集成测试用 mock npm（或桩）验证一个 extension 包端到端安装
+- [ ] Typecheck/lint passes
+
+### US-010: `pigo list` 列出已安装包
+**Description:** 作为用户，我想查看已安装了哪些 pi 包及其版本和类型。
+
+**Acceptance Criteria:**
+- [ ] `pigo list` 读取 lockfile，逐行打印 `name  version  type(s)  source`
+- [ ] 无已安装包时打印 `no packages installed`
+- [ ] 有单元测试覆盖有包/无包两种输出
+- [ ] Typecheck/lint passes
+
+### US-011: `pigo uninstall` 卸载包
+**Description:** 作为用户，我想卸载一个已安装的包并清理其落地文件。
+
+**Acceptance Criteria:**
+- [ ] `pigo uninstall <name>` 删除该包在 lockfile 中记录的全部落地文件，并从 lockfile 移除该条目
+- [ ] 卸载未安装的包时报错 `package not installed: <name>` 并退出非零
+- [ ] 删除文件时若某文件已不存在，跳过并继续（不因残缺而中断），最终 lockfile 条目被移除
+- [ ] 有测试验证安装后 uninstall 能移除文件与 lockfile 条目
+- [ ] Typecheck/lint passes
+
+### US-012: `pigo update` 更新包到最新版本
+**Description:** 作为用户，我想把已安装的包更新到 npm 上的最新版本。
+
+**Acceptance Criteria:**
+- [ ] `pigo update <name>` 对指定包执行「卸载旧文件 → 按记录的 source 重新拉取最新版 → 重新分发 → 更新 lockfile 版本」
+- [ ] `pigo update`（不带包名）遍历更新 lockfile 中全部包
+- [ ] 已是最新版时打印 `<name> is up to date`，不做无谓改动
+- [ ] 更新失败时保留原安装（不留下损坏状态）
+- [ ] 有测试验证 update 后 lockfile 版本被更新
+- [ ] Typecheck/lint passes
+
+## Functional Requirements
+
+- FR-1: 系统必须提供 `pigo install <source>` 子命令。
+- FR-2: 系统必须仅接受 `npm:<name>` 形式的 source（含 `npm:@scope/name` 与 `npm:name@version`），其它前缀必须报错。
+- FR-3: 系统在安装前必须检测本机 `npm` 是否可用，不可用时必须报错并退出非零。
+- FR-4: 系统必须通过本机 npm 将包内容获取到临时目录，完成后必须清理临时目录。
+- FR-5: 系统必须读取包 `package.json` 的 pi 元数据以判定包类型（可为多类型）。
+- FR-6: 系统必须把 extension（含 MCP adapter）类型落地到 `$PIGO_HOME/plugins/` 并设置可执行权限。
+- FR-7: 系统必须把 skill 类型落地到 skills 目录（遵循 `PIGO_SKILLS_DIR` 覆盖）。
+- FR-8: 系统必须把 prompt/command 类型落地到 `$PIGO_HOME/commands/`。
+- FR-9: 系统必须把 theme 类型落地到 `$PIGO_HOME/themes/` 并提示暂未被运行时消费。
+- FR-10: 系统必须在 `$PIGO_HOME/packages.json` 中记录每个已安装包的 name、source、version、type[]、落地文件列表。
+- FR-11: 系统必须提供 `pigo list` 列出 lockfile 中的已安装包。
+- FR-12: 系统必须提供 `pigo uninstall <name>` 删除包的落地文件并移除 lockfile 条目。
+- FR-13: 系统必须提供 `pigo update [name]` 将指定包（或全部包）更新到最新版本。
+- FR-14: 系统在安装/更新任一步骤失败时必须不留下部分 lockfile 记录（原子性）。
+- FR-15: 重复安装同名包时，系统必须先清理旧落地文件再安装新版本（幂等）。
+
+## Non-Goals (Out of Scope)
+
+- 不实现自研 npm registry 客户端；完全依赖本机 npm。
+- 不支持 `github:`、`file:` 等 npm 以外的来源前缀（本期仅 `npm:`）。
+- 不实现 pigo 的主题运行时系统；theme 包仅落盘暂存。
+- 不实现 MCP 协议客户端本身；MCP adapter 作为普通 extension 走现有插件 JSON-RPC 协议（adapter 自身负责桥接 MCP）。
+- 不做包的依赖解析/传递依赖管理（交由 npm 处理）。
+- 不做包签名校验、安全沙箱审计（见 Open Questions 中的安全考量）。
+- 不提供 GUI/交互式包浏览；仅命令行。
+
+## Technical Considerations
+
+- 复用现有发现机制：`plugin.Discover($PIGO_HOME/plugins)`、skills 加载（`~/.agents/skills` / `PIGO_SKILLS_DIR`）、命令加载（`$PIGO_HOME/commands/*.md`）。分发只需把文件放对目录，无需改动加载器。
+- `$PIGO_HOME` 解析沿用现有约定（`PIGO_HOME` 环境变量，默认 `~/.pigo`）。
+- 调用 npm 时用非交互方式（避免交互式提示阻塞），透传 stderr 以便诊断。
+- lockfile 与安装模块建议置于新 package（如 `internal/pkgmgr`），CLI 子命令置于 `cmd/pigo`。
+- 安全提示：安装第三方可执行 extension 会在本机运行外部代码，属于中高风险动作；安装 extension 时应向用户提示来源与风险（可结合已有的 Project Trust 机制，见近期提交 US-018）。
+
+## Success Metrics
+
+- 用户可用单条 `pigo install npm:pi-mcp-adapter` 完成安装，安装后重启 pigo 即可发现该插件（0 额外手动步骤）。
+- `list`/`uninstall`/`update` 对 lockfile 的操作 100% 一致（uninstall 后 list 不再显示该包，磁盘无残留记录文件）。
+- 安装失败场景（无 npm、包不存在、类型无法识别）均给出可操作的明确报错，无半安装残留。
+
+## Open Questions
+
+- extension 若是 node 脚本入口（非原生可执行），pigo 插件协议要求可执行文件——需确定是落地一个调用 `node xxx.js` 的 wrapper 脚本，还是要求包提供原生可执行？（影响 US-005）
+- theme 包落盘后，是否在本期就规划一个最小主题消费点，还是完全留待后续独立 PRD？
+- 是否需要把安装动作纳入 Project Trust 信任确认流程（安装即运行第三方代码的风险）？
+- pi 包元数据的确切字段（`pi.extension` / `pi.skill` / `pi.prompt` / `pi.theme`）需以 pi 官方包文档为准核对——catalog 页指向 GitHub 上的 package docs，实现前需确认真实字段名与结构。
+- 版本升级时若包类型发生变化（旧版是 skill，新版新增 extension），分发与清理如何处理？


### PR DESCRIPTION
## Summary
- 新建 `internal/pkgmgr` package，作为 `pigo install` 系列命令的基础
- `lockfile.go`：`$PIGO_HOME/packages.json` 的读写（name/source/version/types/files），缺失=空清单、损坏=硬错误，对齐 `internal/trust` 约定
- `layout.go`：各包类型的安装目录约定（extension→plugins、prompt→commands、theme→themes、skill→~/.agents/skills）
- 单元测试覆盖读/写/空文件/损坏容错/排序/目录映射

Closes #154

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/pkgmgr/`（全绿）