### PR TITLE
通用 system-reminder 动态上下文注入机制

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -190,6 +190,7 @@ func runInteractive(opts interactiveOptions) error {
 		agentCtx:  agentCtx,
 		live:      live,
 		reg:       reg,
+		reminders: todoReminders(opts.tools),
 		slash:     slash,
 		creds:     creds,
 		trust:     mgr,

--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/provider"
+	"github.com/smallnest/pigo/internal/runtime"
 )
 
 // Build metadata, injected at release time via -ldflags by goreleaser
@@ -281,4 +282,18 @@ func toolRegistry(tools []agentcore.AgentTool) *agenttool.ToolRegistry {
 		_ = reg.Register(t)
 	}
 	return reg
+}
+
+// todoReminders builds the per-turn system-reminder registry for a tool set
+// (US-002): it locates the stateful TodoTool and registers a TodoReminderProvider
+// over its shared store, so the model is reminded of unfinished tasks each turn.
+// Returns nil when no todo tool is present (e.g. --no-tools), leaving injection
+// disabled.
+func todoReminders(tools []agentcore.AgentTool) *runtime.ReminderRegistry {
+	for _, t := range tools {
+		if tt, ok := t.(*agenttool.TodoTool); ok && tt.Store != nil {
+			return runtime.NewReminderRegistry(&runtime.TodoReminderProvider{Store: tt.Store})
+		}
+	}
+	return nil
 }

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -43,8 +43,12 @@ type replDeps struct {
 	agentCtx *agentcore.AgentContext
 	live     *liveRunConfig
 	reg      *agenttool.ToolRegistry
-	slash    *runtime.SlashRegistry
-	creds    *provider.CredentialStore
+	// reminders holds the per-turn system-reminder providers (US-002). It is nil
+	// when no todo tool is present; when set, streamRun wires it so ephemeral
+	// <system-reminder> context is injected into each turn's request.
+	reminders *runtime.ReminderRegistry
+	slash     *runtime.SlashRegistry
+	creds     *provider.CredentialStore
 
 	// notifier delivers agent lifecycle events to subscribed plugins (US-017,
 	// #133). It is nil when no plugin subscribes; DrainStream's OnEvent stays
@@ -329,6 +333,7 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 				BeforeToolCall: trustBeforeToolCall(deps.trust, deps.cwd, deps.in, out, deps.confirmMu),
 			},
 		},
