### PR TITLE
tool executor 层统一工具结果裁剪预算

### DIFF
--- a/internal/agenttool/bash_tool.go
+++ b/internal/agenttool/bash_tool.go
@@ -33,20 +33,12 @@ const bashMaxTimeout = 10 * time.Minute
 // may impose a stricter outer limit.
 const bashMaxOutputBytes = 30_000
 
-// truncateBashOutput caps s at bashMaxOutputBytes. When s is longer it keeps a
-// head and a tail preview (split evenly) joined by a "[truncated N bytes]" marker,
-// so both the start and the end of the output survive. Cut points are pulled back
-// to UTF-8 rune boundaries so no partial rune is emitted; N counts the raw bytes
-// dropped from the middle.
+// truncateBashOutput caps s at bashMaxOutputBytes using the shared
+// truncateToBudget idiom (head + "[truncated N bytes]" marker + tail, cut on
+// UTF-8 rune boundaries). It is the bash tool's own inner cap; the executor
+// layer applies a separate, uniform outer budget afterward.
 func truncateBashOutput(s string) string {
-	if len(s) <= bashMaxOutputBytes {
-		return s
-	}
-	half := bashMaxOutputBytes / 2
-	head := trimUTF8Prefix(s[:half])
-	tail := trimUTF8Suffix(s[len(s)-half:])
-	removed := len(s) - len(head) - len(tail)
-	return head + fmt.Sprintf("\n[truncated %d bytes]\n", removed) + tail
+	return truncateToBudget(s, bashMaxOutputBytes)
 }
 
 // trimUTF8Prefix drops trailing bytes of s that form an incomplete rune, so the

--- a/internal/agenttool/tool_executor.go
+++ b/internal/agenttool/tool_executor.go
@@ -14,9 +14,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 )
+
+// toolResultMaxBytes is the executor-layer budget for a single tool result's
+// combined text, applied uniformly to EVERY tool right before its result enters
+// the AgentToolResult / message list. Individual tools also impose their own,
+// stricter inner caps (read: readToolMaxLines, search: searchMaxResults,
+// webfetch: webFetchMaxBytes, bash: bashMaxOutputBytes); those still run first
+// and clip a tool below this outer budget. This budget is the last line of
+// defense so a tool with no (or a looser) inner cap cannot blow the model's
+// context. Override per-executor via ToolExecutorConfig.MaxResultBytes.
+const toolResultMaxBytes = 100_000
 
 // ToolExecutorConfig holds the registry and the optional per-phase hooks. Every
 // hook is optional (nil = default behavior).
@@ -25,6 +36,10 @@ type ToolExecutorConfig struct {
 	PrepareArguments agentcore.PrepareArgumentsFunc
 	BeforeToolCall   agentcore.BeforeToolCallFunc
 	AfterToolCall    agentcore.AfterToolCallFunc
+	// MaxResultBytes overrides the executor-layer per-result text budget. Zero
+	// (the default) uses toolResultMaxBytes; a negative value disables the
+	// budget entirely.
+	MaxResultBytes int
 }
 
 // executeToolCall runs one tool call through prepare → execute → finalize and
@@ -149,6 +164,11 @@ func finalizeToolCall(ctx context.Context, cfg ToolExecutorConfig, call agentcor
 		}
 	}
 
+	// Result-shaping seam: every tool's output funnels through here before it
+	// becomes a ToolResultMessage, so this is the single point where the
+	// executor-layer byte budget is enforced uniformly for ALL tools.
+	result.Content = clipToolResultContent(result.Content, cfg.MaxResultBytes)
+
 	if emit != nil {
 		_ = emit(ctx, agentcore.ToolExecutionEndEvent{ToolCallID: call.ID, ToolName: call.Name, Result: result, IsError: isError})
 	}
@@ -167,6 +187,67 @@ func finalizeToolCall(ctx context.Context, cfg ToolExecutorConfig, call agentcor
 // errorResult builds an error AgentToolResult carrying a single text block.
 func errorResult(msg string) agentcore.AgentToolResult {
 	return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent(msg)}}
