### PR TITLE
Add commands/call wire types to plugin protocol

### DIFF
--- a/docs/superpowers/specs/2026-07-24-pi-extension-host-design.md
+++ b/docs/superpowers/specs/2026-07-24-pi-extension-host-design.md
@@ -1,0 +1,286 @@
+# Design: pi-extension host for pigo
+
+Date: 2026-07-24
+Status: Approved (design), pending implementation
+
+## Problem
+
+`pigo` loads plugins by discovering every executable regular file in
+`$PIGO_HOME/plugins` (`internal/plugin.Discover`) and speaking line-delimited
+JSON-RPC 2.0 to it: it spawns the executable, calls `initialize`, and expects a
+`Manifest{name, version, tools[], commands[]}` back (`internal/plugin.Load`).
+
+`internal/pkgmgr.DistributeExtension` installs an npm **pi extension** by
+extracting the package to `plugins/<name>.pkg/` and writing a launcher
+`plugins/<name>` that is just `#!/bin/sh\nexec <binAbs> "$@"`, execing the
+package's entrypoint directly.
+
+That works for a native binary or a genuine JSON-RPC server, but a pi extension
+entrypoint is neither. A pi extension is an ESM module whose default export is a
+factory `(pi) => { pi.registerCommand(...); pi.registerTool(...) }`. So the
+current launcher fails two ways:
+
+- **pi-simplify** — `dist/index.js` has no shebang, so `/bin/sh` executes JS as
+  shell: `syntax error near unexpected token '('`.
+- **pi-agent-browser-native** — its `bin` is a real Node script (`config.mjs`)
+  but not a JSON-RPC server, so `initialize` never gets answered:
+  `jsonrpc: reader stopped: EOF`.
+
+A third symptom, `openai stream error: ... model emitted an undeclared tool
+call`, is **downstream**: because the plugins failed to load, their
+tools/commands were never registered, yet the model attempted a call. That is a
+provider-robustness concern, tracked separately and **out of scope** here.
+
+Additionally, `plugin.Manifest.Commands` is declared in the wire protocol but
+**no pigo code consumes it** — nothing turns a plugin-declared command into a
+slash command. So even a correctly loaded pi extension would not surface
+`/simplify` today. This design fixes both the host and the command wiring.
+
+## Goals
+
+- Run JS pi extensions (`export default (pi) => {...}`) under pigo with faithful
+  `pi` API behavior, reusing pi's real runtime (`@earendil-works/pi-coding-agent`).
+- Surface a pi extension's `registerTool` tools as pigo agent tools and its
+  `registerCommand` commands as pigo slash commands.
+- Preserve pigo's existing fault isolation: a broken or missing extension is
+  logged and skipped, never fatal.
+- Require `node` on PATH for pi extensions; native/JSON-RPC plugins are
+  unaffected.
+
+## Non-goals
+
+- Full fidelity of the pi command context (model switching, session
+  fork/navigate, custom TUI widgets/dialogs). Initial command support is
+  **prompt + notifications only**.
+- Bundling a Node runtime. If `node` is absent, pi extensions are skipped with a
+  diagnostic.
+- Fixing the provider "undeclared tool call" error (#3). Noted, tracked
+  elsewhere.
+- Windows support for pi extensions (matches the existing
+  `DistributeExtension` Windows limitation).
+
+## Architecture
+
+Introduce a **pi-extension host**: a self-contained Node program that pigo
+ships, embedded into the Go binary via `go:embed`. The host loads a pi extension
+using pi's real runtime and re-exposes it over pigo's existing JSON-RPC plugin
+protocol. `internal/plugin.Load` then talks to the host exactly as it talks to
+any other plugin — no change to the plugin transport or handshake.
+
+```
+pigo (Go)                          node pihost.mjs (ships with pigo)
+---------                          --------------------------------
+plugin.Discover ──exec launcher──▶ #!/bin/sh
+                                   exec node <pihost.mjs> <pkgDir> "$@"
+                                        │
+plugin.Load ──initialize──────────────▶│ discoverAndLoadExtensions([pkgDir], cwd)
+            ◀──Manifest{tools,commands}─│ build ExtensionRunner, collect
+                                        │   getAllRegisteredTools() + getRegisteredCommands()
+tools/call {name,args} ───────────────▶│ runner tool.execute(...)  → {content,isError}
+commands/call {name,args} ─────────────▶│ command.handler(args, capturingCtx)
+            ◀──{prompt,notifications}───│   captures sendUserMessage / ui.notify
+event / shutdown (notify) ─────────────▶│ runner.emit* / graceful exit
+```
+
+Two launcher shapes result from `DistributeExtension`:
+
+- **pi extension** (entrypoint is a JS module from `pi.extensions`, or the
+  package declares `pi.extensions`): launcher execs the Node host.
+- **native/JSON-RPC plugin** (entrypoint is a binary or self-hosted protocol
+  server, i.e. no `pi.extensions`): launcher keeps the current direct-exec form.
+
+## Components
+
+### 1. The Node host — `internal/pihost/pihost.mjs` (embedded)
+
+A single ESM file, `go:embed`ed and written to disk at install time next to the
+payload (e.g. `plugins/<name>.pkg/.pihost.mjs`). Responsibilities:
+
+1. Parse argv: `pihost.mjs <pkgDir> [extra args...]`.
+2. Import pi's runtime from the public entry `@earendil-works/pi-coding-agent`
+   (resolved from the global npm root; see "SDK resolution"). Use the public
+   `discoverAndLoadExtensions([pkgDir], cwd)` — it reads the package's
+   `pi.extensions` field and loads the declared entrypoints. (`loadExtensions`
+   is not a public export; `discoverAndLoadExtensions` is.)
+3. Build an `ExtensionRunner` from the load result and `bindCore` /
+   `bindCommandContext` with pigo-appropriate action implementations
+   (stubs/bridges — see "Action bridging").
+4. Collect the manifest:
+   - `runner.getAllRegisteredTools()` → `tools[]` (`{name, description, schema}`),
+     converting each tool's TypeBox `parameters` to a JSON Schema
+     `RawMessage`.
+   - `runner.getRegisteredCommands()` → `commands[]`
+     (`{name, description, prompt:""}`; the prompt is produced at call time, not
+     declared).
+5. Serve JSON-RPC 2.0 over stdio (newline-delimited), matching
+   `internal/jsonrpc` framing:
+   - `initialize` → `{name, version, tools, commands}`. `name` is the package
+     name; if multiple extensions load, tools/commands are merged (first
+     registration per name wins, mirroring `getAllRegisteredTools`).
+   - `tools/call {name, arguments}` → look up the tool, run
+     `execute(callId, params, signal, onUpdate, ctx)`, map its
+     `AgentToolResult` to `{content, isError}`. `content` is the tool result's
+     text; a thrown error or `isError` result maps to `{isError:true}`.
+   - `commands/call {name, args}` → run `command.handler(args, cmdCtx)` where
+     `cmdCtx` captures `sendUserMessage(content)` and `ui.notify(msg,type)` into
+     buffers. Return `{prompt, notifications:[{message,type}]}`. `prompt` is the
+     concatenation of captured user messages (empty if none).
+   - `event {type, data}` (notification) → `runner.emit(...)` for the matching
+     event type, best-effort.
+   - `shutdown` (notification) → resolve pending work and `process.exit(0)`.
+
+The host is transport-symmetric with pigo's Go client: read lines from stdin,
+write one JSON object + `\n` per response to stdout. Diagnostics go to stderr
+(pigo pipes plugin stderr through).
+
+### 2. Action bridging (host side)
+
+`ExtensionRunner.bindCore` / `bindCommandContext` require action
+implementations. Since pigo drives the agent loop (not pi), these are stubs or
+capture buffers:
+
+- `exec(command, args, opts)` → real child-process exec in the host (pi
+  extensions like pi-simplify call `pi.exec("git", ...)`); returns
+  `{stdout, stderr, code, killed}`.
+- `sendUserMessage(content, opts)` → capture into the current command's prompt
+  buffer.
+- `ui.notify(message, type)` → capture into the current command's notification
+  buffer. Outside a command call, forward as a stderr line.
+- `ui.select/confirm/input` → return `undefined`/`false` (no interactive UI in
+  this bridge); documented limitation.
+- Read-only context (`cwd`, `isIdle`, `isProjectTrusted`, `getModel`, ...) →
+  sensible constants: `cwd` = process cwd (pigo launches the host in the
+  session cwd), `isIdle` = true, `isProjectTrusted` = true (pigo already gates
+  trust before running tools).
+- Session/model mutation (`setModel`, `newSession`, `fork`, `navigateTree`,
+  `compact`, ...) → no-op stubs. A command relying on these degrades gracefully
+  rather than crashing.
+- `registerProvider` / `getFlag` / renderers / shortcuts / widgets → accepted
+  but inert (recorded, not acted on).
+
+Any action a factory calls that is genuinely unsupported must **not throw** —
+the goal is that loading and basic tool/command use never crash the host.
+
+### 3. SDK resolution (host side)
+
+The host must import `@earendil-works/pi-coding-agent` without assuming pigo's
+plugin dir is inside a node_modules tree. Resolution order:
+
+1. `import(...)` directly (works if the package is resolvable from the host
+   file's location or NODE_PATH).
+2. Fall back to the global npm root: run `npm root -g` (or read `NODE_PATH`),
+   then import the absolute path to the package's entry.
+
+If resolution fails, the host writes a clear stderr message and exits non-zero
+before answering `initialize`, so `plugin.Load` logs and skips it.
+
+The peer-dependency floor observed in installed extensions is `>=0.74.0`; the
+locally installed SDK is `0.80.3`. The host targets the public API surface
+(`discoverAndLoadExtensions`, `ExtensionRunner`, `createEventBus`,
+`createExtensionRuntime`), which is stable across that range.
+
+### 4. pigo-side: distribution — `internal/pkgmgr/distribute.go`
+
+`DistributeExtension` gains a branch on entrypoint kind:
+
+- Determine whether the resolved entrypoint is a **pi extension**: true when the
+  package.json has a non-empty `pi.extensions`, OR the resolved bin ends in
+  `.js`/`.mjs`/`.cjs` and is an ESM module (no protocol shebang). The
+  `pi.extensions` signal is authoritative and checked first.
+- **pi extension** → write the embedded host to `plugins/<name>.pkg/.pihost.mjs`
+  (recorded in the created-files list for uninstall), and write the launcher as:
+  ```sh
+  #!/bin/sh
+  exec node '<.pihost.mjs abs>' '<pkgDir abs>' "$@"
+  ```
+- **otherwise** → keep the current direct-exec launcher.
+
+The chosen shell quoting (`shellQuote`) is reused. `node` is assumed on PATH;
+if absent at run time the exec fails and the plugin is skipped (fault-isolated),
+with a readable stderr hint emitted by a small guard in the launcher.
+
+### 5. pigo-side: plugin command support — `internal/plugin`
+
+- `manifest.go`: add `CommandCallParams{Name, Args}` and
+  `CommandCallResult{Prompt string, Notifications []CommandNotification}` where
+  `CommandNotification{Message, Type string}`.
+- `plugin.go`: add `Plugin.CallCommand(ctx, name, args) (CommandCallResult,
+  error)` that RPCs `commands/call`. Transport errors degrade to an error the
+  caller can surface, never a panic (mirrors `pluginTool.Execute`).
+- Add `Manager.Commands()` returning the aggregated
+  `[]struct{Plugin *Plugin; Spec CommandSpec}` (or a small `PluginCommand`
+  type) across loaded plugins, in load order.
+
+### 6. pigo-side: slash registration — `cmd/pigo/interactive.go`
+
+After plugin discovery (both interactive and, where applicable, headless),
+register each plugin command as a `runtime.SlashCommand`:
+
+- `Name` = command name, `Description` = spec description, source = user-level
+  (built-ins still win on name collision, matching existing precedence).
+- `Action(args)`: call `Plugin.CallCommand`; print each notification to the
+  user; if a non-empty `Prompt` is returned, deliver it as the next agent turn.
+
+  Note: the current `SlashCommand` split is `Expand` (pure prompt producer) vs
+  `Action` (side effect, no run). A plugin command needs both a side effect (the
+  RPC + notifications) *and* to start a run with the returned prompt. The
+  cleanest fit is a small extension to the REPL's slash handling: allow an
+  `Action` to *also* return prompt text to run, or add a third command kind
+  (`SlashPluginCommand`) carrying a closure that returns `(prompt, message)`.
+  The plan will pick one; the design constraint is: **run the returned prompt as
+  a normal turn, after printing notifications.** For the headless path (no REPL
+  turn injection), plugin commands are surfaced but invoking one prints its
+  notifications and, if a prompt is returned, appends it as the prompt for that
+  run.
+
+## Data flow (example: `/simplify`)
+
+1. User types `/simplify` in the REPL.
+2. Slash registry resolves it to the plugin command action.
+3. `Plugin.CallCommand(ctx, "simplify", "")` → host `commands/call`.
+4. Host runs pi-simplify's handler: it calls `pi.exec("git", ["diff", ...])`
+   (bridged to real exec) to find changed files, builds a prompt, and calls
+   `pi.sendUserMessage(prompt, {deliverAs:"followUp"})` (captured).
+5. Host returns `{prompt:<simplify prompt>, notifications:[]}` (or a "no changed
+   files" notification and empty prompt).
+6. pigo prints notifications; if a prompt is present, runs it as the next turn.
+
+## Error handling
+
+- **Extension fails to load / SDK missing / node missing**: host exits non-zero
+  before/at `initialize`; `plugin.Load` logs `plugin "<name>" failed to load` and
+  skips it. Other plugins still load. This is the existing isolation path.
+- **Tool call crashes the host**: `pluginTool.Execute` already converts a
+  transport error into an error result; unchanged.
+- **Command call fails**: `CallCommand` returns an error; the slash action
+  prints a readable message and does not start a run.
+- **Malformed args from the model**: TypeBox validation in the pi tool
+  `execute` rejects; mapped to `{isError:true}` content.
+
+## Testing
+
+- `internal/pkgmgr/distribute_test.go`: assert the pi-extension launcher execs
+  `node <pihost> <pkgDir>` and drops `.pihost.mjs`; assert a binary-bin package
+  keeps the direct-exec launcher; assert both record their created files.
+- `internal/plugin`: unit-test `CallCommand` and `Manager.Commands()` against a
+  scripted fake plugin (the existing `manager_test.go` pattern with a shell/Go
+  fixture speaking the protocol) — no Node needed.
+- End-to-end (guarded, skipped when `node` or the SDK is absent): a tiny fixture
+  extension `export default (pi) => pi.registerCommand("t", {handler: async(a,c)=>{ pi... }})`
+  loaded through the real host + `plugin.Load`, asserting `initialize` returns
+  the command and `commands/call` returns the expected prompt.
+- `cmd/pigo`: test that a discovered plugin command is registered in the slash
+  registry and that invoking it injects the returned prompt.
+
+## Open questions / assumptions
+
+- **SlashCommand shape**: whether to extend `Action` to optionally return a
+  prompt-to-run or add a dedicated plugin-command kind. Resolved in the plan;
+  either satisfies "print notifications, then run the returned prompt".
+- **Host placement**: per-package `.pihost.mjs` (simple, self-contained,
+  uninstall-clean) vs one shared `plugins/.pihost/pihost.mjs`. Default:
+  per-package copy, since it keeps the uninstall lockfile exact and avoids a
+  shared-file lifecycle. Revisit if size becomes a concern.
+- **`node_modules` for extensions**: assumed pre-bundled (as noted in
+  issue#0158). The host does not run `npm install`. An extension needing
+  unbundled deps beyond the pi SDK is out of scope.

--- a/internal/agentcore/content.go
+++ b/internal/agentcore/content.go
@@ -12,6 +12,7 @@
 package agentcore
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -67,6 +68,43 @@ func (TextContent) isContent()     {}
 func (ThinkingContent) isContent() {}
 func (ToolCallContent) isContent() {}
 func (ImageContent) isContent()    {}
+
+// MarshalJSON encodes a ToolCallContent, tolerating malformed Arguments. A
+// model can stream syntactically invalid tool-call JSON (a truncated or
+// duplicated key, e.g. `{"todos": []{}...`); such bytes are kept verbatim in
+// Arguments so schema validation can report "not valid JSON" to the model, but
+// json.RawMessage.MarshalJSON rejects them, which would otherwise abort every
+// downstream serialization (session persistence, provider re-serialization) and
+// take the whole turn down. To keep those paths crash-free we emit invalid
+// arguments as a JSON string of the raw bytes: valid JSON that round-trips the
+// original text. Well-formed arguments are emitted unchanged.
+func (t ToolCallContent) MarshalJSON() ([]byte, error) {
+	args := t.Arguments
+	if len(bytes.TrimSpace(args)) == 0 {
+		args = json.RawMessage("{}")
+	} else if !json.Valid(args) {
+		s, err := json.Marshal(string(args))
+		if err != nil {
+			return nil, fmt.Errorf("content: encode invalid tool arguments: %w", err)
+		}
+		args = s
+	}
+	// A named alias avoids recursing into this MarshalJSON.
+	type wire struct {
+		Type             string          `json:"type"`
+		ID               string          `json:"id"`
+		Name             string          `json:"name"`
+		Arguments        json.RawMessage `json:"arguments"`
+		ThoughtSignature string          `json:"thoughtSignature,omitempty"`
+	}
+	return json.Marshal(wire{
+		Type:             t.Type,
+		ID:               t.ID,
+		Name:             t.Name,
+		Arguments:        args,
+		ThoughtSignature: t.ThoughtSignature,
+	})
+}
 
 // Constructors set the Type discriminant so callers never desync it.
 

--- a/internal/agentcore/types_test.go
+++ b/internal/agentcore/types_test.go
@@ -52,6 +52,57 @@ func TestContentUnknownTypeRejected(t *testing.T) {
 	}
 }
 
+// TestToolCallInvalidArgumentsMarshal verifies a ToolCallContent whose
+// Arguments are syntactically invalid JSON (as a model can stream) still
+// marshals — as a JSON string of the raw bytes — rather than aborting the
+// encode. Without this, session persistence and provider re-serialization would
+// crash the whole turn on a single malformed tool call.
+func TestToolCallInvalidArgumentsMarshal(t *testing.T) {
+	bad := NewToolCallContent("c1", "todo", json.RawMessage(`{"todos": []{}"content": ""x"}`))
+	data, err := json.Marshal(bad)
+	if err != nil {
+		t.Fatalf("marshal invalid tool args: %v", err)
+	}
+	if !json.Valid(data) {
+		t.Fatalf("marshaled output is not valid JSON: %s", data)
+	}
+	// It must round-trip back through the discriminated decoder without error.
+	var out ContentList
+	if err := json.Unmarshal([]byte("["+string(data)+"]"), &out); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	tc, ok := out[0].(ToolCallContent)
+	if !ok {
+		t.Fatalf("want ToolCallContent, got %T", out[0])
+	}
+	// The raw invalid text is preserved (as the decoded string).
+	var recovered string
+	if err := json.Unmarshal(tc.Arguments, &recovered); err != nil {
+		t.Fatalf("arguments not a JSON string: %v", err)
+	}
+	if recovered != `{"todos": []{}"content": ""x"}` {
+		t.Errorf("raw arguments lost: %q", recovered)
+	}
+}
+
+// TestToolCallValidArgumentsUnchanged verifies well-formed arguments are emitted
+// verbatim (not string-wrapped), preserving the object shape providers expect.
+func TestToolCallValidArgumentsUnchanged(t *testing.T) {
+	tc := NewToolCallContent("c1", "read", json.RawMessage(`{"path":"a.go"}`))
+	data, err := json.Marshal(tc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out ContentList
+	if err := json.Unmarshal([]byte("["+string(data)+"]"), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := out[0].(ToolCallContent)
+	if string(got.Arguments) != `{"path":"a.go"}` {
+		t.Errorf("arguments = %s, want the object unchanged", got.Arguments)
+	}
+}
+
 func TestContentMissingTypeRejected(t *testing.T) {
 	var out ContentList
 	err := json.Unmarshal([]byte(`[{"text":"no type"}]`), &out)

--- a/internal/pkgmgr/classify.go
+++ b/internal/pkgmgr/classify.go
@@ -38,15 +38,27 @@ type packageJSON struct {
 }
 
 // piMeta is the "pi" block of a package.json. It supports either a single
-// "type" or a "types" list, plus per-capability booleans/objects so a package
-// can declare, e.g., both an extension and a skill.
+// "type" or a "types" list, plus per-capability keys so a package can declare,
+// e.g., both an extension and a skill.
+//
+// The pi ecosystem convention (observed across published packages such as
+// pi-simplify, pi-mcp-adapter, pi-spark, pi-ask-user) declares capabilities as
+// PLURAL arrays of paths — "extensions", "skills", "prompts", "themes" — each
+// listing the files/dirs that provide that capability. We also accept the
+// singular forms ("extension", "skill", ...) so a package that declares a single
+// capability object is still recognized. Any present value (array or object)
+// registers that type; only its presence matters for classification.
 type piMeta struct {
-	Type      string          `json:"type,omitempty"`
-	Types     []string        `json:"types,omitempty"`
-	Extension json.RawMessage `json:"extension,omitempty"`
-	Skill     json.RawMessage `json:"skill,omitempty"`
-	Prompt    json.RawMessage `json:"prompt,omitempty"`
-	Theme     json.RawMessage `json:"theme,omitempty"`
+	Type       string          `json:"type,omitempty"`
+	Types      []string        `json:"types,omitempty"`
+	Extension  json.RawMessage `json:"extension,omitempty"`
+	Extensions json.RawMessage `json:"extensions,omitempty"`
+	Skill      json.RawMessage `json:"skill,omitempty"`
+	Skills     json.RawMessage `json:"skills,omitempty"`
+	Prompt     json.RawMessage `json:"prompt,omitempty"`
+	Prompts    json.RawMessage `json:"prompts,omitempty"`
+	Theme      json.RawMessage `json:"theme,omitempty"`
+	Themes     json.RawMessage `json:"themes,omitempty"`
 }
 
 // Classify inspects the fetched package directory and returns the set of pi
@@ -73,16 +85,16 @@ func Classify(pkgDir string) (name, version string, types []PackageType, err err
 				set[pt] = true
 			}
 		}
-		if len(pj.Pi.Extension) > 0 {
+		if len(pj.Pi.Extension) > 0 || len(pj.Pi.Extensions) > 0 {
 			set[TypeExtension] = true
 		}
-		if len(pj.Pi.Skill) > 0 {
+		if len(pj.Pi.Skill) > 0 || len(pj.Pi.Skills) > 0 {
 			set[TypeSkill] = true
 		}
-		if len(pj.Pi.Prompt) > 0 {
+		if len(pj.Pi.Prompt) > 0 || len(pj.Pi.Prompts) > 0 {
 			set[TypePrompt] = true
 		}
-		if len(pj.Pi.Theme) > 0 {
+		if len(pj.Pi.Theme) > 0 || len(pj.Pi.Themes) > 0 {
 			set[TypeTheme] = true
 		}
 	}

--- a/internal/pkgmgr/classify_test.go
+++ b/internal/pkgmgr/classify_test.go
@@ -77,6 +77,34 @@ func TestClassifyPerCapabilityKeys(t *testing.T) {
 	}
 }
 
+// TestClassifyPluralCapabilityKeys verifies the pi-ecosystem convention of
+// plural path arrays (pi.extensions, pi.skills, ...) registers each type. This
+// is the shape published packages actually use (pi-simplify, pi-ask-user, ...).
+func TestClassifyPluralCapabilityKeys(t *testing.T) {
+	dir := writePkg(t, `{"name":"pi-ask-user","version":"1.0.0","pi":{"extensions":["./index.ts"],"skills":["./skills"]}}`, nil)
+	_, _, types, err := Classify(dir)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	want := []PackageType{TypeExtension, TypeSkill}
+	if !reflect.DeepEqual(types, want) {
+		t.Errorf("types = %v, want %v", types, want)
+	}
+}
+
+// TestClassifyPluralExtensionsOnly verifies a pure extension declared via
+// pi.extensions (no bin) classifies as an extension — the pi-simplify case.
+func TestClassifyPluralExtensionsOnly(t *testing.T) {
+	dir := writePkg(t, `{"name":"pi-simplify","version":"0.2.3","pi":{"extensions":["dist/index.js"]}}`, nil)
+	_, _, types, err := Classify(dir)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if !reflect.DeepEqual(types, []PackageType{TypeExtension}) {
+		t.Errorf("types = %v, want [extension]", types)
+	}
+}
+
 // TestClassifyStructuralBin verifies a bare package with a bin entry is an
 // extension even without pi metadata.
 func TestClassifyStructuralBin(t *testing.T) {

--- a/internal/pkgmgr/distribute.go
+++ b/internal/pkgmgr/distribute.go
@@ -76,30 +76,34 @@ func DistributeExtension(pkgDir, name string) ([]string, error) {
 	return created, nil
 }
 
-// extensionBin resolves the package's bin entrypoint (relative to the package
-// root) from package.json. npm's "bin" is either a string (single bin) or an
-// object mapping command name → path; for the object form we prefer the entry
-// keyed by the package name, else any single entry.
+// extensionBin resolves the package's entrypoint (relative to the package root)
+// from package.json. It prefers npm's "bin" field (a string, or a {command:
+// path} object keyed by the package name), matching how npm installs bins. When
+// there is no "bin" — the common case for pi extensions, which declare their
+// entrypoint in the pi metadata rather than as an npm bin — it falls back to the
+// first path listed in "pi.extensions", then to "main".
 func extensionBin(pkgDir, name string) (string, error) {
 	data, err := os.ReadFile(filepath.Join(pkgDir, "package.json"))
 	if err != nil {
 		return "", fmt.Errorf("pkgmgr: read package.json: %w", err)
 	}
 	var pj struct {
-		Bin json.RawMessage `json:"bin"`
+		Bin  json.RawMessage `json:"bin"`
+		Main string          `json:"main"`
+		Pi   struct {
+			Extensions []string `json:"extensions"`
+		} `json:"pi"`
 	}
 	if err := json.Unmarshal(data, &pj); err != nil {
 		return "", fmt.Errorf("pkgmgr: parse package.json: %w", err)
 	}
-	if len(pj.Bin) == 0 {
-		return "", fmt.Errorf("pkgmgr: extension %q has no bin entry in package.json", name)
-	}
-	// String form: a single bin path.
+
+	// 1. npm "bin": string form.
 	var s string
 	if err := json.Unmarshal(pj.Bin, &s); err == nil && s != "" {
 		return s, nil
 	}
-	// Object form: {command: path}.
+	// npm "bin": object form {command: path}.
 	var m map[string]string
 	if err := json.Unmarshal(pj.Bin, &m); err == nil && len(m) > 0 {
 		if p, ok := m[name]; ok && p != "" {
@@ -115,7 +119,20 @@ func extensionBin(pkgDir, name string) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("pkgmgr: extension %q has an unreadable bin entry", name)
+
+	// 2. pi metadata entrypoint: pi.extensions is the pi-ecosystem convention.
+	for _, p := range pj.Pi.Extensions {
+		if p != "" {
+			return p, nil
+		}
+	}
+
+	// 3. npm "main" as a last resort.
+	if pj.Main != "" {
+		return pj.Main, nil
+	}
+
+	return "", fmt.Errorf("pkgmgr: extension %q has no bin, pi.extensions, or main entrypoint in package.json", name)
 }
 
 // copyTree recursively copies src into dst (created), preserving file modes and

--- a/internal/pkgmgr/distribute_test.go
+++ b/internal/pkgmgr/distribute_test.go
@@ -122,6 +122,59 @@ func TestDistributeExtensionReinstallReplaces(t *testing.T) {
 	}
 }
 
+// TestDistributeExtensionPiExtensionsEntry verifies a pi extension with no npm
+// "bin" resolves its entrypoint from pi.extensions (the pi-simplify shape).
+func TestDistributeExtensionPiExtensionsEntry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("extension install not supported on windows")
+	}
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+
+	pkg := writePkg(t, `{"name":"pi-simplify","version":"0.2.3","pi":{"extensions":["dist/index.js"]}}`, map[string]string{
+		"dist/index.js": "#!/usr/bin/env node\nconsole.log('hi')\n",
+	})
+
+	if _, err := DistributeExtension(pkg, "pi-simplify"); err != nil {
+		t.Fatalf("DistributeExtension: %v", err)
+	}
+
+	binAbs := filepath.Join(home, "plugins", "pi-simplify.pkg", "dist", "index.js")
+	bi, err := os.Stat(binAbs)
+	if err != nil {
+		t.Fatalf("stat payload bin: %v", err)
+	}
+	if bi.Mode()&0o111 == 0 {
+		t.Errorf("payload bin not executable: mode %v", bi.Mode())
+	}
+	script, _ := os.ReadFile(filepath.Join(home, "plugins", "pi-simplify"))
+	if !contains(string(script), binAbs) {
+		t.Errorf("launcher script = %q, want to exec %q", script, binAbs)
+	}
+}
+
+// TestDistributeExtensionMainEntry verifies the "main" field is used as a
+// last-resort entrypoint when neither bin nor pi.extensions is present.
+func TestDistributeExtensionMainEntry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("extension install not supported on windows")
+	}
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+
+	pkg := writePkg(t, `{"name":"pi-main","version":"1.0.0","main":"./dist/index.js"}`, map[string]string{
+		"dist/index.js": "#!/usr/bin/env node\n",
+	})
+
+	if _, err := DistributeExtension(pkg, "pi-main"); err != nil {
+		t.Fatalf("DistributeExtension: %v", err)
+	}
+	binAbs := filepath.Join(home, "plugins", "pi-main.pkg", "dist", "index.js")
+	if bi, err := os.Stat(binAbs); err != nil || bi.Mode()&0o111 == 0 {
+		t.Errorf("expected main entrypoint executable, err=%v", err)
+	}
+}
+
 // TestDistributeExtensionNoBin verifies a package without a bin errors.
 func TestDistributeExtensionNoBin(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -73,6 +73,35 @@ type CallResult struct {
 	IsError bool   `json:"isError,omitempty"`
 }
 
+// CommandCallParams is the parameter object for a commands/call request. It
+// mirrors CallParams' naming (name/arguments) so a plugin can decode tool and
+// command invocations with the same conventions. Name is the command's name;
+// Args carries its free-form arguments (e.g. the text following the slash
+// command) as raw JSON, passed through verbatim to the plugin.
+type CommandCallParams struct {
+	Name string          `json:"name"`
+	Args json.RawMessage `json:"arguments"`
+}
+
+// CommandCallResult is the reply to a commands/call request. Prompt is the text
+// injected as the next agent turn (matching the declarative-command
+// convention); it may be empty if the command produces no prompt. Notifications
+// are messages the plugin asks pigo to surface to the user out of band from the
+// prompt.
+type CommandCallResult struct {
+	Prompt        string                `json:"prompt,omitempty"`
+	Notifications []CommandNotification `json:"notifications,omitempty"`
+}
+
+// CommandNotification is a single message a command asks pigo to surface to the
+// user. Message is the human-readable text; Type is an optional severity or
+// category hint (e.g. "info", "warning", "error") that pigo may use to style
+// the message.
+type CommandNotification struct {
+	Message string `json:"message"`
+	Type    string `json:"type,omitempty"`
+}
+
 // EventParams is the parameter object for an `event` notification. Type is the
 // event discriminant (an agentcore.Event* value); Data carries a small,
 // wire-safe payload for that event (never secrets — see plugin.EventData).

--- a/internal/plugin/manifest_test.go
+++ b/internal/plugin/manifest_test.go
@@ -1,0 +1,81 @@
+// Tests for the plugin wire types (#261). These assert the commands/call
+// request and result types round-trip through JSON marshal/unmarshal so the
+// on-the-wire shape (field names, omitempty behavior) stays stable.
+package plugin
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestCommandCallParamsRoundTrip(t *testing.T) {
+	want := CommandCallParams{
+		Name: "review",
+		Args: json.RawMessage(`{"path":"foo.go","verbose":true}`),
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Params must name its argument field "arguments" to match CallParams.
+	var shape struct {
+		Name string          `json:"name"`
+		Args json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(data, &shape); err != nil {
+		t.Fatalf("decode shape: %v", err)
+	}
+	if shape.Name != want.Name {
+		t.Errorf("name = %q, want %q", shape.Name, want.Name)
+	}
+
+	var got CommandCallParams
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Name != want.Name {
+		t.Errorf("Name = %q, want %q", got.Name, want.Name)
+	}
+	if !json.Valid(got.Args) || string(got.Args) != string(want.Args) {
+		t.Errorf("Args = %s, want %s", got.Args, want.Args)
+	}
+}
+
+func TestCommandCallResultRoundTrip(t *testing.T) {
+	want := CommandCallResult{
+		Prompt: "Please summarize the following changes.",
+		Notifications: []CommandNotification{
+			{Message: "loaded 3 files", Type: "info"},
+			{Message: "1 file skipped", Type: "warning"},
+			{Message: "done"},
+		},
+	}
+
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got CommandCallResult
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("round-trip mismatch:\n got  %+v\n want %+v", got, want)
+	}
+}
+
+// TestCommandCallResultOmitEmpty confirms empty optional fields drop out of the
+// wire form, keeping notifications-free results minimal.
+func TestCommandCallResultOmitEmpty(t *testing.T) {
+	data, err := json.Marshal(CommandCallResult{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got := string(data); got != "{}" {
+		t.Errorf("empty result marshaled to %s, want {}", got)
+	}
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -102,6 +102,44 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSaveLoadMalformedToolArguments verifies a transcript containing a tool
+// call whose arguments are syntactically invalid JSON (as a model can stream)
+// still saves and loads, rather than aborting the whole session write. This is
+// the regression for the "session save failed: ... invalid character '{' after
+// object key:value pair" crash.
+func TestSaveLoadMalformedToolArguments(t *testing.T) {
+	s := newStore(t)
+	now := time.Now().UTC()
+	h := SessionHeader{ID: "malformed", CreatedAt: now, UpdatedAt: now}
+	msgs := agentcore.MessageList{
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("go")}},
+		agentcore.AssistantMessage{
+			RoleField: agentcore.RoleAssistant,
+			Content: agentcore.ContentList{
+				agentcore.NewToolCallContent("c1", "todo", []byte(`{"todos": []{}"content": ""x"}`)),
+			},
+			StopReason: agentcore.StopReasonToolUse,
+		},
+	}
+	if err := s.Save(h, msgs); err != nil {
+		t.Fatalf("Save with malformed tool args: %v", err)
+	}
+	_, got, err := s.Load("malformed")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("message count = %d, want 2", len(got))
+	}
+	a, ok := got[1].(agentcore.AssistantMessage)
+	if !ok {
+		t.Fatalf("message[1] is not AssistantMessage: %T", got[1])
+	}
+	if calls := a.ToolCalls(); len(calls) != 1 || calls[0].Name != "todo" {
+		t.Errorf("tool calls = %+v, want one 'todo'", calls)
+	}
+}
+
 // TestSaveOverwrites verifies Save replaces an existing session file (same id)
 // atomically rather than appending.
 func TestSaveOverwrites(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `CommandCallParams{Name, Args}` mirroring CallParams' `name`/`arguments` JSON convention
- Add `CommandCallResult{Prompt, Notifications}` for the future commands/call RPC
- Add `CommandNotification{Message, Type}` for out-of-band user messages
- Unit tests assert JSON marshal/unmarshal round-trips (incl. notifications and omitempty)

Closes #261

## Test plan
- [x] go build ./... && go vet ./... clean
- [x] go test ./internal/plugin/... passes