### PR TITLE
结构化 harness 遥测采集

### DIFF
--- a/internal/agentcore/event.go
+++ b/internal/agentcore/event.go
@@ -23,6 +23,7 @@ const (
 	EventToolExecutionUpdate = "tool_execution_update"
 	EventToolExecutionEnd    = "tool_execution_end"
 	EventCompaction          = "compaction"
+	EventTelemetry           = "telemetry"
 )
 
 // AgentStartEvent is emitted once when a loop run begins. SessionID, when set,
@@ -111,6 +112,48 @@ type CompactionEvent struct {
 	ErrorMessage string
 }
 
+// ToolTiming records how long one tool invocation took, keyed by tool name in
+// TelemetryEvent.ToolDurationsMs. It aggregates repeated calls of the same tool
+// so a summary stays compact regardless of turn count.
+type ToolTiming struct {
+	// Count is how many times the tool was invoked over the run.
+	Count int
+	// TotalMs is the summed wall-clock duration of every invocation, in
+	// milliseconds.
+	TotalMs int64
+}
+
+// TelemetryEvent is a lightweight, additive observability summary emitted once
+// at run end (just before agent_end) so scripts consuming the stream-json
+// output can read structured metrics without a new dependency (no
+// Prometheus/OTLP). It is purely observational: consumers that ignore it behave
+// exactly as before. Metrics covered (可观测性——结构化遥测采集):
+//   - per-tool wall-clock durations (ToolDurationsMs, aggregated by tool name),
+//   - how many turns ran (Turns),
+//   - how many assistant responses were truncated by the output cap
+//     (TruncationCount),
+//   - how many times the context was compacted (CompactionCount),
+//   - the latest context-utilization ratio (ContextUtilization = used tokens /
+//     ContextWindow) and the raw numbers behind it.
+type TelemetryEvent struct {
+	// Turns is the number of turns (turn_start events) the run executed.
+	Turns int
+	// ToolDurationsMs maps a tool name to its aggregated timing over the run.
+	ToolDurationsMs map[string]ToolTiming
+	// TruncationCount is how many assistant responses stopped with reason
+	// "length" (truncated by the output token cap), each triggering a resend.
+	TruncationCount int
+	// CompactionCount is how many successful context compactions occurred.
+	CompactionCount int
+	// ContextUtilization is the latest used/window ratio in [0,1], or 0 when the
+	// context window is unknown. Computed as ContextTokens / ContextWindow.
+	ContextUtilization float64
+	// ContextTokens is the most recently observed estimated context-token usage.
+	ContextTokens int
+	// ContextWindow is the model's total context-token budget (0 when unknown).
+	ContextWindow int
+}
+
 func (AgentStartEvent) isAgentEvent()          {}
 func (AgentEndEvent) isAgentEvent()            {}
 func (TurnStartEvent) isAgentEvent()           {}
@@ -122,6 +165,7 @@ func (ToolExecutionStartEvent) isAgentEvent()  {}
 func (ToolExecutionUpdateEvent) isAgentEvent() {}
 func (ToolExecutionEndEvent) isAgentEvent()    {}
 func (CompactionEvent) isAgentEvent()          {}
+func (TelemetryEvent) isAgentEvent()           {}
 
 func (AgentStartEvent) EventType() string          { return EventAgentStart }
 func (AgentEndEvent) EventType() string            { return EventAgentEnd }
