### PR TITLE
headless/stream-json 运行携带 session id 并支持续跑

### DIFF
--- a/cmd/pigo/headless_session.go
+++ b/cmd/pigo/headless_session.go
@@ -1,0 +1,111 @@
+// This file gives headless / stream-json runs the same session persistence and
+// resume the interactive REPL has (cmd/pigo/interactive.go). Before this, a
+// headless run built an in-memory AgentContext and threw it away on exit, so
+// `--output-format stream-json` emitted no session id and `--resume`/`--continue`
+// only worked in the REPL.
+//
+// Now a headless run is backed by a session file: resuming seeds the context
+// from a prior session (and re-anchors the branch leaf), a fresh run creates a
+// new session, and in both cases the run's newly produced messages are appended
+// after it completes. The session id is threaded into the run so it appears in
+// the first stream-json event (对标 pi/Claude Code) and can be passed back via
+// --resume to continue the run.
+package main
+
+import (
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/session"
+)
+
+// headlessSession is the session state backing one headless run: the store, the
+// header (whose ID is the session id emitted and used for resume), and the
+// branch-tracking cursor (curLeaf/persisted) so the run's messages append as a
+// branch descending from the resumed leaf rather than flattening the tree.
+type headlessSession struct {
+	store   *session.Store
+	header  session.SessionHeader
+	curLeaf string // active leaf id to descend from; "" for a fresh session
+	// persisted is the number of agentCtx.Messages already on disk before the
+	// run; persist appends only Messages[persisted:] as a new branch.
+	persisted int
+	// model/provider are the model and provider the run actually used, refreshed
+	// onto the header before persisting so a resumed run does not write back the
+	// original session's stale values (matching the REPL, repl.go persistTurn).
+	model    string
+	provider string
+}
+
+// openHeadlessSession resolves the session backing a headless run: it resumes an
+// existing session when resumeID is set (seeding priorMsgs and re-anchoring the
+// branch leaf) or creates a fresh session header otherwise. It returns the prior
+// messages to seed into the context ahead of the new prompt, plus the session
+// state used to persist the run afterward.
+func openHeadlessSession(resumeID, model, providerName, sysPrompt string) (agentcore.MessageList, headlessSession, error) {
+	store, err := sessionStore()
+	if err != nil {
+		return nil, headlessSession{}, err
+	}
+	now := time.Now().UTC()
+
+	if resumeID != "" {
+		h, entries, err := store.LoadEntries(resumeID)
+		if err != nil {
+			return nil, headlessSession{}, err
+		}
+		msgs := make(agentcore.MessageList, len(entries))
+		for i, e := range entries {
+			msgs[i] = e.Message
+		}
+		curLeaf := ""
+		if len(entries) > 0 {
+			curLeaf = entries[len(entries)-1].ID
+		}
+		// A resumed header keeps its own SystemPrompt when present so the run is
+		// faithful to the original session.
+		if h.SystemPrompt == "" {
+			h.SystemPrompt = sysPrompt
+		}
+		return msgs, headlessSession{store: store, header: h, curLeaf: curLeaf, persisted: len(msgs), model: model, provider: providerName}, nil
+	}
+
+	header := session.SessionHeader{
+		ID:           session.NewID(now),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		Model:        model,
+		Provider:     providerName,
+		SystemPrompt: sysPrompt,
+	}
+	return nil, headlessSession{store: store, header: header, curLeaf: "", persisted: 0, model: model, provider: providerName}, nil
+}
+
+// persist appends the messages produced during the run — everything in
+// agentCtx.Messages past what was already on disk — as a branch descending from
+// the resumed leaf, matching how the REPL grows a session tree (AppendBranch).
+// It is a no-op when the run produced nothing new. Errors are returned for the
+// caller to surface; the run's output has already been emitted regardless.
+func (hs *headlessSession) persist(agentCtx *agentcore.AgentContext) error {
+	// Compaction can rebuild agentCtx.Messages to fewer entries than were on disk
+	// before the run (loop.go maybeAutoCompact replaces the slice). Clamp the
+	// cursor so the tail slice stays in bounds; when the context shrank there is
+	// nothing new to append past what compaction kept.
+	if hs.persisted > len(agentCtx.Messages) {
+		hs.persisted = len(agentCtx.Messages)
+	}
+	tail := agentCtx.Messages[hs.persisted:]
+	if len(tail) == 0 {
+		return nil
+	}
+	// Refresh the header with the model/provider the run actually used so a
+	// resumed session's metadata is not written back stale (matching the REPL).
+	hs.header.Model = hs.model
+	hs.header.Provider = hs.provider
+	hs.header.UpdatedAt = time.Now().UTC()
+	if _, err := hs.store.AppendBranch(hs.header, hs.curLeaf, tail); err != nil {
+		return err
+	}
+	hs.persisted = len(agentCtx.Messages)
+	return nil
+}

