### PR TITLE
识别 pi 包类型 classify

### DIFF
--- a/docs/issue#0157.html
+++ b/docs/issue#0157.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0157</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEEA; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/157">#157</a> &mdash; 识别 pi 包类型 (classify pi package types) &mdash; 2026-07-20</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 显式 <code>pi</code> 元数据 + 结构化信号 双通道识别</h3>
+      <p><strong>Ambiguity:</strong> Issue/PRD 给了映射表（extension via <code>bin</code>/<code>pi.extension</code>；skill via <code>SKILL.md</code>/<code>pi.skill</code>；prompt via <code>pi.prompt</code>/<code>commands/*.md</code>；theme via <code>pi.theme</code>），但未规定当二者冲突或包"少声明"时如何取舍。</p>
+      <p><strong>Choice:</strong> 两路并集：先读 <code>package.json</code> 的 <code>pi</code> 块（支持单 <code>type</code>、<code>types</code> 列表、以及 per-capability 键），再叠加结构化回退（<code>bin</code>→extension、<code>SKILL.md</code>→skill、<code>commands/</code>→prompt）。结果是一个去重后的类型集合。</p>
+      <p><strong>Rationale:</strong> pi 生态里存在 combined "extensionskill" 包，一个包可同时是多类型；并集能覆盖"声明齐全"和"结构清晰但少声明"两种真实情况，稳健且不误判。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 无法识别时报错而非猜测</h3>
+      <p><strong>Ambiguity:</strong> 遇到普通 npm 包（如 lodash）应如何处置。</p>
+      <p><strong>Choice:</strong> 空集合直接返回 <code>unrecognized pi package: no known pi metadata</code>。</p>
+      <p><strong>Rationale:</strong> <code>pigo install</code> 需要对非 pi 包快速失败并给出明确信息，避免把任意 npm 包错误地分发到 pigo 目录。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Classify 同时返回 name/version</h3>
+      <p><strong>Spec:</strong> US-004 只要求"返回类型集合"。</p>
+      <p><strong>Implemented:</strong> 签名为 <code>Classify(pkgDir) (name, version string, types []PackageType, err error)</code>，顺带回传从同一份 <code>package.json</code> 读到的名字与版本。</p>
+      <p><strong>Why:</strong> 后续 issue（#158-#162 分发与写 lockfile）都需要 name/version，且它们和类型来自同一次解析，一并返回避免重复读取 <code>package.json</code>。生产行为不变。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 未知 <code>pi.type</code> 字符串：忽略 vs 报错</h3>
+      <p><strong>Alternatives:</strong> (A) 遇到无法识别的 type 字符串（如 <code>"widget"</code>）直接报错；(B) 忽略该字符串，仅当最终集合为空才报错。</p>
+      <p><strong>Pros/Cons:</strong> A 更严格但对 pi 生态未来新增类型不向前兼容；B 宽容、向前兼容，但可能"静默丢弃"一个真实类型。</p>
+      <p><strong>Winner:</strong> 选 B。若包同时有可识别信号则照常分类；若只有未知 type 则仍因空集合报错，安全兜底。未来 pigo 支持新类型时只需扩展 <code>normalizeType</code>。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> pi 元数据字段名的确切约定</h3>
+      <p><strong>Assumption:</strong> 顶层 <code>pi</code> 对象含 <code>type</code>(string)/<code>types</code>([]string) 以及 per-capability 键 <code>extension/skill/prompt/theme</code>。这是依据 pi 包惯例的推断。</p>
+      <p><strong>Verify:</strong> 若 pi.dev 官方约定的字段名不同，需调整 <code>piMeta</code> 结构；结构化回退（bin/SKILL.md/commands）不受影响，可作为兜底。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/pkgmgr/classify.go
+++ b/internal/pkgmgr/classify.go
@@ -1,0 +1,138 @@
+// This file classifies a fetched pi package into its type(s) — extension,
+// skill, prompt, or theme (#157). Classification reads the package's
+// package.json: pi packages carry a "pi" metadata block declaring what they
+// provide, and pigo also falls back to structural signals (a bin entry, a
+// SKILL.md, a commands/ dir) so a package that omits explicit metadata but
+// clearly is one type is still recognized.
+//
+// A single package may be several types at once — the npm catalog has combined
+// "extensionskill" entries — so Classify returns a set. When nothing matches,
+// it returns an error rather than guessing, so `pigo install` fails clearly on
+// a package that isn't a pi package.
+//
+// NOTE on metadata shape: the exact pi metadata field names are taken from the
+// pi package conventions (a top-level "pi" object with a "type" string or
+// "types" array, and/or per-capability keys). Both the explicit "pi.type(s)"
+// form and structural fallbacks are honored so classification is robust to
+// packages that under-declare. See docs/issue#0157.html for the assumptions.
+package pkgmgr
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+)
+
+// packageJSON is the subset of an npm package.json pigo reads for classification
+// and versioning. Unknown fields are ignored.
+type packageJSON struct {
+	Name    string          `json:"name"`
+	Version string          `json:"version"`
+	// Bin is npm's executable declaration: either a string path or a
+	// {name: path} object. Its presence signals an extension.
+	Bin json.RawMessage `json:"bin,omitempty"`
+	// Pi is the pi-specific metadata block declaring the package's capabilities.
+	Pi *piMeta `json:"pi,omitempty"`
+}
+
+// piMeta is the "pi" block of a package.json. It supports either a single
+// "type" or a "types" list, plus per-capability booleans/objects so a package
+// can declare, e.g., both an extension and a skill.
+type piMeta struct {
+	Type      string          `json:"type,omitempty"`
+	Types     []string        `json:"types,omitempty"`
+	Extension json.RawMessage `json:"extension,omitempty"`
+	Skill     json.RawMessage `json:"skill,omitempty"`
+	Prompt    json.RawMessage `json:"prompt,omitempty"`
+	Theme     json.RawMessage `json:"theme,omitempty"`
+}
+
+// Classify inspects the fetched package directory and returns the set of pi
+// package types it provides, along with the package name and version read from
+// package.json. It returns an error when package.json is missing/unreadable or
+// when no known pi type can be determined.
+func Classify(pkgDir string) (name, version string, types []PackageType, err error) {
+	pjPath := filepath.Join(pkgDir, "package.json")
+	data, err := os.ReadFile(pjPath)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("pkgmgr: read package.json: %w", err)
+	}
+	var pj packageJSON
+	if err := json.Unmarshal(data, &pj); err != nil {
+		return "", "", nil, fmt.Errorf("pkgmgr: parse package.json: %w", err)
+	}
+
+	set := map[PackageType]bool{}
+
+	// 1. Explicit pi metadata wins.
+	if pj.Pi != nil {
+		for _, t := range append(pj.Pi.Types, pj.Pi.Type) {
+			if pt, ok := normalizeType(t); ok {
+				set[pt] = true
+			}
+		}
+		if len(pj.Pi.Extension) > 0 {
+			set[TypeExtension] = true
+		}
+		if len(pj.Pi.Skill) > 0 {
+			set[TypeSkill] = true
+		}
+		if len(pj.Pi.Prompt) > 0 {
+			set[TypePrompt] = true
+		}
+		if len(pj.Pi.Theme) > 0 {
+			set[TypeTheme] = true
+		}
+	}
+
+	// 2. Structural fallbacks for packages that under-declare.
+	if len(pj.Bin) > 0 {
+		set[TypeExtension] = true
+	}
+	if fileExists(filepath.Join(pkgDir, "SKILL.md")) {
+		set[TypeSkill] = true
+	}
+	if dirExists(filepath.Join(pkgDir, "commands")) {
+		set[TypePrompt] = true
+	}
+
+	if len(set) == 0 {
+		return "", "", nil, fmt.Errorf("unrecognized pi package: no known pi metadata")
+	}
+
+	types = make([]PackageType, 0, len(set))
+	for t := range set {
+		types = append(types, t)
+	}
+	slices.Sort(types)
+	return pj.Name, pj.Version, types, nil
+}
+
+// normalizeType maps a pi metadata type string to a PackageType, reporting
+// whether it is recognized.
+func normalizeType(s string) (PackageType, bool) {
+	switch PackageType(s) {
+	case TypeExtension:
+		return TypeExtension, true
+	case TypeSkill:
+		return TypeSkill, true
+	case TypePrompt:
+		return TypePrompt, true
+	case TypeTheme:
+		return TypeTheme, true
+	default:
+		return "", false
+	}
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/pkgmgr/classify_test.go
+++ b/internal/pkgmgr/classify_test.go
@@ -1,0 +1,177 @@
+package pkgmgr
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// writePkg writes a package.json (and optional extra files) into a fresh temp
+// dir and returns the dir. extraFiles maps a relative path to its contents; a
+// path ending in "/" is created as a directory.
+func writePkg(t *testing.T, packageJSON string, extraFiles map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(packageJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range extraFiles {
+		p := filepath.Join(dir, name)
+		if body == "" && name[len(name)-1] == '/' {
+			if err := os.MkdirAll(p, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// TestClassifyExplicitType verifies a single explicit pi.type is recognized.
+func TestClassifyExplicitType(t *testing.T) {
+	dir := writePkg(t, `{"name":"pi-web","version":"1.0.0","pi":{"type":"skill"}}`, nil)
+	name, version, types, err := Classify(dir)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if name != "pi-web" || version != "1.0.0" {
+		t.Errorf("name/version = %q/%q, want pi-web/1.0.0", name, version)
+	}
+	if !reflect.DeepEqual(types, []PackageType{TypeSkill}) {
+		t.Errorf("types = %v, want [skill]", types)
+	}
+}
+
+// TestClassifyMultiType verifies a package declaring several types via pi.types
+// returns them all, sorted.
+func TestClassifyMultiType(t *testing.T) {
+	dir := writePkg(t, `{"name":"combo","version":"2.0.0","pi":{"types":["extension","skill"]}}`, nil)
+	_, _, types, err := Classify(dir)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	want := []PackageType{TypeExtension, TypeSkill}
+	if !reflect.DeepEqual(types, want) {
+		t.Errorf("types = %v, want %v", types, want)
+	}
+}
+
+// TestClassifyPerCapabilityKeys verifies pi.extension + pi.theme blocks both
+// register their types.
+func TestClassifyPerCapabilityKeys(t *testing.T) {
+	dir := writePkg(t, `{"name":"x","version":"0.1.0","pi":{"extension":{"cmd":"x"},"theme":{}}}`, nil)
+	_, _, types, err := Classify(dir)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	want := []PackageType{TypeExtension, TypeTheme}
+	if !reflect.DeepEqual(types, want) {
+		t.Errorf("types = %v, want %v", types, want)
+	}
+}
+
+// TestClassifyStructuralBin verifies a bare package with a bin entry is an
+// extension even without pi metadata.
+func TestClassifyStructuralBin(t *testing.T) {
+	dir := writePkg(t, `{"name":"pi-mcp-adapter","version":"1.0.0","bin":{"pi-mcp-adapter":"./index.js"}}`, nil)
+	_, _, types, err := Classify(dir)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if !reflect.DeepEqual(types, []PackageType{TypeExtension}) {
+		t.Errorf("types = %v, want [extension]", types)
+	}
+}
+
+// TestClassifyStructuralSkillMd verifies a SKILL.md file signals a skill.
+func TestClassifyStructuralSkillMd(t *testing.T) {
+	dir := writePkg(t, `{"name":"pi-skill","version":"1.0.0"}`, map[string]string{
+		"SKILL.md": "# a skill",
+	})
+	_, _, types, err := Classify(dir)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if !reflect.DeepEqual(types, []PackageType{TypeSkill}) {
+		t.Errorf("types = %v, want [skill]", types)
+	}
+}
+
+// TestClassifyStructuralCommandsDir verifies a commands/ dir signals a prompt.
+func TestClassifyStructuralCommandsDir(t *testing.T) {
+	dir := writePkg(t, `{"name":"pi-cmds","version":"1.0.0"}`, map[string]string{
+		"commands/hello.md": "hi",
+	})
+	_, _, types, err := Classify(dir)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if !reflect.DeepEqual(types, []PackageType{TypePrompt}) {
+		t.Errorf("types = %v, want [prompt]", types)
+	}
+}
+
+// TestClassifyExplicitAndStructural verifies explicit metadata and structural
+// signals union together (skill via SKILL.md, extension via pi.type).
+func TestClassifyExplicitAndStructural(t *testing.T) {
+	dir := writePkg(t, `{"name":"both","version":"1.0.0","pi":{"type":"extension"}}`, map[string]string{
+		"SKILL.md": "# skill",
+	})
+	_, _, types, err := Classify(dir)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	want := []PackageType{TypeExtension, TypeSkill}
+	if !reflect.DeepEqual(types, want) {
+		t.Errorf("types = %v, want %v", types, want)
+	}
+}
+
+// TestClassifyUnknown verifies a plain npm package with no pi signals errors.
+func TestClassifyUnknown(t *testing.T) {
+	dir := writePkg(t, `{"name":"lodash","version":"4.17.21"}`, nil)
+	_, _, _, err := Classify(dir)
+	if err == nil {
+		t.Fatal("Classify of non-pi package = nil error, want error")
+	}
+	if !contains(err.Error(), "unrecognized pi package") {
+		t.Errorf("error = %q, want to mention 'unrecognized pi package'", err)
+	}
+}
+
+// TestClassifyMissingPackageJSON verifies a missing package.json errors.
+func TestClassifyMissingPackageJSON(t *testing.T) {
+	if _, _, _, err := Classify(t.TempDir()); err == nil {
+		t.Fatal("Classify with no package.json = nil error, want error")
+	}
+}
+
+// TestClassifyCorruptPackageJSON verifies malformed JSON errors clearly.
+func TestClassifyCorruptPackageJSON(t *testing.T) {
+	dir := writePkg(t, `{not valid json`, nil)
+	_, _, _, err := Classify(dir)
+	if err == nil {
+		t.Fatal("Classify with corrupt package.json = nil error, want error")
+	}
+	if !contains(err.Error(), "parse package.json") {
+		t.Errorf("error = %q, want to mention 'parse package.json'", err)
+	}
+}
+
+// TestClassifyUnknownTypeStringIgnored verifies an unrecognized pi.type string
+// is ignored (not fatal) but leaves the package unclassified if nothing else
+// matches.
+func TestClassifyUnknownTypeStringIgnored(t *testing.T) {
+	dir := writePkg(t, `{"name":"x","version":"1.0.0","pi":{"type":"widget"}}`, nil)
+	_, _, _, err := Classify(dir)
+	if err == nil {
+		t.Fatal("Classify with only unknown pi.type = nil error, want error")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Classify(pkgDir)` in `internal/pkgmgr/classify.go`
- Reads `package.json` `pi` metadata (type/types/per-capability keys) plus structural fallbacks (`bin`→extension, `SKILL.md`→skill, `commands/`→prompt)
- Returns a deduped, sorted set of `PackageType` plus package name/version; errors on unrecognized packages

Closes #157

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/pkgmgr/`
- [x] `go test ./internal/pkgmgr/` — single-type, multi-type, per-capability, structural, unknown, corrupt/missing package.json