### PR TITLE
工具执行失败的分类与有限重试

### DIFF
--- a/internal/agenttool/tool_executor.go
+++ b/internal/agenttool/tool_executor.go
@@ -40,6 +40,11 @@ type ToolExecutorConfig struct {
 	// (the default) uses toolResultMaxBytes; a negative value disables the
 	// budget entirely.
 	MaxResultBytes int
+	// MaxToolRetries overrides the number of RETRIES for a transient tool error
+	// (see isRetryableToolError). Zero (the default) uses maxToolRetries; a
+	// negative value disables retrying (a single attempt). Mirrors the
+	// MaxResultBytes sentinel convention.
+	MaxToolRetries int
 }
 
 // executeToolCall runs one tool call through prepare → execute → finalize and
@@ -61,7 +66,7 @@ func executeToolCall(ctx context.Context, cfg ToolExecutorConfig, call agentcore
 			return errorToolResult(call, "aborted before execution: "+err.Error()), false
 		}
 	}
-	result, isError := runTool(ctx, tool, call, args, emit)
+	result, isError := runToolWithRetry(ctx, cfg, tool, call, args, emit)
 
 	// 3. finalize: afterToolCall overrides.
 	return finalizeToolCall(ctx, cfg, call, result, isError, emit)
@@ -119,12 +124,55 @@ func prepareToolCall(ctx context.Context, cfg ToolExecutorConfig, call agentcore
 	return tool, args, nil, false
 }
 
