### PR TITLE
修复调用大模型降智与严格网关兼容问题

### DIFF
--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -42,6 +42,7 @@ type openaiToolCall struct {
 // not safe for concurrent use — the transport drives it from one goroutine.
 type OpenAIDecoder struct {
 	text      strings.Builder
+	thinking  strings.Builder // reasoning_content / reasoning stream (if any)
 	toolCalls map[int]*openaiToolCall
 	toolOrder []int // tool-call indices in first-seen order
 
@@ -64,8 +65,15 @@ type openaiChunk struct {
 	Model   string `json:"model"`
 	Choices []struct {
 		Delta struct {
-			Content   string            `json:"content"`
-			ToolCalls []openaiToolDelta `json:"tool_calls"`
+			Content string `json:"content"`
+			// ReasoningContent carries the model's reasoning/thinking stream on the
+			// OpenAI wire (DeepSeek-R1, Kimi, and other reasoning models put their
+			// chain-of-thought here). Some gateways name it "reasoning" instead, so
+			// both are accepted; without this field the thinking stream is silently
+			// dropped from the response and from history.
+			ReasoningContent string            `json:"reasoning_content"`
+			Reasoning        string            `json:"reasoning"`
+			ToolCalls        []openaiToolDelta `json:"tool_calls"`
 		} `json:"delta"`
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
@@ -120,6 +128,15 @@ func (d *OpenAIDecoder) Decode(payload []byte) ([]StreamEvent, error) {
 
 	var events []StreamEvent
 	for _, choice := range chunk.Choices {
+		// Reasoning stream (DeepSeek-R1 / Kimi / …): reasoning_content is the
+		// common field; a few gateways use "reasoning". Accumulate whichever is set.
+		if r := choice.Delta.ReasoningContent; r != "" {
+			d.thinking.WriteString(r)
+			events = append(events, StreamThinkingEvent{Partial: d.partial()})
+		} else if r := choice.Delta.Reasoning; r != "" {
+			d.thinking.WriteString(r)
+			events = append(events, StreamThinkingEvent{Partial: d.partial()})
+		}
 		if choice.Delta.Content != "" {
 			d.text.WriteString(choice.Delta.Content)
 			events = append(events, StreamTextEvent{Partial: d.partial()})
@@ -187,6 +204,9 @@ func (d *OpenAIDecoder) partial() agentcore.AssistantMessage {
 	}
 	if d.inputTokens != 0 || d.outputTokens != 0 {
 		msg.Usage = &agentcore.Usage{InputTokens: d.inputTokens, OutputTokens: d.outputTokens}
+	}
+	if d.thinking.Len() > 0 {
+		msg.Content = append(msg.Content, agentcore.NewThinkingContent(d.thinking.String()))
 	}
 	if d.text.Len() > 0 {
 		msg.Content = append(msg.Content, agentcore.NewTextContent(d.text.String()))

--- a/internal/provider/providers.go
+++ b/internal/provider/providers.go
@@ -123,10 +123,36 @@ func encodeOpenAIRequest(req CompletionRequest) ([]byte, error) {
 		"stream":         true,
 		"stream_options": map[string]any{"include_usage": true},
 	}
+	// Reasoning effort: when a thinking level is requested, forward it as the
+	// OpenAI `reasoning_effort` field. Reasoning models (o-series, DeepSeek-R1,
+	// GLM-thinking, …) read this to open their reasoning channel; omitting it
+	// leaves them at their default and effectively disables extended reasoning.
+	if effort := openAIReasoningEffort(req.Config.ThinkingLevel); effort != "" {
+		body["reasoning_effort"] = effort
+	}
 	if tools := encodeOpenAITools(req.Context.Tools); len(tools) > 0 {
 		body["tools"] = tools
 	}
 	return json.Marshal(body)
+}
+
+// openAIReasoningEffort maps the unified ThinkingLevel onto the OpenAI
+// `reasoning_effort` wire value. "off"/"" yields "" (field omitted, default
+// behavior preserved). OpenAI accepts minimal|low|medium|high; xhigh maps to
+// high (the strongest supported value).
+func openAIReasoningEffort(level agentcore.ThinkingLevel) string {
+	switch level {
+	case agentcore.ThinkingMinimal:
+		return "minimal"
+	case agentcore.ThinkingLow:
+		return "low"
+	case agentcore.ThinkingMedium:
+		return "medium"
+	case agentcore.ThinkingHigh, agentcore.ThinkingXHigh:
+		return "high"
+	default: // off or unset
+		return ""
+	}
 }
 
 // encodeOpenAIMessage maps one pigo message onto the OpenAI wire shape. An
@@ -142,7 +168,7 @@ func encodeOpenAIMessage(m agentcore.Message) []map[string]any {
 		return []map[string]any{{"role": "user", "content": openAIUserContent(u.Content)}}
 	case agentcore.AssistantMessage:
 		entry := map[string]any{"role": "assistant"}
-		entry["content"] = agentcore.ContentToText(msg.Content)
+		text := agentcore.ContentToText(msg.Content)
 		var toolCalls []map[string]any
 		for _, c := range msg.Content {
 			if tc, ok := c.(agentcore.ToolCallContent); ok {
@@ -158,6 +184,16 @@ func encodeOpenAIMessage(m agentcore.Message) []map[string]any {
 		}
 		if len(toolCalls) > 0 {
 			entry["tool_calls"] = toolCalls
+			// With tool calls present, send content as JSON null when there is no
+			// accompanying text: an empty string trips strict gateways (e.g. vLLM)
+			// that expect null | non-empty for an assistant tool-call turn.
+			if text == "" {
+				entry["content"] = nil
+			} else {
+				entry["content"] = text
+			}
+		} else {
+			entry["content"] = text
 		}
 		return []map[string]any{entry}
 	case agentcore.ToolResultMessage:
@@ -260,7 +296,7 @@ func (d *anthropicCompatDriver) StreamCompletion(ctx context.Context, req Comple
 	if err := checkImageSupport(d.name, req.Model, d.models, req.Context.Messages); err != nil {
 		return nil, err
 	}
-	body, err := encodeAnthropicRequest(req)
+	body, err := encodeAnthropicRequest(req, d.models)
 	if err != nil {
 		return nil, fmt.Errorf("%s: build request body: %w", d.name, err)
 	}
@@ -286,7 +322,7 @@ func (d *anthropicCompatDriver) StreamCompletion(ctx context.Context, req Comple
 // encodeAnthropicRequest serializes a CompletionRequest into an Anthropic
 // Messages JSON body with streaming enabled. The system prompt is a top-level
 // field; tool results and tool calls follow the Messages content-block shape.
-func encodeAnthropicRequest(req CompletionRequest) ([]byte, error) {
+func encodeAnthropicRequest(req CompletionRequest, models []Model) ([]byte, error) {
 	msgs := make([]map[string]any, 0, len(req.Context.Messages))
 	for _, m := range req.Context.Messages {
 		if enc := encodeAnthropicMessage(m); enc != nil {
@@ -300,16 +336,68 @@ func encodeAnthropicRequest(req CompletionRequest) ([]byte, error) {
 	if sp := req.Context.SystemPrompt; sp != "" {
 		body["system"] = sp
 	}
-	if maxTok := maxOutputTokensFor(req); maxTok > 0 {
-		body["max_tokens"] = maxTok
-	} else {
-		// Anthropic requires max_tokens; supply a safe default when unknown.
-		body["max_tokens"] = 4096
+	maxTok := maxOutputTokensFor(req)
+	if maxTok <= 0 {
+		// Anthropic requires max_tokens. Prefer the model's declared cap; fall
+		// back to a coding-friendly default (4096 was too low and caused
+		// truncation/retry loops on longer edits).
+		maxTok = anthropicDefaultMaxTokens(req.Model, models)
 	}
+	// Extended thinking: when a thinking level is requested, enable the Anthropic
+	// thinking block with a budget derived from the level. Omitted for off/unset
+	// so non-thinking requests keep their prior shape.
+	if budget := anthropicThinkingBudget(req.Config.ThinkingLevel); budget > 0 {
+		// Anthropic counts thinking tokens toward max_tokens and requires
+		// budget_tokens < max_tokens (else a 400). Guarantee headroom for the
+		// visible reply by lifting max_tokens above the budget when the caller's
+		// cap is too low to fit both the reasoning and a real answer.
+		if minTok := budget + anthropicResponseHeadroom; maxTok < minTok {
+			maxTok = minTok
+		}
+		body["thinking"] = map[string]any{"type": "enabled", "budget_tokens": budget}
+	}
+	body["max_tokens"] = maxTok
 	if tools := encodeAnthropicTools(req.Context.Tools); len(tools) > 0 {
 		body["tools"] = tools
 	}
 	return json.Marshal(body)
+}
+
+// anthropicResponseHeadroom is the token margin reserved for the visible reply
+// on top of the thinking budget, so max_tokens always exceeds budget_tokens (an
+// Anthropic hard requirement) with room left for a real answer.
+const anthropicResponseHeadroom = 4096
+
+// anthropicDefaultMaxTokens picks the max_tokens fallback when no explicit hint
+// is given: the model's declared MaxOutputTokens if present in the driver's
+// model catalog, otherwise 8192 (a coding-friendly default that avoids
+// premature truncation while staying within common model caps).
+func anthropicDefaultMaxTokens(model string, models []Model) int {
+	for _, m := range models {
+		if m.ID == model && m.MaxOutputTokens > 0 {
+			return m.MaxOutputTokens
+		}
+	}
+	return 8192
+}
+
+// anthropicThinkingBudget maps a unified ThinkingLevel onto an Anthropic
+// thinking budget_tokens value. off/"" yields 0 (thinking block omitted).
+func anthropicThinkingBudget(level agentcore.ThinkingLevel) int {
+	switch level {
+	case agentcore.ThinkingMinimal:
+		return 1024
+	case agentcore.ThinkingLow:
+		return 2048
+	case agentcore.ThinkingMedium:
+		return 8192
+	case agentcore.ThinkingHigh:
+		return 16384
+	case agentcore.ThinkingXHigh:
+		return 32768
+	default: // off or unset
+		return 0
+	}
 }
 
 // encodeAnthropicMessage maps one pigo message onto the Anthropic Messages
@@ -324,9 +412,34 @@ func encodeAnthropicMessage(m agentcore.Message) map[string]any {
 		return map[string]any{"role": "user", "content": anthropicUserContent(u.Content)}
 	case agentcore.AssistantMessage:
 		var blocks []map[string]any
+		// Thinking blocks must precede tool_use in the same assistant turn:
+		// Anthropic extended-thinking requires the prior thinking block (and its
+		// signature) to be echoed back verbatim on tool-use turns, or the API
+		// rejects/degrades the request. Emit them first.
+		for _, c := range msg.Content {
+			if t, ok := c.(agentcore.ThinkingContent); ok {
+				if t.Redacted {
+					blocks = append(blocks, map[string]any{
+						"type": "redacted_thinking", "data": t.ThinkingSignature,
+					})
+					continue
+				}
+				if t.Thinking == "" {
+					continue
+				}
+				block := map[string]any{"type": "thinking", "thinking": t.Thinking}
+				if t.ThinkingSignature != "" {
+					block["signature"] = t.ThinkingSignature
+				}
+				blocks = append(blocks, block)
+			}
+		}
 		for _, c := range msg.Content {
 			switch b := c.(type) {
 			case agentcore.TextContent:
+				if b.Text == "" {
+					continue
+				}
 				blocks = append(blocks, map[string]any{"type": "text", "text": b.Text})
 			case agentcore.ToolCallContent:
 				var input any
@@ -337,7 +450,9 @@ func encodeAnthropicMessage(m agentcore.Message) map[string]any {
 			}
 		}
 		if len(blocks) == 0 {
-			blocks = []map[string]any{{"type": "text", "text": ""}}
+			// No usable content: emit a single space rather than an empty text
+			// block ("text must be non-empty" is rejected by strict endpoints).
+			blocks = []map[string]any{{"type": "text", "text": " "}}
 		}
 		return map[string]any{"role": "assistant", "content": blocks}
 	case agentcore.ToolResultMessage:

--- a/internal/provider/thinking_test.go
+++ b/internal/provider/thinking_test.go
@@ -1,0 +1,264 @@
+// Tests for reasoning/thinking wiring across both wire protocols (issues
+// #240-#244): request encoders forwarding ThinkingLevel, the Anthropic
+// thinking-block echo on multi-turn tool-use messages, OpenAI reasoning_content
+// stream decoding, the max_tokens fallback, and strict-gateway empty-content
+// handling.
+package provider
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// decodeBody unmarshals an encoded request body into a generic map for asserts.
+func decodeBody(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	return m
+}
+
+// TestOpenAIReasoningEffortEncoding verifies ThinkingLevel maps to
+// reasoning_effort, and that off/unset omits the field entirely (#240).
+func TestOpenAIReasoningEffortEncoding(t *testing.T) {
+	base := CompletionRequest{Model: "o3-mini", Context: LlmContext{}}
+
+	// off / unset → no reasoning_effort.
+	for _, lvl := range []agentcore.ThinkingLevel{"", agentcore.ThinkingOff} {
+		base.Config.ThinkingLevel = lvl
+		b, err := encodeOpenAIRequest(base)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		if _, ok := decodeBody(t, b)["reasoning_effort"]; ok {
+			t.Errorf("level %q: reasoning_effort should be omitted", lvl)
+		}
+	}
+
+	cases := map[agentcore.ThinkingLevel]string{
+		agentcore.ThinkingMinimal: "minimal",
+		agentcore.ThinkingLow:     "low",
+		agentcore.ThinkingMedium:  "medium",
+		agentcore.ThinkingHigh:    "high",
+		agentcore.ThinkingXHigh:   "high",
+	}
+	for lvl, want := range cases {
+		base.Config.ThinkingLevel = lvl
+		b, err := encodeOpenAIRequest(base)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		if got := decodeBody(t, b)["reasoning_effort"]; got != want {
+			t.Errorf("level %q: reasoning_effort = %v, want %q", lvl, got, want)
+		}
+	}
+}
+
+// TestAnthropicThinkingEncoding verifies ThinkingLevel enables the thinking
+// block with a budget, and off/unset omits it (#240).
+func TestAnthropicThinkingEncoding(t *testing.T) {
+	base := CompletionRequest{Model: "claude-x", Context: LlmContext{}}
+
+	base.Config.ThinkingLevel = agentcore.ThinkingOff
+	b, _ := encodeAnthropicRequest(base, nil)
+	if _, ok := decodeBody(t, b)["thinking"]; ok {
+		t.Error("off: thinking block should be omitted")
+	}
+
+	base.Config.ThinkingLevel = agentcore.ThinkingMedium
+	b, _ = encodeAnthropicRequest(base, nil)
+	th, ok := decodeBody(t, b)["thinking"].(map[string]any)
+	if !ok {
+		t.Fatal("medium: thinking block missing")
+	}
+	if th["type"] != "enabled" {
+		t.Errorf("thinking.type = %v, want enabled", th["type"])
+	}
+	if bt, _ := th["budget_tokens"].(float64); bt <= 0 {
+		t.Errorf("thinking.budget_tokens = %v, want > 0", th["budget_tokens"])
+	}
+}
+
+// TestAnthropicMaxTokensFallback verifies the fallback prefers the model's
+// MaxOutputTokens and otherwise uses the coding-friendly 8192 default (#243).
+func TestAnthropicMaxTokensFallback(t *testing.T) {
+	req := CompletionRequest{Model: "claude-x", Context: LlmContext{}}
+
+	// No model metadata → 8192 default.
+	b, _ := encodeAnthropicRequest(req, nil)
+	if got := decodeBody(t, b)["max_tokens"].(float64); got != 8192 {
+		t.Errorf("default max_tokens = %v, want 8192", got)
+	}
+
+	// Model with a declared cap → that cap.
+	models := []Model{{ID: "claude-x", MaxOutputTokens: 12000}}
+	b, _ = encodeAnthropicRequest(req, models)
+	if got := decodeBody(t, b)["max_tokens"].(float64); got != 12000 {
+		t.Errorf("model-cap max_tokens = %v, want 12000", got)
+	}
+
+	// Explicit Extra hint still wins.
+	req.Config.Extra = map[string]any{"max_tokens": 2000}
+	b, _ = encodeAnthropicRequest(req, models)
+	if got := decodeBody(t, b)["max_tokens"].(float64); got != 2000 {
+		t.Errorf("explicit max_tokens = %v, want 2000", got)
+	}
+}
+
+// TestAnthropicThinkingBlockEcho verifies a multi-turn assistant message with a
+// thinking block + tool call re-emits the thinking block (with signature) ahead
+// of the tool_use block (#241).
+func TestAnthropicThinkingBlockEcho(t *testing.T) {
+	think := agentcore.NewThinkingContent("let me reason")
+	think.ThinkingSignature = "sig-abc"
+	msg := agentcore.AssistantMessage{
+		Content: agentcore.ContentList{
+			think,
+			agentcore.NewToolCallContent("call_1", "read", json.RawMessage(`{"path":"x"}`)),
+		},
+	}
+	entry := encodeAnthropicMessage(msg)
+	blocks, ok := entry["content"].([]map[string]any)
+	if !ok || len(blocks) != 2 {
+		t.Fatalf("want 2 content blocks, got %#v", entry["content"])
+	}
+	if blocks[0]["type"] != "thinking" {
+		t.Errorf("first block type = %v, want thinking", blocks[0]["type"])
+	}
+	if blocks[0]["signature"] != "sig-abc" {
+		t.Errorf("thinking signature = %v, want sig-abc", blocks[0]["signature"])
+	}
+	if blocks[1]["type"] != "tool_use" {
+		t.Errorf("second block type = %v, want tool_use", blocks[1]["type"])
+	}
+}
+
+// TestAnthropicRedactedThinkingEcho verifies redacted thinking round-trips as a
+// redacted_thinking block carrying the signature as data (#241).
+func TestAnthropicRedactedThinkingEcho(t *testing.T) {
+	think := agentcore.ThinkingContent{Type: agentcore.ContentTypeThinking, Redacted: true, ThinkingSignature: "redacted-data"}
+	msg := agentcore.AssistantMessage{Content: agentcore.ContentList{think}}
+	entry := encodeAnthropicMessage(msg)
+	blocks := entry["content"].([]map[string]any)
+	if blocks[0]["type"] != "redacted_thinking" || blocks[0]["data"] != "redacted-data" {
+		t.Errorf("redacted block = %#v", blocks[0])
+	}
+}
+
+// TestOpenAIAssistantContentNullWithToolCalls verifies a tool-call-only
+// assistant turn sends content:null (not ""), while a text-only turn keeps its
+// text (#244).
+func TestOpenAIAssistantContentNullWithToolCalls(t *testing.T) {
+	toolOnly := agentcore.AssistantMessage{
+		Content: agentcore.ContentList{
+			agentcore.NewToolCallContent("call_1", "read", json.RawMessage(`{}`)),
+		},
+	}
+	entry := encodeOpenAIMessage(toolOnly)[0]
+	if entry["content"] != nil {
+		t.Errorf("tool-only content = %#v, want nil", entry["content"])
+	}
+	if _, ok := entry["tool_calls"]; !ok {
+		t.Error("tool_calls missing")
+	}
+
+	textOnly := agentcore.AssistantMessage{
+		Content: agentcore.ContentList{agentcore.NewTextContent("hi")},
+	}
+	if got := encodeOpenAIMessage(textOnly)[0]["content"]; got != "hi" {
+		t.Errorf("text content = %#v, want hi", got)
+	}
+}
+
+// TestAnthropicEmptyAssistantNoEmptyText verifies an assistant message with no
+// usable content does not emit an empty-string text block (#244).
+func TestAnthropicEmptyAssistantNoEmptyText(t *testing.T) {
+	msg := agentcore.AssistantMessage{Content: agentcore.ContentList{agentcore.NewTextContent("")}}
+	entry := encodeAnthropicMessage(msg)
+	blocks := entry["content"].([]map[string]any)
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 fallback block, got %d", len(blocks))
+	}
+	if txt, _ := blocks[0]["text"].(string); strings.TrimSpace(txt) == "" && txt == "" {
+		t.Errorf("fallback text block is empty string, want non-empty placeholder")
+	}
+}
+
+// TestAnthropicThinkingRaisesMaxTokens verifies max_tokens is lifted above the
+// thinking budget: Anthropic requires budget_tokens < max_tokens, so a low cap
+// must be raised to leave headroom for the visible reply (#243).
+func TestAnthropicThinkingRaisesMaxTokens(t *testing.T) {
+	req := CompletionRequest{Model: "claude-x", Context: LlmContext{}}
+	req.Config.ThinkingLevel = agentcore.ThinkingXHigh // budget 32768
+
+	// Default cap (8192) is below the budget → must be raised above it.
+	b, _ := encodeAnthropicRequest(req, nil)
+	body := decodeBody(t, b)
+	budget := body["thinking"].(map[string]any)["budget_tokens"].(float64)
+	maxTok := body["max_tokens"].(float64)
+	if maxTok <= budget {
+		t.Errorf("max_tokens = %v, want > budget_tokens %v", maxTok, budget)
+	}
+
+	// A caller cap already above budget+headroom is left untouched.
+	req.Config.Extra = map[string]any{"max_tokens": 100000}
+	b, _ = encodeAnthropicRequest(req, nil)
+	if got := decodeBody(t, b)["max_tokens"].(float64); got != 100000 {
+		t.Errorf("max_tokens = %v, want caller value 100000", got)
+	}
+}
+
+// TestOpenAIReasoningContentDecoding verifies the decoder accumulates
+// reasoning_content into a ThinkingContent block ahead of text (#242).
+func TestOpenAIReasoningContentDecoding(t *testing.T) {
+	d := NewOpenAIDecoder()
+	chunks := []string{
+		`{"id":"c1","choices":[{"delta":{"reasoning_content":"think "}}]}`,
+		`{"choices":[{"delta":{"reasoning_content":"harder"}}]}`,
+		`{"choices":[{"delta":{"content":"answer"}}]}`,
+		`{"choices":[{"finish_reason":"stop"}]}`,
+	}
+	var events []StreamEvent
+	for _, c := range chunks {
+		evs, err := d.Decode([]byte(c))
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		events = append(events, evs...)
+	}
+	done, _ := d.Finish()
+	events = append(events, done...)
+
+	var final agentcore.AssistantMessage
+	for _, e := range events {
+		if de, ok := e.(StreamDoneEvent); ok {
+			final = de.Message
+		}
+	}
+	if len(final.Content) != 2 {
+		t.Fatalf("want thinking+text, got %d blocks: %#v", len(final.Content), final.Content)
+	}
+	th, ok := final.Content[0].(agentcore.ThinkingContent)
+	if !ok || th.Thinking != "think harder" {
+		t.Errorf("block[0] = %#v, want thinking 'think harder'", final.Content[0])
+	}
+	txt, ok := final.Content[1].(agentcore.TextContent)
+	if !ok || txt.Text != "answer" {
+		t.Errorf("block[1] = %#v, want text 'answer'", final.Content[1])
+	}
+
+	sawThinking := false
+	for _, e := range events {
+		if _, ok := e.(StreamThinkingEvent); ok {
+			sawThinking = true
+		}
+	}
+	if !sawThinking {
+		t.Error("expected at least one StreamThinkingEvent")
+	}
+}


### PR DESCRIPTION
## Summary
统一 reasoning/thinking 在 OpenAI 与 Anthropic 两种 wire 协议上的接线，修正若干让开源/推理模型降智或被严格网关拒绝的坑：

- **#240** `ThinkingLevel` 现写入请求体：OpenAI → `reasoning_effort`，Anthropic → `thinking:{type:enabled,budget_tokens}`；`off`/unset 仍省略字段，非思考请求形态不变。
- **#241** 多轮 tool-use 回传 Anthropic thinking 块 + signature，thinking 块排在 `tool_use` 之前；redacted 走 `redacted_thinking`。
- **#242** OpenAI 流解码累积 `reasoning_content` / `reasoning` 到 `ThinkingContent` 块（DeepSeek-R1 / Kimi 等），并发 `StreamThinkingEvent`。
- **#243** Anthropic `max_tokens` 兜底改为模型 `MaxOutputTokens`，否则 8192；开启 thinking 时抬高 `max_tokens` 至 `budget+headroom`，保证 `budget_tokens < max_tokens`（否则 400）。
- **#244** tool-call-only assistant 轮发 `content:null`（兼容 vLLM 等严格网关），空 assistant 内容发单空格而非空 text 块。

新增 `internal/provider/thinking_test.go` 覆盖以上编解码路径。

Closes #240
Closes #241
Closes #242
Closes #243
Closes #244

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./internal/provider/...` clean
- [x] `go test ./...` all packages ok
- [x] 新增 8 个单测覆盖 reasoning_effort / thinking 编码、thinking-block echo、reasoning_content 解码、content:null、max_tokens 抬升