--- a/cmd/pigo/headless_session_test.go
+++ b/cmd/pigo/headless_session_test.go
@@ -1,0 +1,156 @@
+package main
+
+// Tests for headless session persistence and resume (session id in stream-json
+// + --resume for headless runs). openHeadlessSession/persist are exercised
+// directly against an isolated PIGO_HOME so a headless run's session round-trips
+// without spawning a provider.
+
+import (
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+func textUser(s string) agentcore.UserMessage {
+	return agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent(s)}}
+}
+
+func textAssistant(s string) agentcore.AssistantMessage {
+	return agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant, Content: agentcore.ContentList{agentcore.NewTextContent(s)}}
+}
+
+// TestOpenHeadlessSessionFresh verifies a fresh headless session gets a new id
+// and empty prior messages, and that persist writes the run's messages so they
+// can be resumed.
+func TestOpenHeadlessSessionFresh(t *testing.T) {
+	t.Setenv("PIGO_HOME", t.TempDir())
+
+	prior, hs, err := openHeadlessSession("", "faux-model", "faux", "sys prompt")
+	if err != nil {
+		t.Fatalf("openHeadlessSession fresh: %v", err)
+	}
+	if len(prior) != 0 {
+		t.Errorf("fresh session must have no prior messages, got %d", len(prior))
+	}
+	if hs.header.ID == "" {
+		t.Fatal("fresh session must have a non-empty id")
+	}
+	if hs.header.SystemPrompt != "sys prompt" {
+		t.Errorf("header SystemPrompt = %q, want the passed prompt", hs.header.SystemPrompt)
+	}
+
+	// Simulate a completed run: prompt + assistant reply.
+	agentCtx := &agentcore.AgentContext{Messages: agentcore.MessageList{textUser("1+1=?"), textAssistant("2")}}
+	if err := hs.persist(agentCtx); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	// The session must now be loadable with both messages.
+	_, msgs, err := hs.store.Load(hs.header.ID)
+	if err != nil {
+		t.Fatalf("Load persisted session: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("persisted session has %d messages, want 2", len(msgs))
+	}
+}
+
+// TestOpenHeadlessSessionResume verifies that resuming seeds the prior messages
+// and that a subsequent run appends only the new tail as a branch, so the
+// session grows rather than being rewritten.
+func TestOpenHeadlessSessionResume(t *testing.T) {
+	t.Setenv("PIGO_HOME", t.TempDir())
+
+	// First run: create and persist a session.
+	_, hs1, err := openHeadlessSession("", "faux-model", "faux", "sys")
+	if err != nil {
+		t.Fatalf("first openHeadlessSession: %v", err)
+	}
+	ctx1 := &agentcore.AgentContext{Messages: agentcore.MessageList{textUser("first"), textAssistant("reply1")}}
+	if err := hs1.persist(ctx1); err != nil {
+		t.Fatalf("first persist: %v", err)
+	}
+	sessID := hs1.header.ID
+
+	// Second run: resume the session id.
+	prior, hs2, err := openHeadlessSession(sessID, "faux-model", "faux", "sys")
+	if err != nil {
+		t.Fatalf("resume openHeadlessSession: %v", err)
+	}
+	if len(prior) != 2 {
+		t.Fatalf("resume must seed %d prior messages, got %d", 2, len(prior))
+	}
+	if hs2.header.ID != sessID {
+		t.Errorf("resumed session id = %q, want %q", hs2.header.ID, sessID)
+	}
+	if hs2.persisted != 2 {
+		t.Errorf("resumed persisted cursor = %d, want 2", hs2.persisted)
+	}
+
+	// A second turn appends its new tail.
+	ctx2 := &agentcore.AgentContext{Messages: append(prior, textUser("second"), textAssistant("reply2"))}
+	if err := hs2.persist(ctx2); err != nil {
+		t.Fatalf("second persist: %v", err)
+	}
+	_, msgs, err := hs2.store.Load(sessID)
+	if err != nil {
+		t.Fatalf("Load after second turn: %v", err)
+	}
+	if len(msgs) != 4 {
+		t.Fatalf("session after two turns has %d messages, want 4", len(msgs))
+	}
+}
+
+// TestHeadlessPersistNoop verifies persist is a no-op (no error, no growth) when
+// the run produced nothing new past what was already persisted.
+func TestHeadlessPersistNoop(t *testing.T) {
+	t.Setenv("PIGO_HOME", t.TempDir())
+	_, hs, err := openHeadlessSession("", "m", "p", "s")
+	if err != nil {
+		t.Fatalf("openHeadlessSession: %v", err)
+	}
+	ctx := &agentcore.AgentContext{Messages: agentcore.MessageList{textUser("x"), textAssistant("y")}}
+	if err := hs.persist(ctx); err != nil {
+		t.Fatalf("first persist: %v", err)
+	}
+	// Persisting again with no new messages must not error and must not duplicate.
+	if err := hs.persist(ctx); err != nil {
+		t.Fatalf("noop persist: %v", err)
+	}
+	_, msgs, err := hs.store.Load(hs.header.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("noop persist changed message count to %d, want 2", len(msgs))
+	}
+}
+
+// TestHeadlessPersistCompactionShrink verifies persist tolerates the context
+// being rebuilt to fewer messages than were on disk before the run (mid-run
+// compaction replaces agentCtx.Messages). The persisted cursor is clamped so
+// the tail slice stays in bounds rather than panicking.
+func TestHeadlessPersistCompactionShrink(t *testing.T) {
+	t.Setenv("PIGO_HOME", t.TempDir())
+	_, hs, err := openHeadlessSession("", "m", "p", "s")
+	if err != nil {
+		t.Fatalf("openHeadlessSession: %v", err)
+	}
+	// Persist four messages, advancing the cursor to 4.
+	ctx := &agentcore.AgentContext{Messages: agentcore.MessageList{textUser("a"), textAssistant("b"), textUser("c"), textAssistant("d")}}
+	if err := hs.persist(ctx); err != nil {
+		t.Fatalf("first persist: %v", err)
+	}
+	if hs.persisted != 4 {
+		t.Fatalf("cursor = %d, want 4", hs.persisted)
+	}
+	// Simulate compaction: the context is rebuilt to fewer messages than the
+	// cursor. persist must not panic on the out-of-range slice.
+	ctx.Messages = agentcore.MessageList{textAssistant("summary"), textUser("e")}
+	if err := hs.persist(ctx); err != nil {
+		t.Fatalf("persist after compaction shrink: %v", err)
+	}
+	if hs.persisted != 2 {
+		t.Errorf("cursor after clamp = %d, want 2", hs.persisted)
+	}
+}

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -217,22 +217,33 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
 		return 1
 	}
