### PR TITLE
特殊鉴权 provider：Azure/Bedrock/Vertex/Cloudflare 参数校验与端点构造

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -154,10 +154,10 @@ func resolveProvider(model, baseURL, protocol, providerName string) (provider.Pr
 // spec name, so downstream API-key resolution reads the provider's own env var
 // (spec.EnvVars).
 //
-// Special providers whose bespoke auth is not wired yet (azure/bedrock/vertex/
-// cloudflare — AuthScheme aws/azure/special) are routed to the closest generic
-// driver by Protocol against the spec's (possibly templated) base URL so this
-// node does not crash on them; node #188 refines their auth.
+// Special providers with bespoke auth (azure/bedrock/vertex/cloudflare —
+// AuthScheme aws/azure/special, or the cloudflare-* names) are routed to
+// provider.ResolveSpecialProvider, which validates their required env vars and
+// composes the concrete endpoint (node #188).
 func resolveNamedProvider(name, model, baseURL, protocol string) (provider.Provider, string, error) {
 	spec, ok := provider.LookupProviderSpec(name)
 	if !ok {
@@ -167,6 +167,18 @@ func resolveNamedProvider(name, model, baseURL, protocol string) (provider.Provi
 	// an incompatible pair is a user error naming both flags.
 	if p := strings.TrimSpace(protocol); p != "" && p != spec.Protocol {
 		return nil, "", fmt.Errorf("--provider %q speaks the %q protocol, which conflicts with --protocol %q; drop --protocol or set it to %q", name, spec.Protocol, p, spec.Protocol)
+	}
+	// Special-auth providers (Azure / Bedrock / Vertex / Cloudflare) compose
+	// their endpoint from several env vars and/or need non-standard credential
+	// validation, so route them to the dedicated resolver (US-007 / node #188).
+	// It performs its own base-URL composition (honoring the --base-url override)
+	// and returns a clear error naming any absent required env var.
+	if provider.IsSpecialAuthProvider(spec) {
+		p, err := provider.ResolveSpecialProvider(spec, model, baseURL, os.Getenv)
+		if err != nil {
+			return nil, "", err
+		}
+		return p, spec.Name, nil
 	}
 	// Base-URL precedence (US-004 / FR-8, FR-9): --base-url flag > provider-
 	// specific base-url env var(s) > generic <PROVIDER>_BASE_URL > spec default.

--- a/internal/provider/special_auth.go
+++ b/internal/provider/special_auth.go
@@ -1,0 +1,225 @@
+// This file implements parameter validation and endpoint construction for the
+// "special auth" providers (US-007 / FR-12): Azure OpenAI, Amazon Bedrock,
+// Google Vertex, and Cloudflare (Workers AI + AI Gateway). Unlike the generic
+// bearer/x-api-key providers, each of these composes its endpoint from several
+// environment variables and/or needs a non-standard credential path, so a
+// dedicated resolver validates the required parameters and builds the concrete
+// base URL before handing off to the shared OpenAI-/Anthropic-compatible driver.
+//
+// Scope note (PRD Non-Goals): AWS SigV4 request signing is NOT implemented.
+// Bedrock supports only the AWS_BEARER_TOKEN_BEDROCK bearer path; other AWS
+// credential sources (AWS_PROFILE, AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY)
+// are only *detected* so that a clear, actionable error is returned instead of
+// an opaque auth failure.
+//
+// Security: this file reads env var NAMES and composes URLs from non-secret
+// parameters (region, resource name, account id, …). Secret values (API keys,
+// bearer tokens) are never logged or embedded in error text — errors name the
+// absent env var, never a value.
+package provider
+
+import (
+	"fmt"
+	"strings"
+)
+
+// IsSpecialAuthProvider reports whether a provider spec needs the bespoke
+// endpoint-construction / credential-validation handled by ResolveSpecialProvider,
+// rather than the generic driver wiring. It matches the multi-parameter auth
+// schemes (azure/aws/special) and the two Cloudflare providers (which keep a
+// standard auth scheme but still compose their endpoint from env vars).
+func IsSpecialAuthProvider(spec ProviderSpec) bool {
+	switch spec.AuthScheme {
+	case AuthAzure, AuthAWS, AuthSpecial:
+		return true
+	}
+	return strings.HasPrefix(spec.Name, "cloudflare-")
+}
+
+// ResolveSpecialProvider validates the required parameters for a special-auth
+// provider and constructs the matching wire driver against the composed base
+// URL. flagBaseURL is the explicit --base-url override (highest precedence, wins
+// over any composed default); env resolves environment variables (os.Getenv in
+// production, a fake in tests). A missing required parameter yields an error
+// naming exactly which env var is absent; no network request is made here.
+func ResolveSpecialProvider(spec ProviderSpec, model, flagBaseURL string, env func(string) string) (Provider, error) {
+	if env == nil {
+		env = func(string) string { return "" }
+	}
+	models := []Model{{Provider: spec.Name, ID: model, SupportsImages: true}}
+	switch spec.Name {
+	case "azure-openai-responses":
+		return resolveAzureOpenAI(spec, model, flagBaseURL, env, models)
+	case "amazon-bedrock":
+		return resolveBedrock(spec, flagBaseURL, env, models)
+	case "google-vertex":
+		return resolveGoogleVertex(spec, flagBaseURL, env, models)
+	case "cloudflare-workers-ai":
+		return resolveCloudflareWorkersAI(spec, flagBaseURL, env, models)
+	case "cloudflare-ai-gateway":
+		return resolveCloudflareAIGateway(spec, flagBaseURL, env, models)
+	default:
+		return nil, fmt.Errorf("provider %q is not a special-auth provider", spec.Name)
+	}
+}
+
+// resolveAzureOpenAI composes the Azure OpenAI endpoint. The endpoint origin is
+// AZURE_OPENAI_BASE_URL (or the --base-url override), else it is built from
+// AZURE_OPENAI_RESOURCE_NAME as https://{resource}.openai.azure.com. The API
+// version (AZURE_OPENAI_API_VERSION, default "v1") and an optional deployment
+// mapping (AZURE_OPENAI_DEPLOYMENT_NAME_MAP) shape the path. Auth uses
+// AZURE_OPENAI_API_KEY over the OpenAI wire.
+func resolveAzureOpenAI(_ ProviderSpec, model, flagBaseURL string, env func(string) string, models []Model) (Provider, error) {
+	if strings.TrimSpace(env("AZURE_OPENAI_API_KEY")) == "" {
+		return nil, fmt.Errorf("azure-openai-responses: missing required env var AZURE_OPENAI_API_KEY")
+	}
+	origin := strings.TrimSpace(flagBaseURL)
+	if origin == "" {
+		origin = strings.TrimSpace(env("AZURE_OPENAI_BASE_URL"))
+	}
+	if origin == "" {
+		resource := strings.TrimSpace(env("AZURE_OPENAI_RESOURCE_NAME"))
+		if resource == "" {
+			return nil, fmt.Errorf("azure-openai-responses: missing endpoint configuration; set AZURE_OPENAI_BASE_URL or AZURE_OPENAI_RESOURCE_NAME")
+		}
+		origin = fmt.Sprintf("https://%s.openai.azure.com", resource)
+	}
+	apiVersion := strings.TrimSpace(env("AZURE_OPENAI_API_VERSION"))
+	if apiVersion == "" {
+		apiVersion = "v1"
+	}
+	deployment := resolveAzureDeployment(env("AZURE_OPENAI_DEPLOYMENT_NAME_MAP"), model)
+	baseURL := azureEndpoint(origin, apiVersion, deployment)
+	return NewOpenAICompatibleProvider(baseURL, models), nil
+}
+
+// azureEndpoint builds the Azure OpenAI base URL from a validated origin. When a
+// deployment is resolved for the model, the classic deployment-scoped path is
+// used (…/openai/deployments/{deployment}); otherwise the version-scoped v1 path
+// (…/openai/{apiVersion}) is used. The shared driver appends /chat/completions.
+func azureEndpoint(origin, apiVersion, deployment string) string {
+	origin = strings.TrimRight(strings.TrimSpace(origin), "/")
+	if deployment != "" {
+		return fmt.Sprintf("%s/openai/deployments/%s", origin, deployment)
+	}
+	return fmt.Sprintf("%s/openai/%s", origin, apiVersion)
+}
+
+// resolveAzureDeployment parses AZURE_OPENAI_DEPLOYMENT_NAME_MAP (a
+// comma-separated list of model=deployment pairs) and returns the deployment
+// mapped to model, or "" when the map is empty or has no entry for the model.
+func resolveAzureDeployment(raw, model string) string {
+	m := parseDeploymentMap(raw)
+	return m[strings.TrimSpace(model)]
+}
+
+// parseDeploymentMap parses a comma-separated "model=deployment" list into a
+// map. Blank entries and entries without '=' are skipped; keys and values are
+// trimmed. It never returns nil so lookups are always safe.
+func parseDeploymentMap(raw string) map[string]string {
+	out := make(map[string]string)
+	for _, pair := range strings.Split(raw, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(pair, "=")
+		k, v = strings.TrimSpace(k), strings.TrimSpace(v)
+		if !ok || k == "" || v == "" {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// resolveBedrock composes the Amazon Bedrock runtime endpoint
+// (https://bedrock-runtime.{region}.amazonaws.com; region defaults to
+// us-east-1) and validates credentials. Only the AWS_BEARER_TOKEN_BEDROCK
+// bearer path is supported (SigV4 is out of scope): if only AWS_PROFILE or
+// static AWS keys are present, a clear error explains SigV4 is unsupported and
+// names the missing AWS_BEARER_TOKEN_BEDROCK.
+func resolveBedrock(_ ProviderSpec, flagBaseURL string, env func(string) string, models []Model) (Provider, error) {
+	if strings.TrimSpace(env("AWS_BEARER_TOKEN_BEDROCK")) == "" {
+		hasProfile := strings.TrimSpace(env("AWS_PROFILE")) != ""
+		hasStaticKeys := strings.TrimSpace(env("AWS_ACCESS_KEY_ID")) != "" &&
+			strings.TrimSpace(env("AWS_SECRET_ACCESS_KEY")) != ""
+		if hasProfile || hasStaticKeys {
+			return nil, fmt.Errorf("amazon-bedrock: detected AWS credentials (AWS_PROFILE / AWS_ACCESS_KEY_ID) but SigV4 request signing is not supported yet; set AWS_BEARER_TOKEN_BEDROCK to use the bearer-token path")
+		}
+		return nil, fmt.Errorf("amazon-bedrock: missing required env var AWS_BEARER_TOKEN_BEDROCK")
+	}
+	baseURL := strings.TrimSpace(flagBaseURL)
+	if baseURL == "" {
+		region := strings.TrimSpace(env("AWS_REGION"))
+		if region == "" {
+			region = "us-east-1"
+		}
+		baseURL = fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com", region)
+	}
+	return NewBedrockProvider(baseURL, models), nil
+}
+
+// resolveGoogleVertex composes the Vertex AI endpoint
+// (https://{location}-aiplatform.googleapis.com) and validates that a project,
+// a location, and a credential source (GOOGLE_CLOUD_API_KEY or ADC via
+// GOOGLE_APPLICATION_CREDENTIALS) are present, naming any absent env var.
+func resolveGoogleVertex(_ ProviderSpec, flagBaseURL string, env func(string) string, models []Model) (Provider, error) {
+	if strings.TrimSpace(env("GOOGLE_CLOUD_PROJECT")) == "" {
+		return nil, fmt.Errorf("google-vertex: missing required env var GOOGLE_CLOUD_PROJECT")
+	}
+	location := strings.TrimSpace(env("GOOGLE_CLOUD_LOCATION"))
+	if location == "" {
+		return nil, fmt.Errorf("google-vertex: missing required env var GOOGLE_CLOUD_LOCATION")
+	}
+	if strings.TrimSpace(env("GOOGLE_CLOUD_API_KEY")) == "" &&
+		strings.TrimSpace(env("GOOGLE_APPLICATION_CREDENTIALS")) == "" {
+		return nil, fmt.Errorf("google-vertex: missing credentials; set GOOGLE_CLOUD_API_KEY or GOOGLE_APPLICATION_CREDENTIALS (ADC)")
+	}
+	baseURL := strings.TrimSpace(flagBaseURL)
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com", location)
+	}
+	return NewOpenAICompatibleProvider(baseURL, models), nil
+}
+
+// resolveCloudflareWorkersAI composes the Workers AI endpoint
+// (https://api.cloudflare.com/client/v4/accounts/{account}/ai/v1), requiring
+// CLOUDFLARE_API_KEY and CLOUDFLARE_ACCOUNT_ID. OpenAI wire.
+func resolveCloudflareWorkersAI(_ ProviderSpec, flagBaseURL string, env func(string) string, models []Model) (Provider, error) {
+	if strings.TrimSpace(env("CLOUDFLARE_API_KEY")) == "" {
+		return nil, fmt.Errorf("cloudflare-workers-ai: missing required env var CLOUDFLARE_API_KEY")
+	}
+	account := strings.TrimSpace(env("CLOUDFLARE_ACCOUNT_ID"))
+	if account == "" {
+		return nil, fmt.Errorf("cloudflare-workers-ai: missing required env var CLOUDFLARE_ACCOUNT_ID")
+	}
+	baseURL := strings.TrimSpace(flagBaseURL)
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("https://api.cloudflare.com/client/v4/accounts/%s/ai/v1", account)
+	}
+	return NewOpenAICompatibleProvider(baseURL, models), nil
+}
+
+// resolveCloudflareAIGateway composes the AI Gateway endpoint
+// (https://gateway.ai.cloudflare.com/v1/{account}/{gateway}/anthropic),
+// requiring CLOUDFLARE_API_KEY, CLOUDFLARE_ACCOUNT_ID, and CLOUDFLARE_GATEWAY_ID.
+// Anthropic wire.
+func resolveCloudflareAIGateway(_ ProviderSpec, flagBaseURL string, env func(string) string, models []Model) (Provider, error) {
+	if strings.TrimSpace(env("CLOUDFLARE_API_KEY")) == "" {
+		return nil, fmt.Errorf("cloudflare-ai-gateway: missing required env var CLOUDFLARE_API_KEY")
+	}
+	account := strings.TrimSpace(env("CLOUDFLARE_ACCOUNT_ID"))
+	if account == "" {
+		return nil, fmt.Errorf("cloudflare-ai-gateway: missing required env var CLOUDFLARE_ACCOUNT_ID")
+	}
+	gateway := strings.TrimSpace(env("CLOUDFLARE_GATEWAY_ID"))
+	if gateway == "" {
+		return nil, fmt.Errorf("cloudflare-ai-gateway: missing required env var CLOUDFLARE_GATEWAY_ID")
+	}
+	baseURL := strings.TrimSpace(flagBaseURL)
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("https://gateway.ai.cloudflare.com/v1/%s/%s/anthropic", account, gateway)
+	}
+	return NewAnthropicProvider(baseURL, models), nil
+}

--- a/internal/provider/special_auth_test.go
+++ b/internal/provider/special_auth_test.go
@@ -1,0 +1,291 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+// envFrom builds an env(string)string lookup from a map for hermetic tests: no
+// process environment is read, so tests never depend on ambient state and make
+// no network requests.
+func envFrom(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+// baseURLOf extracts the composed base URL from a constructed driver by type
+// asserting the two concrete driver shapes (same-package access to unexported
+// fields). It fails the test if the provider is neither shape.
+func baseURLOf(t *testing.T, p Provider) string {
+	t.Helper()
+	switch d := p.(type) {
+	case *openAICompatDriver:
+		return d.baseURL
+	case *anthropicCompatDriver:
+		return d.baseURL
+	default:
+		t.Fatalf("unexpected provider type %T", p)
+		return ""
+	}
+}
+
+func specFor(t *testing.T, name string) ProviderSpec {
+	t.Helper()
+	spec, ok := LookupProviderSpec(name)
+	if !ok {
+		t.Fatalf("registry missing provider %q", name)
+	}
+	return spec
+}
+
+func TestResolveSpecialProvider_Azure(t *testing.T) {
+	spec := specFor(t, "azure-openai-responses")
+
+	// Missing API key.
+	if _, err := ResolveSpecialProvider(spec, "gpt-4o", "", envFrom(nil)); err == nil ||
+		!strings.Contains(err.Error(), "AZURE_OPENAI_API_KEY") {
+		t.Fatalf("expected AZURE_OPENAI_API_KEY error, got %v", err)
+	}
+
+	// Key present but no endpoint origin.
+	env := envFrom(map[string]string{"AZURE_OPENAI_API_KEY": "k"})
+	if _, err := ResolveSpecialProvider(spec, "gpt-4o", "", env); err == nil ||
+		!strings.Contains(err.Error(), "AZURE_OPENAI_BASE_URL") ||
+		!strings.Contains(err.Error(), "AZURE_OPENAI_RESOURCE_NAME") {
+		t.Fatalf("expected endpoint-config error naming both env vars, got %v", err)
+	}
+
+	// Resource name → composed origin, default api version v1.
+	env = envFrom(map[string]string{
+		"AZURE_OPENAI_API_KEY":       "k",
+		"AZURE_OPENAI_RESOURCE_NAME": "myres",
+	})
+	p, err := ResolveSpecialProvider(spec, "gpt-4o", "", env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := baseURLOf(t, p), "https://myres.openai.azure.com/openai/v1"; got != want {
+		t.Fatalf("azure base_url = %q, want %q", got, want)
+	}
+
+	// Explicit base URL env + custom api version.
+	env = envFrom(map[string]string{
+		"AZURE_OPENAI_API_KEY":     "k",
+		"AZURE_OPENAI_BASE_URL":    "https://custom.example.com",
+		"AZURE_OPENAI_API_VERSION": "2024-10-01",
+	})
+	p, err = ResolveSpecialProvider(spec, "gpt-4o", "", env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := baseURLOf(t, p), "https://custom.example.com/openai/2024-10-01"; got != want {
+		t.Fatalf("azure base_url = %q, want %q", got, want)
+	}
+
+	// Deployment name map → deployment-scoped path.
+	env = envFrom(map[string]string{
+		"AZURE_OPENAI_API_KEY":             "k",
+		"AZURE_OPENAI_RESOURCE_NAME":       "myres",
+		"AZURE_OPENAI_DEPLOYMENT_NAME_MAP": "gpt-4o=prod-4o , other=x",
+	})
+	p, err = ResolveSpecialProvider(spec, "gpt-4o", "", env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := baseURLOf(t, p), "https://myres.openai.azure.com/openai/deployments/prod-4o"; got != want {
+		t.Fatalf("azure deployment base_url = %q, want %q", got, want)
+	}
+
+	// --base-url flag wins over env origin.
+	p, err = ResolveSpecialProvider(spec, "gpt-4o", "https://flag.example.com", envFrom(map[string]string{"AZURE_OPENAI_API_KEY": "k"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := baseURLOf(t, p), "https://flag.example.com/openai/v1"; got != want {
+		t.Fatalf("azure flag base_url = %q, want %q", got, want)
+	}
+}
+
+func TestParseDeploymentMap(t *testing.T) {
+	m := parseDeploymentMap(" a=1, b = 2 ,,bad,c=,=d ")
+	if m["a"] != "1" || m["b"] != "2" {
+		t.Fatalf("parseDeploymentMap = %v, want a=1 b=2", m)
+	}
+	if _, ok := m["bad"]; ok {
+		t.Fatalf("expected 'bad' (no '=') to be skipped: %v", m)
+	}
+	if _, ok := m["c"]; ok {
+		t.Fatalf("expected 'c=' (empty value) to be skipped: %v", m)
+	}
+}
+
+func TestResolveSpecialProvider_Bedrock(t *testing.T) {
+	spec := specFor(t, "amazon-bedrock")
+
+	// No credentials at all → names the bearer token.
+	if _, err := ResolveSpecialProvider(spec, "claude", "", envFrom(nil)); err == nil ||
+		!strings.Contains(err.Error(), "AWS_BEARER_TOKEN_BEDROCK") {
+		t.Fatalf("expected AWS_BEARER_TOKEN_BEDROCK error, got %v", err)
+	}
+
+	// Only profile present → SigV4-unsupported error, still names bearer token.
+	env := envFrom(map[string]string{"AWS_PROFILE": "default"})
+	if _, err := ResolveSpecialProvider(spec, "claude", "", env); err == nil ||
+		!strings.Contains(err.Error(), "SigV4") ||
+		!strings.Contains(err.Error(), "AWS_BEARER_TOKEN_BEDROCK") {
+		t.Fatalf("expected SigV4-unsupported error naming bearer token, got %v", err)
+	}
+
+	// Only static keys present → SigV4-unsupported error.
+	env = envFrom(map[string]string{"AWS_ACCESS_KEY_ID": "id", "AWS_SECRET_ACCESS_KEY": "secret"})
+	if _, err := ResolveSpecialProvider(spec, "claude", "", env); err == nil ||
+		!strings.Contains(err.Error(), "SigV4") {
+		t.Fatalf("expected SigV4-unsupported error for static keys, got %v", err)
+	}
+
+	// Bearer token + default region.
+	env = envFrom(map[string]string{"AWS_BEARER_TOKEN_BEDROCK": "tok"})
+	p, err := ResolveSpecialProvider(spec, "claude", "", env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := baseURLOf(t, p), "https://bedrock-runtime.us-east-1.amazonaws.com"; got != want {
+		t.Fatalf("bedrock base_url = %q, want %q", got, want)
+	}
+
+	// Bearer token + explicit region.
+	env = envFrom(map[string]string{"AWS_BEARER_TOKEN_BEDROCK": "tok", "AWS_REGION": "eu-west-1"})
+	p, err = ResolveSpecialProvider(spec, "claude", "", env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := baseURLOf(t, p), "https://bedrock-runtime.eu-west-1.amazonaws.com"; got != want {
+		t.Fatalf("bedrock base_url = %q, want %q", got, want)
+	}
+}
+
+func TestResolveSpecialProvider_GoogleVertex(t *testing.T) {
+	spec := specFor(t, "google-vertex")
+
+	if _, err := ResolveSpecialProvider(spec, "gemini", "", envFrom(nil)); err == nil ||
+		!strings.Contains(err.Error(), "GOOGLE_CLOUD_PROJECT") {
+		t.Fatalf("expected GOOGLE_CLOUD_PROJECT error, got %v", err)
+	}
+
+	env := envFrom(map[string]string{"GOOGLE_CLOUD_PROJECT": "proj"})
+	if _, err := ResolveSpecialProvider(spec, "gemini", "", env); err == nil ||
+		!strings.Contains(err.Error(), "GOOGLE_CLOUD_LOCATION") {
+		t.Fatalf("expected GOOGLE_CLOUD_LOCATION error, got %v", err)
+	}
+
+	env = envFrom(map[string]string{"GOOGLE_CLOUD_PROJECT": "proj", "GOOGLE_CLOUD_LOCATION": "us-central1"})
+	if _, err := ResolveSpecialProvider(spec, "gemini", "", env); err == nil ||
+		!strings.Contains(err.Error(), "GOOGLE_CLOUD_API_KEY") ||
+		!strings.Contains(err.Error(), "GOOGLE_APPLICATION_CREDENTIALS") {
+		t.Fatalf("expected credentials error naming both sources, got %v", err)
+	}
+
+	// Fully configured with API key.
+	env = envFrom(map[string]string{
+		"GOOGLE_CLOUD_PROJECT":  "proj",
+		"GOOGLE_CLOUD_LOCATION": "us-central1",
+		"GOOGLE_CLOUD_API_KEY":  "k",
+	})
+	p, err := ResolveSpecialProvider(spec, "gemini", "", env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := baseURLOf(t, p), "https://us-central1-aiplatform.googleapis.com"; got != want {
+		t.Fatalf("vertex base_url = %q, want %q", got, want)
+	}
+
+	// ADC credential source also satisfies.
+	env = envFrom(map[string]string{
+		"GOOGLE_CLOUD_PROJECT":           "proj",
+		"GOOGLE_CLOUD_LOCATION":          "europe-west4",
+		"GOOGLE_APPLICATION_CREDENTIALS": "/path/to/adc.json",
+	})
+	p, err = ResolveSpecialProvider(spec, "gemini", "", env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := baseURLOf(t, p), "https://europe-west4-aiplatform.googleapis.com"; got != want {
+		t.Fatalf("vertex ADC base_url = %q, want %q", got, want)
+	}
+}
+
+func TestResolveSpecialProvider_CloudflareWorkersAI(t *testing.T) {
+	spec := specFor(t, "cloudflare-workers-ai")
+
+	if _, err := ResolveSpecialProvider(spec, "m", "", envFrom(nil)); err == nil ||
+		!strings.Contains(err.Error(), "CLOUDFLARE_API_KEY") {
+		t.Fatalf("expected CLOUDFLARE_API_KEY error, got %v", err)
+	}
+
+	env := envFrom(map[string]string{"CLOUDFLARE_API_KEY": "k"})
+	if _, err := ResolveSpecialProvider(spec, "m", "", env); err == nil ||
+		!strings.Contains(err.Error(), "CLOUDFLARE_ACCOUNT_ID") {
+		t.Fatalf("expected CLOUDFLARE_ACCOUNT_ID error, got %v", err)
+	}
+
+	env = envFrom(map[string]string{"CLOUDFLARE_API_KEY": "k", "CLOUDFLARE_ACCOUNT_ID": "acct123"})
+	p, err := ResolveSpecialProvider(spec, "m", "", env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://api.cloudflare.com/client/v4/accounts/acct123/ai/v1"
+	if got := baseURLOf(t, p); got != want {
+		t.Fatalf("workers-ai base_url = %q, want %q", got, want)
+	}
+	if _, ok := p.(*openAICompatDriver); !ok {
+		t.Fatalf("workers-ai should speak OpenAI wire, got %T", p)
+	}
+}
+
+func TestResolveSpecialProvider_CloudflareAIGateway(t *testing.T) {
+	spec := specFor(t, "cloudflare-ai-gateway")
+
+	if _, err := ResolveSpecialProvider(spec, "m", "", envFrom(nil)); err == nil ||
+		!strings.Contains(err.Error(), "CLOUDFLARE_API_KEY") {
+		t.Fatalf("expected CLOUDFLARE_API_KEY error, got %v", err)
+	}
+
+	env := envFrom(map[string]string{"CLOUDFLARE_API_KEY": "k", "CLOUDFLARE_ACCOUNT_ID": "acct123"})
+	if _, err := ResolveSpecialProvider(spec, "m", "", env); err == nil ||
+		!strings.Contains(err.Error(), "CLOUDFLARE_GATEWAY_ID") {
+		t.Fatalf("expected CLOUDFLARE_GATEWAY_ID error, got %v", err)
+	}
+
+	env = envFrom(map[string]string{
+		"CLOUDFLARE_API_KEY":    "k",
+		"CLOUDFLARE_ACCOUNT_ID": "acct123",
+		"CLOUDFLARE_GATEWAY_ID": "gw456",
+	})
+	p, err := ResolveSpecialProvider(spec, "m", "", env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://gateway.ai.cloudflare.com/v1/acct123/gw456/anthropic"
+	if got := baseURLOf(t, p); got != want {
+		t.Fatalf("ai-gateway base_url = %q, want %q", got, want)
+	}
+	if _, ok := p.(*anthropicCompatDriver); !ok {
+		t.Fatalf("ai-gateway should speak Anthropic wire, got %T", p)
+	}
+}
+
+func TestIsSpecialAuthProvider(t *testing.T) {
+	special := []string{
+		"azure-openai-responses", "amazon-bedrock", "google-vertex",
+		"cloudflare-workers-ai", "cloudflare-ai-gateway",
+	}
+	for _, name := range special {
+		if !IsSpecialAuthProvider(specFor(t, name)) {
+			t.Errorf("%s should be a special-auth provider", name)
+		}
+	}
+	for _, name := range []string{"openai", "anthropic", "deepseek"} {
+		if IsSpecialAuthProvider(specFor(t, name)) {
+			t.Errorf("%s should NOT be a special-auth provider", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- 新增 `internal/provider/special_auth.go`：`ResolveSpecialProvider` 为 Azure OpenAI / Amazon Bedrock / Google Vertex / Cloudflare (Workers AI + AI Gateway) 做多参数 env 校验与 base_url 拼接
- Azure：`AZURE_OPENAI_BASE_URL` 或 `AZURE_OPENAI_RESOURCE_NAME` 构造端点，`AZURE_OPENAI_API_VERSION`（默认 v1），`AZURE_OPENAI_DEPLOYMENT_NAME_MAP` 映射 model→deployment
- Bedrock：`https://bedrock-runtime.{AWS_REGION}.amazonaws.com`（默认 us-east-1），仅支持 `AWS_BEARER_TOKEN_BEDROCK` bearer 路径；仅检测到 profile/静态 keys 时明确报错 SigV4 未支持（SigV4 属 Non-Goals）
- Vertex：要求 `GOOGLE_CLOUD_PROJECT`+`GOOGLE_CLOUD_LOCATION`+（`GOOGLE_CLOUD_API_KEY` 或 ADC），端点 `https://{location}-aiplatform.googleapis.com`
- Cloudflare：Workers AI 与 AI Gateway 各自端点模板拼接，缺参报错指明具体 env var
- `cmd/pigo/main.go`：`resolveNamedProvider` 新增 special-provider 分支路由到上述逻辑

Closes #188

## Test plan
- [x] `internal/provider/special_auth_test.go` 覆盖四类 provider 的缺参报错 + 完整配置 base_url（无网络请求）
- [x] `go build ./... && go vet ./... && go test ./...` 全绿