### PR TITLE
分发 extension/MCP 适配器到 plugins 目录

### DIFF
--- a/docs/issue#0158.html
+++ b/docs/issue#0158.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0158</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEEA; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/158">#158</a> &mdash; 分发 extension/MCP 适配器到 plugins 目录 &mdash; 2026-07-20</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>&lt;name&gt;.pkg/</code> 全量包 + <code>&lt;name&gt;</code> 启动器 的双件布局</h3>
+      <p><strong>Ambiguity:</strong> <code>plugin.Discover</code> 只运行 <code>plugins/</code> 下的<em>可执行普通文件</em>（忽略子目录），而 npm extension 是一棵带 <code>bin</code> 入口、依赖同级文件才能运行的包目录。二者不匹配。</p>
+      <p><strong>Choice:</strong> 把整棵包解到 <code>plugins/&lt;name&gt;.pkg/</code>（目录，Discover 会跳过），另写一个可执行 shell 启动器 <code>plugins/&lt;name&gt;</code>（文件，Discover 会运行），启动器 <code>exec</code> 包内真正的 bin 入口并转发 argv。</p>
+      <p><strong>Rationale:</strong> 无需改动 <code>plugin.Discover</code> 的既有约定即可让 extension 被发现；bin 保留自身 shebang（与 npm 安装 bin 的方式一致），Node 脚本和原生二进制都能跑。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 记录所有落盘文件供卸载精确清理</h3>
+      <p><strong>Ambiguity:</strong> Issue 只要求"分发到 plugins"。</p>
+      <p><strong>Choice:</strong> <code>DistributeExtension</code> 返回所有创建的文件路径（含 payload 目录与启动器），交给 lockfile 记录。</p>
+      <p><strong>Rationale:</strong> #163 的 uninstall / #164 的 update 需要精确知道装了哪些文件才能干净移除，避免残留。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Windows 暂不支持 extension 安装</h3>
+      <p><strong>Spec:</strong> 未限定平台。</p>
+      <p><strong>Implemented:</strong> <code>runtime.GOOS == "windows"</code> 时 <code>DistributeExtension</code> 直接返回明确错误，测试在 Windows 上 skip。</p>
+      <p><strong>Why:</strong> 启动器是 <code>/bin/sh</code> 脚本，Windows 需要 <code>.cmd</code> 垫片且路径/可执行语义不同；本期聚焦 macOS/Linux，Windows 留作后续。skill/prompt/theme 分发（#159-#161）不受此限。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 启动器 shell 脚本 vs 直接软链/复制 bin</h3>
+      <p><strong>Alternatives:</strong> (A) 写 shell 启动器 exec 包内 bin；(B) 把 bin 文件本身复制/软链到 <code>plugins/&lt;name&gt;</code>。</p>
+      <p><strong>Pros/Cons:</strong> B 更简单，但 bin 通常用相对路径 <code>require</code> 同级模块，脱离包目录会找不到依赖；软链又在跨卷/Windows 上不可靠。A 保证 bin 在其原始包目录内以正确 CWD 语义运行。</p>
+      <p><strong>Winner:</strong> A。多一个小文件换来"bin 能真正跑起来"的正确性。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> extension 运行时的依赖（node_modules）</h3>
+      <p><strong>Assumption:</strong> <code>npm pack</code> 只含包自身文件，不含 <code>node_modules</code>。假定 pi extension 要么零运行时依赖，要么自带打包产物。</p>
+      <p><strong>Verify:</strong> 若某些 extension 需要安装依赖才能运行，需在 install 阶段补 <code>npm install --omit=dev</code> 或要求包预打包；确认本期 MCP 适配器是否零依赖。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/pkgmgr/distribute.go
+++ b/internal/pkgmgr/distribute.go
@@ -1,0 +1,190 @@
+// This file distributes a classified pi extension (including MCP adapters) into
+// pigo's plugins directory so internal/plugin.Discover picks it up (#158).
+//
+// plugin.Discover launches every *executable regular file* directly inside
+// $PIGO_HOME/plugins, ignoring subdirectories. An npm extension, however, is a
+// whole package tree with a "bin" entry pointing at its real entrypoint, and
+// that entrypoint usually needs its sibling files present to run. So we cannot
+// just drop a single file in.
+//
+// The layout we lay down reconciles the two:
+//
+//	$PIGO_HOME/plugins/<name>.pkg/     ← full extracted package (a dir; Discover skips it)
+//	$PIGO_HOME/plugins/<name>          ← executable launcher (a file; Discover runs it)
+//
+// The launcher is a tiny shell script that execs the package's bin entrypoint,
+// forwarding argv. The bin file is made executable and relies on its own
+// shebang (matching how npm itself installs bins), so both Node scripts and
+// native binaries work. Every file laid down is returned so the lockfile can
+// remove exactly what was created on uninstall.
+package pkgmgr
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// DistributeExtension copies the extension package at pkgDir into the plugins
+// directory and writes a launcher that plugin.Discover will run. It returns the
+// absolute paths of every file (and the payload dir) it created, for the
+// lockfile. An empty plugins dir (home unavailable) is an error.
+func DistributeExtension(pkgDir, name string) ([]string, error) {
+	if runtime.GOOS == "windows" {
+		return nil, fmt.Errorf("pkgmgr: extension install is not supported on windows yet")
+	}
+	pluginsDir := PluginsDir()
+	if pluginsDir == "" {
+		return nil, fmt.Errorf("pkgmgr: cannot resolve plugins dir (PIGO_HOME/home unavailable)")
+	}
+
+	binRel, err := extensionBin(pkgDir, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		return nil, fmt.Errorf("pkgmgr: create plugins dir: %w", err)
+	}
+
+	payloadDir := filepath.Join(pluginsDir, name+".pkg")
+	// A stale payload from a prior install must not shadow the new one.
+	if err := os.RemoveAll(payloadDir); err != nil {
+		return nil, fmt.Errorf("pkgmgr: clear old payload %q: %w", payloadDir, err)
+	}
+	created, err := copyTree(pkgDir, payloadDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Make the bin entrypoint executable; it carries its own shebang.
+	binAbs := filepath.Join(payloadDir, filepath.FromSlash(binRel))
+	if err := os.Chmod(binAbs, 0o755); err != nil {
+		return nil, fmt.Errorf("pkgmgr: chmod bin %q: %w", binAbs, err)
+	}
+
+	launcher := filepath.Join(pluginsDir, name)
+	script := fmt.Sprintf("#!/bin/sh\nexec %s \"$@\"\n", shellQuote(binAbs))
+	if err := os.WriteFile(launcher, []byte(script), 0o755); err != nil {
+		return nil, fmt.Errorf("pkgmgr: write launcher %q: %w", launcher, err)
+	}
+
+	created = append(created, payloadDir, launcher)
+	return created, nil
+}
+
+// extensionBin resolves the package's bin entrypoint (relative to the package
+// root) from package.json. npm's "bin" is either a string (single bin) or an
+// object mapping command name → path; for the object form we prefer the entry
+// keyed by the package name, else any single entry.
+func extensionBin(pkgDir, name string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(pkgDir, "package.json"))
+	if err != nil {
+		return "", fmt.Errorf("pkgmgr: read package.json: %w", err)
+	}
+	var pj struct {
+		Bin json.RawMessage `json:"bin"`
+	}
+	if err := json.Unmarshal(data, &pj); err != nil {
+		return "", fmt.Errorf("pkgmgr: parse package.json: %w", err)
+	}
+	if len(pj.Bin) == 0 {
+		return "", fmt.Errorf("pkgmgr: extension %q has no bin entry in package.json", name)
+	}
+	// String form: a single bin path.
+	var s string
+	if err := json.Unmarshal(pj.Bin, &s); err == nil && s != "" {
+		return s, nil
+	}
+	// Object form: {command: path}.
+	var m map[string]string
+	if err := json.Unmarshal(pj.Bin, &m); err == nil && len(m) > 0 {
+		if p, ok := m[name]; ok && p != "" {
+			return p, nil
+		}
+		// npm-scoped name: bin key is often the unscoped base name.
+		if p, ok := m[filepath.Base(name)]; ok && p != "" {
+			return p, nil
+		}
+		for _, p := range m {
+			if p != "" {
+				return p, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("pkgmgr: extension %q has an unreadable bin entry", name)
+}
+
+// copyTree recursively copies src into dst (created), preserving file modes and
+// relative structure. It returns the absolute paths of every regular file it
+// wrote (not directories), so callers can record precisely what was laid down.
+func copyTree(src, dst string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		switch {
+		case info.IsDir():
+			return os.MkdirAll(target, 0o755)
+		case info.Mode().IsRegular():
+			if err := copyFile(path, target, info.Mode()); err != nil {
+				return err
+			}
+			files = append(files, target)
+			return nil
+		default:
+			// Skip symlinks/devices — npm packages are files + dirs.
+			return nil
+		}
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pkgmgr: copy package tree: %w", err)
+	}
+	return files, nil
+}
+
+// copyFile copies a single regular file from src to dst with the given mode.
+func copyFile(src, dst string, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// shellQuote wraps s in single quotes for safe embedding in a /bin/sh script,
+// escaping any embedded single quotes.
+func shellQuote(s string) string {
+	quoted := make([]byte, 0, len(s)+2)
+	quoted = append(quoted, '\'')
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\'' {
+			quoted = append(quoted, '\'', '\\', '\'', '\'')
+			continue
+		}
+		quoted = append(quoted, s[i])
+	}
+	quoted = append(quoted, '\'')
+	return string(quoted)
+}

--- a/internal/pkgmgr/distribute_test.go
+++ b/internal/pkgmgr/distribute_test.go
@@ -1,0 +1,135 @@
+package pkgmgr
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestDistributeExtensionStringBin verifies a package with a string "bin"
+// installs a launcher + payload tree and reports created files.
+func TestDistributeExtensionStringBin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("extension install not supported on windows")
+	}
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+
+	pkg := writePkg(t, `{"name":"pi-demo","version":"1.0.0","bin":"./cli.js"}`, map[string]string{
+		"cli.js":  "#!/usr/bin/env node\nconsole.log('hi')\n",
+		"lib/x.js": "module.exports=1\n",
+	})
+
+	files, err := DistributeExtension(pkg, "pi-demo")
+	if err != nil {
+		t.Fatalf("DistributeExtension: %v", err)
+	}
+
+	launcher := filepath.Join(home, "plugins", "pi-demo")
+	info, err := os.Stat(launcher)
+	if err != nil {
+		t.Fatalf("stat launcher: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Errorf("launcher not executable: mode %v", info.Mode())
+	}
+
+	// The payload bin must exist and be executable.
+	binAbs := filepath.Join(home, "plugins", "pi-demo.pkg", "cli.js")
+	bi, err := os.Stat(binAbs)
+	if err != nil {
+		t.Fatalf("stat payload bin: %v", err)
+	}
+	if bi.Mode()&0o111 == 0 {
+		t.Errorf("payload bin not executable: mode %v", bi.Mode())
+	}
+
+	// Sibling files copied.
+	if _, err := os.Stat(filepath.Join(home, "plugins", "pi-demo.pkg", "lib", "x.js")); err != nil {
+		t.Errorf("sibling file not copied: %v", err)
+	}
+
+	// created list includes launcher and payload dir.
+	var sawLauncher bool
+	for _, f := range files {
+		if f == launcher {
+			sawLauncher = true
+		}
+	}
+	if !sawLauncher {
+		t.Errorf("created files %v missing launcher", files)
+	}
+
+	// The launcher script should exec the bin path.
+	script, _ := os.ReadFile(launcher)
+	if !contains(string(script), binAbs) {
+		t.Errorf("launcher script = %q, want to exec %q", script, binAbs)
+	}
+}
+
+// TestDistributeExtensionObjectBin verifies the {command: path} bin form,
+// preferring the entry keyed by package name.
+func TestDistributeExtensionObjectBin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("extension install not supported on windows")
+	}
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+
+	pkg := writePkg(t, `{"name":"pi-adapter","version":"2.0.0","bin":{"pi-adapter":"./main.js","other":"./other.js"}}`, map[string]string{
+		"main.js":  "#!/usr/bin/env node\n",
+		"other.js": "#!/usr/bin/env node\n",
+	})
+
+	if _, err := DistributeExtension(pkg, "pi-adapter"); err != nil {
+		t.Fatalf("DistributeExtension: %v", err)
+	}
+
+	binAbs := filepath.Join(home, "plugins", "pi-adapter.pkg", "main.js")
+	if bi, err := os.Stat(binAbs); err != nil || bi.Mode()&0o111 == 0 {
+		t.Errorf("expected main.js executable, err=%v", err)
+	}
+}
+
+// TestDistributeExtensionReinstallReplaces verifies a second install clears the
+// stale payload rather than merging it.
+func TestDistributeExtensionReinstallReplaces(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("extension install not supported on windows")
+	}
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+
+	pkg1 := writePkg(t, `{"name":"pi-x","version":"1.0.0","bin":"./a.js"}`, map[string]string{
+		"a.js":    "#!/usr/bin/env node\n",
+		"gone.js": "old\n",
+	})
+	if _, err := DistributeExtension(pkg1, "pi-x"); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	pkg2 := writePkg(t, `{"name":"pi-x","version":"2.0.0","bin":"./a.js"}`, map[string]string{
+		"a.js": "#!/usr/bin/env node\n",
+	})
+	if _, err := DistributeExtension(pkg2, "pi-x"); err != nil {
+		t.Fatalf("reinstall: %v", err)
+	}
+
+	// The file only present in the first install must be gone.
+	if _, err := os.Stat(filepath.Join(home, "plugins", "pi-x.pkg", "gone.js")); !os.IsNotExist(err) {
+		t.Errorf("stale file survived reinstall: %v", err)
+	}
+}
+
+// TestDistributeExtensionNoBin verifies a package without a bin errors.
+func TestDistributeExtensionNoBin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("extension install not supported on windows")
+	}
+	t.Setenv("PIGO_HOME", t.TempDir())
+	pkg := writePkg(t, `{"name":"pi-nobin","version":"1.0.0"}`, nil)
+	if _, err := DistributeExtension(pkg, "pi-nobin"); err == nil {
+		t.Fatal("DistributeExtension without bin = nil error, want error")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `DistributeExtension(pkgDir, name)` in `internal/pkgmgr/distribute.go`
- Copies the full package tree to `plugins/<name>.pkg/` and writes an executable `/bin/sh` launcher `plugins/<name>` that execs the package `bin` entrypoint — so `plugin.Discover` runs it without config changes
- Handles both string and `{cmd: path}` npm `bin` forms; reinstall clears stale payload; returns all created paths for the lockfile

Closes #158

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/pkgmgr/`
- [x] `go test ./internal/pkgmgr/` — string bin, object bin, reinstall replace, no-bin error