+		Reminders: deps.reminders,
 	}
 	stream := runtime.StartRun(ctx, deps.agentCtx, cfg)
 

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -188,7 +188,7 @@ func resolveThinkingLevel(cliLevel string) (agentcore.ThinkingLevel, error) {
 // provider stream, the dynamic API-key resolver, and the tool registry. It is
 // the single definition of "how a run is wired", so the REPL (streamRun) and the
 // headless driver cannot drift apart.
-func newRunConfig(model, providerName string, thinking agentcore.ThinkingLevel, prov provider.Provider, creds *provider.CredentialStore, reg *agenttool.ToolRegistry) runtime.RunConfig {
+func newRunConfig(model, providerName string, thinking agentcore.ThinkingLevel, prov provider.Provider, creds *provider.CredentialStore, reg *agenttool.ToolRegistry, reminders *runtime.ReminderRegistry) runtime.RunConfig {
 	return runtime.RunConfig{
 		LoopConfig: runtime.LoopConfig{
 			Model:         model,
@@ -200,6 +200,7 @@ func newRunConfig(model, providerName string, thinking agentcore.ThinkingLevel, 
 		Batch: agenttool.BatchConfig{
 			ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: reg},
 		},
+		Reminders: reminders,
 	}
 }
 
@@ -378,7 +379,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 	// An explicit --api-key overrides env/config for the resolved provider.
 	creds := provider.NewCredentialStore(nil)
 	creds.SetOverride(env.providerName, opts.apiKey)
-	runCfg := newRunConfig(opts.model, env.providerName, thinking, env.provider, creds, toolRegistry(env.tools))
+	runCfg := newRunConfig(opts.model, env.providerName, thinking, env.provider, creds, toolRegistry(env.tools), todoReminders(env.tools))
 	runCfg.SessionID = hs.header.ID
 	cfg := runtime.HeadlessConfig{
 		Mode: mode,

--- a/internal/runtime/loop.go
+++ b/internal/runtime/loop.go
@@ -68,6 +68,12 @@ type RunConfig struct {
 	// agent_end event (FR-7).
 	ShouldStopAfterTurn func(ctx context.Context, agentCtx *agentcore.AgentContext) bool
 
+	// Reminders holds the per-turn system-reminder providers (US-002, FR-1/FR-2).
+	// When non-empty, ephemeral <system-reminder> messages are injected into each
+	// turn's LLM request through the existing TransformContext seam, so they never
+	// enter the persisted history. nil / empty = no injection.
+	Reminders *ReminderRegistry
+
 	// EventBuffer is the buffer size of the emitted EventStream. 0 gives fully
 	// synchronous back-pressure (matching pi's awaited emit).
 	EventBuffer int
@@ -103,6 +109,13 @@ func StartRun(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConf
 // runLoop is the producer: it drives the two-layer loop, emitting events onto
 // stream and setting the stream result to the messages produced during the run.
 func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfig, stream *LoopEventStream) {
+	// Wire per-turn system-reminder injection (US-002) onto the TransformContext
+	// seam. Reminders are appended to the request-shaped copy only, so they stay
+	// ephemeral: never written back to agentCtx.Messages, never persisted, never
+	// swept into a compaction summary.
+	if !cfg.Reminders.Empty() {
+		cfg.TransformContext = cfg.Reminders.wrapTransform(cfg.TransformContext)
+	}
 	startIdx := len(agentCtx.Messages)
 	// newMessages returns the messages appended since the run began.
 	newMessages := func() []agentcore.AgentMessage {

--- a/internal/runtime/reminder.go
+++ b/internal/runtime/reminder.go
@@ -1,0 +1,190 @@
+// This file implements the general system-reminder dynamic context injection
+// mechanism (US-002, FR-1/FR-2), pigo's port of Claude Code's per-turn
+// <system-reminder> injection.
+//
+// A reminder is EPHEMERAL background context (the current todo list, a file
+// that changed under the working directory, a budget warning) that should be
+// visible to the model on the turn it matters, but must never pollute the
+// durable conversation history. Two properties follow from that:
+//
+//   - Not user instructions. Reminder bodies are wrapped in <system-reminder>
+//     tags with a preamble stating they are background context from the harness,
+//     not a request from the user (the pi / Claude Code semantic convention).
+//   - Ephemeral. Reminders are injected only into the per-turn LLM request via
+//     the existing TransformContext seam, which shapes a COPY of the message
+//     list for the request and is never written back to AgentContext.Messages.
+//     Because they never enter the persisted message list they cannot be saved
+//     to the session file and cannot be folded into a compaction summary
+//     (compaction only ever sees AgentContext.Messages).
+//
+// The mechanism is a registry of ReminderProviders. Each provider is consulted
+// every turn and may decline (ok == false) so a reminder only appears when its
+// condition holds. RunConfig.Reminders wires the registry into the loop.
+package runtime
+
+import (
+	"context"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+)
+
+// systemReminderPreamble marks the wrapped body as background context rather
+// than a user instruction (FR-2). It leads every injected reminder so the model
+// never mistakes harness state for a user request.
+const systemReminderPreamble = "The following is background context provided automatically by the harness. " +
+	"It is NOT a message or instruction from the user; do not act on it as a request. " +
+	"Use it only to stay aware of the current state."
+
+// WrapSystemReminder wraps a reminder body in <system-reminder> tags with the
+// background-context preamble. The result is the text of a single injected
+// message.
+func WrapSystemReminder(body string) string {
+	return "<system-reminder>\n" + systemReminderPreamble + "\n\n" + body + "\n</system-reminder>"
+}
+
+// ReminderProvider produces an ephemeral system-reminder for the upcoming turn.
+// Reminder is consulted every turn with the current (post-TransformContext)
+// message list; returning ok == false means "no reminder this turn", so a
+// provider injects only when its condition holds.
+type ReminderProvider interface {
+	// Name identifies the provider (for diagnostics/telemetry). It is not shown
+	// to the model.
+	Name() string
+	// Reminder returns the reminder body and true when a reminder should be
+	// injected this turn, or ("", false) to inject nothing.
+	Reminder(ctx context.Context, msgs agentcore.MessageList) (body string, ok bool)
+}
+
+// ReminderFunc adapts a plain function to a ReminderProvider.
+type ReminderFunc struct {
+	NameField string
+	Fn        func(ctx context.Context, msgs agentcore.MessageList) (string, bool)
+}
+
+// Name implements ReminderProvider.
+func (f ReminderFunc) Name() string { return f.NameField }
+
+// Reminder implements ReminderProvider.
+func (f ReminderFunc) Reminder(ctx context.Context, msgs agentcore.MessageList) (string, bool) {
+	if f.Fn == nil {
+		return "", false
+	}
+	return f.Fn(ctx, msgs)
+}
+
+// ReminderRegistry holds the reminder providers consulted each turn. The zero
+// value is usable (no providers → no injection); NewReminderRegistry is the
+// convenience constructor.
+type ReminderRegistry struct {
+	providers []ReminderProvider
+}
+
+// NewReminderRegistry returns a registry pre-populated with providers.
+func NewReminderRegistry(providers ...ReminderProvider) *ReminderRegistry {
+	r := &ReminderRegistry{}
+	for _, p := range providers {
+		r.Register(p)
+	}
+	return r
+}
+
+// Register appends a provider. nil providers are ignored.
+func (r *ReminderRegistry) Register(p ReminderProvider) {
+	if p == nil {
+		return
+	}
+	r.providers = append(r.providers, p)
+}
+
+// Empty reports whether the registry has no providers (so callers can skip the
+// injection wiring entirely).
+func (r *ReminderRegistry) Empty() bool { return r == nil || len(r.providers) == 0 }
+
+// Messages consults every provider in registration order and returns the
+// ephemeral reminder messages to inject this turn (one UserMessage per provider
+// that fires). Reminders are modeled as user-role messages carrying
+// <system-reminder>-wrapped text — matching the pi / Claude Code convention
+// where dynamic context enters through a user turn but is explicitly labeled as
+// background context, not a user instruction.
+func (r *ReminderRegistry) Messages(ctx context.Context, msgs agentcore.MessageList) []agentcore.AgentMessage {
+	if r.Empty() {
+		return nil
+	}
+	var out []agentcore.AgentMessage
+	for _, p := range r.providers {
+		body, ok := p.Reminder(ctx, msgs)
+		if !ok || body == "" {
+			continue
+		}
+		out = append(out, agentcore.UserMessage{
+			RoleField: agentcore.RoleUser,
+			Content:   agentcore.ContentList{agentcore.NewTextContent(WrapSystemReminder(body))},
+		})
+	}
+	return out
+}
+
+// wrapTransform composes the registry into a TransformContext hook: it runs the
+// caller's existing TransformContext (if any) first, then appends this turn's
+// reminders to the shaped list. Because TransformContext output is used only to
+// build the LLM request and is never written back to AgentContext.Messages, the
+// appended reminders are ephemeral — they do not enter the persisted history and
+// cannot be swept into a compaction summary. This is the single injection seam
+// the loop wires in.
+func (r *ReminderRegistry) wrapTransform(
+	inner func(ctx context.Context, msgs agentcore.MessageList) agentcore.MessageList,
+) func(ctx context.Context, msgs agentcore.MessageList) agentcore.MessageList {
+	return func(ctx context.Context, msgs agentcore.MessageList) agentcore.MessageList {
+		if inner != nil {
+			msgs = inner(ctx, msgs)
+		}
+		rem := r.Messages(ctx, msgs)
+		if len(rem) == 0 {
+			return msgs
+		}
+		out := make(agentcore.MessageList, 0, len(msgs)+len(rem))
+		out = append(out, msgs...)
+		out = append(out, rem...)
+		return out
+	}
+}
+
+// TodoReminderProvider is the built-in reference reminder provider (US-002): it
+// surfaces the current todo list as background context whenever there is
+// incomplete work, so the model is reminded of outstanding tasks each turn
+// without the list having to be re-sent as a durable message. It reads the same
+// TodoStore the todo tool writes, so the reminder always reflects the latest
+// plan. When the list is empty or every item is completed it stays silent.
+type TodoReminderProvider struct {
+	// Store is the session todo list. When nil the provider never fires.
+	Store *agenttool.TodoStore
+}
+
+// Name implements ReminderProvider.
+func (p *TodoReminderProvider) Name() string { return "todo" }
+
+// Reminder implements ReminderProvider. It fires only when the store holds at
+// least one item that is not yet completed, keeping the condition deterministic
+// and easy to test.
+func (p *TodoReminderProvider) Reminder(ctx context.Context, _ agentcore.MessageList) (string, bool) {
+	if p.Store == nil {
+		return "", false
+	}
+	items := p.Store.Snapshot()
+	if len(items) == 0 {
+		return "", false
+	}
+	incomplete := false
+	for _, it := range items {
+		if it.Status != agenttool.TodoCompleted {
+			incomplete = true
+			break
+		}
+	}
+	if !incomplete {
+		return "", false
+	}
+	return "Your todo list has unfinished items. Keep it up to date with the todo tool.\n\n" +
+		agenttool.RenderTodoList(items), true
+}

--- a/internal/runtime/reminder_test.go
+++ b/internal/runtime/reminder_test.go
@@ -1,0 +1,168 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+// wrapStreamCapture wraps a StreamFn to record every text-block message the
+// request carried into seen, so a test can assert what the model was sent.
+func wrapStreamCapture(inner provider.StreamFn, seen *[]string) provider.StreamFn {
+	return func(ctx context.Context, model string, llm provider.LlmContext, cfg provider.StreamConfig) (*provider.AssistantMessageEventStream, error) {
+		for _, m := range llm.Messages {
+			if um, ok := m.(agentcore.UserMessage); ok {
+				*seen = append(*seen, agentcore.ContentToText(um.Content))
+			}
+		}
+		return inner(ctx, model, llm, cfg)
+	}
+}
+
+// reminderTextsInRequest drives one turn and returns the <system-reminder>
+// message texts the provider stream actually received (the request-shaped list),
+// so a test can assert what the model saw without touching persisted state.
+func reminderTextsInRequest(t *testing.T, reg *ReminderRegistry, agentCtx *agentcore.AgentContext) []string {
+	t.Helper()
+	var seen []string
+	streamFn := scriptedStream([]agentcore.AssistantMessage{
+		{RoleField: agentcore.RoleAssistant, StopReason: agentcore.StopReasonEndTurn, Content: agentcore.ContentList{agentcore.NewTextContent("ok")}},
+	})
+	// Wrap the stream so we can inspect the LlmContext it is handed.
+	cfg := newRunCfg(nil)
+	cfg.Reminders = reg
+	cfg.LoopConfig.Stream = wrapStreamCapture(streamFn, &seen)
+	collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+	return seen
+}
+
+func TestWrapSystemReminderLabelsBackgroundContext(t *testing.T) {
+	out := WrapSystemReminder("body here")
+	if !strings.Contains(out, "<system-reminder>") || !strings.Contains(out, "</system-reminder>") {
+		t.Errorf("reminder must be wrapped in <system-reminder> tags, got %q", out)
+	}
+	if !strings.Contains(out, "NOT a message or instruction from the user") {
+		t.Errorf("reminder must be labeled as background context, not a user instruction, got %q", out)
+	}
+	if !strings.Contains(out, "body here") {
+		t.Errorf("reminder must contain the body, got %q", out)
+	}
+}
+
+func TestReminderInjectedWhenConditionHolds(t *testing.T) {
+	fired := ReminderFunc{NameField: "always", Fn: func(ctx context.Context, msgs agentcore.MessageList) (string, bool) {
+		return "budget is low", true
+	}}
+	reg := NewReminderRegistry(fired)
+	agentCtx := &agentcore.AgentContext{Messages: agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser}}}
+
+	seen := reminderTextsInRequest(t, reg, agentCtx)
+	found := false
+	for _, s := range seen {
+		if strings.Contains(s, "budget is low") && strings.Contains(s, "<system-reminder>") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a system-reminder in the request, saw %v", seen)
+	}
+	// Ephemeral: the reminder must NOT be written back into the persisted history.
+	for _, m := range agentCtx.Messages {
+		if um, ok := m.(agentcore.UserMessage); ok {
+			if strings.Contains(agentcore.ContentToText(um.Content), "system-reminder") {
+				t.Errorf("reminder leaked into persisted message history: %+v", um)
+			}
+		}
+	}
+}
+
+func TestReminderNotInjectedWhenConditionFails(t *testing.T) {
+	silent := ReminderFunc{NameField: "never", Fn: func(ctx context.Context, msgs agentcore.MessageList) (string, bool) {
+		return "", false
+	}}
+	reg := NewReminderRegistry(silent)
+	agentCtx := &agentcore.AgentContext{Messages: agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser}}}
+
+	seen := reminderTextsInRequest(t, reg, agentCtx)
+	for _, s := range seen {
+		if strings.Contains(s, "system-reminder") {
+			t.Errorf("no reminder should be injected when the provider declines, saw %q", s)
+		}
+	}
+}
+
+func TestReminderPreservesInnerTransform(t *testing.T) {
+	var innerRan bool
+	reg := NewReminderRegistry(ReminderFunc{NameField: "always", Fn: func(ctx context.Context, msgs agentcore.MessageList) (string, bool) {
+		return "note", true
+	}})
+	inner := func(ctx context.Context, msgs agentcore.MessageList) agentcore.MessageList {
+		innerRan = true
+		return msgs
+	}
+	wrapped := reg.wrapTransform(inner)
+	out := wrapped(context.Background(), agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser}})
+	if !innerRan {
+		t.Errorf("wrapTransform must call the inner TransformContext")
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected original + 1 reminder message, got %d", len(out))
+	}
+}
+
+func TestTodoReminderProvider(t *testing.T) {
+	store := agenttool.NewTodoStore()
+	p := &TodoReminderProvider{Store: store}
+
+	// Empty store: silent.
+	if _, ok := p.Reminder(context.Background(), nil); ok {
+		t.Errorf("empty todo store must not fire a reminder")
+	}
+
+	// All completed: silent.
+	store.Set([]agenttool.TodoItem{{Content: "done", Status: agenttool.TodoCompleted}})
+	if _, ok := p.Reminder(context.Background(), nil); ok {
+		t.Errorf("fully-completed todo list must not fire a reminder")
+	}
+
+	// Incomplete work: fires with the rendered list.
+	store.Set([]agenttool.TodoItem{
+		{Content: "write code", Status: agenttool.TodoInProgress},
+		{Content: "review", Status: agenttool.TodoPending},
+	})
+	body, ok := p.Reminder(context.Background(), nil)
+	if !ok {
+		t.Fatalf("incomplete todo list must fire a reminder")
+	}
+	if !strings.Contains(body, "write code") || !strings.Contains(body, "review") {
+		t.Errorf("reminder body should render the todo items, got %q", body)
+	}
+
+	// nil store: never fires.
+	nilP := &TodoReminderProvider{}
+	if _, ok := nilP.Reminder(context.Background(), nil); ok {
+		t.Errorf("nil todo store must not fire a reminder")
+	}
+}
+
+func TestTodoReminderEndToEndInjection(t *testing.T) {
+	store := agenttool.NewTodoStore()
+	store.Set([]agenttool.TodoItem{{Content: "unfinished task", Status: agenttool.TodoInProgress}})
+	reg := NewReminderRegistry(&TodoReminderProvider{Store: store})
+	agentCtx := &agentcore.AgentContext{Messages: agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser}}}
+
+	seen := reminderTextsInRequest(t, reg, agentCtx)
+	found := false
+	for _, s := range seen {
+		if strings.Contains(s, "unfinished task") && strings.Contains(s, "<system-reminder>") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("todo reminder should be injected into the request, saw %v", seen)
+	}
+}


### PR DESCRIPTION
## Summary
- 新增 `internal/runtime/reminder.go`：`ReminderProvider` 注册表，每轮经现有 `TransformContext` seam 注入 `<system-reminder>` 包裹的易失背景上下文
- 注入内容带背景上下文前缀（明确非用户指令，FR-2），且不污染持久化会话历史、不进入压缩摘要（FR-1）
- 内置 `TodoReminderProvider` 参考实现：仅在存在未完成待办时触发
- 单测证明满足条件注入、不满足不注入

Closes #248

## Test plan
- [x] go build ./... 通过
- [x] go vet ./... 通过
- [x] go test ./... 全部通过