### PR TITLE
pigo update 更新包到最新版本

### DIFF
--- a/cmd/pigo/pkgcmd.go
+++ b/cmd/pigo/pkgcmd.go
@@ -35,6 +35,8 @@ func runPackageCommand(cmd string, args []string, out, errOut io.Writer) int {
 		return runList(lockPath, out, errOut)
 	case "uninstall":
 		return runUninstall(args, lockPath, out, errOut)
+	case "update":
+		return runUpdate(args, lockPath, out, errOut)
 	default:
 		fmt.Fprintf(errOut, "pigo: %q is not yet implemented\n", cmd)
 		return 2
@@ -106,6 +108,32 @@ func runInstall(refs []string, lockPath string, out, errOut io.Writer) int {
 		}
 		fmt.Fprintf(out, "Installed %s@%s (%s) — %d file(s)\n",
 			res.Name, res.Version, joinPkgTypes(res.Types), len(res.Files))
+	}
+	if failed {
+		return 1
+	}
+	return 0
+}
+
+// runUpdate handles `pigo update [name...]`. With no names it updates every
+// installed package; otherwise it updates each named package, continuing past a
+// failure so one bad package does not abort the rest. The exit code is non-zero
+// if any update failed.
+func runUpdate(names []string, lockPath string, out, errOut io.Writer) int {
+	if len(names) == 0 {
+		if _, err := pkgmgr.UpdateAll(lockPath, out); err != nil {
+			fmt.Fprintf(errOut, "pigo: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	failed := false
+	for _, name := range names {
+		if _, err := pkgmgr.Update(name, lockPath, out); err != nil {
+			fmt.Fprintf(errOut, "pigo: update %s failed: %v\n", name, err)
+			failed = true
+			continue
+		}
 	}
 	if failed {
 		return 1

--- a/docs/issue#0164.html
+++ b/docs/issue#0164.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0164</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEEA; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/164">#164</a> &mdash; pigo update 更新包到最新版本 &mdash; 2026-07-20</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> fetch+classify 先行，确认有新版本后才删旧文件</h3>
+      <p><strong>Ambiguity:</strong> AC 要求"更新失败时保留原安装（不留下损坏状态）"，但未规定失败点与顺序。</p>
+      <p><strong>Choice:</strong> <code>Update</code> 先 <code>Fetch</code>+<code>Classify</code> 拿到新版本号；只有当新版本 ≠ 已装版本时，才 <code>Uninstall</code> 旧文件再 <code>installFetched</code> 新版本。</p>
+      <p><strong>Rationale:</strong> 网络/解析失败发生在任何删除之前，旧安装原封不动，天然满足"不留损坏状态"。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 抽出 <code>installFetched</code> 供 install 与 update 共用</h3>
+      <p><strong>Ambiguity:</strong> update 的"重新分发+写 lockfile"与 install 后半段重复。</p>
+      <p><strong>Choice:</strong> 把 <code>Install</code> 的 classify→distribute→lockfile 抽成 <code>installFetched(pkgDir, ref, ...)</code>，<code>Install</code> 与 <code>Update</code> 都走它。</p>
+      <p><strong>Rationale:</strong> 单一路径保证 install/update 分发与记账行为一致，减少漂移。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> update 以 source 去掉 pinned 版本拉最新</h3>
+      <p><strong>Choice:</strong> 从 lockfile 的 <code>Source</code> 解析出 ref 后清空 <code>Version</code>，让 <code>npm pack</code> 取最新已发布版本。</p>
+      <p><strong>Rationale:</strong> "update to latest"的语义即忽略当初固定的版本。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 更新旧文件用「Uninstall 后再装」而非原地覆盖</h3>
+      <p><strong>Spec:</strong> AC 描述为"卸载旧文件 → 重新拉取 → 重新分发"。</p>
+      <p><strong>Implemented:</strong> 精确按此：复用 <code>Uninstall</code> 删除 lockfile 记录的旧文件，再 <code>installFetched</code>。这保证跨版本删掉的文件不会残留（原地覆盖会漏删旧版本独有文件）。</p>
+      <p><strong>Why:</strong> 与 spec 一致，且比覆盖更干净。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> <code>update</code>（不带名）遇错：中止 vs 继续</h3>
+      <p><strong>Alternatives:</strong> (A) 任一包失败即整体中止；(B) 逐包更新，失败收集进 joined error，最终退出码非零。</p>
+      <p><strong>Pros/Cons:</strong> A 简单但一个坏包卡住全部；B 尽力而为，与 install/uninstall 的多目标行为对称。</p>
+      <p><strong>Winner:</strong> B（<code>UpdateAll</code>）。CLI <code>runUpdate</code> 无参走 UpdateAll，有参逐个 Update。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> "最新版本"由本机 npm 决定，无版本比较</h3>
+      <p><strong>Assumption:</strong> 判定"是否需要更新"仅比较 <code>npm pack</code> 返回的版本字符串是否等于已装版本；不做 semver 大小比较。</p>
+      <p><strong>Verify:</strong> 若 registry 回退到更旧的 latest（罕见），当前逻辑会"更新"到那个版本。是否需要"仅当更高才更新"的 semver 守卫，留待确认。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/pkgmgr/install.go
+++ b/internal/pkgmgr/install.go
@@ -53,7 +53,15 @@ func Install(rawRef, lockfilePath string, logw io.Writer) (InstallResult, error)
 	}
 	defer fetched.Cleanup()
 
-	name, version, types, err := Classify(fetched.Dir)
+	return installFetched(fetched.Dir, ref, lockfilePath, logf)
+}
+
+// installFetched runs the post-fetch half of an install: classify the already
+// extracted package at pkgDir, distribute each type, and record the result in
+// the lockfile. It is shared by Install (#162) and Update (#164) so both go
+// through the same classify→distribute→lockfile path.
+func installFetched(pkgDir string, ref PackageRef, lockfilePath string, logf func(string, ...any)) (InstallResult, error) {
+	name, version, types, err := Classify(pkgDir)
 	if err != nil {
 		return InstallResult{}, err
 	}
@@ -61,7 +69,7 @@ func Install(rawRef, lockfilePath string, logw io.Writer) (InstallResult, error)
 
 	var files []string
 	for _, t := range types {
-		created, derr := distribute(t, fetched.Dir, name)
+		created, derr := distribute(t, pkgDir, name)
 		if derr != nil {
 			return InstallResult{}, derr
 		}

--- a/internal/pkgmgr/update.go
+++ b/internal/pkgmgr/update.go
@@ -1,0 +1,110 @@
+// This file implements the update operation (#164): bring an installed package
+// up to the latest version published on npm. Update builds on the pieces the
+// earlier issues provided — the lockfile (#154) records what is installed and
+// from which source, Fetch (#156) pulls the latest tarball, and the shared
+// installFetched path (#162) re-classifies and re-distributes.
+//
+// The flow per package is: look up its recorded source, fetch the latest
+// version, and compare against the installed version. If unchanged, it is a
+// no-op ("up to date"). Otherwise the old files are removed and the freshly
+// fetched version is distributed and recorded. Fetch/classify happen before any
+// removal, so a fetch failure leaves the existing install untouched.
+package pkgmgr
+
+import (
+	"fmt"
+	"io"
+)
+
+// UpdateResult reports what Update did for one package.
+type UpdateResult struct {
+	Name string
+	// OldVersion is the version that was installed before the update.
+	OldVersion string
+	// NewVersion is the version after the update (== OldVersion when no-op).
+	NewVersion string
+	// Updated is true when a newer version was fetched and installed.
+	Updated bool
+}
+
+// Update brings the single installed package name up to the latest version from
+// its recorded source. Progress is written to logw when non-nil. Updating a
+// package that is not installed is an error. When the installed version is
+// already latest, it is a no-op and Updated is false.
+//
+// The latest tarball is fetched and classified before the old files are
+// removed, so a fetch or classify failure leaves the prior install intact.
+func Update(name, lockfilePath string, logw io.Writer) (UpdateResult, error) {
+	logf := func(format string, a ...any) {
+		if logw != nil {
+			fmt.Fprintf(logw, format, a...)
+		}
+	}
+
+	lf, err := Load(lockfilePath)
+	if err != nil {
+		return UpdateResult{}, err
+	}
+	p, ok := lf.Get(name)
+	if !ok {
+		return UpdateResult{}, fmt.Errorf("package not installed: %s", name)
+	}
+
+	// Resolve the source to its latest version by dropping any pinned version,
+	// so `update` always targets the newest published release.
+	ref, err := ParsePackageRef(p.Source)
+	if err != nil {
+		return UpdateResult{}, fmt.Errorf("pkgmgr: bad recorded source for %s: %w", name, err)
+	}
+	ref.Version = ""
+
+	logf("Fetching %s ...\n", ref.String())
+	fetched, err := Fetch(ref)
+	if err != nil {
+		return UpdateResult{}, err // old install untouched
+	}
+	defer fetched.Cleanup()
+
+	_, newVersion, _, err := Classify(fetched.Dir)
+	if err != nil {
+		return UpdateResult{}, err // old install untouched
+	}
+	if newVersion == p.Version {
+		logf("%s is up to date\n", name)
+		return UpdateResult{Name: name, OldVersion: p.Version, NewVersion: p.Version, Updated: false}, nil
+	}
+
+	// Newer version fetched: remove the old files, then distribute the new one.
+	if err := Uninstall(name, lockfilePath, logw); err != nil {
+		return UpdateResult{}, err
+	}
+	if _, err := installFetched(fetched.Dir, ref, lockfilePath, logf); err != nil {
+		return UpdateResult{}, err
+	}
+	logf("Updated %s %s -> %s\n", name, p.Version, newVersion)
+	return UpdateResult{Name: name, OldVersion: p.Version, NewVersion: newVersion, Updated: true}, nil
+}
+
+// UpdateAll updates every installed package in the lockfile, in sorted order.
+// It continues past a per-package failure, collecting results; the returned
+// error is non-nil (a joined summary) when any package failed to update.
+func UpdateAll(lockfilePath string, logw io.Writer) ([]UpdateResult, error) {
+	pkgs, err := ListInstalled(lockfilePath)
+	if err != nil {
+		return nil, err
+	}
+	var results []UpdateResult
+	var failures []string
+	for _, p := range pkgs {
+		res, uerr := Update(p.Name, lockfilePath, logw)
+		if uerr != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", p.Name, uerr))
+			continue
+		}
+		results = append(results, res)
+	}
+	if len(failures) > 0 {
+		return results, fmt.Errorf("pkgmgr: %d package(s) failed to update: %v", len(failures), failures)
+	}
+	return results, nil
+}

--- a/internal/pkgmgr/update_test.go
+++ b/internal/pkgmgr/update_test.go
@@ -1,0 +1,141 @@
+package pkgmgr
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// fakeNPMVersioned writes a fake `npm` onto PATH that packs whichever tarball is
+// currently pointed to by a small "which version" file, so a test can flip the
+// version `npm pack` returns between Install and Update.
+func fakeNPMVersioned(t *testing.T, tarballs map[string]map[string]string, whichFile string) {
+	t.Helper()
+	binDir := t.TempDir()
+	// Build every tarball once under binDir; the script copies the one named in
+	// whichFile.
+	for ver, files := range tarballs {
+		makeTarGz(t, filepath.Join(binDir, ver+".tgz"), files)
+	}
+	// Script reads whichFile -> version, then copies <version>.tgz as its pack
+	// output and echoes the tarball name (mimicking `npm pack`).
+	script := `#!/bin/sh
+dest=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--pack-destination" ]; then dest="$a"; fi
+  prev="$a"
+done
+ver=$(cat "` + whichFile + `")
+cp "` + binDir + `/$ver.tgz" "$dest/$ver.tgz"
+echo "$ver.tgz"
+`
+	if err := os.WriteFile(filepath.Join(binDir, "npm"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestUpdateToNewerVersion installs v1.0.0 then updates to v2.0.0, verifying the
+// lockfile version is bumped and the new payload is in place.
+func TestUpdateToNewerVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake npm shell script is POSIX-only")
+	}
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+	whichFile := filepath.Join(t.TempDir(), "which")
+
+	tarballs := map[string]map[string]string{
+		"1.0.0": {
+			"package/package.json": `{"name":"pi-demo","version":"1.0.0","bin":"./cli.js"}`,
+			"package/cli.js":       "#!/usr/bin/env node\n// v1\n",
+		},
+		"2.0.0": {
+			"package/package.json": `{"name":"pi-demo","version":"2.0.0","bin":"./cli.js"}`,
+			"package/cli.js":       "#!/usr/bin/env node\n// v2\n",
+		},
+	}
+	fakeNPMVersioned(t, tarballs, whichFile)
+
+	lockPath := filepath.Join(home, "packages.json")
+
+	// Install v1.
+	if err := os.WriteFile(whichFile, []byte("1.0.0"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Install("npm:pi-demo", lockPath, nil); err != nil {
+		t.Fatalf("Install v1: %v", err)
+	}
+
+	// Flip to v2 and update.
+	if err := os.WriteFile(whichFile, []byte("2.0.0"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := Update("pi-demo", lockPath, nil)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !res.Updated || res.OldVersion != "1.0.0" || res.NewVersion != "2.0.0" {
+		t.Errorf("update result = %+v, want 1.0.0->2.0.0 updated", res)
+	}
+
+	lf, err := Load(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, ok := lf.Get("pi-demo")
+	if !ok || p.Version != "2.0.0" {
+		t.Errorf("lockfile version after update = %+v, want 2.0.0", p)
+	}
+	// v2 payload content is present.
+	data, err := os.ReadFile(filepath.Join(home, "plugins", "pi-demo.pkg", "cli.js"))
+	if err != nil {
+		t.Fatalf("read updated payload: %v", err)
+	}
+	if want := "// v2"; !contains(string(data), want) {
+		t.Errorf("payload = %q, want to contain %q", string(data), want)
+	}
+}
+
+// TestUpdateUpToDate installs v1.0.0 and updates against the same version,
+// expecting a no-op (Updated false, version unchanged).
+func TestUpdateUpToDate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX-only")
+	}
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+	whichFile := filepath.Join(t.TempDir(), "which")
+
+	tarballs := map[string]map[string]string{
+		"1.0.0": {
+			"package/package.json": `{"name":"pi-demo","version":"1.0.0","bin":"./cli.js"}`,
+			"package/cli.js":       "#!/usr/bin/env node\n",
+		},
+	}
+	fakeNPMVersioned(t, tarballs, whichFile)
+	if err := os.WriteFile(whichFile, []byte("1.0.0"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lockPath := filepath.Join(home, "packages.json")
+	if _, err := Install("npm:pi-demo", lockPath, nil); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	res, err := Update("pi-demo", lockPath, nil)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if res.Updated {
+		t.Errorf("update result = %+v, want no-op (Updated false)", res)
+	}
+}
+
+// TestUpdateNotInstalled verifies updating an unknown package errors.
+func TestUpdateNotInstalled(t *testing.T) {
+	if _, err := Update("nope", filepath.Join(t.TempDir(), "packages.json"), nil); err == nil {
+		t.Fatal("Update of missing package = nil error, want error")
+	}
+}


### PR DESCRIPTION
## Summary
- `pigo update <name>...`：从 lockfile 记录的 source 拉最新版，新版本 ≠ 已装版本时才卸旧装新
- `pigo update`（无参）：`UpdateAll` 遍历更新全部包，逐包尽力而为，任一失败退出码非零
- 已是最新版打印 `<name> is up to date`，不做无谓改动
- fetch+classify 先行，失败保留原安装（不留损坏状态）
- 抽出 `installFetched` 供 install/update 共用同一 classify→distribute→lockfile 路径

Closes #164

## Test plan
- [x] `go build ./...` / `go vet`
- [x] `go test ./internal/pkgmgr/ ./cmd/pigo/`：v1→v2 更新（lockfile 版本+payload 内容）、up-to-date no-op、未安装报错