@@ -134,3 +178,4 @@ func (ToolExecutionStartEvent) EventType() string  { return EventToolExecutionSt
 func (ToolExecutionUpdateEvent) EventType() string { return EventToolExecutionUpdate }
 func (ToolExecutionEndEvent) EventType() string    { return EventToolExecutionEnd }
 func (CompactionEvent) EventType() string          { return EventCompaction }
+func (TelemetryEvent) EventType() string           { return EventTelemetry }

--- a/internal/runtime/headless.go
+++ b/internal/runtime/headless.go
@@ -202,6 +202,22 @@ func eventEnvelope(ev agentcore.AgentEvent) map[string]any {
 		if e.ErrorMessage != "" {
 			env["error"] = e.ErrorMessage
 		}
+	case agentcore.TelemetryEvent:
+		// The run-end telemetry summary: structured metrics a script can read
+		// directly from the stream-json output (可观测性——结构化遥测采集). Per-tool
+		// timings are flattened into a name→{count,totalMs} object so a JSON
+		// consumer can index by tool name.
+		env["turns"] = e.Turns
+		env["truncationCount"] = e.TruncationCount
+		env["compactionCount"] = e.CompactionCount
+		env["contextUtilization"] = e.ContextUtilization
+		env["contextTokens"] = e.ContextTokens
+		env["contextWindow"] = e.ContextWindow
+		tools := make(map[string]map[string]any, len(e.ToolDurationsMs))
+		for name, t := range e.ToolDurationsMs {
+			tools[name] = map[string]any{"count": t.Count, "totalMs": t.TotalMs}
+		}
+		env["toolDurationsMs"] = tools
 	}
 	return env
 }

--- a/internal/runtime/loop.go
+++ b/internal/runtime/loop.go
@@ -117,6 +117,10 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 		cfg.TransformContext = cfg.Reminders.wrapTransform(cfg.TransformContext)
 	}
 	startIdx := len(agentCtx.Messages)
+	// tel accumulates structured telemetry (turn count, per-tool durations,
+	// truncation count, compaction count, latest context-utilization ratio) from
+	// the events emitted below, surfaced as a TelemetryEvent at run end.
+	tel := newTelemetry()
 	// newMessages returns the messages appended since the run began.
 	newMessages := func() []agentcore.AgentMessage {
 		if len(agentCtx.Messages) <= startIdx {
@@ -126,11 +130,24 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 		copy(out, agentCtx.Messages[startIdx:])
 		return out
 	}
-	emit := func(ev agentcore.AgentEvent) error { return stream.Emit(ctx, ev) }
+	emit := func(ev agentcore.AgentEvent) error {
+		tel.observe(ev)
+		return stream.Emit(ctx, ev)
+	}
+	// emitFrom wraps the raw stream.Emit callback handed to streamAssistantResponse
+	// and ExecuteToolCalls so telemetry observes those events (message_* and
+	// tool_execution_*) too, without changing their signatures.
+	emitFrom := func(c context.Context, ev agentcore.AgentEvent) error {
+		tel.observe(ev)
+		return stream.Emit(c, ev)
+	}
 
-	// finish emits agent_end (unless suppressed by a prior emit error), records
-	// the run result, and closes the stream exactly once.
+	// finish emits the telemetry summary then agent_end (unless suppressed by a
+	// prior emit error), records the run result, and closes the stream exactly
+	// once. Telemetry is emitted first so a consumer sees the run's structured
+	// metrics immediately before the terminal event.
 	finish := func() {
+		_ = emit(tel.summary())
 		msgs := newMessages()
 		_ = emit(agentcore.AgentEndEvent{Messages: msgs})
 		stream.SetResult(msgs)
@@ -149,9 +166,7 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 				return
 			}
 
-			assistant, err := streamAssistantResponse(ctx, agentCtx, cfg.LoopConfig, func(c context.Context, ev agentcore.AgentEvent) error {
-				return stream.Emit(c, ev)
-			})
+			assistant, err := streamAssistantResponse(ctx, agentCtx, cfg.LoopConfig, emitFrom)
 			if err != nil {
 				// emit was cancelled mid-stream; end the run.
 				finish()
@@ -167,7 +182,7 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 					finish()
 					return
 				}
-				if afterTurn(ctx, agentCtx, &cfg, true, emit) {
+				if afterTurn(ctx, agentCtx, &cfg, true, emit, tel) {
 					finish()
 					return
 				}
@@ -186,16 +201,14 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 					finish()
 					return
 				}
-				if afterTurn(ctx, agentCtx, &cfg, false, emit) {
+				if afterTurn(ctx, agentCtx, &cfg, false, emit, tel) {
 					finish()
 					return
 				}
 				break // exit inner loop → consult follow-up messages
 			}
 
-			toolResults, allTerminate := agenttool.ExecuteToolCalls(ctx, cfg.Batch, calls, func(c context.Context, ev agentcore.AgentEvent) error {
-				return stream.Emit(c, ev)
-			})
+			toolResults, allTerminate := agenttool.ExecuteToolCalls(ctx, cfg.Batch, calls, emitFrom)
 			for _, tr := range toolResults {
 				agentCtx.Messages = append(agentCtx.Messages, tr)
 			}
@@ -208,7 +221,7 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 				finish()
 				return
 			}
