### PR TITLE
Add --provider flag to select a built-in provider

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -365,7 +365,7 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 			if id == "" {
 				return fmt.Sprintf("model: %s (provider: %s)\nrun /models to see presets, or /model <id> to switch", live.model, live.providerName)
 			}
-			prov, providerName, err := resolveProvider(id, live.baseURL, live.protocol)
+			prov, providerName, err := resolveProvider(id, live.baseURL, live.protocol, "")
 			if err != nil {
 				return fmt.Sprintf("model: cannot switch to %q: %v", id, err)
 			}

--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -46,6 +46,7 @@ func main() {
 	flag.StringVarP(&opts.baseURL, "base-url", "u", "", "override provider base URL (e.g. local Ollama)")
 	flag.StringVarP(&opts.apiKey, "api-key", "k", "", "API key for the resolved provider (overrides env/config; else <PROVIDER>_API_KEY)")
 	flag.StringVarP(&opts.protocol, "protocol", "P", "", "force wire protocol for a custom endpoint: openai | anthropic (default: inferred from model id)")
+	flag.StringVar(&opts.provider, "provider", "", "select a built-in provider by name (e.g. deepseek, minimax); uses its default base URL, protocol, and API-key env var (see --help provider list)")
 	flag.StringVarP(&opts.outputFmt, "output-format", "o", "text", "output format: text | stream-json")
 	flag.BoolVarP(&opts.noTools, "no-tools", "n", false, "disable the built-in file/shell tools")
 	flag.BoolVarP(&opts.listSessions, "list-sessions", "l", false, "list stored interactive sessions and exit")
@@ -73,12 +74,17 @@ func main() {
 	os.Exit(dispatch(context.Background(), opts, os.Stdout, os.Stderr))
 }
 
-// resolveProvider maps a model id to a built-in provider. When protocol is a
-// non-empty explicit selection ("openai" or "anthropic") it wins over all
-// heuristics: the provider is built directly for that wire format against
-// baseURL, which is how a user points pigo at a self-hosted or third-party
-// endpoint and says which protocol it speaks. An "anthropic" selection with no
-// baseURL targets the public Anthropic API.
+// resolveProvider maps a model id to a built-in provider. An explicit
+// --provider name wins over every other rule: it selects a built-in provider
+// from the registry and constructs the matching wire driver (see
+// resolveNamedProvider). When provider is empty, protocol and model-id
+// heuristics apply as before.
+//
+// When protocol is a non-empty explicit selection ("openai" or "anthropic") it
+// wins over the model-id heuristics: the provider is built directly for that
+// wire format against baseURL, which is how a user points pigo at a self-hosted
+// or third-party endpoint and says which protocol it speaks. An "anthropic"
+// selection with no baseURL targets the public Anthropic API.
 //
 // When protocol is empty, resolution falls back to model-id heuristics:
 //
@@ -90,7 +96,13 @@ func main() {
 //
 // An unknown protocol value is an error, surfaced to the caller for exit-code
 // mapping rather than silently falling back.
-func resolveProvider(model, baseURL, protocol string) (provider.Provider, string, error) {
+func resolveProvider(model, baseURL, protocol, providerName string) (provider.Provider, string, error) {
+	// Explicit --provider selects a built-in provider from the registry and
+	// wins over both --protocol inference and model-id heuristics.
+	if strings.TrimSpace(providerName) != "" {
+		return resolveNamedProvider(providerName, model, baseURL, protocol)
+	}
+
 	// 0. Explicit protocol selection wins over every heuristic.
 	switch protocol {
 	case "openai":
@@ -131,6 +143,51 @@ func resolveProvider(model, baseURL, protocol string) (provider.Provider, string
 	}
 	// 4. Default: OpenRouter.
 	return provider.NewOpenRouterProvider(baseURL, []provider.Model{{Provider: "openrouter", ID: model, SupportsImages: true}}), "openrouter", nil
+}
+
+// resolveNamedProvider builds the driver for an explicit --provider selection.
+// It looks the name up in the built-in registry and constructs the wire driver
+// matching the spec's Protocol: "openai" → an OpenAI-compatible (Bearer) driver,
+// "anthropic" → an Anthropic-Messages driver. The provider's DefaultBaseURL is
+// used unless --base-url overrides it (node #185 layers <PROVIDER>_BASE_URL on
+// top afterward; this node keeps the flag precedence unchanged). The returned
+// provider-name string is the spec name, so downstream API-key resolution reads
+// the provider's own env var (spec.EnvVars).
+//
+// Special providers whose bespoke auth is not wired yet (azure/bedrock/vertex/
+// cloudflare — AuthScheme aws/azure/special) are routed to the closest generic
+// driver by Protocol against the spec's (possibly templated) base URL so this
+// node does not crash on them; node #188 refines their auth.
+func resolveNamedProvider(name, model, baseURL, protocol string) (provider.Provider, string, error) {
+	spec, ok := provider.LookupProviderSpec(name)
+	if !ok {
+		return nil, "", fmt.Errorf("unknown --provider %q (available: %s)", name, strings.Join(provider.ProviderNames(), ", "))
+	}
+	// A concurrently-set --protocol must agree with the provider's own protocol;
+	// an incompatible pair is a user error naming both flags.
+	if p := strings.TrimSpace(protocol); p != "" && p != spec.Protocol {
+		return nil, "", fmt.Errorf("--provider %q speaks the %q protocol, which conflicts with --protocol %q; drop --protocol or set it to %q", name, spec.Protocol, p, spec.Protocol)
+	}
+	// --base-url overrides the spec default; otherwise use the spec's default
+	// endpoint. (Base-URL override precedence beyond this is node #185's.)
+	url := strings.TrimSpace(baseURL)
+	if url == "" {
+		url = spec.DefaultBaseURL
+	}
+	models := []provider.Model{{Provider: spec.Name, ID: model, SupportsImages: true}}
+	// Note: spec.ExtraHeaders would be attached here, but the exported generic
+	// constructors do not yet accept custom headers; all built-in specs currently
+	// carry no ExtraHeaders, so this is a no-op today (refined alongside #188).
+	switch spec.Protocol {
+	case provider.ProtocolAnthropic:
+		return provider.NewAnthropicProvider(url, models), spec.Name, nil
+	case provider.ProtocolOpenAI:
+		return provider.NewOpenAICompatibleProvider(url, models), spec.Name, nil
+	default:
+		// The registry only ever stores openai/anthropic; guard anyway so an
+		// unexpected value is a clear error rather than a nil provider.
+		return nil, "", fmt.Errorf("--provider %q has unsupported protocol %q", name, spec.Protocol)
+	}
 }
 
 // builtinTools returns the default file/shell tool set rooted at cwd, or nil

--- a/cmd/pigo/presets_test.go
+++ b/cmd/pigo/presets_test.go
@@ -23,7 +23,7 @@ func TestResolveProviderPresetCatalog(t *testing.T) {
 		{"anthropic/claude-3.5-sonnet", "openrouter"}, // OpenRouter preset
 	}
 	for _, c := range cases {
-		_, name, err := resolveProvider(c.model, "", "")
+		_, name, err := resolveProvider(c.model, "", "", "")
 		if err != nil {
 			t.Errorf("resolveProvider(%q) error: %v", c.model, err)
 			continue
@@ -48,7 +48,7 @@ func TestResolveProviderPrefixAndDefault(t *testing.T) {
 		{"m", "http://host:11434/v1", "ollama"},   // ollama port
 	}
 	for _, c := range cases {
-		_, name, err := resolveProvider(c.model, c.baseURL, "")
+		_, name, err := resolveProvider(c.model, c.baseURL, "", "")
 		if err != nil {
 			t.Errorf("resolveProvider(%q) error: %v", c.model, err)
 			continue
@@ -65,19 +65,66 @@ func TestResolveProviderPrefixAndDefault(t *testing.T) {
 // errors instead of silently falling back.
 func TestResolveProviderExplicitProtocol(t *testing.T) {
 	// openai protocol → "openai" provider name, requires base-url.
-	if _, name, err := resolveProvider("any-model", "https://example.com/v1", "openai"); err != nil || name != "openai" {
+	if _, name, err := resolveProvider("any-model", "https://example.com/v1", "openai", ""); err != nil || name != "openai" {
 		t.Errorf("protocol=openai = (%q, %v), want (openai, nil)", name, err)
 	}
-	if _, _, err := resolveProvider("any-model", "", "openai"); err == nil {
+	if _, _, err := resolveProvider("any-model", "", "openai", ""); err == nil {
 		t.Error("protocol=openai with no base-url should error")
 	}
 	// anthropic protocol → "anthropic" provider name, base-url optional (defaults).
-	if _, name, err := resolveProvider("claude-x", "", "anthropic"); err != nil || name != "anthropic" {
+	if _, name, err := resolveProvider("claude-x", "", "anthropic", ""); err != nil || name != "anthropic" {
 		t.Errorf("protocol=anthropic = (%q, %v), want (anthropic, nil)", name, err)
 	}
 	// Unknown protocol errors rather than falling back to a heuristic.
-	if _, _, err := resolveProvider("any-model", "", "grpc"); err == nil {
+	if _, _, err := resolveProvider("any-model", "", "grpc", ""); err == nil {
 		t.Error("unknown protocol should error")
+	}
+}
+
+// TestResolveProviderExplicitProvider verifies that --provider selects a
+// built-in provider from the registry: the returned provider-name is the spec
+// name (so key resolution reads the right env var), an OpenAI-protocol provider
+// (deepseek) and an Anthropic-protocol provider (minimax) both resolve, an
+// incompatible --protocol is a conflict error naming both flags, and an unknown
+// provider name errors while listing the available names.
+func TestResolveProviderExplicitProvider(t *testing.T) {
+	// OpenAI-protocol provider: returns its own name for key lookup.
+	if _, name, err := resolveProvider("deepseek-chat", "", "", "deepseek"); err != nil || name != "deepseek" {
+		t.Errorf("provider=deepseek = (%q, %v), want (deepseek, nil)", name, err)
+	}
+	// Anthropic-protocol provider.
+	if _, name, err := resolveProvider("MiniMax-M2", "", "", "minimax"); err != nil || name != "minimax" {
+		t.Errorf("provider=minimax = (%q, %v), want (minimax, nil)", name, err)
+	}
+	// A matching --protocol is not a conflict (deepseek speaks openai).
+	if _, name, err := resolveProvider("deepseek-chat", "", "openai", "deepseek"); err != nil || name != "deepseek" {
+		t.Errorf("provider=deepseek + protocol=openai = (%q, %v), want (deepseek, nil)", name, err)
+	}
+	// --provider wins over model-id heuristics: an ollama/-prefixed id still
+	// resolves to the named provider, not local Ollama.
+	if _, name, err := resolveProvider("ollama/x", "", "", "deepseek"); err != nil || name != "deepseek" {
+		t.Errorf("provider=deepseek with ollama/ model = (%q, %v), want (deepseek, nil)", name, err)
+	}
+	// --base-url overrides the spec default without changing the provider name.
+	if _, name, err := resolveProvider("deepseek-chat", "https://proxy.local/v1", "", "deepseek"); err != nil || name != "deepseek" {
+		t.Errorf("provider=deepseek + base-url = (%q, %v), want (deepseek, nil)", name, err)
+	}
+	// Conflict: minimax speaks anthropic; forcing --protocol openai errors and
+	// names both flags.
+	_, _, err := resolveProvider("MiniMax-M2", "", "openai", "minimax")
+	if err == nil {
+		t.Fatal("provider=minimax + protocol=openai should conflict")
+	}
+	if !strings.Contains(err.Error(), "--provider") || !strings.Contains(err.Error(), "--protocol") {
+		t.Errorf("conflict error should name both flags, got: %v", err)
+	}
+	// Unknown provider errors and lists available names.
+	_, _, err = resolveProvider("m", "", "", "no-such-provider")
+	if err == nil {
+		t.Fatal("unknown provider should error")
+	}
+	if !strings.Contains(err.Error(), "deepseek") {
+		t.Errorf("unknown-provider error should list available names, got: %v", err)
 	}
 }
 

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -44,9 +44,9 @@ type agentEnv struct {
 // read, otherwise the value is literal text) and layered onto the end of the
 // prompt (对标 pi 的 --append-system-prompt). It returns an error rather than
 // exiting so the caller owns exit-code mapping.
-func setupAgentEnv(model, baseURL, protocol string, noTools bool, systemPrompt string, appendSystemPrompt []string) (agentEnv, error) {
+func setupAgentEnv(model, baseURL, protocol, providerName string, noTools bool, systemPrompt string, appendSystemPrompt []string) (agentEnv, error) {
 	cwd, _ := os.Getwd()
-	prov, providerName, err := resolveProvider(model, baseURL, protocol)
+	prov, resolvedName, err := resolveProvider(model, baseURL, protocol, providerName)
 	if err != nil {
 		return agentEnv{}, err
 	}
@@ -80,7 +80,7 @@ func setupAgentEnv(model, baseURL, protocol string, noTools bool, systemPrompt s
 		cwd:          cwd,
 		tools:        tools,
 		provider:     prov,
-		providerName: providerName,
+		providerName: resolvedName,
 		sysPrompt:    sysPrompt,
 		plugins:      mgr,
 	}, nil
@@ -155,7 +155,12 @@ type cliOptions struct {
 	baseURL      string
 	apiKey       string
 	protocol     string
-	outputFmt    string
+	// provider, when non-empty, selects a built-in provider by name from the
+	// registry (对标 pi 的 provider selection): resolveProvider then builds the
+	// matching wire driver using the provider's default base URL, protocol, and
+	// API-key env var, ignoring the model-id heuristics.
+	provider  string
+	outputFmt string
 	noTools      bool
 	listSessions bool
 	resumeID     string
@@ -229,7 +234,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			fmt.Fprintln(errOut, "pigo: no prompt (use -p \"...\" or positional args)")
 			return 2
 		}
-		env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.noTools, opts.systemPrompt, opts.appendSystemPrompt)
+		env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.noTools, opts.systemPrompt, opts.appendSystemPrompt)
 		if err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 1
@@ -263,7 +268,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		return 2
 	}
 
-	env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.noTools, opts.systemPrompt, opts.appendSystemPrompt)
+	env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.noTools, opts.systemPrompt, opts.appendSystemPrompt)
 	if err != nil {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
 		return 1

--- a/cmd/pigo/subagent_rpc.go
+++ b/cmd/pigo/subagent_rpc.go
@@ -87,7 +87,7 @@ func handleSubAgentRequest(ctx context.Context, enc *json.Encoder, req *jsonrpc.
 	// Resolve the provider the same way the CLI does, so the subprocess targets
 	// the same gateway the parent's NewRunConfig encoded. Credentials come from
 	// the inherited environment (the parent's env vars).
-	prov, providerName, err := resolveProvider(params.Model, params.BaseURL, params.Protocol)
+	prov, providerName, err := resolveProvider(params.Model, params.BaseURL, params.Protocol, "")
 	if err != nil {
 		writeSubAgentError(enc, req.ID, -32603, "resolve provider: "+err.Error())
 		return


### PR DESCRIPTION
## Summary
- Add a `--provider <name>` flag that selects a built-in provider from the registry (node #182)
- `resolveProvider` looks up the spec via `LookupProviderSpec` and builds the matching wire driver: `openai` protocol → OpenAI-compatible (Bearer) driver, `anthropic` → Anthropic-Messages driver, using `spec.DefaultBaseURL` unless `--base-url` overrides
- Returned provider-name is the spec name so downstream API-key resolution reads the provider's own env var
- Incompatible `--provider`/`--protocol` pair errors naming both flags; unknown provider lists available names
- Special providers (azure/bedrock/vertex/cloudflare) route to the closest generic driver by protocol without crashing (auth refined by #188)
- When `--provider` is unset, existing model-prefix/protocol resolution is unchanged

Closes #184

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` all green
- [x] Unit tests: `--provider` openai-protocol (deepseek) and anthropic-protocol (minimax), matching protocol, provider-wins-over-heuristic, base-url override, conflict error, unknown provider