+}
+
+// clipToolResultContent enforces the executor-layer byte budget on a tool
+// result's text, uniformly for every tool. budget<=0 with the sentinel meaning:
+// 0 => toolResultMaxBytes default, <0 => disabled. Non-text blocks (e.g. images)
+// pass through untouched and keep their order; the combined text of all text
+// blocks is measured against the budget and, when over, collapsed into a single
+// truncated text block via truncateToBudget (head + "[truncated N bytes]" +
+// tail, matching the bash idiom). Per-tool inner caps have already run, so this
+// only bites when a tool's own cap is looser or absent.
+func clipToolResultContent(content agentcore.ContentList, cfgMax int) agentcore.ContentList {
+	budget := cfgMax
+	if budget == 0 {
+		budget = toolResultMaxBytes
+	}
+	if budget < 0 {
+		return content
+	}
+
+	total := 0
+	textBlocks := 0
+	for _, c := range content {
+		if t, ok := c.(agentcore.TextContent); ok {
+			total += len(t.Text)
+			textBlocks++
+		}
+	}
+	if textBlocks == 0 || total <= budget {
+		return content
+	}
+
+	// Over budget: gather all text (in order) and non-text blocks separately,
+	// then emit the non-text blocks followed by one truncated text block.
+	var sb strings.Builder
+	out := make(agentcore.ContentList, 0, len(content))
+	for _, c := range content {
+		if t, ok := c.(agentcore.TextContent); ok {
+			sb.WriteString(t.Text)
+			continue
+		}
+		out = append(out, c)
+	}
+	out = append(out, agentcore.NewTextContent(truncateToBudget(sb.String(), budget)))
+	return out
+}
+
+// truncateToBudget caps s at budget bytes. When s is longer it keeps a head and
+// a tail preview (split evenly) joined by a "[truncated N bytes]" marker, so
+// both the start and the end of the text survive. Cut points are pulled back to
+// UTF-8 rune boundaries so no partial rune is emitted; N counts the raw bytes
+// dropped from the middle. This is the single shared truncation idiom reused by
+// both the bash tool's inner cap and the executor-layer budget.
+func truncateToBudget(s string, budget int) string {
+	if budget <= 0 || len(s) <= budget {
+		return s
+	}
+	half := budget / 2
+	head := trimUTF8Prefix(s[:half])
+	tail := trimUTF8Suffix(s[len(s)-half:])
+	removed := len(s) - len(head) - len(tail)
+	return head + fmt.Sprintf("\n[truncated %d bytes]\n", removed) + tail
 }
 
 // decodeArgs unmarshals a tool's JSON arguments into T. On failure it returns an

