### PR TITLE
feat(cli): add --thinking-level flag with layered config resolution

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -46,8 +46,12 @@ type interactiveOptions struct {
 	baseURL      string
 	apiKey       string
 	protocol     string
-	tools        []agentcore.AgentTool
-	sysPrompt    string
+	// thinkingLevel is the resolved reasoning-effort level (US-023): it seeds the
+	// live run config so every REPL turn requests it, until a control command
+	// changes it.
+	thinkingLevel agentcore.ThinkingLevel
+	tools         []agentcore.AgentTool
+	sysPrompt     string
 
 	// resumeID, when non-empty, resumes an existing session: its messages seed
 	// the context and replayed transcript. Otherwise a fresh session is created.
@@ -131,6 +135,7 @@ func runInteractive(opts interactiveOptions) error {
 		provider:      opts.provider,
 		baseURL:       opts.baseURL,
 		protocol:      opts.protocol,
+		thinkingLevel: opts.thinkingLevel,
 		contextWindow: defaultContextWindow,
 	}
 
@@ -338,6 +343,9 @@ type liveRunConfig struct {
 	provider     provider.Provider
 	baseURL      string
 	protocol     string
+	// thinkingLevel is the reasoning-effort level applied to each turn. It is
+	// seeded from the resolved config chain and read by streamRun on every prompt.
+	thinkingLevel agentcore.ThinkingLevel
 	// contextWindow is the model's total context-token budget, used to gate
 	// automatic compaction. When 0 the window is unknown and auto-compaction is
 	// disabled; the REPL seeds it with a conservative default so long sessions

--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -57,6 +57,7 @@ func main() {
 	flag.BoolVar(&opts.noSkills, "no-skills", false, "disable skill discovery (do not load skills under ~/.agents/skills as /skill-name commands)")
 	flag.StringVar(&opts.systemPrompt, "system-prompt", "", "system prompt to use instead of the default coding-assistant prompt (对标 pi --system-prompt)")
 	flag.StringArrayVar(&opts.appendSystemPrompt, "append-system-prompt", nil, "append text or file contents to the system prompt; repeatable (对标 pi --append-system-prompt)")
+	flag.StringVar(&opts.thinkingLevel, "thinking-level", "", "reasoning effort: off|minimal|low|medium|high|xhigh (overrides PIGO_THINKING_LEVEL and config; default medium)")
 	flag.BoolVar(&opts.subagentRPC, "subagent-rpc", false, "internal: run as a process-isolated sub-agent JSON-RPC server over stdio (US-019)")
 	flag.BoolVarP(&opts.showVersion, "version", "v", false, "print version information and exit")
 	// Extend the default pflag usage with a "Supported providers" block so

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -317,6 +317,7 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 		LoopConfig: runtime.LoopConfig{
 			Model:         deps.live.model,
 			Provider:      deps.live.providerName,
+			ThinkingLevel: deps.live.thinkingLevel,
 			Stream:        provider.StreamFnFromProvider(deps.live.provider),
 			GetAPIKey:     deps.creds.GetAPIKey,
 			ContextWindow: deps.live.contextWindow,

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
@@ -128,17 +129,73 @@ func pluginsDir() string {
 	return filepath.Join(dir, "plugins")
 }
 
+// configDir returns the directory pigo reads its global config layer from:
+// $PIGO_HOME, or ~/.pigo by default. An empty string is returned when the home
+// directory cannot be resolved and no override is set (the caller then treats
+// the global layer as absent).
+func configDir() string {
+	dir := os.Getenv("PIGO_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		dir = filepath.Join(home, ".pigo")
+	}
+	return dir
+}
+
+// resolveThinkingLevel resolves the effective reasoning-effort level through the
+// layered config chain (US-023): default < global < project < env < CLI flag.
+// The global layer is $PIGO_HOME/config.json (or ~/.pigo/config.json); the
+// project layer is ./.pigo/config.json in the working directory. A malformed
+// layer file or an invalid resolved value is a hard error, surfaced to the
+// caller for exit-code mapping. cliLevel is the raw --thinking-level flag ("" =
+// unset, so lower layers show through).
+func resolveThinkingLevel(cliLevel string) (agentcore.ThinkingLevel, error) {
+	def := runtime.DefaultConfigLayer()
+	layers := []*runtime.ConfigLayer{&def}
+
+	if dir := configDir(); dir != "" {
+		global, err := runtime.LoadConfigLayer(filepath.Join(dir, "config.json"))
+		if err != nil {
+			return "", err
+		}
+		layers = append(layers, global)
+	}
+	project, err := runtime.LoadConfigLayer(filepath.Join(".pigo", "config.json"))
+	if err != nil {
+		return "", err
+	}
+	layers = append(layers, project)
+
+	env := runtime.EnvConfigLayer(os.Getenv)
+	layers = append(layers, &env)
+
+	if v := strings.TrimSpace(cliLevel); v != "" {
+		cli := runtime.ConfigLayer{ThinkingLevel: &v}
+		layers = append(layers, &cli)
+	}
+
+	cfg, err := runtime.ResolveConfig(layers...)
+	if err != nil {
+		return "", err
+	}
+	return cfg.ThinkingLevel, nil
+}
+
 // newRunConfig builds the loop configuration shared by every driver: the
 // provider stream, the dynamic API-key resolver, and the tool registry. It is
 // the single definition of "how a run is wired", so the REPL (streamRun) and the
 // headless driver cannot drift apart.
-func newRunConfig(model, providerName string, prov provider.Provider, creds *provider.CredentialStore, reg *agenttool.ToolRegistry) runtime.RunConfig {
+func newRunConfig(model, providerName string, thinking agentcore.ThinkingLevel, prov provider.Provider, creds *provider.CredentialStore, reg *agenttool.ToolRegistry) runtime.RunConfig {
 	return runtime.RunConfig{
 		LoopConfig: runtime.LoopConfig{
-			Model:     model,
-			Provider:  providerName,
-			Stream:    provider.StreamFnFromProvider(prov),
-			GetAPIKey: creds.GetAPIKey,
+			Model:         model,
+			Provider:      providerName,
+			ThinkingLevel: thinking,
+			Stream:        provider.StreamFnFromProvider(prov),
+			GetAPIKey:     creds.GetAPIKey,
 		},
 		Batch: agenttool.BatchConfig{
 			ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: reg},
@@ -184,6 +241,11 @@ type cliOptions struct {
 	// #135): pigo reads JSON-RPC sub-agent run requests from stdin and writes
 	// results to stdout. Internal, used by SubAgentTool's process mode.
 	subagentRPC bool
+	// thinkingLevel, when non-empty, is the --thinking-level flag: the reasoning
+	// effort for requests (off|minimal|low|medium|high|xhigh). It is the highest-
+	// precedence layer in resolveThinkingLevel, overriding PIGO_THINKING_LEVEL, the
+	// config files, and the built-in default (medium).
+	thinkingLevel string
 	// showVersion prints build metadata (version/commit/date, injected at release
 	// time by goreleaser) and exits, without running the agent.
 	showVersion bool
@@ -242,19 +304,25 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		if env.plugins != nil {
 			defer env.plugins.Close()
 		}
+		thinking, err := resolveThinkingLevel(opts.thinkingLevel)
+		if err != nil {
+			fmt.Fprintf(errOut, "pigo: %v\n", err)
+			return 2
+		}
 		if err := runInteractive(interactiveOptions{
-			model:        opts.model,
-			providerName: env.providerName,
-			provider:     env.provider,
-			baseURL:      opts.baseURL,
-			apiKey:       opts.apiKey,
-			protocol:     opts.protocol,
-			tools:        env.tools,
-			sysPrompt:    env.sysPrompt,
-			resumeID:     resumeID,
-			approve:      opts.approve,
-			noSkills:     opts.noSkills,
-			plugins:      env.plugins,
+			model:         opts.model,
+			providerName:  env.providerName,
+			provider:      env.provider,
+			baseURL:       opts.baseURL,
+			apiKey:        opts.apiKey,
+			protocol:      opts.protocol,
+			thinkingLevel: thinking,
+			tools:         env.tools,
+			sysPrompt:     env.sysPrompt,
+			resumeID:      resumeID,
+			approve:       opts.approve,
+			noSkills:      opts.noSkills,
+			plugins:       env.plugins,
 		}); err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 1
@@ -298,11 +366,19 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		Tools:        env.tools,
 	}
 
+	// Resolve the effective reasoning-effort level through the layered config
+	// chain (default < global < project < env < --thinking-level flag).
+	thinking, err := resolveThinkingLevel(opts.thinkingLevel)
+	if err != nil {
+		fmt.Fprintf(errOut, "pigo: %v\n", err)
+		return 2
+	}
+
 	// Resolve the API key by provider name from the environment (never logged).
 	// An explicit --api-key overrides env/config for the resolved provider.
 	creds := provider.NewCredentialStore(nil)
 	creds.SetOverride(env.providerName, opts.apiKey)
-	runCfg := newRunConfig(opts.model, env.providerName, env.provider, creds, toolRegistry(env.tools))
+	runCfg := newRunConfig(opts.model, env.providerName, thinking, env.provider, creds, toolRegistry(env.tools))
 	runCfg.SessionID = hs.header.ID
 	cfg := runtime.HeadlessConfig{
 		Mode: mode,

--- a/cmd/pigo/thinking_test.go
+++ b/cmd/pigo/thinking_test.go
@@ -1,0 +1,120 @@
+package main
+
+// Tests for resolveThinkingLevel: the CLI end of the layered config chain
+// (US-023). It resolves the effective reasoning-effort level through
+// default < global ($PIGO_HOME/config.json) < project (./.pigo/config.json)
+// < env (PIGO_THINKING_LEVEL) < --thinking-level flag, and rejects an invalid
+// value. Each test isolates PIGO_HOME and the working directory so it never
+// reads the developer's real config.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// isolateConfig points PIGO_HOME at a temp dir and chdir's into a temp working
+// directory (restored on cleanup), so no real global/project config leaks in.
+func isolateConfig(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+	t.Setenv("PIGO_THINKING_LEVEL", "")
+
+	wd := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(wd); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+	return home
+}
+
+// writeConfig writes a config.json layer with the given thinkingLevel at path.
+func writeConfig(t *testing.T, path, level string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := `{"thinkingLevel":"` + level + `"}`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+// TestResolveThinkingLevelDefault verifies the built-in default (medium) applies
+// when no layer sets a level.
+func TestResolveThinkingLevelDefault(t *testing.T) {
+	isolateConfig(t)
+	got, err := resolveThinkingLevel("")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != agentcore.ThinkingMedium {
+		t.Errorf("level = %q, want medium", got)
+	}
+}
+
+// TestResolveThinkingLevelFlagWins verifies the --thinking-level flag overrides
+// every lower layer (global, project, and env).
+func TestResolveThinkingLevelFlagWins(t *testing.T) {
+	home := isolateConfig(t)
+	writeConfig(t, filepath.Join(home, "config.json"), "low")
+	writeConfig(t, filepath.Join(".pigo", "config.json"), "high")
+	t.Setenv("PIGO_THINKING_LEVEL", "minimal")
+
+	got, err := resolveThinkingLevel("xhigh")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != agentcore.ThinkingXHigh {
+		t.Errorf("level = %q, want xhigh (flag wins)", got)
+	}
+}
+
+// TestResolveThinkingLevelEnvOverProject verifies env beats project, and project
+// beats global (precedence: global < project < env).
+func TestResolveThinkingLevelEnvOverProject(t *testing.T) {
+	home := isolateConfig(t)
+	writeConfig(t, filepath.Join(home, "config.json"), "low")
+	writeConfig(t, filepath.Join(".pigo", "config.json"), "high")
+	t.Setenv("PIGO_THINKING_LEVEL", "off")
+
+	got, err := resolveThinkingLevel("")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != agentcore.ThinkingOff {
+		t.Errorf("level = %q, want off (env over project/global)", got)
+	}
+}
+
+// TestResolveThinkingLevelProjectOverGlobal verifies the project layer overrides
+// the global layer when env and flag are unset.
+func TestResolveThinkingLevelProjectOverGlobal(t *testing.T) {
+	home := isolateConfig(t)
+	writeConfig(t, filepath.Join(home, "config.json"), "low")
+	writeConfig(t, filepath.Join(".pigo", "config.json"), "high")
+
+	got, err := resolveThinkingLevel("")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != agentcore.ThinkingHigh {
+		t.Errorf("level = %q, want high (project over global)", got)
+	}
+}
+
+// TestResolveThinkingLevelInvalid verifies an unknown value is a hard error
+// (surfaced for exit-code mapping), not silently coerced.
+func TestResolveThinkingLevelInvalid(t *testing.T) {
+	isolateConfig(t)
+	if _, err := resolveThinkingLevel("turbo"); err == nil {
+		t.Error("expected error for invalid thinking level, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Add a `--thinking-level` CLI flag (`off|minimal|low|medium|high|xhigh`) to `cmd/pigo`.
- `resolveThinkingLevel` resolves the effective reasoning effort through the layered config chain: **default(medium) < global (`$PIGO_HOME/config.json`) < project (`./.pigo/config.json`) < env (`PIGO_THINKING_LEVEL`) < `--thinking-level` flag**, reusing `runtime.ResolveConfig`.
- Thread the resolved `ThinkingLevel` into `LoopConfig.ThinkingLevel` at both run seams: headless (`newRunConfig`) and REPL (`interactiveOptions` → `liveRunConfig` → `streamRun`).
- Invalid values are a hard error (exit 2), not silently coerced.

Previously the thinking wiring existed in `internal/runtime`/`internal/provider` but `cmd/pigo` never connected it, so neither the flag nor `PIGO_THINKING_LEVEL` had any effect from the CLI.

## Test plan
- [x] `cmd/pigo/thinking_test.go`: default→medium, flag-wins-over-all-layers, env-over-project, project-over-global, invalid-value-errors (each isolates PIGO_HOME + cwd)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] `pigo --help` shows the flag