### PR TITLE
feat: Plugin.CallCommand 与 Manager.Commands 聚合插件命令

### DIFF
--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -76,6 +76,29 @@ func (m *Manager) Tools() []agentcore.AgentTool {
 // Plugins returns the loaded plugins (for command aggregation and diagnostics).
 func (m *Manager) Plugins() []*Plugin { return m.plugins }
 
+// PluginCommand pairs a plugin-declared slash command with the plugin that owns
+// it, so a caller can dispatch the command back to its plugin via
+// Plugin.CallCommand.
+type PluginCommand struct {
+	// Plugin is the plugin that declared and handles this command.
+	Plugin *Plugin
+	// Spec is the command's declaration from the owning plugin's manifest.
+	Spec CommandSpec
+}
+
+// Commands returns the aggregated slash commands of every loaded plugin, in load
+// order (and, within a plugin, in manifest order). Each carries the owning
+// plugin so the caller can dispatch it via Plugin.CallCommand.
+func (m *Manager) Commands() []PluginCommand {
+	var out []PluginCommand
+	for _, p := range m.plugins {
+		for _, spec := range p.Manifest.Commands {
+			out = append(out, PluginCommand{Plugin: p, Spec: spec})
+		}
+	}
+	return out
+}
+
 // Subscribers reports whether any loaded plugin subscribes to the given event
 // type. It lets a caller skip building an event payload when nobody is listening
 // (US-017, #133).

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -86,3 +86,52 @@ func TestDiscoverLoadsAndIsolatesBad(t *testing.T) {
 		t.Errorf("aggregated tools = %+v, want one 'shout'", tools)
 	}
 }
+
+// TestManagerCommandsAggregatesInLoadOrder checks that Commands() returns every
+// loaded plugin's commands in load order (plugins ordered by discovery, and
+// within a plugin by manifest order), each carrying its owning plugin.
+func TestManagerCommandsAggregatesInLoadOrder(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script/compiled plugins are unix-only in this test")
+	}
+	dir := t.TempDir()
+
+	// Two command plugins. Load order is by filename, so "a-cmd" loads before
+	// "b-cmd"; within each plugin the manifest declares greet then bye.
+	a := buildTestPlugin(t, "a-cmd", cmdPluginSrc)
+	if err := os.Rename(a, filepath.Join(dir, "a-cmd")); err != nil {
+		t.Fatal(err)
+	}
+	b := buildTestPlugin(t, "b-cmd", cmdPluginSrc)
+	if err := os.Rename(b, filepath.Join(dir, "b-cmd")); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := Discover(dir, nil, os.Stderr)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	defer m.Close()
+
+	cmds := m.Commands()
+	// Both plugins report the same name "cmd" (from cmdPluginSrc's manifest), so
+	// the two loaded *Plugin pointers are what distinguish load order.
+	if len(m.Plugins()) != 2 {
+		t.Fatalf("want 2 plugins loaded, got %d", len(m.Plugins()))
+	}
+	p0, p1 := m.Plugins()[0], m.Plugins()[1]
+	want := []PluginCommand{
+		{Plugin: p0, Spec: CommandSpec{Name: "greet", Description: "greets"}},
+		{Plugin: p0, Spec: CommandSpec{Name: "bye", Description: "farewell"}},
+		{Plugin: p1, Spec: CommandSpec{Name: "greet", Description: "greets"}},
+		{Plugin: p1, Spec: CommandSpec{Name: "bye", Description: "farewell"}},
+	}
+	if len(cmds) != len(want) {
+		t.Fatalf("Commands() len = %d, want %d (%+v)", len(cmds), len(want), cmds)
+	}
+	for i, w := range want {
+		if cmds[i].Plugin != w.Plugin || cmds[i].Spec != w.Spec {
+			t.Errorf("Commands()[%d] = {%p, %+v}, want {%p, %+v}", i, cmds[i].Plugin, cmds[i].Spec, w.Plugin, w.Spec)
+		}
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -105,6 +105,24 @@ func (p *Plugin) call(ctx context.Context, name string, args json.RawMessage) (C
 	return res, nil
 }
 
+// CallCommand forwards a slash-command invocation to the plugin over JSON-RPC
+// (commands/call) and returns the plugin's result. args carries the command's
+// free-form arguments (passed through verbatim). A transport error (e.g. the
+// plugin crashed) or a malformed reply is surfaced as a returned error rather
+// than a panic — mirroring how pluginTool.Execute isolates a dead plugin, but
+// leaving the caller to decide how to present the failure.
+func (p *Plugin) CallCommand(ctx context.Context, name string, args json.RawMessage) (CommandCallResult, error) {
+	raw, err := p.client.Call(ctx, "commands/call", CommandCallParams{Name: name, Args: args})
+	if err != nil {
+		return CommandCallResult{}, fmt.Errorf("plugin %q: command %q: %w", p.Manifest.Name, name, err)
+	}
+	var res CommandCallResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return CommandCallResult{}, fmt.Errorf("plugin %q: decode command result for %q: %w", p.Manifest.Name, name, err)
+	}
+	return res, nil
+}
+
 // Subscribes reports whether the plugin asked to receive the given event type in
 // its manifest (US-017, #133). pigo only delivers subscribed events.
 func (p *Plugin) Subscribes(eventType string) bool {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -182,3 +182,139 @@ func TestPluginCrashIsolation(t *testing.T) {
 		t.Errorf("expected isolated error result, got %q", txt)
 	}
 }
