### PR TITLE
Add model-name → provider inference table

### DIFF
--- a/docs/issue#0234.html
+++ b/docs/issue#0234.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0234</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/234">#234</a> &mdash; Add model-name → provider inference table &mdash; 2026-07-23</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Ordered prefix table instead of a map</h3>
+      <p><strong>Ambiguity:</strong> The issue lists name→provider pairs but not the data structure.</p>
+      <p><strong>Choice:</strong> A top-to-bottom ordered slice <code>modelPrefixProvider</code>, first-match-wins.</p>
+      <p><strong>Rationale:</strong> Prefix matching is inherently order-sensitive (a longer prefix must be tried before a shorter overlapping one). A slice makes that ordering explicit and reviewable; a map would hide it.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Routed <code>provider/model</code> ids are not inferred</h3>
+      <p><strong>Ambiguity:</strong> The issue only names bare model families; it is silent on OpenRouter-style routed ids like <code>openai/gpt-4o</code> or <code>ollama/llama3.3</code>.</p>
+      <p><strong>Choice:</strong> Any id containing <code>/</code> returns <code>ok=false</code>.</p>
+      <p><strong>Rationale:</strong> Those ids are already handled by the preset catalog and the <code>ollama/</code> / <code>nvidia/</code> prefix paths in <code>resolveProvider</code>. Inferring from the leading segment would wrongly route <code>openai/gpt-4o</code> to the direct OpenAI provider instead of OpenRouter, silently changing behavior.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>qwen-*</code> → dashscope, <code>glm-*</code> → zai</h3>
+      <p><strong>Ambiguity:</strong> Qwen and GLM are served by multiple built-ins (dashscope/together/openrouter; zai/zai-coding-cn/cerebras).</p>
+      <p><strong>Choice:</strong> Map to the model family's first-party direct provider (Alibaba DashScope, Z.AI) per the issue table.</p>
+      <p><strong>Rationale:</strong> The issue explicitly names these targets; the first-party provider is the least surprising default for a bare family name.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Added <code>o4-*</code> to the OpenAI patterns</h3>
+      <p><strong>Spec:</strong> Listed <code>gpt-*</code> / <code>o1-*</code> / <code>o3-*</code> → openai.</p>
+      <p><strong>Implemented:</strong> Also mapped <code>o4-*</code> → openai.</p>
+      <p><strong>Why:</strong> The o-series naming is sequential; omitting <code>o4</code> would be an obvious gap and matches the issue's clear intent. Low risk — the prefix is unambiguously OpenAI.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Conservative prefix matching over broad heuristics</h3>
+      <p><strong>Alternatives:</strong> (a) substring/regex matching to catch more names; (b) strict prefix-only for names that map to exactly one provider.</p>
+      <p><strong>Chosen:</strong> (b). Ambiguous families (<code>llama-*</code>, <code>qwq-*</code>, <code>gemma-*</code>, <code>mixtral-*</code>) deliberately return <code>ok=false</code>.</p>
+      <p><strong>Why it won:</strong> A false inference silently sends traffic to the wrong gateway with the wrong API key — worse than falling through to the existing OpenRouter default. Precision beats recall here.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Qwen/GLM provider choice</h3>
+      <p><strong>Assumption:</strong> A bare <code>qwen-*</code> should reach DashScope and <code>glm-*</code> should reach Z.AI (international), not their CN-specific siblings.</p>
+      <p><strong>Verify:</strong> Confirm this matches the intended default audience; CN users can still pass <code>--provider dashscope-cn</code>-style flags explicitly (wired in #235).</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/provider/infer.go
+++ b/internal/provider/infer.go
@@ -1,0 +1,78 @@
+// This file implements model-name → provider inference (US: auto-infer provider
+// from --model alone). When a user supplies only --model, with no --provider,
+// --protocol, or --base-url, pigo tries to guess the owning provider from the
+// model id's well-known name prefix (e.g. "claude-*" → anthropic, "deepseek-*"
+// → deepseek). This lets `pigo -m claude-opus-4-8` reach the Anthropic API
+// without the user spelling out the provider or its wire protocol.
+//
+// The mapping is deliberately conservative: only names that unambiguously
+// identify a single built-in provider are inferred. Ambiguous families served
+// by many gateways (notably "llama-*", "qwq-*", "gemma-*", "mixtral-*") are NOT
+// inferred — they return ok=false so the caller falls through to its existing
+// default (OpenRouter), which is the safe, unchanged behavior.
+//
+// Every provider name returned here is guaranteed to exist in providerRegistry
+// (enforced by a test), so callers can hand the result straight to the
+// registry-driven resolution path.
+package provider
+
+import "strings"
+
+// modelPrefixProvider maps a lowercase model-name prefix to the built-in
+// provider name that serves that family. Order matters: the table is scanned
+// top-to-bottom and the FIRST matching prefix wins, so list more specific
+// prefixes before shorter ones that would also match.
+//
+// Each provider name here must be present in providerRegistry (registry.go).
+var modelPrefixProvider = []struct {
+	prefix   string
+	provider string
+}{
+	{"claude-", "anthropic"},
+	{"gpt-", "openai"},
+	{"o1-", "openai"},
+	{"o3-", "openai"},
+	{"o4-", "openai"},
+	{"gemini-", "google"},
+	{"deepseek-", "deepseek"},
+	{"glm-", "zai"},
+	{"kimi-", "moonshotai"},
+	{"moonshot-", "moonshotai"},
+	{"qwen-", "dashscope"},
+	{"ernie-", "qianfan"},
+	{"doubao-", "volcengine"},
+	{"grok-", "xai"},
+	{"mistral-", "mistral"},
+	{"codestral-", "mistral"},
+	{"devstral-", "mistral"},
+	{"hunyuan-", "hunyuan"},
+	{"minimax-", "minimax"},
+	{"mimo-", "xiaomi"},
+}
+
+// InferProviderFromModel guesses the built-in provider name that serves a given
+// model id, based on the id's well-known name prefix. It returns the provider
+// name and ok=true on a confident match, or ("", false) when the id is unknown
+// or ambiguous (served by multiple gateways). Matching is case-insensitive.
+//
+// The returned name is always a valid entry in providerRegistry. Callers should
+// use it only when no explicit --provider/--protocol/--base-url was given; those
+// flags take precedence over any inference.
+func InferProviderFromModel(model string) (string, bool) {
+	id := strings.ToLower(strings.TrimSpace(model))
+	if id == "" {
+		return "", false
+	}
+	// A "provider/model" style id (e.g. "openai/gpt-4o") is an OpenRouter-style
+	// routed id, not a bare model name — leave those to the caller's preset/
+	// prefix handling rather than inferring from the leading segment.
+	if strings.Contains(id, "/") {
+		return "", false
+	}
+	for _, m := range modelPrefixProvider {
+		if strings.HasPrefix(id, m.prefix) {
+			return m.provider, true
+		}
+	}
+	return "", false
+}

--- a/internal/provider/infer_test.go
+++ b/internal/provider/infer_test.go
@@ -1,0 +1,96 @@
+package provider
+
+// Tests for model-name → provider inference (InferProviderFromModel). They
+// verify each documented name prefix resolves to the expected built-in
+// provider, that ambiguous/unknown ids and routed "provider/model" ids do not
+// resolve, that matching is case-insensitive, and that every inferred provider
+// name actually exists in the provider registry (the single source of truth).
+
+import "testing"
+
+// TestInferProviderFromModelKnown verifies each documented model-name prefix
+// resolves to its expected built-in provider.
+func TestInferProviderFromModelKnown(t *testing.T) {
+	cases := []struct {
+		model string
+		want  string
+	}{
+		{"claude-opus-4-8", "anthropic"},
+		{"claude-3.5-sonnet", "anthropic"},
+		{"gpt-4o", "openai"},
+		{"gpt-4o-mini", "openai"},
+		{"o1-preview", "openai"},
+		{"o3-mini", "openai"},
+		{"o4-mini", "openai"},
+		{"gemini-2.5-pro", "google"},
+		{"deepseek-chat", "deepseek"},
+		{"deepseek-v4-pro", "deepseek"},
+		{"glm-5.1", "zai"},
+		{"kimi-k2-thinking", "moonshotai"},
+		{"moonshot-v1-8k", "moonshotai"},
+		{"qwen-max", "dashscope"},
+		{"ernie-4.5-turbo-32k", "qianfan"},
+		{"doubao-seed-1-6", "volcengine"},
+		{"grok-4.5", "xai"},
+		{"mistral-large-latest", "mistral"},
+		{"codestral-latest", "mistral"},
+		{"devstral-medium-latest", "mistral"},
+		{"hunyuan-turbos-latest", "hunyuan"},
+		{"minimax-m2.7", "minimax"},
+		{"mimo-v2-pro", "xiaomi"},
+	}
+	for _, c := range cases {
+		got, ok := InferProviderFromModel(c.model)
+		if !ok {
+			t.Errorf("InferProviderFromModel(%q): ok=false, want provider %q", c.model, c.want)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("InferProviderFromModel(%q) = %q, want %q", c.model, got, c.want)
+		}
+	}
+}
+
+// TestInferProviderFromModelCaseInsensitive verifies matching ignores case and
+// surrounding whitespace.
+func TestInferProviderFromModelCaseInsensitive(t *testing.T) {
+	for _, m := range []string{"Claude-Opus-4-8", "  GPT-4o  ", "DeepSeek-Chat"} {
+		if _, ok := InferProviderFromModel(m); !ok {
+			t.Errorf("InferProviderFromModel(%q): ok=false, want a match", m)
+		}
+	}
+}
+
+// TestInferProviderFromModelAmbiguousOrUnknown verifies ids that are ambiguous
+// (served by many gateways), routed ("provider/model"), empty, or simply
+// unknown do NOT resolve — the caller must fall through to its default.
+func TestInferProviderFromModelAmbiguousOrUnknown(t *testing.T) {
+	for _, m := range []string{
+		"",                        // empty
+		"   ",                     // whitespace only
+		"llama-3.3-70b-instruct",  // ambiguous: many gateways
+		"qwq-32b",                 // ambiguous
+		"gemma-2-9b-it",           // ambiguous
+		"mixtral-8x22b",           // ambiguous
+		"openai/gpt-4o",           // routed id, leave to preset/prefix handling
+		"anthropic/claude-3.5",    // routed id
+		"ollama/llama3.3",         // routed id (ollama prefix path)
+		"totally-made-up-model",   // unknown
+	} {
+		if got, ok := InferProviderFromModel(m); ok {
+			t.Errorf("InferProviderFromModel(%q) = (%q, true), want ok=false", m, got)
+		}
+	}
+}
+
+// TestInferProviderNamesExistInRegistry verifies every provider name the
+// inference table can return is a real built-in provider (registry is the
+// single source of truth), so a hit can be handed straight to registry-driven
+// resolution.
+func TestInferProviderNamesExistInRegistry(t *testing.T) {
+	for _, m := range modelPrefixProvider {
+		if _, ok := LookupProviderSpec(m.provider); !ok {
+			t.Errorf("inference maps prefix %q → %q, which is not in providerRegistry", m.prefix, m.provider)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `InferProviderFromModel` in `internal/provider/infer.go`: infers the built-in provider from a bare model name via a conservative first-match-wins prefix table (claude→anthropic, gpt/o1/o3/o4→openai, gemini→google, deepseek, glm→zai, kimi/moonshot→moonshotai, qwen→dashscope, ernie→qianfan, doubao→volcengine, grok→xai, mistral/codestral/devstral→mistral, hunyuan, minimax, mimo→xiaomi)
- Ambiguous families (`llama-*`, `qwq-*`, `gemma-*`, `mixtral-*`) and routed `provider/model` ids return `ok=false`, preserving the existing OpenRouter default
- Case-insensitive; a test asserts every inferred name exists in `providerRegistry`

Closes #234

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/provider/`
- [x] `go test ./internal/provider/` (table-driven: known / case-insensitive / ambiguous+routed / registry-consistency)