### PR TITLE
Wire Anthropic-Messages protocol providers via --provider

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -177,7 +177,11 @@ func resolveNamedProvider(name, model, baseURL, protocol string) (provider.Provi
 	// carry no ExtraHeaders, so this is a no-op today (refined alongside #188).
 	switch spec.Protocol {
 	case provider.ProtocolAnthropic:
-		return provider.NewAnthropicProvider(url, models), spec.Name, nil
+		// Auth header follows the spec's AuthScheme (x-api-key + anthropic-version
+		// for anthropic/minimax/minimax-cn; Bearer for any anthropic-protocol
+		// gateway that authenticates with a plain bearer token). The driver name is
+		// the spec name so errors reference the selected provider.
+		return provider.NewAnthropicProtocolProvider(spec.Name, url, spec.AuthScheme, models), spec.Name, nil
 	case provider.ProtocolOpenAI:
 		return provider.NewOpenAICompatibleProvider(url, models), spec.Name, nil
 	default:

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -564,6 +564,33 @@ func newAnthropicCompat(name, defaultURL, baseURL string, models []Model, authHe
 	}
 }
 
+// anthropicAuthHeaderFor returns the auth-header setter for an Anthropic-Messages
+// provider given its registry AuthScheme (spec.AuthScheme). The two shapes seen
+// among anthropic-protocol providers are:
+//
+//   - AuthBearer      → Authorization: Bearer <key>. Used by anthropic-protocol
+//     gateways that authenticate with a plain bearer token on their /anthropic
+//     endpoint.
+//   - AuthXAPIKey     → x-api-key: <key> plus the required anthropic-version
+//     header. This is the direct-Anthropic convention and, per pi's behavior,
+//     also what MiniMax (minimax / minimax-cn) uses on its /anthropic endpoint.
+//
+// Any other scheme (e.g. AuthAWS for Bedrock, AuthSpecial) falls back to the
+// x-api-key convention so a generic anthropic-protocol provider does not crash;
+// bespoke auth for those is layered by a later node. The returned func never
+// logs the secret value.
+func anthropicAuthHeaderFor(authScheme string) func(*http.Request, string) {
+	if authScheme == AuthBearer {
+		return func(req *http.Request, apiKey string) {
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+		}
+	}
+	return func(req *http.Request, apiKey string) {
+		req.Header.Set("x-api-key", apiKey)
+		req.Header.Set("anthropic-version", anthropicAPIVersion)
+	}
+}
+
 // NewAnthropicProvider builds a provider that speaks the Anthropic Messages wire
 // format directly (POST {baseURL}/messages), the target of an explicit
 // --protocol=anthropic selection. baseURL defaults to the public Anthropic API
@@ -573,10 +600,20 @@ func newAnthropicCompat(name, defaultURL, baseURL string, models []Model, authHe
 // secret values are never logged.
 func NewAnthropicProvider(baseURL string, models []Model) Provider {
 	return newAnthropicCompat("anthropic", anthropicBaseURL, baseURL, models,
-		func(req *http.Request, apiKey string) {
-			req.Header.Set("x-api-key", apiKey)
-			req.Header.Set("anthropic-version", anthropicAPIVersion)
-		})
+		anthropicAuthHeaderFor(AuthXAPIKey))
+}
+
+// NewAnthropicProtocolProvider builds a named Anthropic-Messages provider whose
+// auth header follows the given registry AuthScheme. It is the target of an
+// explicit --provider selection for any anthropic-protocol built-in (anthropic,
+// minimax, minimax-cn, and — routed generically for now — bedrock/
+// cloudflare-ai-gateway): the driver identity is the provider's own name (so
+// errors reference it), baseURL is the already-resolved endpoint (spec default
+// or override), and authScheme selects the header shape (see
+// anthropicAuthHeaderFor). Secret values are never logged.
+func NewAnthropicProtocolProvider(name, baseURL, authScheme string, models []Model) Provider {
+	return newAnthropicCompat(name, anthropicBaseURL, baseURL, models,
+		anthropicAuthHeaderFor(authScheme))
 }
 
 // NewBedrockProvider builds the Bedrock provider, reusing the Anthropic Messages

--- a/internal/provider/providers_anthropic_test.go
+++ b/internal/provider/providers_anthropic_test.go
@@ -1,0 +1,166 @@
+// Tests for the Anthropic-Messages-protocol built-in providers (US-006, node
+// #187): anthropic, minimax, minimax-cn. They assert the registry metadata
+// (base_url, protocol, key env var) and that the constructed anthropic-compat
+// driver attaches the auth header dictated by the provider's AuthScheme.
+//
+// No real network calls are made: the auth header is exercised by invoking the
+// driver's authHeader func against a dummy *http.Request and inspecting the
+// resulting headers (the same package can reach the unexported driver fields).
+package provider
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestAnthropicProtocolProviderRegistrySpecs asserts the registry metadata for
+// each Anthropic-Messages-protocol built-in: default base URL, wire protocol,
+// and the key env var (via envAPIKey + t.Setenv).
+func TestAnthropicProtocolProviderRegistrySpecs(t *testing.T) {
+	cases := []struct {
+		name        string
+		wantBaseURL string
+		wantEnv     string
+	}{
+		{"anthropic", "https://api.anthropic.com/v1", "ANTHROPIC_API_KEY"},
+		{"minimax", "https://api.minimax.io/anthropic", "MINIMAX_API_KEY"},
+		{"minimax-cn", "https://api.minimaxi.com/anthropic", "MINIMAX_CN_API_KEY"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec, ok := LookupProviderSpec(tc.name)
+			if !ok {
+				t.Fatalf("provider %q not found in registry", tc.name)
+			}
+			if spec.Protocol != ProtocolAnthropic {
+				t.Errorf("protocol = %q, want %q", spec.Protocol, ProtocolAnthropic)
+			}
+			if spec.DefaultBaseURL != tc.wantBaseURL {
+				t.Errorf("base_url = %q, want %q", spec.DefaultBaseURL, tc.wantBaseURL)
+			}
+			// Key resolution: the provider's key comes from tc.wantEnv.
+			t.Setenv(tc.wantEnv, "SEKRET-"+tc.name)
+			if got := envAPIKey(tc.name); got != "SEKRET-"+tc.name {
+				t.Errorf("envAPIKey(%q) = %q, want key resolved from %s", tc.name, got, tc.wantEnv)
+			}
+		})
+	}
+}
+
+// TestAnthropicProtocolProviderAuthHeader verifies that the driver built for
+// each provider (the way resolveNamedProvider builds it: name + resolved
+// base_url + spec.AuthScheme) targets the provider's base URL and sets the auth
+// header matching its AuthScheme. anthropic/minimax/minimax-cn are all
+// x-api-key + anthropic-version per pi's convention.
+func TestAnthropicProtocolProviderAuthHeader(t *testing.T) {
+	for _, name := range []string{"anthropic", "minimax", "minimax-cn"} {
+		t.Run(name, func(t *testing.T) {
+			spec, ok := LookupProviderSpec(name)
+			if !ok {
+				t.Fatalf("provider %q not found in registry", name)
+			}
+			p := NewAnthropicProtocolProvider(spec.Name, spec.DefaultBaseURL, spec.AuthScheme, nil)
+			d, ok := p.(*anthropicCompatDriver)
+			if !ok {
+				t.Fatalf("provider %q is not an *anthropicCompatDriver", name)
+			}
+			if d.baseURL != spec.DefaultBaseURL {
+				t.Errorf("baseURL = %q, want %q", d.baseURL, spec.DefaultBaseURL)
+			}
+			req, err := http.NewRequest(http.MethodPost, d.baseURL+"/messages", nil)
+			if err != nil {
+				t.Fatalf("build request: %v", err)
+			}
+			d.authHeader(req, "SEKRET")
+			assertAuthHeaderForScheme(t, req, spec.AuthScheme)
+			if got := req.Header.Get("Authorization"); got != "" && spec.AuthScheme != AuthBearer {
+				t.Errorf("unexpected Authorization header %q for x-api-key scheme", got)
+			}
+		})
+	}
+}
+
+// TestAnthropicAuthSchemeSelection proves the auth-header mechanism itself:
+// AuthBearer yields Authorization: Bearer, AuthXAPIKey yields x-api-key plus the
+// anthropic-version header. This guarantees an anthropic-protocol provider can
+// select either header shape from its registry AuthScheme.
+func TestAnthropicAuthSchemeSelection(t *testing.T) {
+	t.Run("bearer", func(t *testing.T) {
+		p := NewAnthropicProtocolProvider("gw", "https://example.test/anthropic", AuthBearer, nil)
+		req := newDummyReq(t)
+		p.(*anthropicCompatDriver).authHeader(req, "SEKRET")
+		if got := req.Header.Get("Authorization"); got != "Bearer SEKRET" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer SEKRET")
+		}
+		if got := req.Header.Get("x-api-key"); got != "" {
+			t.Errorf("x-api-key = %q, want empty for bearer scheme", got)
+		}
+	})
+	t.Run("x-api-key", func(t *testing.T) {
+		p := NewAnthropicProtocolProvider("anthropic", "", AuthXAPIKey, nil)
+		req := newDummyReq(t)
+		p.(*anthropicCompatDriver).authHeader(req, "SEKRET")
+		if got := req.Header.Get("x-api-key"); got != "SEKRET" {
+			t.Errorf("x-api-key = %q, want %q", got, "SEKRET")
+		}
+		if got := req.Header.Get("anthropic-version"); got != anthropicAPIVersion {
+			t.Errorf("anthropic-version = %q, want %q", got, anthropicAPIVersion)
+		}
+	})
+	// A non-crashing fallback for unwired schemes (e.g. Bedrock's AuthAWS): must
+	// not panic and defaults to the x-api-key convention.
+	t.Run("fallback", func(t *testing.T) {
+		p := NewAnthropicProtocolProvider("bedrock", "", AuthAWS, nil)
+		req := newDummyReq(t)
+		p.(*anthropicCompatDriver).authHeader(req, "SEKRET")
+		if got := req.Header.Get("x-api-key"); got != "SEKRET" {
+			t.Errorf("fallback x-api-key = %q, want %q", got, "SEKRET")
+		}
+	})
+}
+
+// TestNewAnthropicProviderUnchanged guards against regressing the direct
+// Anthropic constructor: it must still default to the public endpoint and use
+// x-api-key + anthropic-version.
+func TestNewAnthropicProviderUnchanged(t *testing.T) {
+	d, ok := NewAnthropicProvider("", nil).(*anthropicCompatDriver)
+	if !ok {
+		t.Fatal("NewAnthropicProvider did not return *anthropicCompatDriver")
+	}
+	if d.baseURL != anthropicBaseURL {
+		t.Errorf("baseURL = %q, want %q", d.baseURL, anthropicBaseURL)
+	}
+	req := newDummyReq(t)
+	d.authHeader(req, "SEKRET")
+	if got := req.Header.Get("x-api-key"); got != "SEKRET" {
+		t.Errorf("x-api-key = %q, want %q", got, "SEKRET")
+	}
+	if got := req.Header.Get("anthropic-version"); got != anthropicAPIVersion {
+		t.Errorf("anthropic-version = %q, want %q", got, anthropicAPIVersion)
+	}
+}
+
+func newDummyReq(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/messages", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	return req
+}
+
+func assertAuthHeaderForScheme(t *testing.T, req *http.Request, scheme string) {
+	t.Helper()
+	if scheme == AuthBearer {
+		if got := req.Header.Get("Authorization"); got != "Bearer SEKRET" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer SEKRET")
+		}
+		return
+	}
+	if got := req.Header.Get("x-api-key"); got != "SEKRET" {
+		t.Errorf("x-api-key = %q, want %q", got, "SEKRET")
+	}
+	if got := req.Header.Get("anthropic-version"); got != anthropicAPIVersion {
+		t.Errorf("anthropic-version = %q, want %q", got, anthropicAPIVersion)
+	}
+}


### PR DESCRIPTION
## Summary
- Wire anthropic/minimax/minimax-cn through `resolveNamedProvider`'s anthropic branch, passing the spec's resolved base_url and naming the driver after the selected provider
- Add `NewAnthropicProtocolProvider` + `anthropicAuthHeaderFor` so the auth header follows `spec.AuthScheme`: x-api-key + anthropic-version for anthropic/minimax/minimax-cn (per pi's convention), Authorization: Bearer for bearer-scheme anthropic gateways
- `NewAnthropicProvider`/`NewBedrockProvider` behavior unchanged; unwired schemes (e.g. Bedrock AuthAWS) fall back to x-api-key without crashing (node #188 refines)

Closes #187

## Test plan
- [x] New `internal/provider/providers_anthropic_test.go`: registry specs (base_url/protocol/key env via t.Setenv) + auth-header selection for anthropic/minimax/minimax-cn and both schemes
- [x] `go build ./... && go vet ./... && go test ./...` all green