### PR TITLE
支持 --system-prompt / --append-system-prompt (对标 pi)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ go.work.sum
 # .vscode/
 
 .loop-state.json
+
+# Compiled binary (go build ./cmd/pigo produces ./pigo)
+/pigo

--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -44,6 +44,8 @@ func main() {
 	flag.BoolVarP(&opts.continueLast, "continue", "c", false, "resume the most recent interactive session")
 	flag.BoolVarP(&opts.approve, "approve", "a", false, "trust the working directory for this run: skip the first-launch trust prompt and run side-effect tools without per-call confirmation")
 	flag.BoolVar(&opts.noSkills, "no-skills", false, "disable skill discovery (do not load skills under ~/.agents/skills as /skill-name commands)")
+	flag.StringVar(&opts.systemPrompt, "system-prompt", "", "system prompt to use instead of the default coding-assistant prompt (对标 pi --system-prompt)")
+	flag.StringArrayVar(&opts.appendSystemPrompt, "append-system-prompt", nil, "append text or file contents to the system prompt; repeatable (对标 pi --append-system-prompt)")
 	flag.BoolVar(&opts.subagentRPC, "subagent-rpc", false, "internal: run as a process-isolated sub-agent JSON-RPC server over stdio (US-019)")
 	flag.Parse()
 

--- a/cmd/pigo/prompt_flags_test.go
+++ b/cmd/pigo/prompt_flags_test.go
@@ -1,0 +1,88 @@
+package main
+
+// Tests for --append-system-prompt value resolution (对标 pi): each value is
+// either a path to an existing file whose contents are appended, or literal
+// text when it is not an existing file. A value that names an unreadable file
+// (a real I/O error other than not-exist) is surfaced rather than silently
+// appended verbatim.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveAppendInstructionsEmpty verifies no values yields no appends.
+func TestResolveAppendInstructionsEmpty(t *testing.T) {
+	out, err := resolveAppendInstructions(nil)
+	if err != nil {
+		t.Fatalf("resolveAppendInstructions: %v", err)
+	}
+	if out != nil {
+		t.Errorf("expected nil for no values, got %#v", out)
+	}
+}
+
+// TestResolveAppendInstructionsLiteral verifies a value that is not an existing
+// file is treated as literal text and passed through verbatim.
+func TestResolveAppendInstructionsLiteral(t *testing.T) {
+	out, err := resolveAppendInstructions([]string{"be concise and helpful"})
+	if err != nil {
+		t.Fatalf("resolveAppendInstructions: %v", err)
+	}
+	if len(out) != 1 || out[0] != "be concise and helpful" {
+		t.Errorf("literal text must pass through verbatim, got %#v", out)
+	}
+}
+
+// TestResolveAppendInstructionsFile verifies a value that names an existing
+// file has its contents read and appended.
+func TestResolveAppendInstructionsFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "guidance.txt")
+	if err := os.WriteFile(path, []byte("FILE GUIDANCE"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	out, err := resolveAppendInstructions([]string{path, "literal tail"})
+	if err != nil {
+		t.Fatalf("resolveAppendInstructions: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 resolved values, got %#v", out)
+	}
+	if out[0] != "FILE GUIDANCE" {
+		t.Errorf("existing file must be read into the append, got %q", out[0])
+	}
+	if out[1] != "literal tail" {
+		t.Errorf("literal value must pass through verbatim, got %q", out[1])
+	}
+}
+
+// TestResolveAppendInstructionsUnreadableFile verifies a value that looks like a
+// path but points at an unreadable file (here, a directory) surfaces an error
+// rather than being appended verbatim. A directory is used because os.Stat
+// succeeds on it (so it is not treated as literal text) while os.ReadFile fails.
+func TestResolveAppendInstructionsUnreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	// A directory: Stat succeeds and IsDir() is true, so it is treated as literal
+	// text — assert that. Then create an actually-unreadable regular file to hit
+	// the read-error path.
+	if out, err := resolveAppendInstructions([]string{dir}); err != nil {
+		t.Fatalf("a directory should be treated as literal text, got error: %v", err)
+	} else if len(out) != 1 || out[0] != dir {
+		t.Errorf("a directory path must pass through as literal text, got %#v", out)
+	}
+
+	unreadable := filepath.Join(dir, "secret.txt")
+	if err := os.WriteFile(unreadable, []byte("nope"), 0o000); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	// Root can read 0o000 files, so skip the read-error assertion when running as
+	// root (common in CI containers) — the path would succeed instead of erroring.
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: 0o000 file is still readable, cannot exercise read-error path")
+	}
+	if _, err := resolveAppendInstructions([]string{unreadable}); err == nil {
+		t.Error("an unreadable append file must surface an error, got nil")
+	}
+}

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -38,15 +38,28 @@ type agentEnv struct {
 
 // setupAgentEnv resolves the provider for model/baseURL, builds the tool set
 // rooted at the working directory, and constructs the system prompt — the setup
-// the REPL and headless drivers both need. It returns an error rather than
+// the REPL and headless drivers both need. systemPrompt, when non-empty,
+// replaces the default base instruction (对标 pi 的 --system-prompt);
+// appendSystemPrompt entries are each resolved (a path to an existing file is
+// read, otherwise the value is literal text) and layered onto the end of the
+// prompt (对标 pi 的 --append-system-prompt). It returns an error rather than
 // exiting so the caller owns exit-code mapping.
-func setupAgentEnv(model, baseURL, protocol string, noTools bool) (agentEnv, error) {
+func setupAgentEnv(model, baseURL, protocol string, noTools bool, systemPrompt string, appendSystemPrompt []string) (agentEnv, error) {
 	cwd, _ := os.Getwd()
 	prov, providerName, err := resolveProvider(model, baseURL, protocol)
 	if err != nil {
 		return agentEnv{}, err
 	}
-	sysPrompt, err := runtime.BuildSystemPrompt(runtime.PromptConfig{WorkingDir: cwd, Root: cwd})
+	appends, err := resolveAppendInstructions(appendSystemPrompt)
+	if err != nil {
+		return agentEnv{}, err
+	}
+	sysPrompt, err := runtime.BuildSystemPrompt(runtime.PromptConfig{
+		BaseInstruction:    systemPrompt,
+		WorkingDir:         cwd,
+		Root:               cwd,
+		AppendInstructions: appends,
+	})
 	if err != nil {
 		return agentEnv{}, err
 	}
@@ -71,6 +84,32 @@ func setupAgentEnv(model, baseURL, protocol string, noTools bool) (agentEnv, err
 		sysPrompt:    sysPrompt,
 		plugins:      mgr,
 	}, nil
+}
+
+// resolveAppendInstructions maps each --append-system-prompt value to the text
+// to append. Following pi, a value that names an existing regular file is read
+// and its contents are appended; any other value (a non-existent path, or a
+// directory) is treated as literal text. Only a value that stats as a regular
+// file but then fails to read (e.g. a permission error) is reported, so a
+// genuinely broken file path is not silently appended verbatim.
+func resolveAppendInstructions(values []string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		info, statErr := os.Stat(v)
+		if statErr == nil && !info.IsDir() {
+			data, err := os.ReadFile(v)
+			if err != nil {
+				return nil, fmt.Errorf("read --append-system-prompt file %q: %w", v, err)
+			}
+			out = append(out, string(data))
+			continue
+		}
+		out = append(out, v)
+	}
+	return out, nil
 }
 
 // pluginsDir returns the directory external plugins are discovered from:
@@ -128,6 +167,14 @@ type cliOptions struct {
 	// noSkills disables skill discovery (对标 pi 的 --no-skills): skills under
 	// ~/.agents/skills are not loaded as /skill-name commands.
 	noSkills bool
+	// systemPrompt, when non-empty, replaces the default coding-assistant base
+	// instruction (对标 pi 的 --system-prompt). The environment block and
+	// AGENTS.md injection still apply on top of it.
+	systemPrompt string
+	// appendSystemPrompt holds --append-system-prompt values (对标 pi, repeatable):
+	// each is a path to a file whose contents are appended, or literal text when
+	// it is not an existing file. Appended after the base prompt and AGENTS.md.
+	appendSystemPrompt []string
 	// subagentRPC selects the process-isolated sub-agent server mode (US-019,
 	// #135): pigo reads JSON-RPC sub-agent run requests from stdin and writes
 	// results to stdout. Internal, used by SubAgentTool's process mode.
@@ -179,7 +226,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			fmt.Fprintln(errOut, "pigo: no prompt (use -p \"...\" or positional args)")
 			return 2
 		}
-		env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.noTools)
+		env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.noTools, opts.systemPrompt, opts.appendSystemPrompt)
 		if err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 1