-			if afterTurn(ctx, agentCtx, &cfg, true, emit) {
+			if afterTurn(ctx, agentCtx, &cfg, true, emit, tel) {
 				finish()
 				return
 			}
@@ -233,7 +246,7 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 // (pi per-turn semantics). It then applies prepareNextTurn, runs auto-compaction
 // when the context has outgrown its window, and finally consults
 // shouldStopAfterTurn, returning true when the run should end.
-func afterTurn(ctx context.Context, agentCtx *agentcore.AgentContext, cfg *RunConfig, hadToolExecution bool, emit func(agentcore.AgentEvent) error) (stop bool) {
+func afterTurn(ctx context.Context, agentCtx *agentcore.AgentContext, cfg *RunConfig, hadToolExecution bool, emit func(agentcore.AgentEvent) error, tel *telemetry) (stop bool) {
 	if hadToolExecution && cfg.GetSteeringMessages != nil {
 		if steer := cfg.GetSteeringMessages(ctx); len(steer) > 0 {
 			agentCtx.Messages = append(agentCtx.Messages, steer...)
@@ -244,7 +257,15 @@ func afterTurn(ctx context.Context, agentCtx *agentcore.AgentContext, cfg *RunCo
 			applyTurnUpdate(agentCtx, cfg, upd)
 		}
 	}
-	maybeAutoCompact(ctx, agentCtx, cfg, emit)
+	maybeAutoCompact(ctx, agentCtx, cfg, emit, tel)
+	// Record the latest context-utilization ratio once the turn has settled (after
+	// any compaction), so the telemetry summary reports the current used/window
+	// figure. This runs even when auto-compaction is disabled so utilization is
+	// still observable whenever the context window is known.
+	if tel != nil && cfg.ContextWindow > 0 {
+		tokens := compaction.EstimateContextTokens(agentCtx.Messages).Tokens
+		tel.recordContext(tokens, cfg.ContextWindow)
+	}
 	if cfg.ShouldStopAfterTurn != nil {
 		return cfg.ShouldStopAfterTurn(ctx, agentCtx)
 	}
@@ -257,11 +278,17 @@ func afterTurn(ctx context.Context, agentCtx *agentcore.AgentContext, cfg *RunCo
 // under threshold. A compaction failure is non-fatal: the original context is
 // preserved and a CompactionEvent carrying ErrorMessage is emitted so the failure
 // is observable without aborting the run (US-004).
-func maybeAutoCompact(ctx context.Context, agentCtx *agentcore.AgentContext, cfg *RunConfig, emit func(agentcore.AgentEvent) error) {
+func maybeAutoCompact(ctx context.Context, agentCtx *agentcore.AgentContext, cfg *RunConfig, emit func(agentcore.AgentEvent) error, tel *telemetry) {
 	if !cfg.Compaction.Enabled || cfg.ContextWindow <= 0 {
 		return
 	}
 	before := compaction.EstimateContextTokens(agentCtx.Messages).Tokens
+	// Record pre-compaction utilization so the ratio reflects the peak that
+	// triggered (or nearly triggered) compaction even when the summary is read
+	// mid-run. afterTurn overwrites it with the post-settle figure.
+	if tel != nil {
+		tel.recordContext(before, cfg.ContextWindow)
+	}
 	if !compaction.ShouldCompact(before, cfg.ContextWindow, cfg.Compaction) {
 		return
 	}

--- a/internal/runtime/loop_test.go
+++ b/internal/runtime/loop_test.go
@@ -74,7 +74,7 @@ func TestAgentLoopNoToolCallsSingleTurn(t *testing.T) {
 
 	kinds, msgs := collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
 
-	want := []string{agentcore.EventAgentStart, agentcore.EventTurnStart, agentcore.EventMessageEnd, agentcore.EventTurnEnd, agentcore.EventAgentEnd}
+	want := []string{agentcore.EventAgentStart, agentcore.EventTurnStart, agentcore.EventMessageEnd, agentcore.EventTurnEnd, agentcore.EventTelemetry, agentcore.EventAgentEnd}
 	assertEventKinds(t, kinds, want)
 	if len(msgs) != 1 {
 		t.Fatalf("run produced %d messages, want 1: %+v", len(msgs), msgs)

--- a/internal/runtime/telemetry.go
+++ b/internal/runtime/telemetry.go
@@ -1,0 +1,137 @@
+// This file implements structured telemetry collection for a loop run (可观测性
+// ——结构化遥测采集). A lightweight accumulator observes the AgentEvents the loop
+// already emits and folds them into a compact summary — per-tool wall-clock
+// durations, turn count, truncation count, compaction count, and the latest
+// context-utilization ratio — that is surfaced once at run end as a
+// TelemetryEvent (just before agent_end).
+//
+// The design is deliberately additive: telemetry rides the existing AgentEvent
+// family and the existing stream-json output path, so no new dependency
+// (Prometheus/OTLP) is introduced and existing stream-json consumers that do
+// not know the "telemetry" event type keep working unchanged. Collection is
+// passive — observing an event never changes loop behavior.
+package runtime
+
+import (
+	"sync"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// telemetry is the per-run accumulator. Most fields are folded from events on
+// the single runLoop goroutine, but tool_execution_* events fire from the
+// parallel tool-batch goroutines (ExecuteToolCalls), so all mutation goes
+// through mu.
+type telemetry struct {
+	mu              sync.Mutex
+	turns           int
+	truncationCount int
+	compactionCount int
+
+	// toolStarts maps an in-flight tool call id to the wall-clock time its
+	// execution began, so the matching end event can compute a duration. Keying
+	// by call id (not tool name) keeps parallel tool batches correct.
+	toolStarts map[string]time.Time
+	// toolTimings aggregates finished tool durations by tool name.
+	toolTimings map[string]agentcore.ToolTiming
+
+	// contextTokens / contextWindow capture the most recent context accounting so
+	// the summary can report the latest utilization ratio. contextWindow == 0
+	// means the window is unknown (utilization is then reported as 0).
+	contextTokens int
+	contextWindow int
+
+	// now is the clock, injectable for deterministic tests. Defaults to
+	// time.Now.
+	now func() time.Time
+}
+
+// newTelemetry constructs an empty accumulator using the wall clock.
+func newTelemetry() *telemetry {
+	return &telemetry{
+		toolStarts:  make(map[string]time.Time),
+		toolTimings: make(map[string]agentcore.ToolTiming),
+		now:         time.Now,
+	}
+}
+
+// observe folds a single emitted event into the accumulator. It is a no-op for
+// event types that carry no telemetry signal, and it never mutates the event.
+func (t *telemetry) observe(ev agentcore.AgentEvent) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	switch e := ev.(type) {
+	case agentcore.TurnStartEvent:
+		t.turns++
+	case agentcore.ToolExecutionStartEvent:
+		t.toolStarts[e.ToolCallID] = t.now()
+	case agentcore.ToolExecutionEndEvent:
+		start, ok := t.toolStarts[e.ToolCallID]
+		if !ok {
+			return
+		}
+		delete(t.toolStarts, e.ToolCallID)
+		elapsed := t.now().Sub(start).Milliseconds()
+		if elapsed < 0 {
+			elapsed = 0
+		}
+		agg := t.toolTimings[e.ToolName]
+		agg.Count++
+		agg.TotalMs += elapsed
+		t.toolTimings[e.ToolName] = agg
+	case agentcore.TurnEndEvent:
+		if e.Message.StopReason == agentcore.StopReasonLength {
+			t.truncationCount++
+		}
+	case agentcore.CompactionEvent:
+		// Count only successful compactions; a failed one (ErrorMessage set) left
+		// the context unchanged.
+		if e.ErrorMessage == "" {
+			t.compactionCount++
+		}
+	}
+}
+
+// recordContext captures the latest context-token usage and window so the
+// summary can report the current utilization ratio. A non-positive window is
+// treated as unknown.
+func (t *telemetry) recordContext(tokens, window int) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.contextTokens = tokens
+	if window > 0 {
+		t.contextWindow = window
+	}
+}
+
+// summary materializes the accumulated metrics into a TelemetryEvent. The
+// per-tool map is copied so the emitted event does not alias the accumulator's
+// live state.
+func (t *telemetry) summary() agentcore.TelemetryEvent {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	timings := make(map[string]agentcore.ToolTiming, len(t.toolTimings))
+	for name, v := range t.toolTimings {
+		timings[name] = v
+	}
+	var utilization float64
+	if t.contextWindow > 0 {
+		utilization = float64(t.contextTokens) / float64(t.contextWindow)
+	}
+	return agentcore.TelemetryEvent{
+		Turns:              t.turns,
+		ToolDurationsMs:    timings,
+		TruncationCount:    t.truncationCount,
+		CompactionCount:    t.compactionCount,
+		ContextUtilization: utilization,
+		ContextTokens:      t.contextTokens,
+		ContextWindow:      t.contextWindow,
+	}
+}

--- a/internal/runtime/telemetry_test.go
+++ b/internal/runtime/telemetry_test.go
@@ -1,0 +1,276 @@
+package runtime
+
+// Tests for structured telemetry collection (可观测性——结构化遥测采集, node-251):
+// the loop accumulates per-tool durations, turn count, truncation count,
+// compaction count, and the latest context-utilization ratio, then surfaces
+// them as a TelemetryEvent emitted just before agent_end. Both the unit-level
+// accumulator and the end-to-end loop wiring (including the stream-json
+// headless surface a script reads) are covered.
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/compaction"
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+// fakeClock returns a now() closure that advances by step on every call, so a
+// tool_execution_start/end pair yields a deterministic non-zero duration.
+func fakeClock(start time.Time, step time.Duration) func() time.Time {
+	cur := start
+	return func() time.Time {
+		t := cur
+		cur = cur.Add(step)
+		return t
+	}
+}
+
+// findTelemetry returns the first TelemetryEvent emitted, or nil.
+func findTelemetry(events []agentcore.AgentEvent) *agentcore.TelemetryEvent {
+	for _, ev := range events {
+		if te, ok := ev.(agentcore.TelemetryEvent); ok {
+			return &te
+		}
+	}
+	return nil
+}
+
+// TestTelemetryObserveToolTiming verifies a start/end pair records an aggregated
+// per-tool duration, and repeated calls accumulate count and total.
+func TestTelemetryObserveToolTiming(t *testing.T) {
+	tel := newTelemetry()
+	tel.now = fakeClock(time.Unix(0, 0), 5*time.Millisecond)
+
+	// Two invocations of "echo": each start advances the clock 5ms, each end
+	// advances another 5ms, so each invocation measures 5ms.
+	for _, id := range []string{"c1", "c2"} {
+		tel.observe(agentcore.ToolExecutionStartEvent{ToolCallID: id, ToolName: "echo"})
+		tel.observe(agentcore.ToolExecutionEndEvent{ToolCallID: id, ToolName: "echo"})
+	}
+
+	sum := tel.summary()
+	got, ok := sum.ToolDurationsMs["echo"]
+	if !ok {
+		t.Fatalf("expected timing for tool echo, got %+v", sum.ToolDurationsMs)
+	}
+	if got.Count != 2 {
+		t.Errorf("echo count = %d, want 2", got.Count)
+	}
+	if got.TotalMs != 10 {
+		t.Errorf("echo totalMs = %d, want 10", got.TotalMs)
+	}
+}
+
+// TestTelemetryObserveCounters verifies turn/truncation/compaction counters and
+// that a failed compaction is not counted.
+func TestTelemetryObserveCounters(t *testing.T) {
+	tel := newTelemetry()
+	tel.observe(agentcore.TurnStartEvent{})
+	tel.observe(agentcore.TurnStartEvent{})
+	tel.observe(agentcore.TurnEndEvent{Message: agentcore.AssistantMessage{StopReason: agentcore.StopReasonLength}})
+	tel.observe(agentcore.TurnEndEvent{Message: agentcore.AssistantMessage{StopReason: agentcore.StopReasonEndTurn}})
+	tel.observe(agentcore.CompactionEvent{}) // success
+	tel.observe(agentcore.CompactionEvent{ErrorMessage: "boom"}) // failure, not counted
+
+	sum := tel.summary()
+	if sum.Turns != 2 {
+		t.Errorf("turns = %d, want 2", sum.Turns)
+	}
+	if sum.TruncationCount != 1 {
+		t.Errorf("truncationCount = %d, want 1", sum.TruncationCount)
+	}
+	if sum.CompactionCount != 1 {
+		t.Errorf("compactionCount = %d, want 1 (failed compaction must not count)", sum.CompactionCount)
+	}
+}
+
+// TestTelemetryContextUtilization verifies the ratio is used/window and is 0
+// when the window is unknown.
+func TestTelemetryContextUtilization(t *testing.T) {
+	tel := newTelemetry()
+	tel.recordContext(500, 2000)
+	if got := tel.summary().ContextUtilization; got != 0.25 {
+		t.Errorf("utilization = %v, want 0.25", got)
+	}
+
+	unknown := newTelemetry()
+	unknown.recordContext(500, 0)
+	if got := unknown.summary().ContextUtilization; got != 0 {
+		t.Errorf("utilization with unknown window = %v, want 0", got)
+	}
+}
+
+// TestLoopEmitsTelemetryBeforeAgentEnd verifies the loop emits exactly one
+// telemetry event immediately before agent_end and that it captures a tool
+// execution.
+func TestLoopEmitsTelemetryBeforeAgentEnd(t *testing.T) {
+	cfg := newRunCfg(scriptedStream([]agentcore.AssistantMessage{
+		oneToolAssistant("c1", "echo"),
+		{RoleField: agentcore.RoleAssistant, StopReason: agentcore.StopReasonEndTurn, Content: agentcore.ContentList{agentcore.NewTextContent("done")}},
+	}), echoTool("echo", agentcore.ToolExecutionParallel, false))
+	agentCtx := &agentcore.AgentContext{Messages: agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser}}}
+
+	events := collectEvents(t, agentLoop(context.Background(), agentCtx, cfg))
+
+	te := findTelemetry(events)
+	if te == nil {
+		t.Fatalf("expected a TelemetryEvent, got %+v", eventKinds(events))
+	}
+	// Telemetry must be the penultimate event, immediately before agent_end.
+	if n := len(events); n < 2 || events[n-1].EventType() != agentcore.EventAgentEnd || events[n-2].EventType() != agentcore.EventTelemetry {
+		t.Errorf("telemetry must be emitted just before agent_end, got %v", eventKinds(events))
+	}
+	if te.Turns != 2 {
+		t.Errorf("telemetry turns = %d, want 2", te.Turns)
+	}
+	if _, ok := te.ToolDurationsMs["echo"]; !ok {
+		t.Errorf("telemetry should record the echo tool timing, got %+v", te.ToolDurationsMs)
+	}
+	if te.ToolDurationsMs["echo"].Count != 1 {
+		t.Errorf("echo count = %d, want 1", te.ToolDurationsMs["echo"].Count)
+	}
+}
+
+// TestLoopTelemetryCountsCompaction verifies a compaction that fires during the
+// run increments the telemetry compaction counter and records a non-zero
+// context-utilization ratio.
+func TestLoopTelemetryCountsCompaction(t *testing.T) {
+	main := scriptedStream([]agentcore.AssistantMessage{
+		{RoleField: agentcore.RoleAssistant, StopReason: agentcore.StopReasonEndTurn, Content: agentcore.ContentList{agentcore.NewTextContent("ok")}},
+	})
+	cfg := newRunCfg(main)
+	cfg.SummaryStream = summaryStream("## Goal\ncompacted")
+	cfg.ContextWindow = 2000
+	cfg.Compaction = compaction.CompactionSettings{Enabled: true, ReserveTokens: 500, KeepRecentTokens: 100}
+	agentCtx := &agentcore.AgentContext{Messages: bigUserMessages(12, 800)}
+
+	events := collectEvents(t, agentLoop(context.Background(), agentCtx, cfg))
+	te := findTelemetry(events)
+	if te == nil {
+		t.Fatal("expected a TelemetryEvent")
+	}
+	if te.CompactionCount != 1 {
+		t.Errorf("telemetry compactionCount = %d, want 1", te.CompactionCount)
+	}
+	if te.ContextWindow != 2000 {
+		t.Errorf("telemetry contextWindow = %d, want 2000", te.ContextWindow)
+	}
+	if te.ContextUtilization <= 0 {
+		t.Errorf("telemetry contextUtilization = %v, want > 0", te.ContextUtilization)
+	}
+}
+
+// TestLoopTelemetryCountsTruncation verifies a length-truncated assistant
+// response increments the telemetry truncation counter.
+func TestLoopTelemetryCountsTruncation(t *testing.T) {
+	truncated := oneToolAssistant("c1", "echo")
+	truncated.StopReason = agentcore.StopReasonLength
+	cfg := newRunCfg(scriptedStream([]agentcore.AssistantMessage{
+		truncated,
+		{RoleField: agentcore.RoleAssistant, StopReason: agentcore.StopReasonEndTurn},
+	}), echoTool("echo", agentcore.ToolExecutionParallel, false))
+	agentCtx := &agentcore.AgentContext{Messages: agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser}}}
+
+	events := collectEvents(t, agentLoop(context.Background(), agentCtx, cfg))
+	te := findTelemetry(events)
+	if te == nil {
+		t.Fatal("expected a TelemetryEvent")
+	}
+	if te.TruncationCount != 1 {
+		t.Errorf("telemetry truncationCount = %d, want 1", te.TruncationCount)
+	}
+}
+
+// TestTelemetryEventEnvelope verifies the stream-json envelope carries every
+// telemetry field, including a name-keyed per-tool timings object, so a script
+// can read the metrics directly (headless surface, acceptance criterion 3).
+func TestTelemetryEventEnvelope(t *testing.T) {
+	env := eventEnvelope(agentcore.TelemetryEvent{
+		Turns:              3,
+		TruncationCount:    1,
+		CompactionCount:    2,
+		ContextUtilization: 0.5,
+		ContextTokens:      1000,
+		ContextWindow:      2000,
+		ToolDurationsMs:    map[string]agentcore.ToolTiming{"echo": {Count: 2, TotalMs: 40}},
+	})
+	if env["type"] != agentcore.EventTelemetry {
+		t.Errorf("type = %v, want %q", env["type"], agentcore.EventTelemetry)
+	}
+	if env["turns"] != 3 || env["truncationCount"] != 1 || env["compactionCount"] != 2 {
+		t.Errorf("counter fields wrong: %+v", env)
+	}
+	if env["contextUtilization"] != 0.5 || env["contextTokens"] != 1000 || env["contextWindow"] != 2000 {
+		t.Errorf("context fields wrong: %+v", env)
+	}
+	tools, ok := env["toolDurationsMs"].(map[string]map[string]any)
+	if !ok {
+		t.Fatalf("toolDurationsMs type = %T, want map[string]map[string]any", env["toolDurationsMs"])
+	}
+	if tools["echo"]["count"] != 2 || tools["echo"]["totalMs"] != int64(40) {
+		t.Errorf("echo timing wrong: %+v", tools["echo"])
+	}
+}
+
+// TestHeadlessStreamJSONSurfacesTelemetry verifies the run-end telemetry summary
+// reaches the stream-json headless output as a parseable JSON line — the
+// script-readable metric surface required by acceptance criterion 3.
+func TestHeadlessStreamJSONSurfacesTelemetry(t *testing.T) {
+	p := &fauxProvider{
+		name:   "faux",
+		models: []provider.Model{{Provider: "faux", ID: "faux"}},
+		turns: []fauxTurn{
+			toolCallTurn("call-1", "echo", `{"msg":"hi"}`),
+			textTurn("done"),
+		},
+	}
+	cfg := newFauxRunCfg(p, echoTool("echo", agentcore.ToolExecutionParallel, false))
+	var out bytes.Buffer
+	agentCtx := &agentcore.AgentContext{Messages: agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("start")}}}}
+
+	if err := RunHeadless(context.Background(), agentCtx, HeadlessConfig{Run: cfg, Mode: StreamJSONMode, Out: &out}); err != nil {
+		t.Fatalf("RunHeadless stream-json: %v", err)
+	}
+
+	var telemetryLine map[string]any
+	sc := bufio.NewScanner(&out)
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var env map[string]any
+		if err := json.Unmarshal(line, &env); err != nil {
+			t.Fatalf("stream-json line not valid JSON: %q (%v)", line, err)
+		}
+		if env["type"] == agentcore.EventTelemetry {
+			telemetryLine = env
+		}
+	}
+	if telemetryLine == nil {
+		t.Fatal("stream-json output must contain a telemetry event a script can read")
+	}
+	// turns is a JSON number; a script would read it as float64.
+	if turns, ok := telemetryLine["turns"].(float64); !ok || turns < 2 {
+		t.Errorf("telemetry turns = %v, want >= 2", telemetryLine["turns"])
+	}
+	tools, ok := telemetryLine["toolDurationsMs"].(map[string]any)
+	if !ok || tools["echo"] == nil {
+		t.Errorf("telemetry must report the echo tool timing, got %v", telemetryLine["toolDurationsMs"])
+	}
+}
+
+// eventKinds maps events to their type strings for readable failure output.
+func eventKinds(events []agentcore.AgentEvent) []string {
+	out := make([]string, len(events))
+	for i, ev := range events {
+		out[i] = ev.EventType()
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- 新增 `internal/runtime/telemetry.go`：轻量 per-run 累加器被动观测循环已发出的 `AgentEvent`，折叠出轮次数、按工具名聚合的工具耗时、截断次数（length stop）、成功压缩次数、最新上下文占用率（used/window）
- 新增 additive 的 `agentcore.TelemetryEvent`（事件类型 `telemetry`），在 `agent_end` 前发出一次
- headless stream-json 序列化该事件（含 `toolDurationsMs` name→{count,totalMs} 映射），脚本可直接读取
- 不引入新依赖（无 Prometheus/OTLP），向后兼容旧 stream-json 消费者
- 单测：累加器单测 + 端到端 loop 测试（telemetry 在 agent_end 前发出、工具耗时/压缩/截断计数）+ headless stream-json 可读性测试

Closes #251

## Test plan
- [x] go build ./... 通过
- [x] go vet ./... 通过
- [x] go test ./... 全部通过（含 -race）