### PR TITLE
Add base_url override precedence for selected providers

### DIFF
--- a/cmd/pigo/baseurl.go
+++ b/cmd/pigo/baseurl.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+// resolveBaseURL determines the effective base URL for a selected provider,
+// applying the base_url override precedence (US-004 / FR-8, FR-9). The first
+// non-empty source wins, in this order:
+//
+//  1. flagBaseURL — the explicit --base-url/-u flag (highest).
+//  2. provider-specific base-url env var(s) from spec.BaseURLEnvVars, in the
+//     order the registry declares them (e.g. AZURE_OPENAI_BASE_URL).
+//  3. the generic <PROVIDER>_BASE_URL env var, where <PROVIDER> is the provider
+//     name uppercased with '-' rewritten to '_' (e.g. zai-coding-cn →
+//     ZAI_CODING_CN_BASE_URL).
+//  4. spec.DefaultBaseURL — the registry default (lowest).
+//
+// Values are trimmed of surrounding whitespace before the non-empty check, so a
+// whitespace-only env var does not shadow a lower-precedence source.
+func resolveBaseURL(spec provider.ProviderSpec, flagBaseURL string) string {
+	// 1. Explicit flag wins over every env-var convention.
+	if v := strings.TrimSpace(flagBaseURL); v != "" {
+		return v
+	}
+	// 2. Provider-specific override env vars, in registry precedence order.
+	for _, name := range spec.BaseURLEnvVars {
+		if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+			return v
+		}
+	}
+	// 3. Generic <PROVIDER>_BASE_URL convention.
+	if envName := genericBaseURLEnvVar(spec.Name); envName != "" {
+		if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
+			return v
+		}
+	}
+	// 4. Registry default.
+	return spec.DefaultBaseURL
+}
+
+// genericBaseURLEnvVar derives the generic base-url override env var name for a
+// provider: the provider name uppercased with hyphens rewritten to underscores,
+// suffixed with _BASE_URL. For example "zai-coding-cn" → "ZAI_CODING_CN_BASE_URL"
+// and "deepseek" → "DEEPSEEK_BASE_URL". An empty provider name yields "".
+func genericBaseURLEnvVar(providerName string) string {
+	n := strings.TrimSpace(providerName)
+	if n == "" {
+		return ""
+	}
+	n = strings.ReplaceAll(n, "-", "_")
+	return strings.ToUpper(n) + "_BASE_URL"
+}