@@ -213,7 +260,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		return 2
 	}
 
-	env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.noTools)
+	env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.noTools, opts.systemPrompt, opts.appendSystemPrompt)
 	if err != nil {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
 		return 1

--- a/docs/issue#0180.html
+++ b/docs/issue#0180.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0180</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/180">#180</a> &mdash; 支持 --system-prompt / --append-system-prompt (对标 pi) &mdash; 2026-07-20</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>--system-prompt</code> maps directly onto the existing <code>PromptConfig.BaseInstruction</code></h3>
+      <p><strong>Ambiguity:</strong> The issue asked to "use a custom system prompt instead of the default coding-assistant prompt" but the prompt assembler already had a <code>BaseInstruction</code> field with empty-string-means-default semantics.</p>
+      <p><strong>Choice:</strong> Wire the flag straight into <code>BaseInstruction</code> — no new field, no new branch. The existing <code>base := cfg.BaseInstruction; if base == "" { base = DefaultBaseInstruction }</code> logic already does the override.</p>
+      <p><strong>Rationale:</strong> Reuses proven code, keeps the environment block and AGENTS.md injection layered on top exactly as before. Minimal surface area.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> File-or-literal resolution lives in <code>cmd/pigo</code>, not in the pure assembler</h3>
+      <p><strong>Ambiguity:</strong> The spec says <code>--append-system-prompt</code> takes "text or file contents" but is silent on where the file read happens.</p>
+      <p><strong>Choice:</strong> Added <code>resolveAppendInstructions</code> in <code>cmd/pigo/run.go</code> (the I/O layer) which stats each value and reads it if it's a regular file, else treats it as literal text. <code>BuildSystemPrompt</code> stays a pure string assembler receiving already-resolved <code>AppendInstructions []string</code>.</p>
+      <p><strong>Rationale:</strong> Keeps the assembler deterministic and disk-free (its tests inject a fake <code>ReadFile</code>). Disk I/O for append values is an CLI concern, so it belongs at the CLI boundary.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Empty append entries are trimmed and skipped</h3>
+      <p><strong>Ambiguity:</strong> The repeatable flag can receive blank or whitespace-only values; the spec doesn't say what to do with them.</p>
+      <p><strong>Choice:</strong> <code>strings.TrimSpace</code> each entry in the append loop and <code>continue</code> on empty, so a stray <code>--append-system-prompt ""</code> doesn't inject dangling blank lines.</p>
+      <p><strong>Rationale:</strong> Avoids polluting the assembled prompt with empty separators; matches the tolerant behavior tested in <code>TestBuildSystemPromptAppendInstructions</code>.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None — implementation follows pi's semantics as described in the issue.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Asymmetric file resolution: <code>--system-prompt</code> is literal, <code>--append-system-prompt</code> is file-or-literal</h3>
+      <p><strong>Alternatives:</strong> (a) make both flags file-or-literal for consistency; (b) keep <code>--system-prompt</code> literal-only, matching pi.</p>
+      <p><strong>Pros/cons:</strong> Symmetry would be tidier, but pi/Claude Code treat <code>--system-prompt</code> as literal text and only <code>--append-system-prompt</code> as file-capable. Diverging would break the "对标 pi" contract callers expect.</p>
+      <p><strong>Why chosen:</strong> Fidelity to pi wins over internal symmetry — this is a compatibility feature.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Widening <code>setupAgentEnv</code>'s positional signature vs. passing a config struct</h3>
+      <p><strong>Alternatives:</strong> (a) add two more positional params (current, now 6 args); (b) pass the whole <code>cliOptions</code> struct or a dedicated prompt-config struct.</p>
+      <p><strong>Pros/cons:</strong> A struct would stop the signature widening as more flags land, but refactoring the call sites now is out of scope for this feature and would enlarge the diff/review surface.</p>
+      <p><strong>Why chosen:</strong> Kept positional params to stay minimal; flagged the struct refactor as a possible future cleanup (see Open Questions).</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Directory paths for <code>--append-system-prompt</code> are treated as literal text</h3>
+      <p><strong>Assumption:</strong> If a value stats as a directory, it falls through to literal-text append (not an error). A genuine typo pointing at a dir would be appended verbatim.</p>
+      <p><strong>Verify:</strong> Is silent literal-append acceptable for a directory path, or should it error like an unreadable regular file does? Current behavior matches "only a regular file is read; everything else is literal."</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should <code>setupAgentEnv</code> take a config struct?</h3>
+      <p><strong>Assumption:</strong> The 6-positional-arg signature is fine for now.</p>
+      <p><strong>Follow-up:</strong> If more prompt/config flags arrive, consider collapsing the params into a struct to avoid arg-order mistakes at the two call sites.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/runtime/prompt.go
+++ b/internal/runtime/prompt.go
@@ -41,6 +41,11 @@ type PromptConfig struct {
 	// every directory from Root down to WorkingDir, inclusive. When empty, only
 	// WorkingDir's own AGENTS.md (if any) is considered — no ancestor walk.
 	Root string
+	// AppendInstructions are appended verbatim to the end of the assembled
+	// prompt, in order, each preceded by a blank line. This is the sink for
+	// --append-system-prompt (对标 pi): extra guidance layered after the base
+	// instruction, environment block, and AGENTS.md. Empty entries are skipped.
+	AppendInstructions []string
 	// Now supplies the timestamp for the environment block. When nil, time.Now
 	// is used. Injected for deterministic tests.
 	Now func() time.Time
@@ -112,6 +117,18 @@ func BuildSystemPrompt(cfg PromptConfig) (string, error) {
 			continue
 		}
 		fmt.Fprintf(&b, "\n\n# Project instructions (%s)\n%s", path, content)
+	}
+
+	// Appended instructions (--append-system-prompt) come last so they layer on
+	// top of the base instruction, environment, and AGENTS.md. Each is separated
+	// by a blank line; empty entries are skipped.
+	for _, extra := range cfg.AppendInstructions {
+		extra = strings.TrimSpace(extra)
+		if extra == "" {
+			continue
+		}
+		b.WriteString("\n\n")
+		b.WriteString(extra)
 	}
 
 	return b.String(), nil

--- a/internal/runtime/prompt_test.go
+++ b/internal/runtime/prompt_test.go
@@ -153,3 +153,51 @@ func TestBuildSystemPromptReadErrorSurfaces(t *testing.T) {
 		t.Fatal("an unreadable AGENTS.md must surface an error, got nil")
 	}
 }
