### PR TITLE
为 bash 工具增加输出字节上限与 head/tail 预览截断

### DIFF
--- a/internal/agenttool/bash_tool.go
+++ b/internal/agenttool/bash_tool.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 )
@@ -22,6 +23,57 @@ const bashDefaultTimeout = 2 * time.Minute
 
 // bashMaxTimeout caps any requested timeout.
 const bashMaxTimeout = 10 * time.Minute
+
+// bashMaxOutputBytes caps how many bytes of combined stdout/stderr the bash tool
+// returns to the model. A single command can emit megabytes (build logs, a big
+// cat), which — unlike the timeout cap — would otherwise flow into context whole
+// and blow the window. Output past this size is truncated to a head + tail
+// preview (see truncateBashOutput), mirroring search's searchMaxResults/"[truncated
+// …]" convention. This is the tool's own inner cap; a later executor-layer budget
+// may impose a stricter outer limit.
+const bashMaxOutputBytes = 30_000
+
+// truncateBashOutput caps s at bashMaxOutputBytes. When s is longer it keeps a
+// head and a tail preview (split evenly) joined by a "[truncated N bytes]" marker,
+// so both the start and the end of the output survive. Cut points are pulled back
+// to UTF-8 rune boundaries so no partial rune is emitted; N counts the raw bytes
+// dropped from the middle.
+func truncateBashOutput(s string) string {
+	if len(s) <= bashMaxOutputBytes {
+		return s
+	}
+	half := bashMaxOutputBytes / 2
+	head := trimUTF8Prefix(s[:half])
+	tail := trimUTF8Suffix(s[len(s)-half:])
+	removed := len(s) - len(head) - len(tail)
+	return head + fmt.Sprintf("\n[truncated %d bytes]\n", removed) + tail
+}
+
+// trimUTF8Prefix drops trailing bytes of s that form an incomplete rune, so the
+// returned prefix ends on a rune boundary.
+func trimUTF8Prefix(s string) string {
+	for len(s) > 0 {
+		if r, size := utf8.DecodeLastRuneInString(s); r == utf8.RuneError && size <= 1 {
+			s = s[:len(s)-1]
+			continue
+		}
+		break
+	}
+	return s
+}
+
+// trimUTF8Suffix drops leading bytes of s that form an incomplete rune, so the
+// returned suffix starts on a rune boundary.
+func trimUTF8Suffix(s string) string {
+	for len(s) > 0 {
+		if r, size := utf8.DecodeRuneInString(s); r == utf8.RuneError && size <= 1 {
+			s = s[1:]
+			continue
+		}
+		break
+	}
+	return s
+}
 
 // BashTool runs shell commands. Dir bounds the working directory (empty = the
 // process CWD). Shell selects the interpreter (empty = "bash -c").