+
+	// Back the headless run with a session so its id appears in the first
+	// stream-json event and the run can be resumed with --resume/--continue,
+	// matching the interactive REPL and pi/Claude Code. A resumed session seeds
+	// its prior messages ahead of the new prompt.
+	priorMsgs, hs, err := openHeadlessSession(resumeID, opts.model, env.providerName, env.sysPrompt)
+	if err != nil {
+		fmt.Fprintf(errOut, "pigo: %v\n", err)
+		return 1
+	}
+	messages := append(priorMsgs, agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: promptContent})
 	agentCtx := &agentcore.AgentContext{
-		SystemPrompt: env.sysPrompt,
-		Messages: agentcore.MessageList{
-			agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: promptContent},
-		},
-		Tools: env.tools,
+		SystemPrompt: hs.header.SystemPrompt,
+		Messages:     messages,
+		Tools:        env.tools,
 	}
 
 	// Resolve the API key by provider name from the environment (never logged).
 	// An explicit --api-key overrides env/config for the resolved provider.
 	creds := provider.NewCredentialStore(nil)
 	creds.SetOverride(env.providerName, opts.apiKey)
+	runCfg := newRunConfig(opts.model, env.providerName, env.provider, creds, toolRegistry(env.tools))
+	runCfg.SessionID = hs.header.ID
 	cfg := runtime.HeadlessConfig{
 		Mode: mode,
 		Out:  out,
-		Run:  newRunConfig(opts.model, env.providerName, env.provider, creds, toolRegistry(env.tools)),
+		Run:  runCfg,
 	}
 	// Deliver agent lifecycle events to any subscribed plugin (US-017, #133).
 	// NewEventNotifier returns nil when no plugin subscribes, so the OnEvent hook
@@ -240,8 +251,15 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 	if n := plugin.NewEventNotifier(env.plugins, errOut); n != nil {
 		cfg.OnEvent = n.Handle
 	}