--- a/cmd/pigo/baseurl_test.go
+++ b/cmd/pigo/baseurl_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+// TestGenericBaseURLEnvVar verifies the <PROVIDER>_BASE_URL name derivation,
+// especially the hyphen→underscore conversion and uppercasing.
+func TestGenericBaseURLEnvVar(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"deepseek", "DEEPSEEK_BASE_URL"},
+		{"zai-coding-cn", "ZAI_CODING_CN_BASE_URL"},
+		{"vercel-ai-gateway", "VERCEL_AI_GATEWAY_BASE_URL"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := genericBaseURLEnvVar(c.name); got != c.want {
+			t.Errorf("genericBaseURLEnvVar(%q) = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// TestResolveBaseURLPrecedence exercises all four precedence levels for a
+// hyphenated provider (zai-coding-cn → ZAI_CODING_CN_BASE_URL), asserting that
+// each higher-precedence source shadows every lower one.
+func TestResolveBaseURLPrecedence(t *testing.T) {
+	spec, ok := provider.LookupProviderSpec("zai-coding-cn")
+	if !ok {
+		t.Fatal("expected zai-coding-cn in registry")
+	}
+	// The default (lowest) applies when nothing else is set.
+	if got := resolveBaseURL(spec, ""); got != spec.DefaultBaseURL {
+		t.Errorf("default: got %q, want %q", got, spec.DefaultBaseURL)
+	}
+
+	// Generic <PROVIDER>_BASE_URL beats the default. Confirms hyphen→underscore.
+	t.Setenv("ZAI_CODING_CN_BASE_URL", "https://generic.example/v4")
+	if got := resolveBaseURL(spec, ""); got != "https://generic.example/v4" {
+		t.Errorf("generic env: got %q, want %q", got, "https://generic.example/v4")
+	}
+
+	// --base-url flag beats the generic env var.
+	if got := resolveBaseURL(spec, "https://flag.example/v4"); got != "https://flag.example/v4" {
+		t.Errorf("flag over generic: got %q, want %q", got, "https://flag.example/v4")
+	}
+}
+
+// TestResolveBaseURLProviderSpecificEnv covers a provider that declares a
+// provider-specific base-url env var (azure) and asserts it sits between the
+// flag and the generic convention in precedence.
+func TestResolveBaseURLProviderSpecificEnv(t *testing.T) {
+	spec, ok := provider.LookupProviderSpec("azure-openai-responses")
+	if !ok {
+		t.Fatal("expected azure-openai-responses in registry")
+	}
+	if len(spec.BaseURLEnvVars) == 0 {
+		t.Fatal("expected azure-openai-responses to declare BaseURLEnvVars")
+	}
+
+	// Provider-specific env var beats the default (which is empty here).
+	t.Setenv("AZURE_OPENAI_BASE_URL", "https://specific.example")
+	if got := resolveBaseURL(spec, ""); got != "https://specific.example" {
+		t.Errorf("provider-specific env: got %q, want %q", got, "https://specific.example")
+	}
+
+	// Provider-specific env var beats the generic <PROVIDER>_BASE_URL.
+	t.Setenv("AZURE_OPENAI_RESPONSES_BASE_URL", "https://generic.example")
+	if got := resolveBaseURL(spec, ""); got != "https://specific.example" {
+		t.Errorf("provider-specific beats generic: got %q, want %q", got, "https://specific.example")
+	}
+
+	// --base-url flag beats the provider-specific env var.
+	if got := resolveBaseURL(spec, "https://flag.example"); got != "https://flag.example" {
+		t.Errorf("flag beats provider-specific: got %q, want %q", got, "https://flag.example")
+	}
+}

--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -148,11 +148,11 @@ func resolveProvider(model, baseURL, protocol, providerName string) (provider.Pr
 // resolveNamedProvider builds the driver for an explicit --provider selection.
 // It looks the name up in the built-in registry and constructs the wire driver
 // matching the spec's Protocol: "openai" → an OpenAI-compatible (Bearer) driver,
-// "anthropic" → an Anthropic-Messages driver. The provider's DefaultBaseURL is
-// used unless --base-url overrides it (node #185 layers <PROVIDER>_BASE_URL on
-// top afterward; this node keeps the flag precedence unchanged). The returned
-// provider-name string is the spec name, so downstream API-key resolution reads
-// the provider's own env var (spec.EnvVars).
+// "anthropic" → an Anthropic-Messages driver. The base URL follows the override
+// precedence in resolveBaseURL (--base-url > provider-specific env > generic
+// <PROVIDER>_BASE_URL > spec default). The returned provider-name string is the
+// spec name, so downstream API-key resolution reads the provider's own env var
+// (spec.EnvVars).
 //
 // Special providers whose bespoke auth is not wired yet (azure/bedrock/vertex/
 // cloudflare — AuthScheme aws/azure/special) are routed to the closest generic
@@ -168,12 +168,9 @@ func resolveNamedProvider(name, model, baseURL, protocol string) (provider.Provi
 	if p := strings.TrimSpace(protocol); p != "" && p != spec.Protocol {
 		return nil, "", fmt.Errorf("--provider %q speaks the %q protocol, which conflicts with --protocol %q; drop --protocol or set it to %q", name, spec.Protocol, p, spec.Protocol)
 	}
-	// --base-url overrides the spec default; otherwise use the spec's default
-	// endpoint. (Base-URL override precedence beyond this is node #185's.)
-	url := strings.TrimSpace(baseURL)
-	if url == "" {
-		url = spec.DefaultBaseURL
-	}
+	// Base-URL precedence (US-004 / FR-8, FR-9): --base-url flag > provider-
+	// specific base-url env var(s) > generic <PROVIDER>_BASE_URL > spec default.
+	url := resolveBaseURL(spec, baseURL)
 	models := []provider.Model{{Provider: spec.Name, ID: model, SupportsImages: true}}
 	// Note: spec.ExtraHeaders would be attached here, but the exported generic
 	// constructors do not yet accept custom headers; all built-in specs currently


### PR DESCRIPTION
## Summary
- Add `resolveBaseURL` helper implementing base_url override precedence: `--base-url` flag > provider-specific env var(s) (`spec.BaseURLEnvVars`, e.g. `AZURE_OPENAI_BASE_URL`) > generic `<PROVIDER>_BASE_URL` (name uppercased, `-`→`_`) > `spec.DefaultBaseURL`.
- Wire it into `resolveNamedProvider` so a `--provider` endpoint can be overridden via env without passing `--base-url` each run.
- Legacy inference path (no `--provider`) is untouched; existing tests unaffected.

Closes #185

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` all green
- [x] Unit tests cover all four precedence levels and hyphen→underscore name derivation (`zai-coding-cn` → `ZAI_CODING_CN_BASE_URL`)