--- a/internal/agenttool/tool_executor_test.go
+++ b/internal/agenttool/tool_executor_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/smallnest/pigo/internal/agentcore"
@@ -187,5 +189,86 @@ func TestExecutorAbortedContext(t *testing.T) {
 	msg, _ := executeToolCall(ctx, cfg, agentcore.AgentToolCall{ID: "1", Name: "echo"}, nil)
 	if !msg.IsError {
 		t.Fatalf("aborted call should be error result: %+v", msg)
+	}
+}
+
+// TestExecutorResultBudget proves the executor-layer byte budget applies to any
+// tool: a stub tool emitting output larger than the budget gets its result text
+// truncated with an accurate "[truncated N bytes]" marker, while a small output
+// is left untouched.
+func TestExecutorResultBudget(t *testing.T) {
+	const budget = 1000
+	big := strings.Repeat("A", budget) + strings.Repeat("B", budget) // 2*budget bytes
+	tool := execTool{name: "flood", run: func(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+		return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent(big)}}, nil
+	}}
+	cfg := newExecCfg(t, tool)
+	cfg.MaxResultBytes = budget
+
+	msg, _ := executeToolCall(context.Background(), cfg, agentcore.AgentToolCall{ID: "1", Name: "flood"}, nil)
+	got := textOf(msg)
+	if len(got) >= len(big) {
+		t.Fatalf("output not truncated: len=%d, original=%d", len(got), len(big))
+	}
+	half := budget / 2
+	removed := len(big) - 2*half
+	marker := fmt.Sprintf("\n[truncated %d bytes]\n", removed)
+	if !strings.Contains(got, marker) {
+		t.Fatalf("missing/incorrect truncation marker %q in output %q", marker, got)
+	}
+	want := big[:half] + marker + big[len(big)-half:]
+	if got != want {
+		t.Fatalf("truncated output mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+// TestExecutorResultBudgetSmallOutputUntouched proves outputs within budget are
+// passed through verbatim.
+func TestExecutorResultBudgetSmallOutputUntouched(t *testing.T) {
+	small := "just a little output"
+	tool := execTool{name: "tiny", run: func(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+		return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent(small)}}, nil
+	}}
+	cfg := newExecCfg(t, tool)
+	cfg.MaxResultBytes = 1000
+
+	msg, _ := executeToolCall(context.Background(), cfg, agentcore.AgentToolCall{ID: "1", Name: "tiny"}, nil)
+	if got := textOf(msg); got != small {
+		t.Fatalf("small output altered: got=%q want=%q", got, small)
+	}
+}
+
+// TestExecutorResultBudgetDefault proves the default (zero MaxResultBytes) uses
+// toolResultMaxBytes and truncates output beyond it.
+func TestExecutorResultBudgetDefault(t *testing.T) {
+	big := strings.Repeat("x", toolResultMaxBytes+5000)
+	tool := execTool{name: "flood", run: func(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+		return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent(big)}}, nil
+	}}
+	cfg := newExecCfg(t, tool) // MaxResultBytes == 0 -> default
+
+	msg, _ := executeToolCall(context.Background(), cfg, agentcore.AgentToolCall{ID: "1", Name: "flood"}, nil)
+	got := textOf(msg)
+	if !strings.Contains(got, "[truncated ") {
+		t.Fatalf("default budget did not truncate: len=%d", len(got))
+	}
+	if len(got) > toolResultMaxBytes+64 {
+		t.Fatalf("default-truncated output too large: %d", len(got))
+	}
+}
+
+// TestExecutorResultBudgetDisabled proves a negative MaxResultBytes disables the
+// budget entirely.
+func TestExecutorResultBudgetDisabled(t *testing.T) {
+	big := strings.Repeat("y", toolResultMaxBytes*2)
+	tool := execTool{name: "flood", run: func(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+		return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent(big)}}, nil
+	}}
+	cfg := newExecCfg(t, tool)
+	cfg.MaxResultBytes = -1
+
+	msg, _ := executeToolCall(context.Background(), cfg, agentcore.AgentToolCall{ID: "1", Name: "flood"}, nil)
+	if got := textOf(msg); got != big {
+		t.Fatalf("disabled budget altered output: len=%d want=%d", len(got), len(big))
 	}
 }


### PR DESCRIPTION
## Summary
- 在 `finalizeToolCall` 结果整形 seam 引入统一单条工具结果字节预算 `const toolResultMaxBytes = 100_000`，对所有工具生效
- `ToolExecutorConfig.MaxResultBytes` 可覆盖（0=默认，<0=禁用），经嵌入被 `BatchConfig` 继承
- 单点 helper `clipToolResultContent` + `truncateToBudget`：提取 bash 的 head+tail+`[truncated N bytes]` 幂等 idiom（UTF-8 边界安全）
- 各工具特化上限（read 行数 / search 条数 / webfetch 字节 / bash 字节）作为更严格内层约束仍先生效，executor 预算为统一外层兜底
- 单测用 flood 桩工具驱动 executor：覆盖 override 预算（精确标注/字节断言）、小输出直通、默认预算、禁用预算

Closes #250

## Test plan
- [x] go build ./... 通过
- [x] go vet ./... 通过
- [x] go test ./... 全部通过