### PR TITLE
补齐 pi 的 --approve / --no-skills 命令行参数

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -53,6 +53,14 @@ type interactiveOptions struct {
 	// the context and replayed transcript. Otherwise a fresh session is created.
 	resumeID string
 
+	// approve, when true, grants the launch directory session trust before the
+	// run so the first-launch trust prompt is skipped and side-effect tools run
+	// without per-call confirmation (对标 pi 的 --approve/-a).
+	approve bool
+	// noSkills, when true, skips skill discovery so no /skill-name commands are
+	// registered from ~/.agents/skills (对标 pi 的 --no-skills).
+	noSkills bool
+
 	// plugins holds the loaded plugin manager so the REPL can deliver lifecycle
 	// events to subscribed plugins (US-017, #133). It may be nil (no plugins).
 	plugins *plugin.Manager
@@ -152,16 +160,19 @@ func runInteractive(opts interactiveOptions) error {
 	// ~/.agents/skills. A load error is non-fatal — the REPL still runs with the
 	// built-ins. Instance built-ins that need live state (/model, /help) are
 	// registered against `live`.
-	slash, err := buildSlashRegistry(live)
+	slash, err := buildSlashRegistry(live, opts.noSkills)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "pigo: slash-commands: %v\n", err)
 	}
 	registerTrustCommand(slash, mgr, cwd)
 