+
+// TestBuildSystemPromptBaseInstructionOverride verifies a non-empty
+// BaseInstruction replaces the default coding-assistant prompt (对标 pi 的
+// --system-prompt) while the environment block still follows it.
+func TestBuildSystemPromptBaseInstructionOverride(t *testing.T) {
+	got, err := BuildSystemPrompt(PromptConfig{
+		BaseInstruction: "You are a haiku poet.",
+		WorkingDir:      "/work/proj",
+		Now:             fixedTime,
+		ReadFile:        func(string) ([]byte, error) { return nil, os.ErrNotExist },
+	})
+	if err != nil {
+		t.Fatalf("BuildSystemPrompt: %v", err)
+	}
+	if !strings.HasPrefix(got, "You are a haiku poet.") {
+		t.Errorf("custom base instruction should lead the prompt, got:\n%s", got)
+	}
+	if strings.Contains(got, DefaultBaseInstruction) {
+		t.Errorf("default base instruction must not appear when overridden:\n%s", got)
+	}
+	if !strings.Contains(got, "Working directory: /work/proj") {
+		t.Errorf("environment block must still follow the custom base:\n%s", got)
+	}
+}
+
+// TestBuildSystemPromptAppendInstructions verifies --append-system-prompt
+// entries are layered onto the end of the prompt in order, after the base
+// instruction and environment block, with empty entries skipped.
+func TestBuildSystemPromptAppendInstructions(t *testing.T) {
+	got, err := BuildSystemPrompt(PromptConfig{
+		WorkingDir:         "/work/proj",
+		Now:                fixedTime,
+		AppendInstructions: []string{"FIRST APPEND", "   ", "SECOND APPEND"},
+		ReadFile:           func(string) ([]byte, error) { return nil, os.ErrNotExist },
+	})
+	if err != nil {
+		t.Fatalf("BuildSystemPrompt: %v", err)
+	}
+	iEnv := strings.Index(got, "Working directory")
+	iFirst := strings.Index(got, "FIRST APPEND")
+	iSecond := strings.Index(got, "SECOND APPEND")
+	if iFirst < 0 || iSecond < 0 {
+		t.Fatalf("both appended instructions must be present, got:\n%s", got)
+	}
+	if !(iEnv < iFirst && iFirst < iSecond) {
+		t.Errorf("appends must follow the env block and keep order (env<first<second), got env=%d first=%d second=%d", iEnv, iFirst, iSecond)
+	}
+}


### PR DESCRIPTION
## Summary
- `--system-prompt <text>`：用自定义文本替换默认 coding-assistant 提示词（映射到 `PromptConfig.BaseInstruction`），环境块与 AGENTS.md 注入仍生效
- `--append-system-prompt <text>`（可重复）：每个值若为存在的普通文件则读取其内容追加，否则作为字面文本追加；位于 base/环境块/AGENTS.md 之后按顺序排列，空条目跳过
- 文件-或-字面解析放在 CLI 层 `resolveAppendInstructions`，`BuildSystemPrompt` 保持无 I/O 的纯装配器
- 顺带将未跟踪的编译产物 `pigo` 加入 `.gitignore`

Closes #180

## Test plan
- [x] `go build ./...` 通过
- [x] `go vet ./...` 通过
- [x] `go test ./...` 全绿
- [x] 新增 `TestBuildSystemPromptBaseInstructionOverride` / `TestBuildSystemPromptAppendInstructions`（runtime）
- [x] 新增 `resolveAppendInstructions` 测试：字面文本 / 文件读取 / 目录按字面 / 不可读文件报错
- [x] /review-it 通过（仅一处文档注释与实现不符，已修正）