-// runTool executes the tool, converting a returned error or a panic into an
-// error result instead of propagating it (FR: never panic).
-func runTool(ctx context.Context, tool agentcore.AgentTool, call agentcore.AgentToolCall, args json.RawMessage, emit agentcore.EmitFunc) (result agentcore.AgentToolResult, isError bool) {
+// runToolWithRetry wraps runTool with the classified, bounded retry policy at
+// the single tool-execution seam so EVERY tool gets uniform resilience. It only
+// retries when runTool surfaces a non-nil Go error (transport/agent-error path)
+// AND isRetryableToolError says that error is transient; a (result, nil) is
+// done regardless of the result's IsError flag (a tool's own terminal result is
+// never retried). Retries are capped by toolRetryCap and separated by a small
+// backoff. Context cancellation short-circuits immediately: a cancelled/expired
+// outer ctx is never retried.
+func runToolWithRetry(ctx context.Context, cfg ToolExecutorConfig, tool agentcore.AgentTool, call agentcore.AgentToolCall, args json.RawMessage, emit agentcore.EmitFunc) (agentcore.AgentToolResult, bool) {
+	retryCap := toolRetryCap(cfg.MaxToolRetries)
+
+	var lastResult agentcore.AgentToolResult
+	var lastIsError bool
+	for attempt := 0; attempt <= retryCap; attempt++ {
+		result, err, isError := runTool(ctx, tool, call, args, emit)
+		if err == nil {
+			// Execute returned (result, nil): terminal success regardless of
+			// the result's own IsError flag. Done, no retry.
+			return result, isError
+		}
+
+		lastResult, lastIsError = result, isError
+
+		// Do not retry if the outer context is done (Canceled or its deadline
+		// has passed) — a dead context means stop.
+		if ctx.Err() != nil {
+			break
+		}
+		// Only transient errors are retried, and only if we have budget left.
+		if attempt >= retryCap || !isRetryableToolError(err) {
+			break
+		}
+		// Small backoff; abort the wait early if ctx dies mid-sleep.
+		if !waitToolRetryBackoff(ctx, attempt) {
+			break
+		}
+	}
+	return lastResult, lastIsError
+}
+
+// runTool executes the tool, recovering a panic into an error. It returns the
+// shaped error result, the raw error (nil on success), and the isError flag.
+// The raw error is surfaced so the caller can classify it for retry; on success
+// err is nil even if the result itself carries IsError semantics.
+func runTool(ctx context.Context, tool agentcore.AgentTool, call agentcore.AgentToolCall, args json.RawMessage, emit agentcore.EmitFunc) (result agentcore.AgentToolResult, rawErr error, isError bool) {
 	defer func() {
 		if r := recover(); r != nil {
 			result = errorResult(fmt.Sprintf("tool %q panicked: %v", call.Name, r))
+			rawErr = toolPanic{value: r}
 			isError = true
 		}
 	}()
@@ -138,9 +186,9 @@ func runTool(ctx context.Context, tool agentcore.AgentTool, call agentcore.Agent
 
 	res, err := tool.Execute(ctx, call.ID, args, onUpdate)
 	if err != nil {
-		return errorResult(fmt.Sprintf("tool %q failed: %v", call.Name, err)), true
+		return errorResult(fmt.Sprintf("tool %q failed: %v", call.Name, err)), err, true
 	}
-	return res, false
+	return res, nil, false
 }
 
 // finalizeToolCall applies the afterToolCall hook (field-level override, no deep

--- a/internal/agenttool/tool_executor_test.go
+++ b/internal/agenttool/tool_executor_test.go
@@ -5,7 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"os"
 	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
 
 	"github.com/smallnest/pigo/internal/agentcore"
@@ -272,3 +276,190 @@ func TestExecutorResultBudgetDisabled(t *testing.T) {
 		t.Fatalf("disabled budget altered output: len=%d want=%d", len(got), len(big))
 	}
 }
+
+// --- Tool-execution retry (node #252) ---------------------------------------
+
+// countingTool returns a transient error for its first failN attempts, then
+// succeeds; if failN < 0 it always fails. It records how many times Execute ran.
+type retryStub struct {
+	failN   int   // number of leading failures before success; <0 = always fail
+	err     error // error to return on a failing attempt
+	attempts int32
+}
+
+func (s *retryStub) run(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+	n := atomic.AddInt32(&s.attempts, 1)
+	if s.failN < 0 || int(n) <= s.failN {
+		return agentcore.AgentToolResult{}, s.err
+	}
+	return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent("ok")}}, nil
+}
+
+func newRetryCfg(t *testing.T, name string, s *retryStub) ToolExecutorConfig {
+	t.Helper()
+	return newExecCfg(t, execTool{name: name, run: s.run})
+}
+
+func TestExecutorRetryTransientThenSuccess(t *testing.T) {
+	// Fails 2 times with a transient error, then succeeds. With the default cap
+	// (2 retries = 3 attempts) this should ultimately succeed on attempt 3.
+	s := &retryStub{failN: 2, err: syscall.ECONNRESET}
+	cfg := newRetryCfg(t, "flaky", s)
+	msg, _ := executeToolCall(context.Background(), cfg, agentcore.AgentToolCall{ID: "1", Name: "flaky"}, nil)
+	if msg.IsError {
+		t.Fatalf("expected eventual success, got error: %q", textOf(msg))
+	}
+	if got := atomic.LoadInt32(&s.attempts); got != 3 {
+		t.Fatalf("expected 3 attempts (2 retries), got %d", got)
+	}
+}
+
+func TestExecutorRetryCapExhausted(t *testing.T) {
+	// Always fails with a transient error: must stop after maxToolRetries+1
+	// attempts (default cap) and give up with an error result.
+	s := &retryStub{failN: -1, err: syscall.ETIMEDOUT}
+	cfg := newRetryCfg(t, "always", s)
+	msg, _ := executeToolCall(context.Background(), cfg, agentcore.AgentToolCall{ID: "1", Name: "always"}, nil)
+	if !msg.IsError {
+		t.Fatalf("expected error result after exhausting retries: %+v", msg)
+	}
+	want := int32(maxToolRetries + 1)
+	if got := atomic.LoadInt32(&s.attempts); got != want {
+		t.Fatalf("expected %d attempts, got %d", want, got)
+	}
+}
+
+func TestExecutorRetryTerminalNoRetry(t *testing.T) {
+	// A terminal (non-transient) error must be tried exactly once.
+	s := &retryStub{failN: -1, err: errors.New("invalid argument: bad")}
+	cfg := newRetryCfg(t, "terminal", s)
+	msg, _ := executeToolCall(context.Background(), cfg, agentcore.AgentToolCall{ID: "1", Name: "terminal"}, nil)
+	if !msg.IsError {
+		t.Fatalf("expected error result: %+v", msg)
+	}
+	if got := atomic.LoadInt32(&s.attempts); got != 1 {
+		t.Fatalf("terminal error must not retry: got %d attempts", got)
+	}
+}
+
+func TestExecutorRetryDisabled(t *testing.T) {
+	// MaxToolRetries < 0 disables retry even for a transient error.
+	s := &retryStub{failN: -1, err: syscall.ECONNRESET}
+	cfg := newRetryCfg(t, "notretry", s)
+	cfg.MaxToolRetries = -1
+	msg, _ := executeToolCall(context.Background(), cfg, agentcore.AgentToolCall{ID: "1", Name: "notretry"}, nil)
+	if !msg.IsError {
+		t.Fatalf("expected error result: %+v", msg)
+	}
+	if got := atomic.LoadInt32(&s.attempts); got != 1 {
+		t.Fatalf("disabled retry must try once: got %d attempts", got)
+	}
+}
+
+func TestExecutorRetryCustomCap(t *testing.T) {
+	// A custom positive cap is honored: always-failing transient error stops at
+	// cap+1 attempts.
+	s := &retryStub{failN: -1, err: syscall.EAGAIN}
+	cfg := newRetryCfg(t, "custom", s)
+	cfg.MaxToolRetries = 4
+	msg, _ := executeToolCall(context.Background(), cfg, agentcore.AgentToolCall{ID: "1", Name: "custom"}, nil)
+	if !msg.IsError {
+		t.Fatalf("expected error result: %+v", msg)
+	}
+	if got := atomic.LoadInt32(&s.attempts); got != 5 {
+		t.Fatalf("expected 5 attempts (cap 4), got %d", got)
+	}
+}
+
+func TestExecutorRetryCanceledContextNoRetry(t *testing.T) {
+	// context.Canceled surfaced by the tool must never be retried.
+	s := &retryStub{failN: -1, err: context.Canceled}
+	cfg := newRetryCfg(t, "cancel", s)
+	msg, _ := executeToolCall(context.Background(), cfg, agentcore.AgentToolCall{ID: "1", Name: "cancel"}, nil)
+	if !msg.IsError {
+		t.Fatalf("expected error result: %+v", msg)
+	}
+	if got := atomic.LoadInt32(&s.attempts); got != 1 {
+		t.Fatalf("context.Canceled must not retry: got %d attempts", got)
+	}
+}
+
+func TestExecutorRetryStopsWhenOuterCtxCanceled(t *testing.T) {
+	// If the outer ctx is cancelled during execution, retries stop even though
+	// the returned error is transient.
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &retryStub{failN: -1, err: syscall.ECONNRESET}
+	tool := execTool{name: "abortmid", run: func(c context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+		atomic.AddInt32(&s.attempts, 1)
+		cancel() // outer ctx dies after the first attempt
+		return agentcore.AgentToolResult{}, syscall.ECONNRESET
+	}}
+	cfg := newExecCfg(t, tool)
+	msg, _ := executeToolCall(ctx, cfg, agentcore.AgentToolCall{ID: "1", Name: "abortmid"}, nil)
+	if !msg.IsError {
+		t.Fatalf("expected error result: %+v", msg)
+	}
+	if got := atomic.LoadInt32(&s.attempts); got != 1 {
+		t.Fatalf("cancelled outer ctx must stop retry: got %d attempts", got)
+	}
+}
+
+func TestIsRetryableToolError(t *testing.T) {
+	transient := []error{
+		syscall.ETIMEDOUT,
+		syscall.ECONNRESET,
+		syscall.EAGAIN,
+		context.DeadlineExceeded,
+		os.ErrDeadlineExceeded,
+		fmt.Errorf("dial tcp: %w", syscall.ECONNRESET),
+		errors.New("connection refused"),
+		errors.New("resource temporarily unavailable"),
+		errors.New("read: i/o timeout"),
+		&net.DNSError{IsTimeout: true},
+	}
+	for _, err := range transient {
+		if !isRetryableToolError(err) {
+			t.Errorf("expected transient (retryable): %v", err)
+		}
+	}
+	terminal := []error{
+		nil,
+		context.Canceled,
+		fmt.Errorf("wrapped: %w", context.Canceled),
+		errors.New("file not found"),
+		errors.New("invalid argument"),
+		os.ErrNotExist,
+		toolPanic{value: "boom"},
+	}
+	for _, err := range terminal {
+		if isRetryableToolError(err) {
+			t.Errorf("expected terminal (not retryable): %v", err)
+		}
+	}
+}
+
+// TestExecutorRetrySuccessResultWithIsErrorNotRetried proves that a
+// (result, nil) whose own content signals an error is NOT retried: only a
+// non-nil Go error triggers retry.
+func TestExecutorRetrySuccessResultWithIsErrorNotRetried(t *testing.T) {
+	var attempts int32
+	term := false
+	tool := execTool{name: "toolerr", run: func(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+		atomic.AddInt32(&attempts, 1)
+		return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent("tool-level error")}, Terminate: &term}, nil
+	}}
+	cfg := newExecCfg(t, tool)
+	// afterToolCall marks it as an error result; still must not be retried.
+	isErr := true
+	cfg.AfterToolCall = func(ctx context.Context, call agentcore.AgentToolCall, result agentcore.AgentToolResult, isError bool) *agentcore.AfterToolCallResult {
+		return &agentcore.AfterToolCallResult{IsError: &isErr}
+	}
+	msg, _ := executeToolCall(context.Background(), cfg, agentcore.AgentToolCall{ID: "1", Name: "toolerr"}, nil)
+	if !msg.IsError {
+		t.Fatalf("expected error result from afterToolCall override")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("(result,nil) must not be retried: got %d attempts", got)
+	}
+}
+