+
+// cmdPluginSrc declares two slash commands and answers commands/call by echoing
+// the command name back as a prompt plus one notification. Its manifest command
+// order (greet, then bye) lets tests assert manifest-order aggregation.
+const cmdPluginSrc = `package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type req struct {
+	ID     *json.RawMessage ` + "`json:\"id\"`" + `
+	Method string           ` + "`json:\"method\"`" + `
+	Params json.RawMessage  ` + "`json:\"params\"`" + `
+}
+
+func main() {
+	sc := bufio.NewScanner(os.Stdin)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	w := bufio.NewWriter(os.Stdout)
+	for sc.Scan() {
+		var r req
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			continue
+		}
+		switch r.Method {
+		case "initialize":
+			reply(w, r.ID, json.RawMessage(` + "`" + `{"name":"cmd","commands":[{"name":"greet","description":"greets"},{"name":"bye","description":"farewell"}]}` + "`" + `))
+		case "commands/call":
+			var p struct {
+				Name string          ` + "`json:\"name\"`" + `
+				Args json.RawMessage ` + "`json:\"arguments\"`" + `
+			}
+			json.Unmarshal(r.Params, &p)
+			res, _ := json.Marshal(map[string]any{
+				"prompt": "did:" + p.Name,
+				"notifications": []map[string]any{
+					{"message": "ran " + p.Name, "type": "info"},
+				},
+			})
+			reply(w, r.ID, res)
+		case "shutdown":
+			return
+		}
+	}
+}
+
+func reply(w *bufio.Writer, id *json.RawMessage, result json.RawMessage) {
+	if id == nil {
+		return
+	}
+	out, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "result": result})
+	fmt.Fprintf(w, "%s\n", out)
+	w.Flush()
+}
+`
+
+// TestPluginCallCommand checks CallCommand round-trips a prompt and its
+// notifications from a plugin over the real subprocess transport.
+func TestPluginCallCommand(t *testing.T) {
+	bin := buildTestPlugin(t, "cmd", cmdPluginSrc)
+	p, err := Load(bin, nil, os.Stderr)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer p.Close()
+
+	res, err := p.CallCommand(context.Background(), "greet", json.RawMessage(`{"text":"hi"}`))
+	if err != nil {
+		t.Fatalf("CallCommand: %v", err)
+	}
+	if res.Prompt != "did:greet" {
+		t.Errorf("prompt = %q, want did:greet", res.Prompt)
+	}
+	if len(res.Notifications) != 1 {
+		t.Fatalf("notifications = %+v, want one", res.Notifications)
+	}
+	if res.Notifications[0].Message != "ran greet" || res.Notifications[0].Type != "info" {
+		t.Errorf("notification = %+v, want {ran greet, info}", res.Notifications[0])
+	}
+}
+
+// TestPluginCallCommandTransportError checks that a transport error (the plugin
+// crashed mid-call) surfaces as a returned error, never a panic.
+func TestPluginCallCommandTransportError(t *testing.T) {
+	bin := buildTestPlugin(t, "cmdcrash", cmdCrashPluginSrc)
+	p, err := Load(bin, nil, os.Stderr)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	defer p.Close()
+
+	_, err = p.CallCommand(context.Background(), "greet", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("CallCommand must return an error when the plugin crashes mid-call")
+	}
+}
+
+// cmdCrashPluginSrc initializes with one command then exits abruptly on the
+// first commands/call, so no response is ever sent.
+const cmdCrashPluginSrc = `package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type req struct {
+	ID     *json.RawMessage ` + "`json:\"id\"`" + `
+	Method string           ` + "`json:\"method\"`" + `
+}
+
+func main() {
+	sc := bufio.NewScanner(os.Stdin)
+	w := bufio.NewWriter(os.Stdout)
+	for sc.Scan() {
+		var r req
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			continue
+		}
+		switch r.Method {
+		case "initialize":
+			out, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": r.ID, "result": json.RawMessage(` + "`" + `{"name":"cmdcrash","commands":[{"name":"greet","description":"greets"}]}` + "`" + `)})
+			fmt.Fprintf(w, "%s\n", out)
+			w.Flush()
+		case "commands/call":
+			os.Exit(1) // crash mid-call: no response is ever sent
+		}
+	}
+}
+`


### PR DESCRIPTION
## Summary
- 新增 `Plugin.CallCommand(ctx, name, args)`：通过 JSON-RPC `commands/call` 转发斜杠命令，解码 `CommandCallResult`
- 传输/RPC 错误降级为返回 error（不 panic），镜像 `pluginTool.Execute` 的隔离风格
- 新增 `PluginCommand` 类型（携带所属 `*Plugin` 与 `CommandSpec`）与 `Manager.Commands()`，按加载顺序聚合各插件命令

Closes #262

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/plugin/...`
- [x] CallCommand round-trips prompt + notifications
- [x] 传输错误返回 error（无 panic）
- [x] Commands() 按加载顺序聚合