### PR TITLE
精选模型目录扩展：新增 11 个 provider 及精选模型 (node #189)

### DIFF
--- a/internal/provider/presets.go
+++ b/internal/provider/presets.go
@@ -42,6 +42,17 @@ var PresetProviders = []struct {
 }{
 	{Name: "openrouter", EnvVar: "OPENROUTER_API_KEY"},
 	{Name: "nvidia", EnvVar: "NVIDIA_API_KEY"},
+	{Name: "deepseek", EnvVar: "DEEPSEEK_API_KEY"},
+	{Name: "groq", EnvVar: "GROQ_API_KEY"},
+	{Name: "xai", EnvVar: "XAI_API_KEY"},
+	{Name: "cerebras", EnvVar: "CEREBRAS_API_KEY"},
+	{Name: "mistral", EnvVar: "MISTRAL_API_KEY"},
+	{Name: "moonshotai", EnvVar: "MOONSHOT_API_KEY"},
+	{Name: "zai", EnvVar: "ZAI_API_KEY"},
+	{Name: "fireworks", EnvVar: "FIREWORKS_API_KEY"},
+	{Name: "together", EnvVar: "TOGETHER_API_KEY"},
+	{Name: "minimax", EnvVar: "MINIMAX_API_KEY"},
+	{Name: "xiaomi", EnvVar: "XIAOMI_API_KEY"},
 	{Name: "ollama", EnvVar: ""}, // local, no key
 }
 
@@ -88,6 +99,59 @@ var PresetCatalog = []PresetModel{
 	{Provider: "nvidia", ID: "qwen/qwen2.5-7b-instruct", DisplayName: "Qwen 2.5 7B (NVIDIA)"},
 	{Provider: "nvidia", ID: "google/gemma-2-9b-it", DisplayName: "Gemma 2 9B (NVIDIA)"},
 	{Provider: "nvidia", ID: "microsoft/phi-3.5-mini-instruct", DisplayName: "Phi-3.5 Mini (NVIDIA)"},
+
+	// --- DeepSeek (direct, OpenAI-compatible; ids from pi deepseek.models.ts) ---
+	{Provider: "deepseek", ID: "deepseek-v4-flash", DisplayName: "DeepSeek V4 Flash"},
+	{Provider: "deepseek", ID: "deepseek-v4-pro", DisplayName: "DeepSeek V4 Pro"},
+
+	// --- Groq (fast inference; ids from pi groq.models.ts) ---
+	{Provider: "groq", ID: "llama-3.3-70b-versatile", DisplayName: "Llama 3.3 70B (Groq)"},
+	{Provider: "groq", ID: "openai/gpt-oss-120b", DisplayName: "GPT OSS 120B (Groq)"},
+	{Provider: "groq", ID: "qwen/qwen3-32b", DisplayName: "Qwen3 32B (Groq)"},
+
+	// --- xAI Grok (ids from pi xai.models.ts) ---
+	{Provider: "xai", ID: "grok-4.5", DisplayName: "Grok 4.5"},
+	{Provider: "xai", ID: "grok-4.3", DisplayName: "Grok 4.3"},
+
+	// --- Cerebras (fast inference; ids from pi cerebras.models.ts) ---
+	{Provider: "cerebras", ID: "gpt-oss-120b", DisplayName: "GPT OSS 120B (Cerebras)"},
+	{Provider: "cerebras", ID: "zai-glm-4.7", DisplayName: "Z.AI GLM-4.7 (Cerebras)"},
+	{Provider: "cerebras", ID: "gemma-4-31b", DisplayName: "Gemma 4 31B (Cerebras)"},
+
+	// --- Mistral (ids from pi mistral.models.ts) ---
+	{Provider: "mistral", ID: "mistral-large-latest", DisplayName: "Mistral Large (latest)"},
+	{Provider: "mistral", ID: "mistral-medium-latest", DisplayName: "Mistral Medium (latest)"},
+	{Provider: "mistral", ID: "codestral-latest", DisplayName: "Codestral (latest)"},
+	{Provider: "mistral", ID: "devstral-medium-latest", DisplayName: "Devstral Medium (latest)"},
+
+	// --- Moonshot AI Kimi (ids from pi moonshotai.models.ts) ---
+	{Provider: "moonshotai", ID: "kimi-k2-thinking", DisplayName: "Kimi K2 Thinking"},
+	{Provider: "moonshotai", ID: "kimi-k2.6", DisplayName: "Kimi K2.6"},
+	{Provider: "moonshotai", ID: "kimi-k3", DisplayName: "Kimi K3"},
+
+	// --- Z.AI GLM (ids from pi zai.models.ts) ---
+	{Provider: "zai", ID: "glm-4.7", DisplayName: "GLM-4.7"},
+	{Provider: "zai", ID: "glm-5.1", DisplayName: "GLM-5.1"},
+	{Provider: "zai", ID: "glm-5.2", DisplayName: "GLM-5.2"},
+
+	// --- Fireworks (ids from pi fireworks.models.ts) ---
+	{Provider: "fireworks", ID: "accounts/fireworks/models/deepseek-v4-pro", DisplayName: "DeepSeek V4 Pro (Fireworks)"},
+	{Provider: "fireworks", ID: "accounts/fireworks/models/gpt-oss-120b", DisplayName: "GPT OSS 120B (Fireworks)"},
+	{Provider: "fireworks", ID: "accounts/fireworks/models/kimi-k2p7-code", DisplayName: "Kimi K2.7 Code (Fireworks)"},
+
+	// --- Together AI (ids from pi together.models.ts) ---
+	{Provider: "together", ID: "deepseek-ai/DeepSeek-V4-Pro", DisplayName: "DeepSeek V4 Pro (Together)"},
+	{Provider: "together", ID: "Qwen/Qwen3.7-Max", DisplayName: "Qwen3.7 Max (Together)"},
+	{Provider: "together", ID: "meta-llama/Llama-3.3-70B-Instruct-Turbo", DisplayName: "Llama 3.3 70B Turbo (Together)"},
+
+	// --- MiniMax (Anthropic-protocol; ids from pi minimax.models.ts) ---
+	{Provider: "minimax", ID: "MiniMax-M2.7", DisplayName: "MiniMax-M2.7"},
+	{Provider: "minimax", ID: "MiniMax-M3", DisplayName: "MiniMax-M3"},
+
+	// --- Xiaomi MiMo (ids from pi xiaomi.models.ts) ---
+	{Provider: "xiaomi", ID: "mimo-v2-pro", DisplayName: "MiMo-V2-Pro"},
+	{Provider: "xiaomi", ID: "mimo-v2.5", DisplayName: "MiMo-V2.5"},
+	{Provider: "xiaomi", ID: "mimo-v2.5-pro", DisplayName: "MiMo-V2.5-Pro"},
 
 	// --- Ollama (local, no API key) ---
 	{Provider: "ollama", ID: "ollama/llama3.3", DisplayName: "Llama 3.3 (local Ollama)"},

--- a/internal/provider/presets_catalog_test.go
+++ b/internal/provider/presets_catalog_test.go
@@ -1,0 +1,118 @@
+package provider
+
+import "testing"
+
+// TestPresetProvidersIncludeNewProviders verifies the curated preset provider
+// list gained the expanded set of gateways, each paired with the correct API-key
+// environment variable (referenced by name only).
+func TestPresetProvidersIncludeNewProviders(t *testing.T) {
+	byName := make(map[string]string, len(PresetProviders))
+	for _, p := range PresetProviders {
+		byName[p.Name] = p.EnvVar
+	}
+
+	want := map[string]string{
+		"deepseek":   "DEEPSEEK_API_KEY",
+		"groq":       "GROQ_API_KEY",
+		"xai":        "XAI_API_KEY",
+		"cerebras":   "CEREBRAS_API_KEY",
+		"mistral":    "MISTRAL_API_KEY",
+		"moonshotai": "MOONSHOT_API_KEY",
+		"zai":        "ZAI_API_KEY",
+		"fireworks":  "FIREWORKS_API_KEY",
+		"together":   "TOGETHER_API_KEY",
+		"minimax":    "MINIMAX_API_KEY",
+		"xiaomi":     "XIAOMI_API_KEY",
+	}
+	for name, env := range want {
+		got, ok := byName[name]
+		if !ok {
+			t.Errorf("PresetProviders missing provider %q", name)
+			continue
+		}
+		if got != env {
+			t.Errorf("provider %q env var = %q, want %q", name, got, env)
+		}
+	}
+
+	// Every preset provider must be a known provider in the central registry, so
+	// selecting a preset can always be resolved to a working Provider.
+	for _, p := range PresetProviders {
+		if p.Name == "ollama" {
+			continue // local pseudo-provider, not in the registry
+		}
+		if _, ok := LookupProviderSpec(p.Name); !ok {
+			t.Errorf("preset provider %q has no ProviderSpec in the registry", p.Name)
+		}
+	}
+}
+
+// TestPresetCatalogCountsPerProvider asserts each expanded provider contributes
+// the expected number of curated entries.
+func TestPresetCatalogCountsPerProvider(t *testing.T) {
+	wantAtLeast := map[string]int{
+		"deepseek":   2,
+		"groq":       3,
+		"xai":        2,
+		"cerebras":   3,
+		"mistral":    4,
+		"moonshotai": 3,
+		"zai":        3,
+		"fireworks":  3,
+		"together":   3,
+		"minimax":    2,
+		"xiaomi":     3,
+	}
+	for provider, min := range wantAtLeast {
+		got := PresetsByProvider(provider)
+		if len(got) < min {
+			t.Errorf("PresetsByProvider(%q) returned %d entries, want >= %d", provider, len(got), min)
+		}
+		for _, p := range got {
+			if p.Provider != provider {
+				t.Errorf("PresetsByProvider(%q) returned entry for %q", provider, p.Provider)
+			}
+			if p.ID == "" {
+				t.Errorf("PresetsByProvider(%q) returned entry with empty ID", provider)
+			}
+		}
+	}
+}
+
+// TestLookupPresetNewEntries verifies representative new model ids resolve to the
+// correct owning provider and carry a non-empty label.
+func TestLookupPresetNewEntries(t *testing.T) {
+	cases := []struct {
+		id       string
+		provider string
+	}{
+		{"deepseek-v4-pro", "deepseek"},
+		{"llama-3.3-70b-versatile", "groq"},
+		{"grok-4.5", "xai"},
+		{"zai-glm-4.7", "cerebras"},
+		{"mistral-large-latest", "mistral"},
+		{"kimi-k2-thinking", "moonshotai"},
+		{"glm-5.1", "zai"},
+		{"accounts/fireworks/models/gpt-oss-120b", "fireworks"},
+		{"deepseek-ai/DeepSeek-V4-Pro", "together"},
+		{"MiniMax-M3", "minimax"},
+		{"mimo-v2.5-pro", "xiaomi"},
+	}
+	for _, tc := range cases {
+		p, ok := LookupPreset(tc.id)
+		if !ok {
+			t.Errorf("LookupPreset(%q) not found", tc.id)
+			continue
+		}
+		if p.Provider != tc.provider {
+			t.Errorf("LookupPreset(%q).Provider = %q, want %q", tc.id, p.Provider, tc.provider)
+		}
+		if p.Label() == "" {
+			t.Errorf("LookupPreset(%q).Label() is empty", tc.id)
+		}
+	}
+
+	if _, ok := LookupPreset("this-model-does-not-exist"); ok {
+		t.Error("LookupPreset returned ok for an unknown id")
+	}
+}


### PR DESCRIPTION
## Summary
- `PresetProviders` 新增 deepseek/groq/xai/cerebras/mistral/moonshotai/zai/fireworks/together/minimax/xiaomi 及对应 API key 环境变量
- `PresetCatalog` 为每个新 provider 增加 2-4 条精选模型，model id 全部取自 pi 各 provider 的 `.models.ts` 源文件（已逐条 grep 校验，无杜撰）
- 新增 `presets_catalog_test.go`：校验各 provider 条目数、`PresetsByProvider`/`LookupPreset` 解析及未知 id 行为
- 仅改动 internal/provider/presets.go，未触碰 registry.go/providers.go/auth.go 等他人节点文件

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./...（全绿）