-	// On the first launch in an undecided directory, ask the user how much to
-	// trust it before any tool runs. This happens before replay so the trust
-	// question is the first thing the user sees, not their prior history.
-	ensureTrustPrompt(os.Stdout, reader, mgr, cwd)
+	// --approve grants the launch directory session trust up front (对标 pi 的
+	// --approve/-a), so the first-launch prompt is skipped and side-effect tools
+	// run without per-call confirmation. Otherwise, on the first launch in an
+	// undecided directory, ask the user how much to trust it before any tool
+	// runs. This happens before replay so the trust question is the first thing
+	// the user sees, not their prior history.
+	establishTrust(os.Stdout, reader, mgr, cwd, opts.approve)
 
 	// Replay the resumed conversation so the user sees history before re-prompting.
 	if len(history) > 0 {
@@ -240,8 +251,10 @@ func stdoutIsTerminal() bool {
 // ~/.agents/skills — each surfaced as a "/skill-name" command (对标 Claude
 // Code's /skill invocation). A missing directory is not an error. Names that
 // collide with a built-in are shadowed (the built-in wins) and reported on
-// stderr.
-func buildSlashRegistry(live *liveRunConfig) (*runtime.SlashRegistry, error) {
+// stderr. When noSkills is true, skill discovery is skipped entirely (对标 pi
+// 的 --no-skills): user command templates still load, but no /skill-name
+// commands are registered.
+func buildSlashRegistry(live *liveRunConfig, noSkills bool) (*runtime.SlashRegistry, error) {
 	reg := runtime.NewSlashRegistry()
 	registerLiveCommands(reg, live)
 	dir := os.Getenv("PIGO_HOME")
@@ -260,16 +273,19 @@ func buildSlashRegistry(live *liveRunConfig) (*runtime.SlashRegistry, error) {
 		reg.AddUser(c)
 	}
 	// Load skills from ~/.agents/skills and register each as a /skill-name
-	// command. A skill invocation expands to the skill's instructions as the next
-	// prompt. A partial parse error is non-fatal: the skills that DID load are
-	// still registered, and the error is only reported on stderr — so one
-	// malformed skill file cannot hide every other skill.
-	skillCmds, serr := loadSkillCommands()
-	for _, c := range skillCmds {
-		reg.AddUser(c)
-	}
-	if serr != nil {
-		fmt.Fprintf(os.Stderr, "pigo: skills: some skills failed to load: %v\n", serr)
+	// command, unless discovery is disabled. A skill invocation expands to the
+	// skill's instructions as the next prompt. A partial parse error is
+	// non-fatal: the skills that DID load are still registered, and the error is
+	// only reported on stderr — so one malformed skill file cannot hide every
+	// other skill.
+	if !noSkills {
+		skillCmds, serr := loadSkillCommands()
+		for _, c := range skillCmds {
+			reg.AddUser(c)
+		}
+		if serr != nil {
+			fmt.Fprintf(os.Stderr, "pigo: skills: some skills failed to load: %v\n", serr)
+		}
 	}
 	if shadowed := reg.Shadowed(); len(shadowed) > 0 {
 		fmt.Fprintf(os.Stderr, "pigo: user commands shadowed by built-ins (rename to use): %v\n", shadowed)

--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -42,6 +42,8 @@ func main() {
 	flag.BoolVarP(&opts.listSessions, "list-sessions", "l", false, "list stored interactive sessions and exit")
 	flag.StringVarP(&opts.resumeID, "resume", "r", "", "resume the interactive session with this id")
 	flag.BoolVarP(&opts.continueLast, "continue", "c", false, "resume the most recent interactive session")
+	flag.BoolVarP(&opts.approve, "approve", "a", false, "trust the working directory for this run: skip the first-launch trust prompt and run side-effect tools without per-call confirmation")
+	flag.BoolVar(&opts.noSkills, "no-skills", false, "disable skill discovery (do not load skills under ~/.agents/skills as /skill-name commands)")
 	flag.BoolVar(&opts.subagentRPC, "subagent-rpc", false, "internal: run as a process-isolated sub-agent JSON-RPC server over stdio (US-019)")
 	flag.Parse()
 

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -121,6 +121,13 @@ type cliOptions struct {
 	listSessions bool
 	resumeID     string
 	continueLast bool
+	// approve grants the launch directory session-level trust up front (对标 pi
+	// 的 --approve/-a): the first-launch trust prompt is skipped and side-effect
+	// tools (bash/write/edit) run without per-call confirmation for this run.
+	approve bool
+	// noSkills disables skill discovery (对标 pi 的 --no-skills): skills under
+	// ~/.agents/skills are not loaded as /skill-name commands.
+	noSkills bool
 	// subagentRPC selects the process-isolated sub-agent server mode (US-019,
 	// #135): pigo reads JSON-RPC sub-agent run requests from stdin and writes
 	// results to stdout. Internal, used by SubAgentTool's process mode.
@@ -190,6 +197,8 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			tools:        env.tools,
 			sysPrompt:    env.sysPrompt,
 			resumeID:     resumeID,
+			approve:      opts.approve,
+			noSkills:     opts.noSkills,
 			plugins:      env.plugins,
 		}); err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)

--- a/cmd/pigo/skills_test.go
+++ b/cmd/pigo/skills_test.go
@@ -71,7 +71,7 @@ func TestBuildSlashRegistryIncludesSkills(t *testing.T) {
 	t.Setenv("PIGO_HOME", t.TempDir())
 	writeSkill(t, dir, "summarize.md", "---\nname: summarize\ndescription: summarize input\n---\nSummarize the following: $ARGUMENTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"})
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, false)
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -87,5 +87,25 @@ func TestBuildSlashRegistryIncludesSkills(t *testing.T) {
 	}
 	if out.Prompt != "Summarize the following: hello world" {
 		t.Errorf("Prompt = %q, want $ARGUMENTS substituted", out.Prompt)
+	}
+}
+
+// TestBuildSlashRegistryNoSkills verifies that when noSkills is true, skill
+// discovery is skipped so a /skill-name command is not registered even though a
+// skill file exists on disk (对标 pi 的 --no-skills).
+func TestBuildSlashRegistryNoSkills(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PIGO_SKILLS_DIR", dir)
+	t.Setenv("PIGO_HOME", t.TempDir())
+	writeSkill(t, dir, "summarize.md", "---\nname: summarize\ndescription: summarize input\n---\nSummarize the following: $ARGUMENTS")
+
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, true)
+	if err != nil {
+		t.Fatalf("buildSlashRegistry: %v", err)
+	}
+	// With discovery disabled, /summarize was never registered, so the registry
+	// treats it as an unknown command (an error) rather than a handled one.
+	if _, err := reg.ResolveOutcome("/summarize hello world"); err == nil {
+		t.Error("/summarize must be unknown when --no-skills disables discovery")
 	}
 }

--- a/cmd/pigo/trust.go
+++ b/cmd/pigo/trust.go
@@ -39,6 +39,22 @@ var sideEffectTools = map[string]bool{
 	"edit":  true,
 }
 
+// establishTrust decides how the launch directory's trust is established before
+// the REPL runs. When approve is true (对标 pi 的 --approve/-a), it grants
+// session trust up front so the first-launch prompt is skipped and side-effect
+// tools run without per-call confirmation. Otherwise it defers to
+// ensureTrustPrompt, which asks only on the first launch in an undecided
+// directory. mgr==nil disables trust entirely, so approve is a no-op.
+func establishTrust(out io.Writer, in *bufio.Reader, mgr *trust.Manager, cwd string, approve bool) {
+	if approve {
+		if mgr != nil {
+			mgr.SetSessionTrust(cwd)
+		}
+		return
+	}
+	ensureTrustPrompt(out, in, mgr, cwd)
+}
+
 // ensureTrustPrompt runs the first-run trust dialog when cwd has no saved
 // decision (NearestTrustDecision reports Found=false). When a decision already
 // exists (trusted/untrusted/null) it is a no-op: the user already answered, so

--- a/cmd/pigo/trust_test.go
+++ b/cmd/pigo/trust_test.go
@@ -102,6 +102,46 @@ func TestEnsureTrustPromptSkipsWhenDecided(t *testing.T) {
 	}
 }
 
+// TestEstablishTrustApprove verifies --approve grants session trust up front
+// without prompting: IsTrusted is true immediately, nothing is written, and the
+// (empty) reader is never consumed. Session trust must not persist across a
+// reload — --approve is per-run, not a saved decision.
+func TestEstablishTrustApprove(t *testing.T) {
+	mgr, path := newTrustManager(t)
+	cwd := t.TempDir()
+	var out bytes.Buffer
+	establishTrust(&out, readerOf(""), mgr, cwd, true)
+
+	if !mgr.IsTrusted(cwd) {
+		t.Error("IsTrusted(cwd) = false after --approve, want true")
+	}
+	if out.Len() != 0 {
+		t.Errorf("establishTrust wrote %q with --approve, want no prompt", out.String())
+	}
+	m2 := newTrustManagerAt(t, path)
+	if m2.IsTrusted(cwd) {
+		t.Error("reload IsTrusted(cwd) = true, want false (--approve must not persist)")
+	}
+}
+
+// TestEstablishTrustWithoutApprove verifies that without --approve, establishTrust
+// defers to the first-launch prompt (which runs for an undecided directory).
+func TestEstablishTrustWithoutApprove(t *testing.T) {
+	mgr, _ := newTrustManager(t)
+	cwd := t.TempDir()
+	var out bytes.Buffer
+	// "2\n" answers the just-once prompt; if the prompt did not run, this input
+	// would be left unread and IsTrusted would stay false.
+	establishTrust(&out, readerOf("2\n"), mgr, cwd, false)
+
+	if !strings.Contains(out.String(), "First time in this directory") {
+		t.Errorf("without --approve, expected the trust prompt; got %q", out.String())
+	}
+	if !mgr.IsTrusted(cwd) {
+		t.Error("IsTrusted(cwd) = false after just-once via establishTrust, want true")
+	}
+}
+
 // TestConfirmToolCall verifies the y/n/a responses.
 func TestConfirmToolCall(t *testing.T) {
 	call := agentcore.AgentToolCall{Name: "bash", Arguments: []byte(`{"command":"ls"}`)}

--- a/docs/issue#0178.html
+++ b/docs/issue#0178.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0178</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/178">#178</a> &mdash; 补齐 pi 的 --approve / --no-skills 命令行参数 &mdash; 2026-07-20</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Map <code>--approve</code> onto session trust, not a persisted decision</h3>
+      <p><strong>Ambiguity:</strong> pi's <code>--approve</code>/<code>-a</code> means "trust project-local files for this run". The trust store offers two grants: <code>SetSessionTrust</code> (in-memory, per-run) and <code>SetDecision</code> (persisted to trust.json).</p>
+      <p><strong>Choice:</strong> <code>--approve</code> calls <code>mgr.SetSessionTrust(cwd)</code>, granting trust only for the current process.</p>
+      <p><strong>Rationale:</strong> "for this run" is per-invocation. Persisting would silently record a permanent trust decision the user never explicitly confirmed via the menu, changing behavior of future launches. A verifying test (<code>TestEstablishTrustApprove</code>) asserts trust does NOT survive a store reload.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Introduce <code>establishTrust</code> as the single trust-entry seam</h3>
+      <p><strong>Ambiguity:</strong> The <code>--approve</code> branch could have been inlined into <code>runInteractive</code> as an <code>if/else</code> around <code>ensureTrustPrompt</code>.</p>
+      <p><strong>Choice:</strong> Extracted <code>establishTrust(out, in, mgr, cwd, approve)</code> in trust.go, which either grants session trust up front or defers to <code>ensureTrustPrompt</code>.</p>
+      <p><strong>Rationale:</strong> Keeps the trust-establishment policy beside the other trust helpers (testable in isolation), and keeps <code>runInteractive</code> a straight wiring function. Two focused unit tests cover both branches without spinning up a REPL.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Gate skill discovery via a <code>noSkills</code> parameter on <code>buildSlashRegistry</code></h3>
+      <p><strong>Ambiguity:</strong> pi's <code>--no-skills</code> disables skill discovery but still loads explicit <code>--skill</code> paths. pigo has no <code>--skill</code> path flag yet, only directory discovery under <code>~/.agents/skills</code>.</p>
+      <p><strong>Choice:</strong> Threaded a <code>noSkills bool</code> into <code>buildSlashRegistry</code> that skips only the <code>loadSkillCommands</code> block; user command templates under <code>~/.pigo/commands</code> still load.</p>
+      <p><strong>Rationale:</strong> Matches pi's semantics as closely as the current feature set allows — discovery off, everything else unchanged. When an explicit <code>--skill</code> path flag is added later, it slots in beside this gate untouched.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Flags are REPL-only; silently inert in headless (<code>-p</code>) mode</h3>
+      <p><strong>Spec:</strong> pi applies <code>--approve</code>/<code>--no-skills</code> as global CLI flags.</p>
+      <p><strong>Implemented:</strong> Both flags parse in all modes but only affect the interactive REPL path. The headless <code>-p</code> path has no trust gating hook and does no slash/skill resolution, so they are no-ops there.</p>
+      <p><strong>Why:</strong> Trust gating and skill slash-commands only exist in the REPL. Headless already runs side-effect tools ungated and has no <code>/skill-name</code> concept, so there is nothing for the flags to change. Wiring them into headless would require inventing behavior that does not exist. Documented as a known limitation (see Open Questions).</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Silently ignore vs. warn on the two flags in headless mode</h3>
+      <p><strong>Alternatives:</strong> (a) silently accept the flags in headless mode; (b) print a "flag has no effect in headless mode" warning to stderr; (c) error out.</p>
+      <p><strong>Chosen:</strong> (a) silent acceptance.</p>
+      <p><strong>Pros/cons:</strong> (c) would break scripts that pass the flag defensively across modes. (b) is the safest but adds output that could contaminate stream-json/CI pipelines. (a) keeps the CLI surface uniform and pipeline-clean; the cost is a user could believe the flag took effect in <code>-p</code> mode when it did not. Review flagged this as the single low-severity finding; deferred to a docs/warning follow-up rather than blocking this change.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should headless mode warn when <code>--approve</code>/<code>--no-skills</code> are passed?</h3>
+      <p><strong>Assumption:</strong> Silent acceptance is acceptable because both flags are conceptually REPL-only.</p>
+      <p><strong>Verify:</strong> Confirm whether a one-line stderr warning (guarded so it never lands on stdout/stream-json) is worth adding, or whether documenting the REPL-only scope in <code>--help</code>/README suffices.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Future <code>--skill &lt;path&gt;</code> explicit-load flag</h3>
+      <p><strong>Assumption:</strong> pigo currently only discovers skills by directory, so <code>--no-skills</code> fully matches pi's observable behavior today.</p>
+      <p><strong>Verify:</strong> If an explicit <code>--skill</code> path flag is added later, ensure <code>--no-skills</code> continues to disable only discovery and still honors explicit paths, matching pi.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- `--approve`/`-a`：为启动目录预先授予会话级信任，跳过首启信任提示，副作用工具（bash/write/edit）无需逐次确认即可运行（对标 pi 的 --approve/-a）
- `--no-skills`：关闭技能发现，不再从 `~/.agents/skills` 注册 `/skill-name` 命令（对标 pi 的 --no-skills）
- 两个参数经 `cliOptions` → `dispatch` → `interactiveOptions` 贯通至 REPL
- 抽出 `establishTrust` 统一信任入口策略；`buildSlashRegistry` 增加 `noSkills` 参数以门控技能加载
- 新增 `TestEstablishTrustApprove`、`TestEstablishTrustWithoutApprove`、`TestBuildSlashRegistryNoSkills`

## Notes
- 这两个参数仅作用于交互式 REPL 路径：headless（`-p`）模式无信任门控与 /skill 解析，故对其为 no-op（详见 docs/issue#0178.html）

Closes #178

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./cmd/pigo/...