-	if err := runtime.RunHeadless(ctx, agentCtx, cfg); err != nil {
-		fmt.Fprintf(errOut, "pigo: %v\n", err)
+	runErr := runtime.RunHeadless(ctx, agentCtx, cfg)
+	// Persist the run's messages regardless of run outcome so a partial run is
+	// still resumable; a persistence failure is reported but does not mask a run
+	// error.
+	if perr := hs.persist(agentCtx); perr != nil {
+		fmt.Fprintf(errOut, "pigo: warning: could not persist session %s: %v\n", hs.header.ID, perr)
+	}
+	if runErr != nil {
+		fmt.Fprintf(errOut, "pigo: %v\n", runErr)
 		return 1
 	}
 	return 0

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pigo 使用手册</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    :root {
+      --bg: #FAF9F6;
+      --surface: #FFFFFF;
+      --ink: #1a1a1a;
+      --ink-soft: #4A4540;
+      --muted: #8B8680;
+      --faint: #B0AAA4;
+      --line: #E8E4DE;
+      --accent: #D97757;
+      --accent-soft: #FFF5F0;
+      --code-bg: #F0EEEA;
+      --green: #5B8A72;
+      --blue: #4A6FA5;
+    }
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
+      background: var(--bg); color: var(--ink); line-height: 1.75;
+      font-size: 15px;
+    }
+    .layout { display: flex; max-width: 1180px; margin: 0 auto; }
+    /* Sidebar */
+    aside {
+      width: 240px; flex-shrink: 0; position: sticky; top: 0; height: 100vh;
+      overflow-y: auto; padding: 2rem 1.25rem; border-right: 1px solid var(--line);
+    }
+    aside .brand { font-size: 1.25rem; font-weight: 700; margin-bottom: 0.25rem; }
+    aside .brand .dot { color: var(--accent); }
+    aside .tag { font-size: 0.75rem; color: var(--muted); margin-bottom: 1.75rem; }
+    aside nav a {
+      display: block; color: var(--ink-soft); text-decoration: none;
+      font-size: 0.8125rem; padding: 0.3rem 0.6rem; border-radius: 6px; margin-bottom: 0.1rem;
+    }
+    aside nav a:hover { background: var(--code-bg); color: var(--ink); }
+    aside nav a.group { color: var(--muted); font-weight: 600; font-size: 0.7rem;
+      text-transform: uppercase; letter-spacing: 0.04em; margin-top: 1.1rem; padding-left: 0.6rem; }
+    aside nav a.group:hover { background: none; }
+    /* Main */
+    main { flex: 1; min-width: 0; padding: 2.75rem 3rem 5rem; }
+    h1 { font-size: 2rem; font-weight: 700; margin-bottom: 0.5rem; }
+    .lead { color: var(--muted); font-size: 0.95rem; margin-bottom: 2.5rem; }
+    section { margin-bottom: 3rem; scroll-margin-top: 1.5rem; }
+    h2 { font-size: 1.375rem; font-weight: 700; margin-bottom: 1rem; padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--line); }
+    h3 { font-size: 1.0625rem; font-weight: 600; margin: 1.75rem 0 0.6rem; }
+    p { margin-bottom: 0.9rem; color: var(--ink-soft); }
+    ul, ol { margin: 0 0 1rem 1.3rem; color: var(--ink-soft); }
+    li { margin-bottom: 0.35rem; }
+    a { color: var(--accent); }
+    code {
+      background: var(--code-bg); padding: 0.1rem 0.38rem; border-radius: 4px;
+      font-family: 'SF Mono', ui-monospace, Menlo, Consolas, monospace; font-size: 0.82em;
+      color: #9a4a30;
+    }
+    pre {
+      background: #2b2b2b; color: #e8e6e0; border-radius: 10px; padding: 1rem 1.15rem;
+      overflow-x: auto; margin-bottom: 1.1rem; font-size: 0.82rem; line-height: 1.65;
+      font-family: 'SF Mono', ui-monospace, Menlo, Consolas, monospace;
+    }
+    pre code { background: none; padding: 0; color: inherit; font-size: 1em; }
+    pre .c { color: #8b9a8f; } /* comment */
+    pre .p { color: #d99a76; } /* prompt/keyword */
+    .callout {
+      background: var(--accent-soft); border: 1px solid #f0d0c2; border-left: 3px solid var(--accent);
+      border-radius: 8px; padding: 0.85rem 1.1rem; margin-bottom: 1.1rem; font-size: 0.86rem;
+    }
+    .callout.info { background: #F0F4F8; border-color: #cdd9e6; border-left-color: var(--blue); }
+    .callout.ok { background: #F5F8F6; border-color: #cfe0d5; border-left-color: var(--green); }
+    .callout strong { color: var(--ink); }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 1.2rem; font-size: 0.84rem; }
+    th, td { text-align: left; padding: 0.55rem 0.7rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+    th { color: var(--muted); font-weight: 600; font-size: 0.76rem; text-transform: uppercase; letter-spacing: 0.03em; }
+    td code { white-space: nowrap; }
+    .cards { display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.85rem; margin-bottom: 1rem; }
+    .card { background: var(--surface); border: 1px solid var(--line); border-radius: 10px; padding: 1rem 1.15rem; }
+    .card h4 { font-size: 0.9rem; margin-bottom: 0.3rem; display: flex; align-items: center; gap: 0.45rem; }
+    .card .pill { font-size: 0.68rem; padding: 0.08rem 0.45rem; border-radius: 20px; background: var(--code-bg); color: var(--muted); font-weight: 500; }
+    .card p { font-size: 0.8rem; margin: 0; color: var(--muted); }
+    footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--line); color: var(--faint); font-size: 0.75rem; }
+    @media (max-width: 820px) {
+      aside { display: none; }
+      main { padding: 2rem 1.25rem 3rem; }
+      .cards { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <aside>
+      <div class="brand">pigo<span class="dot">.</span></div>
+      <div class="tag">命令行 AI Agent · 使用手册</div>
+      <nav>
+        <a class="group">入门</a>
+        <a href="#intro">简介</a>
+        <a href="#install">安装与构建</a>
+        <a href="#quickstart">快速开始</a>
+        <a class="group">Agent 模式</a>
+        <a href="#agent">运行 Agent</a>
+        <a href="#models">模型与 Provider</a>
+        <a class="group">包管理</a>
+        <a href="#pkg-overview">概览</a>
+        <a href="#pkg-install">install</a>
+        <a href="#pkg-list">list</a>
+        <a href="#pkg-uninstall">uninstall</a>
+        <a href="#pkg-update">update</a>
+        <a class="group">参考</a>
+        <a href="#layout">目录与环境变量</a>
+        <a href="#faq">常见问题</a>
+      </nav>
+    </aside>
+
+    <main>
+      <h1>pigo 使用手册</h1>
+      <p class="lead">pigo 是一个面向命令行的 AI Agent，可在脚本与 CI 中无头运行，并支持安装 pi 生态的扩展、技能、命令与主题包。</p>
+
+      <section id="intro">
+        <h2>简介</h2>
+        <p>pigo 提供两类能力：</p>
+        <ul>
+          <li><strong>Agent 模式</strong>——以 flag 驱动，针对单条 prompt 运行 Agent 循环，适合脚本化与流水线。</li>
+          <li><strong>包管理</strong>——通过 <code>install / list / uninstall / update</code> 子命令，从 npm 安装 <a href="https://pi.dev/packages">pi 生态</a>的扩展、技能、命令模板与主题。</li>
+        </ul>
+        <div class="callout info">
+          <strong>提示</strong>　包管理子命令是位置参数，独立于 Agent 模式的 flag；pigo 会在解析 flag 之前先把它们剥离出来。
+        </div>
+      </section>
+
+      <section id="install">
+        <h2>安装与构建</h2>
+        <p>pigo 使用 Go 编写。从源码构建：</p>
+        <pre><code><span class="c"># 克隆并构建</span>
+git clone https://github.com/smallnest/pigo.git
+cd pigo
+go build -o pigo ./cmd/pigo
+
+<span class="c"># 或直接安装到 $GOBIN</span>
+go install github.com/smallnest/pigo/cmd/pigo@latest</code></pre>
+        <div class="callout">
+          <strong>前置依赖</strong>　包管理功能（<code>install</code>/<code>update</code>）依赖本机已安装的 <code>npm</code>，pigo 通过 <code>npm pack --ignore-scripts</code> 安全下载包，不会执行包的生命周期脚本。
+        </div>
+      </section>
+
+      <section id="quickstart">
+        <h2>快速开始</h2>
+        <pre><code><span class="c"># 1) 用 Agent 跑一条 prompt</span>
+<span class="p">pigo</span> -p "读取 README 并用中文总结"
+
+<span class="c"># 2) 安装一个 pi 扩展包</span>
+<span class="p">pigo</span> install npm:pi-mcp-adapter
+
+<span class="c"># 3) 查看已安装的包</span>
+<span class="p">pigo</span> list
+
+<span class="c"># 4) 更新到最新版本</span>
+<span class="p">pigo</span> update pi-mcp-adapter</code></pre>
+      </section>
+
+      <section id="agent">
+        <h2>运行 Agent</h2>
+        <p>Agent 模式对单条 prompt 运行一次 Agent 循环，退出码反映成功（0）或失败（1），便于在管道中组合。</p>
+        <pre><code><span class="c"># 打印模式：仅输出最终文本</span>
+<span class="p">pigo</span> -p "解释这段代码" -m openrouter/free
+
+<span class="c"># 流式 JSON 事件（行分隔），适合程序消费</span>
+<span class="p">pigo</span> -p "..." --output-format stream-json
+
+<span class="c"># prompt 也可作为位置参数传入</span>
+<span class="p">pigo</span> "帮我写一个 Go 的快排"</code></pre>
+
+        <h3>常用 flag</h3>
+        <table>
+          <thead><tr><th>Flag</th><th>简写</th><th>说明</th></tr></thead>
+          <tbody>
+            <tr><td><code>--print</code></td><td><code>-p</code></td><td>要运行的 prompt（无头打印模式）</td></tr>
+            <tr><td><code>--model</code></td><td><code>-m</code></td><td>模型 id，默认 <code>openrouter/free</code></td></tr>
+            <tr><td><code>--base-url</code></td><td><code>-u</code></td><td>覆盖 Provider 的 base URL（如本地 Ollama）</td></tr>
+            <tr><td><code>--api-key</code></td><td><code>-k</code></td><td>Provider 的 API Key（覆盖环境变量/配置）</td></tr>
+            <tr><td><code>--protocol</code></td><td><code>-P</code></td><td>强制线协议：<code>openai</code> | <code>anthropic</code></td></tr>
+            <tr><td><code>--output-format</code></td><td><code>-o</code></td><td>输出格式：<code>text</code> | <code>stream-json</code></td></tr>
+            <tr><td><code>--no-tools</code></td><td><code>-n</code></td><td>禁用内置的文件/Shell 工具</td></tr>
+            <tr><td><code>--continue</code></td><td><code>-c</code></td><td>恢复最近一次交互会话</td></tr>
+            <tr><td><code>--resume</code></td><td><code>-r</code></td><td>按 id 恢复指定的交互会话</td></tr>
+            <tr><td><code>--list-sessions</code></td><td><code>-l</code></td><td>列出已存储的交互会话并退出</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="models">
+        <h2>模型与 Provider</h2>
+        <p>pigo 从 <code>--model</code> 解析对应的内置 Provider，API Key 从环境变量取用（<code>&lt;PROVIDER&gt;_API_KEY</code>）。解析规则如下：</p>
+        <ol>
+          <li>若显式指定 <code>--protocol</code>（<code>openai</code>/<code>anthropic</code>），优先于一切启发式；<code>openai</code> 需配合 <code>--base-url</code>。</li>
+          <li>预置目录中的模型 id 使用其自带 Provider（OpenRouter / NVIDIA / Ollama）。</li>
+          <li><code>ollama/</code> 前缀或指向 11434 端口的 base URL → 本地 Ollama。</li>
+          <li><code>nvidia/</code> 前缀 → NVIDIA NIM。</li>
+          <li>其余一律走 OpenRouter（参考 OpenAI 兼容网关）。</li>
+        </ol>
+        <pre><code><span class="c"># 本地 Ollama</span>
+<span class="p">pigo</span> -p "你好" -m ollama/qwen2.5
+
+<span class="c"># 自建 OpenAI 兼容端点</span>
+<span class="p">pigo</span> -p "..." -P openai -u https://my-endpoint/v1 -m my-model</code></pre>
+      </section>
+
+      <section id="pkg-overview">
+        <h2>包管理概览</h2>
+        <p>pigo 可安装 <a href="https://pi.dev/packages">pi 生态</a>发布到 npm 的四类包，并把内容分发到 pigo 现有发现机制能识别的目录，无需额外配置：</p>
+        <div class="cards">
+          <div class="card"><h4>extension <span class="pill">扩展</span></h4><p>可执行扩展，常见为 MCP adapter。落到 <code>plugins/</code>，由 pigo 插件系统发现。</p></div>
+          <div class="card"><h4>skill <span class="pill">技能</span></h4><p>含 <code>SKILL.md</code> 的技能包，落到技能目录（<code>~/.agents/skills</code>）。</p></div>
+          <div class="card"><h4>prompt <span class="pill">命令</span></h4><p>命令/prompt 模板（<code>*.md</code>），落到 <code>commands/</code>。</p></div>
+          <div class="card"><h4>theme <span class="pill">主题</span></h4><p>主题包，存储到 <code>themes/</code>（暂无运行时消费者）。</p></div>
+        </div>
+        <p>安装信息记录在 <strong>lockfile</strong>（<code>$PIGO_HOME/packages.json</code>）中，作为 list/uninstall/update 的事实来源。</p>
+        <div class="callout info"><strong>来源前缀</strong>　当前仅支持 <code>npm:</code>，包括作用域包 <code>npm:@scope/name</code>，可选带版本 <code>npm:name@1.2.3</code>。</div>
+      </section>
+
+      <section id="pkg-install">
+        <h2>install</h2>
+        <p>安装一个或多个 pi 包。流程为：解析引用 → <code>npm pack</code> 拉取并解压 → 分类 → 按类型分发 → 写 lockfile。</p>
+        <pre><code><span class="c"># 安装最新版</span>
+<span class="p">pigo</span> install npm:pi-mcp-adapter
+
+<span class="c"># 指定版本 / 作用域包</span>
+<span class="p">pigo</span> install npm:pi-mcp-adapter@1.2.0
+<span class="p">pigo</span> install npm:@myscope/pi-theme
+
+<span class="c"># 一次安装多个（某个失败不影响其余）</span>
+<span class="p">pigo</span> install npm:pi-mcp-adapter npm:pi-some-skill</code></pre>
+        <p>安装成功后打印 <code>Installed &lt;name&gt;@&lt;ver&gt; (&lt;types&gt;) — N file(s)</code>。多包安装时，若任一失败退出码为 <code>1</code>，但其余包照常安装。</p>
+        <div class="callout ok"><strong>幂等</strong>　每个分发器会先清理自身旧目标再写入，因此重复安装可覆盖收敛；安装非 pi 包会失败且不写 lockfile。</div>
+      </section>
+
+      <section id="pkg-list">
+        <h2>list</h2>
+        <p>列出全部已安装的包，每行以制表符分隔 <code>名称　版本　类型　来源</code>，便于用 <code>cut -f</code> 等工具消费。</p>
+        <pre><code><span class="p">pigo</span> list
+<span class="c"># pi-mcp-adapter    1.2.0    extension    npm:pi-mcp-adapter</span>
+<span class="c"># pi-demo-skill     0.3.1    skill        npm:pi-demo-skill</span>
+
+<span class="c"># 未安装任何包时</span>
+<span class="p">pigo</span> list
+<span class="c"># no packages installed</span></code></pre>
+      </section>
+
+      <section id="pkg-uninstall">
+        <h2>uninstall</h2>
+        <p>卸载包：删除 lockfile 中记录的全部落地文件，再移除该条目。支持一次卸载多个。</p>
+        <pre><code><span class="p">pigo</span> uninstall pi-mcp-adapter
+<span class="p">pigo</span> uninstall pi-mcp-adapter pi-demo-skill</code></pre>
+        <ul>
+          <li>按路径长度降序删除，并对目录使用 <code>RemoveAll</code>，确保 payload 目录被整体清理。</li>
+          <li>某个记录文件若已不存在，跳过并继续，最终仍会移除 lockfile 条目（收敛到"已卸载"状态）。</li>
+          <li>卸载未安装的包会报错 <code>package not installed: &lt;name&gt;</code> 并以非零码退出。</li>
+        </ul>
+      </section>
+
+      <section id="pkg-update">
+        <h2>update</h2>
+        <p>把已安装的包更新到 npm 上的最新版本。</p>
+        <pre><code><span class="c"># 更新指定包（可多个）</span>
+<span class="p">pigo</span> update pi-mcp-adapter
+
+<span class="c"># 不带包名：遍历更新全部已安装包</span>
+<span class="p">pigo</span> update</code></pre>
+        <ul>
+          <li>先拉取并分类最新版本，仅当版本与已装不同才「卸旧文件 → 重新分发 → 更新 lockfile 版本」。</li>
+          <li>已是最新版时打印 <code>&lt;name&gt; is up to date</code>，不做无谓改动。</li>
+          <li><strong>失败安全</strong>：网络或分类失败发生在任何删除之前，原安装保持不变，不会留下损坏状态。</li>
+          <li>无参 <code>update</code> 逐包尽力而为，任一失败则退出码非零。</li>
+        </ul>
+      </section>
+
+      <section id="layout">
+        <h2>目录与环境变量</h2>
+        <table>
+          <thead><tr><th>路径 / 变量</th><th>说明</th></tr></thead>
+          <tbody>
+            <tr><td><code>$PIGO_HOME</code></td><td>pigo 主目录，默认 <code>~/.pigo</code></td></tr>
+            <tr><td><code>$PIGO_HOME/packages.json</code></td><td>lockfile，记录已安装包</td></tr>
+            <tr><td><code>$PIGO_HOME/plugins/</code></td><td>扩展（extension）落地目录</td></tr>
+            <tr><td><code>$PIGO_HOME/commands/</code></td><td>命令/prompt 模板落地目录</td></tr>
+            <tr><td><code>$PIGO_HOME/themes/</code></td><td>主题存储目录</td></tr>
+            <tr><td><code>技能目录</code></td><td>默认 <code>~/.agents/skills</code>，可用 <code>PIGO_SKILLS_DIR</code> 覆盖</td></tr>
+            <tr><td><code>&lt;PROVIDER&gt;_API_KEY</code></td><td>各 Provider 的 API Key，如 <code>OPENROUTER_API_KEY</code></td></tr>
+          </tbody>
+        </table>
+        <div class="callout"><strong>注意</strong>　技能是 <code>$PIGO_HOME</code> 之外的唯一例外：pigo 从 <code>~/.agents/skills</code>（或 <code>PIGO_SKILLS_DIR</code>）加载技能，而非嵌套在主目录下。</div>
+      </section>
+
+      <section id="faq">
+        <h2>常见问题</h2>
+        <h3>提示找不到 npm？</h3>
+        <p><code>install</code>/<code>update</code> 依赖本机 <code>npm</code>。请先安装 Node.js（自带 npm），并确认 <code>npm</code> 在 <code>PATH</code> 中。</p>
+        <h3>安装报"unrecognized pi package"？</h3>
+        <p>该包不含任何可识别的 pi 元数据或结构特征（如 <code>bin</code>、<code>SKILL.md</code>、<code>commands/</code>），因此不是 pi 包，pigo 拒绝安装且不写 lockfile。</p>
+        <h3>只支持 npm 来源吗？</h3>
+        <p>本版本仅支持 <code>npm:</code>（含作用域包）。<code>github:</code>/<code>file:</code> 等来源不在当前范围内。</p>
+        <h3>update 会做版本大小比较吗？</h3>
+        <p>当前仅比较 <code>npm pack</code> 返回的版本字符串是否与已装版本相同，不做 semver 大小判断——即"更新到 latest"。</p>
+      </section>
+
+      <footer>
+        pigo 使用手册 · 生成于 2026-07-20 · 项目地址 <a href="https://github.com/smallnest/pigo">github.com/smallnest/pigo</a>
+      </footer>
+    </main>
+  </div>
+</body>
+</html>

--- a/internal/agentcore/event.go
+++ b/internal/agentcore/event.go
@@ -25,8 +25,13 @@ const (
 	EventCompaction          = "compaction"
 )
 
-// AgentStartEvent is emitted once when a loop run begins.
-type AgentStartEvent struct{}
+// AgentStartEvent is emitted once when a loop run begins. SessionID, when set,
+// is the id of the session backing this run; it is carried in the first
+// stream-json event so a caller can associate output with a session and resume
+// it later (对标 pi/Claude Code, which put a session id in the first event).
+type AgentStartEvent struct {
+	SessionID string
+}
 
 // AgentEndEvent is emitted once when a loop run ends, carrying the messages
 // newly produced during this run (the EventStream result).

--- a/internal/runtime/headless.go
+++ b/internal/runtime/headless.go
@@ -158,6 +158,14 @@ func writeEventJSON(w io.Writer, ev agentcore.AgentEvent) error {
 func eventEnvelope(ev agentcore.AgentEvent) map[string]any {
 	env := map[string]any{"type": ev.EventType()}
 	switch e := ev.(type) {
+	case agentcore.AgentStartEvent:
+		// The first event carries the backing session id (对标 pi/Claude Code),
+		// so a consumer can associate the run's output with a session and resume
+		// it later. Omitted only when the run has no backing session (SessionID
+		// unset), which the envelope treats as "not resumable".
+		if e.SessionID != "" {
+			env["sessionId"] = e.SessionID
+		}
 	case agentcore.AgentEndEvent:
 		env["messageCount"] = len(e.Messages)
 	case agentcore.TurnEndEvent:

--- a/internal/runtime/headless_test.go
+++ b/internal/runtime/headless_test.go
@@ -93,6 +93,53 @@ func TestRunHeadlessStreamJSON(t *testing.T) {
 	}
 }
 
+// TestRunHeadlessStreamJSONSessionID verifies that when RunConfig.SessionID is
+// set, the first stream-json event (agent_start) carries it under "sessionId",
+// so a consumer can associate the run's output with a session and resume it
+// later (对标 pi/Claude Code). When SessionID is empty the key is omitted.
+func TestRunHeadlessStreamJSONSessionID(t *testing.T) {
+	run := func(sessionID string) map[string]any {
+		p := &fauxProvider{
+			name:   "faux",
+			models: []provider.Model{{Provider: "faux", ID: "faux"}},
+			turns:  []fauxTurn{textTurn("done")},
+		}
+		cfg := newFauxRunCfg(p)
+		cfg.SessionID = sessionID
+		var out bytes.Buffer
+		agentCtx := &agentcore.AgentContext{Messages: agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("start")}}}}
+		if err := RunHeadless(context.Background(), agentCtx, HeadlessConfig{Run: cfg, Mode: StreamJSONMode, Out: &out}); err != nil {
+			t.Fatalf("RunHeadless stream-json: unexpected error %v", err)
+		}
+		sc := bufio.NewScanner(&out)
+		for sc.Scan() {
+			line := sc.Bytes()
+			if len(bytes.TrimSpace(line)) == 0 {
+				continue
+			}
+			var env map[string]any
+			if err := json.Unmarshal(line, &env); err != nil {
+				t.Fatalf("stream-json line is not valid JSON: %q (%v)", line, err)
+			}
+			if env["type"] == agentcore.EventAgentStart {
+				return env
+			}
+		}
+		t.Fatal("no agent_start event found")
+		return nil
+	}
+
+	first := run("sess-123")
+	if got, ok := first["sessionId"].(string); !ok || got != "sess-123" {
+		t.Errorf("agent_start sessionId = %v, want %q", first["sessionId"], "sess-123")
+	}
+
+	none := run("")
+	if _, present := none["sessionId"]; present {
+		t.Errorf("agent_start must omit sessionId when SessionID is empty, got %v", none["sessionId"])
+	}
+}
+
 // TestRunHeadlessReportsFailure verifies that a run whose final assistant message
 // carries stopReason=error surfaces as an ErrRunFailed, so the CLI maps it to a
 // non-zero exit code.

--- a/internal/runtime/loop.go
+++ b/internal/runtime/loop.go
@@ -71,6 +71,11 @@ type RunConfig struct {
 	// EventBuffer is the buffer size of the emitted EventStream. 0 gives fully
 	// synchronous back-pressure (matching pi's awaited emit).
 	EventBuffer int
+
+	// SessionID, when set, is carried in the run's agent_start event so a
+	// stream-json consumer sees the backing session id in the first event and can
+	// resume the run later (对标 pi/Claude Code).
+	SessionID string
 }
 
 // LoopEventStream is the stream returned by the loop entry points: it carries
@@ -119,7 +124,7 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 		stream.Close()
 	}
 
-	if err := emit(agentcore.AgentStartEvent{}); err != nil {
+	if err := emit(agentcore.AgentStartEvent{SessionID: cfg.SessionID}); err != nil {
 		finish()
 		return
 	}


### PR DESCRIPTION
## Summary
- headless 运行由会话文件支撑（`openHeadlessSession` 创建/恢复，`persist` 分支追加）
- session id 落到首个 stream-json 事件（`agent_start.sessionId`，对标 pi/Claude Code）
- headless 支持 `--resume <id>` / `--continue`：恢复历史上下文并续写
- 附带中文使用手册 `docs/manual.html`

Closes #176

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` 全绿
- [x] 手动 e2e：首个事件含 `sessionId`；`-r`/`-c` 恢复上下文