--- a/internal/agenttool/tool_retry.go
+++ b/internal/agenttool/tool_retry.go
@@ -1,0 +1,124 @@
+// This file adds resilience to the single tool-execution seam (see
+// tool_executor.go): when a tool's Execute returns a non-nil Go error, the
+// error is classified as transient (worth a bounded retry) or terminal (give
+// up immediately). This is deliberately separate from and does NOT touch the
+// transport-layer connect-time retry in internal/provider/transport.go, which
+// keeps its own, stricter semantics (only 429/503/529, respect Retry-After,
+// never replay a consumed stream).
+package agenttool
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// maxToolRetries is the default cap on RETRIES (not attempts) for a transient
+// tool error: 2 retries => at most 3 attempts total. Override per-executor via
+// ToolExecutorConfig.MaxToolRetries. This is always finite; the retry loop can
+// never spin forever.
+const maxToolRetries = 2
+
+// toolRetryBaseDelay is the unit of the small linear backoff between attempts
+// (attempt N waits (N+1)*base). Kept intentionally short so retries add
+// resilience without stalling the agent loop.
+const toolRetryBaseDelay = 20 * time.Millisecond
+
+// toolPanic wraps a recovered panic value so the retry loop can (a) tell a
+// panic apart from an ordinary error to shape the right message and (b) treat
+// it as terminal (never retryable).
+type toolPanic struct{ value any }
+
+func (p toolPanic) Error() string { return "panic" }
+
+// isRetryableToolError reports whether a non-nil error returned by a tool's
+// Execute is a TRANSIENT failure worth retrying. Transient means a temporary
+// IO/network/timeout condition that may succeed on a fresh attempt:
+//
+//   - syscall.ETIMEDOUT / ECONNRESET / EAGAIN
+//   - a net.Error whose Timeout() or Temporary() is true
+//   - context.DeadlineExceeded (a per-attempt/inner deadline; the caller
+//     separately refuses to retry when the OUTER ctx is already done)
+//   - os.ErrDeadlineExceeded (i/o deadline)
+//   - error text containing "connection refused" / "temporarily unavailable" /
+//     "i/o timeout" / "connection reset"
+//
+// Everything else is TERMINAL and must not be retried: argument/validation
+// errors, file-not-found, and — importantly — context.Canceled, which always
+// means "stop", never "try again". A recovered panic (toolPanic) is terminal
+// too.
+func isRetryableToolError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Cancellation is always terminal, even if some inner cause looks transient.
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	// A recovered panic is a programming error, never transient.
+	var tp toolPanic
+	if errors.As(err, &tp) {
+		return false
+	}
+
+	// Deadline / timeout sentinels.
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+	// Transient syscall errnos.
+	if errors.Is(err, syscall.ETIMEDOUT) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EAGAIN) {
+		return true
+	}
+	// net.Error temporary/timeout conditions.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() || netErr.Temporary() {
+			return true
+		}
+	}
+	// Best-effort string fallbacks for errors that lost their typed cause.
+	msg := strings.ToLower(err.Error())
+	for _, s := range []string{
+		"connection refused",
+		"temporarily unavailable",
+		"i/o timeout",
+		"connection reset",
+	} {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// toolRetryCap resolves the effective retry cap from the config field,
+// mirroring the sentinel convention used by MaxResultBytes: 0 => default
+// (maxToolRetries), <0 => disabled (0 retries, i.e. a single attempt).
+func toolRetryCap(cfgMax int) int {
+	if cfgMax == 0 {
+		return maxToolRetries
+	}
+	if cfgMax < 0 {
+		return 0
+	}
+	return cfgMax
+}
+
+// waitToolRetryBackoff sleeps a small, attempt-scaled delay before the next
+// attempt, but returns early (false) if ctx is cancelled/expired during the
+// wait so a dead context never costs the full backoff.
+func waitToolRetryBackoff(ctx context.Context, attempt int) bool {
+	d := time.Duration(attempt+1) * toolRetryBaseDelay
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}


### PR DESCRIPTION
## Summary
- 在单一工具执行 seam 引入分类重试：`runTool` 返回原始 Go error，`runToolWithRetry` 据 `isRetryableToolError` 区分瞬态（超时/网络/临时 IO：ETIMEDOUT/ECONNRESET/EAGAIN、net.Error Timeout/Temporary、DeadlineExceeded 等）与终态错误
- 瞬态按 `const maxToolRetries = 2`（最多 3 次尝试）带线性退避重试；`context.Canceled`/panic/终态错误绝不重试，外层 ctx 死亡立即短路
- 可经 `ToolExecutorConfig.MaxToolRetries` 配置（0=默认，<0=禁用），沿用 #250 的 sentinel 约定
- **传输层 `internal/provider/transport.go` 连接期重试语义（仅 429/503/529、尊重 Retry-After、绝不重放已消费的流）保持不变、未改动**
- 单测：瞬态→成功、瞬态耗尽封顶、终态单次、canceled 不重试、外层 ctx 中途取消、禁用/自定义上限、分类真值表、IsError 成功结果不重试

Closes #252

## Test plan
- [x] go build ./... 通过
- [x] go vet ./... 通过
- [x] go test ./... 全部通过