@@ -133,6 +185,11 @@ func (t *BashTool) Execute(ctx context.Context, id string, args json.RawMessage,
 	mu.Lock()
 	output := combined.String()
 	mu.Unlock()
+
+	// Cap the output before it enters any ToolResult / error message, so a single
+	// command's huge output cannot blow the model's context. Truncation keeps a
+	// head + tail preview with a "[truncated N bytes]" marker in the middle.
+	output = truncateBashOutput(output)
 
 	// Context cancellation / timeout takes precedence in the message.
 	if runCtx.Err() == context.DeadlineExceeded {

--- a/internal/agenttool/bash_tool_test.go
+++ b/internal/agenttool/bash_tool_test.go
@@ -3,6 +3,7 @@ package agenttool
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"runtime"
 	"strings"
 	"sync"
@@ -153,3 +154,78 @@ func TestBashToolMode(t *testing.T) {
 		t.Errorf("schema not valid JSON: %v", err)
 	}
 }
+
+func TestBashToolSmallOutputNotTruncated(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash not available on windows")
+	}
+	tool := &BashTool{}
+	res, gerr := runBash(t, tool, map[string]any{"command": "echo hello world"}, nil)
+	if gerr != nil {
+		t.Fatalf("unexpected go error: %v", gerr)
+	}
+	out := resultText(res)
+	if strings.Contains(out, "truncated") {
+		t.Errorf("small output should not be truncated, got %q", out)
+	}
+	if strings.TrimSpace(out) != "hello world" {
+		t.Errorf("output = %q, want %q", out, "hello world")
+	}
+}
+
+func TestBashToolLargeOutputTruncatedHeadTail(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash not available on windows")
+	}
+	tool := &BashTool{}
+	// Emit a marker at the very start and very end, with a large filler between,
+	// so we can prove both the head and the tail survive truncation.
+	total := bashMaxOutputBytes * 3
+	filler := bashMaxOutputBytes // bytes of 'x' between the two markers
+	cmd := fmt.Sprintf("printf 'HEADMARK'; head -c %d /dev/zero | tr '\\0' 'x'; printf 'TAILMARK'", filler)
+	_ = total
+	res, gerr := runBash(t, tool, map[string]any{"command": cmd}, nil)
+	if gerr != nil {
+		t.Fatalf("unexpected go error: %v", gerr)
+	}
+	out := resultText(res)
+	if len(out) > bashMaxOutputBytes+128 {
+		t.Errorf("truncated output too long: %d bytes (cap %d)", len(out), bashMaxOutputBytes)
+	}
+	if !strings.HasPrefix(out, "HEADMARK") {
+		t.Errorf("head not preserved; output starts with %q", out[:min(16, len(out))])
+	}
+	if !strings.HasSuffix(out, "TAILMARK") {
+		t.Errorf("tail not preserved; output ends with %q", out[max(0, len(out)-16):])
+	}
+	if !strings.Contains(out, "[truncated ") || !strings.Contains(out, " bytes]") {
+		t.Errorf("missing truncation marker in %q", out)
+	}
+}
+
+func TestTruncateBashOutputByteCount(t *testing.T) {
+	// A pure-ASCII input of a known size: the marker's N must equal the exact
+	// number of middle bytes dropped, i.e. total - head - tail.
+	total := bashMaxOutputBytes * 2
+	in := strings.Repeat("z", total)
+	out := truncateBashOutput(in)
+
+	half := bashMaxOutputBytes / 2
+	// For all-ASCII input no rune-boundary trimming happens, so head/tail are
+	// each exactly half and N = total - 2*half.
+	wantRemoved := total - 2*half
+	wantMarker := fmt.Sprintf("[truncated %d bytes]", wantRemoved)
+	if !strings.Contains(out, wantMarker) {
+		t.Errorf("marker = ...%q..., want to contain %q", out, wantMarker)
+	}
+	if got := strings.Count(out, "z"); got != 2*half {
+		t.Errorf("preserved %d content bytes, want %d (head+tail)", got, 2*half)
+	}
+
+	// Input at or below the cap is returned verbatim.
+	small := strings.Repeat("b", bashMaxOutputBytes)
+	if got := truncateBashOutput(small); got != small {
+		t.Errorf("input at cap should be unchanged")
+	}
+}
+


### PR DESCRIPTION
## Summary
- 新增 `bashMaxOutputBytes`（30000 字节）包级常量，为 bash 工具输出设置字节上限
- 超限时在结果进入 ToolResult 之前截断为 head + tail 预览，中间以 `[truncated N bytes]` 标注，首尾均保留
- 切点回退到 UTF-8 rune 边界，避免输出半个 rune
- 风格对齐 `search_tool` 的 `searchMaxResults`/`[truncated ...]` 约定

Closes #249

## Test plan
- [x] 小输出不截断
- [x] 大输出截断且保留首尾（HEADMARK/TAILMARK）
- [x] 标注字节数正确（N = total - head - tail）
- [x] go build ./... && go vet ./... && go test ./... 全绿