### PR TITLE
构建 PDF 管线：健康 xelatex 探测 + rsvg SVG 嵌入 (#205)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ book/*.aux
 book/*.log
 book/*.toc
 book/*.out
+# Figures pre-rendered from SVG by build_pdf.sh (rsvg-convert); source is the .svg
+book/images/*.pdf

--- a/book/README.md
+++ b/book/README.md
@@ -13,7 +13,8 @@ book/
 ├── cover.tex           # 封面（书名/副标题/作者）
 ├── crossref.lua        # pandoc 过滤器：图表编号与交叉引用链接
 ├── experiment_box.lua  # pandoc 过滤器：「实验 N-M」渲染为带框盒子
-├── images/             # 图片资源目录
+├── svg2pdf.lua         # pandoc 过滤器：SVG 图引用改写为 rsvg 预转的 PDF
+├── images/             # 图片资源目录（.svg 源；构建时生成同名 .pdf）
 ├── introduction.md     # 引言（占位，待 #202/#203/#204 替换）
 └── chapter*.md         # 各章正文（由后续节点补全）
 ```
@@ -24,14 +25,17 @@ book/
 
 | 依赖 | 说明 | 安装 |
 | --- | --- | --- |
-| pandoc | Markdown → LaTeX 转换 | `brew install pandoc` / `apt-get install pandoc` |
-| xelatex | PDF 引擎（TeX Live 或 MiKTeX） | TeX Live，或本机 MiKTeX（`~/miktex/bin/xelatex`，脚本自动探测） |
-| ElegantBook | 文档类 `elegantbook.cls` | 随 TeX 发行版安装，或 MiKTeX 按需自动拉取 |
-| rsvg-convert | librsvg，嵌入 SVG 图（可选） | `brew install librsvg` / `apt-get install librsvg2-bin` |
+| pandoc | Markdown → LaTeX 转换（本书使用 3.10 验证） | `brew install pandoc` / `apt-get install pandoc` |
+| xelatex | PDF 引擎，**需要可正常工作的 TeX Live**（推荐） | TeX Live（`brew install --cask mactex` 或 `apt-get install texlive-xetex texlive-lang-chinese`） |
+| ElegantBook | 文档类 `elegantbook.cls` | 随 TeX Live 安装（`tlmgr install elegantbook`），或 MiKTeX 按需拉取 |
+| rsvg-convert | librsvg，将 SVG 图预转为 PDF 后嵌入（**无需 Inkscape / shell-escape**） | `brew install librsvg` / `apt-get install librsvg2-bin` |
 | 中文字体 | macOS：Songti SC / Heiti SC；Linux：Noto Serif/Sans CJK SC | 系统自带或 `fonts-noto-cjk` |
 
-`build_pdf.sh` 会在缺失 `pandoc` 或 `xelatex` 时给出明确提示并退出；缺 `rsvg-convert`
-仅告警。若本机检测到 `~/miktex/bin/xelatex`，脚本会自动将其加入 `PATH`。
+`build_pdf.sh` 会在缺失 `pandoc` 或找不到**可用**的 `xelatex` 时给出明确提示并退出；
+缺 `rsvg-convert` 仅告警（SVG 图将无法嵌入）。脚本不再盲目信任 PATH 上的第一个
+`xelatex`，而是**逐个 smoke-test** 候选引擎（依次为 `/Library/TeX/texbin`、
+`/usr/local/texlive`、PATH、`~/miktex`），选用第一个能编译出 PDF 的引擎，从而自动跳过
+损坏的引擎（见下文「已知问题 / 构建环境」）。
 
 ## 构建
 
@@ -39,9 +43,69 @@ book/
 bash build_pdf.sh
 ```
 
-脚本会按顺序编译当前存在的 `introduction.md`、`chapter1.md` … `chapter10.md`、
-`afterword.md`（不存在的文件自动跳过），输出单个 PDF：`庖丁解牛-pigo.pdf`。
-因此书稿可随章节逐步补全而增量构建。
+脚本流程：
+
+1. 收集当前存在的 `introduction.md`、`chapter1.md` … `chapter10.md`、`afterword.md`
+   （不存在的文件自动跳过），因此书稿可随章节逐步补全而增量构建。
+2. 用 `rsvg-convert` 把 `images/*.svg` 预转为同名 `images/*.pdf`（向量，无损）。
+3. `pandoc` 经 `svg2pdf.lua`、`crossref.lua`、`experiment_box.lua` 三个 Lua 过滤器
+   生成 LaTeX，再用探测到的可用 `xelatex` 编译为单个 PDF：`庖丁解牛-pigo.pdf`。
+
+`svg2pdf.lua` 把图片引用中的 `.svg` 改写为已生成的 `.pdf`，避免 pandoc 默认的
+`\usepackage{svg}` + `\includesvg`（那条路径依赖 Inkscape 与 `-shell-escape`）。
+生成的 `庖丁解牛-pigo.pdf` 与 `images/*.pdf` 均为构建产物，不纳入版本管理
+（见根目录 `.gitignore`）。
+
+### 验证产物
+
+```bash
+pdfinfo 庖丁解牛-pigo.pdf              # 页数、页面尺寸
+pdftotext 庖丁解牛-pigo.pdf - | grep -n '庖丁解牛\|引言\|CLI 装配\|图1-1'
+```
+
+正常产出应包含：封面 + 目录（TOC）+ 引言 + 第 1 章（含图 1-1）。
+
+## 已知问题 / 构建环境
+
+本仓库开发机（macOS）自带的 **MiKTeX 21.7（`~/miktex/bin/xelatex`，MiKTeX-XeTeX 4.4）
+存在引擎级故障**，任何输入都会在启动阶段直接崩溃：
+
+```
+FATAL xelatex.core - Bad parameter value.
+FATAL xelatex.core - Data: parameterName="save_size"
+Source: Libraries/MiKTeX/TeXAndFriends/include/miktex/TeXAndFriends/TeXMFMemoryHandlerImpl.h:107
+```
+
+该故障早于本书构建管线即已存在，且**与配置无关**：`initexmf --set-config-value
+'[xetex]save_size=<N>'`（试过 5000 / 32768 / 40000 / 80000 / 200000）配合
+`initexmf --update-fndb` 后仍复现——问题出在引擎的内存处理器（memory handler），而非
+`save_size` 取值。本机也没有其他可用的 xelatex（无 TeX Live、无 tectonic）。
+
+因此在本机 `bash build_pdf.sh` 会在引擎 smoke-test 后**明确报错退出**，不产出 PDF。
+这是环境问题，不是管线问题。已逐段验证到最后一个可用阶段：
+
+- ✅ pandoc → LaTeX：正确生成 `elegantbook` 文档类（`lang=cn, cyan, device=normal`）、
+  注入 `preamble.tex`（中文字体回退）、`cover.tex`（封面 titlepage）、`\tableofcontents`；
+- ✅ Lua 过滤器：`crossref.lua`（`\crossreflink` 交叉引用）、`experiment_box.lua`
+  （`\begin{experimentbox}`、「实验 1-1」）、`svg2pdf.lua`（图片引用改写为 `.pdf`）均生效；
+- ✅ SVG → PDF：`rsvg-convert -f pdf` 将 `images/fig1-1.svg` 转为有效单页向量 PDF
+  （`pdfinfo` 确认 1 页），并以 `\includegraphics{images/fig1-1.pdf}` 嵌入。
+- ⛔ xelatex → PDF：因上述引擎故障阻塞，无法在本机完成。
+
+**在健康的 TeX 环境上构建**（任一即可）：
+
+```bash
+# macOS：安装 MacTeX（含可用 xelatex + tlmgr）
+brew install --cask mactex
+# 或 Linux：
+sudo apt-get install -y texlive-xetex texlive-lang-chinese pandoc librsvg2-bin fonts-noto-cjk
+tlmgr install elegantbook            # 若发行版未自带
+
+bash book/build_pdf.sh               # 脚本会自动选用 /Library/TeX/texbin 等处的可用 xelatex
+```
+
+只要 PATH 或 `/Library/TeX/texbin`、`/usr/local/texlive` 下存在一个能编译的 xelatex，
+脚本即会优先选用它，绕开损坏的 MiKTeX，正常产出 `庖丁解牛-pigo.pdf`。
 
 ## 写作约定
 

--- a/book/build_pdf.sh
+++ b/book/build_pdf.sh
@@ -5,10 +5,13 @@
 #
 # Requirements:
 #   - pandoc
-#   - xelatex (TeX Live or MiKTeX; this repo's dev machine ships MiKTeX at
-#     ~/miktex/bin/xelatex, which this script auto-detects and prepends to PATH)
+#   - a WORKING xelatex (TeX Live recommended). The script smoke-tests candidate
+#     engines and picks the first that compiles a trivial document, so a broken
+#     engine (e.g. the MiKTeX build in ~/miktex that aborts with
+#     'Bad parameter value: save_size') is skipped automatically. See README.md.
 #   - ElegantBook document class (elegantbook.cls)
-#   - rsvg-convert (librsvg) for SVG figure embedding (optional)
+#   - rsvg-convert (librsvg) for SVG figure embedding (SVGs are pre-converted to
+#     PDF, so neither Inkscape nor -shell-escape is required)
 #   - Chinese fonts: macOS Songti SC / Heiti SC, or Linux Noto Sans/Serif CJK SC
 #
 # Usage:  bash book/build_pdf.sh   (or: cd book && bash build_pdf.sh)
@@ -54,20 +57,65 @@ if [ "${#INPUTS[@]}" -eq 0 ]; then
 fi
 
 # ── Dependency detection ─────────────────────────────────────────
-# MiKTeX on this machine lives here; prepend so xelatex + kpsewhich resolve.
-if [ -x "$HOME/miktex/bin/xelatex" ]; then
-    export PATH="$HOME/miktex/bin:$PATH"
-fi
-
 missing=0
 if ! command -v pandoc >/dev/null 2>&1; then
     echo "Error: 'pandoc' not found on PATH. Install it (brew install pandoc / apt-get install pandoc)." >&2
     missing=1
 fi
-if ! command -v xelatex >/dev/null 2>&1; then
-    echo "Error: 'xelatex' not found on PATH. Install TeX Live or MiKTeX." >&2
+
+# ── Pick a WORKING xelatex ───────────────────────────────────────
+# Some engines (notably the MiKTeX 21.7 build shipped in ~/miktex on this repo's
+# dev machine) start but immediately abort with a fatal engine fault:
+#     FATAL xelatex.core - Bad parameter value.  parameterName="save_size"
+# No config value (initexmf --set-config-value '[xetex]save_size=...') fixes it —
+# the fault is in the engine's memory handler, not the config. So instead of
+# trusting whatever xelatex is first on PATH, we smoke-test each candidate on a
+# trivial document and prefer the first one that actually produces a PDF.
+smoke_ok() {  # $1 = path to a xelatex binary
+    local eng="$1" tmp
+    tmp="$(mktemp -d)"
+    printf '\\documentclass{article}\\begin{document}ok\\end{document}' > "$tmp/_smoke.tex"
+    ( cd "$tmp" && "$eng" -interaction=nonstopmode -halt-on-error _smoke.tex ) >/dev/null 2>&1
+    local rc=$?
+    local ok=1
+    [ "$rc" -eq 0 ] && [ -f "$tmp/_smoke.pdf" ] && ok=0
+    rm -rf "$tmp"
+    return $ok
+}
+
+# Candidate engines, in preference order: healthy TeX Live locations first, then
+# whatever is on PATH, then this machine's MiKTeX. First that passes wins.
+XELATEX=""
+CANDIDATE_ENGINES=(
+    /Library/TeX/texbin/xelatex
+    /usr/local/texlive/bin/xelatex
+    "$(command -v xelatex 2>/dev/null || true)"
+    "$HOME/miktex/bin/xelatex"
+)
+# De-dup while preserving order.
+seen=""
+for eng in "${CANDIDATE_ENGINES[@]}"; do
+    [ -n "$eng" ] || continue
+    case "$seen" in *"|$eng|"*) continue;; esac
+    seen="$seen|$eng|"
+    if [ -x "$eng" ] || command -v "$eng" >/dev/null 2>&1; then
+        if smoke_ok "$eng"; then
+            XELATEX="$eng"
+            break
+        else
+            echo "Note: xelatex at '$eng' failed a smoke test (broken engine); trying next." >&2
+        fi
+    fi
+done
+
+if [ -z "$XELATEX" ]; then
+    echo "Error: no WORKING xelatex found. Every candidate engine either is missing or" >&2
+    echo "       fails to compile a trivial document. The MiKTeX build in ~/miktex on this" >&2
+    echo "       machine aborts with 'Bad parameter value: save_size' (engine-level fault)." >&2
+    echo "       Install a healthy TeX Live (see book/README.md → 已知问题 / 构建环境) and re-run." >&2
     missing=1
 fi
+
 if ! command -v rsvg-convert >/dev/null 2>&1; then
     echo "Warning: 'rsvg-convert' (librsvg) not found; SVG figures may not embed." >&2
 fi
@@ -76,12 +124,34 @@ if [ "$missing" -ne 0 ]; then
     exit 1
 fi
 
+echo "Using xelatex: $XELATEX"
+
+# Prepend the chosen engine's directory so its companion tools (kpsewhich,
+# mktextfm, …) resolve from the same TeX installation.
+XELATEX_BIN_DIR="$(cd "$(dirname "$XELATEX")" && pwd)"
+export PATH="$XELATEX_BIN_DIR:$PATH"
+
+# ── Pre-convert SVG figures to PDF via rsvg-convert ──────────────
+# pandoc emits \usepackage{svg} + \includesvg for .svg images, which needs
+# Inkscape + -shell-escape at compile time. Instead we rasterise each SVG to a
+# vector PDF up front with the documented rsvg-convert dependency; svg2pdf.lua
+# then rewrites the image reference to the .pdf, so the build needs neither
+# Inkscape nor shell-escape.
+if command -v rsvg-convert >/dev/null 2>&1; then
+    for svg in images/*.svg; do
+        [ -f "$svg" ] || continue
+        rsvg-convert -f pdf -o "${svg%.svg}.pdf" "$svg" \
+            && echo "Converted $svg -> ${svg%.svg}.pdf"
+    done
+fi
+
 echo "Building PDF from ${#INPUTS[@]} file(s): ${INPUTS[*]}"
 
 pandoc "${INPUTS[@]}" \
     -o "$OUT" \
     --from markdown+lists_without_preceding_blankline \
-    --pdf-engine=xelatex \
+    --pdf-engine="$XELATEX" \
+    --lua-filter=svg2pdf.lua \
     --lua-filter=crossref.lua \
     --lua-filter=experiment_box.lua \
     --toc \

--- a/book/svg2pdf.lua
+++ b/book/svg2pdf.lua
@@ -1,0 +1,34 @@
+-- svg2pdf.lua — pandoc Lua filter for the 《庖丁解牛 pigo》 book build.
+--
+-- Purpose: when producing PDF via xelatex, rewrite image references that point
+-- at an `.svg` file to the sibling `.pdf` that `build_pdf.sh` pre-generates with
+-- rsvg-convert. This lets the book embed vector figures through the documented
+-- `rsvg-convert` dependency (librsvg) instead of pandoc's default `\usepackage{svg}`
+-- + `\includesvg`, which would require Inkscape and `-shell-escape` at compile time.
+--
+-- The rewrite only happens for the LaTeX/PDF writer and only when the pre-converted
+-- `.pdf` actually exists on disk, so other output formats (e.g. HTML) keep the SVG.
+
+local function file_exists(path)
+  local f = io.open(path, "r")
+  if f then f:close(); return true end
+  return false
+end
+
+function Image(img)
+  -- Only rewrite for LaTeX/PDF output.
+  if not (FORMAT:match("latex") or FORMAT:match("beamer")) then
+    return nil
+  end
+  local src = img.src
+  if not src then return nil end
+  local base = src:match("^(.*)%.svg$")
+  if not base then return nil end
+  local pdf = base .. ".pdf"
+  -- Resolve relative to the build directory (build_pdf.sh cd's into book/).
+  if file_exists(pdf) then
+    img.src = pdf
+    return img
+  end
+  return nil
+end


### PR DESCRIPTION
## Summary
- `build_pdf.sh` 现在 smoke-test 候选 xelatex 引擎，选用第一个能编译出 PDF 的，自动跳过本机 MiKTeX 的 `save_size` 引擎级故障；找不到可用引擎时给出明确诊断退出。
- SVG 图由 `rsvg-convert` 预转为向量 PDF，新增 `svg2pdf.lua` 过滤器把图片引用改写为 `.pdf`，摆脱 pandoc 默认 `\includesvg` 对 Inkscape / `-shell-escape` 的依赖。
- `book/README.md` 补全可复现构建命令、依赖清单，以及「已知问题 / 构建环境」：记录 `save_size` 引擎故障、健康 TeX 环境构建步骤，并标注已验证阶段。
- `.gitignore` 忽略 `book/images/*.pdf` 构建产物。

## 构建结果 / 环境说明
本机 MiKTeX 21.7 存在**先于本工作即已存在**的引擎级故障（`FATAL xelatex.core - Bad parameter value: save_size`，位于 TeXMFMemoryHandlerImpl.h:107），任何 `save_size` 取值均无法修复，本机亦无其他可用 xelatex，故**未能在本机产出 PDF**。管线已逐段验证到最后一个可用阶段：pandoc→LaTeX（elegantbook/cyan/preamble/cover/TOC 正确）、三个 Lua 过滤器生效、`rsvg-convert` 将 fig1-1.svg 转为有效单页 PDF 并以 `\includegraphics` 嵌入。健康 TeX 环境下脚本会自动选用可用引擎正常出书。

Closes #205

## Test plan
- [x] `bash -n build_pdf.sh` 语法通过
- [x] `bash build_pdf.sh` 在损坏引擎下 smoke-test 跳过并明确报错退出
- [x] pandoc + svg2pdf.lua/crossref.lua/experiment_box.lua 生成的 .tex 正确装配 elegantbook/cover/TOC/实验盒子/交叉引用
- [x] `rsvg-convert -f pdf` 产出有效单页向量 PDF（pdfinfo 确认），.tex 引用改写为 images/fig1-1.pdf
- [ ] 在健康 TeX Live 环境完整产出 PDF（受本机引擎故障阻塞，无法在此验证）