### PR TITLE
Route pi-extension launchers through the embedded Node host

### DIFF
--- a/internal/pihost/embed.go
+++ b/internal/pihost/embed.go
@@ -1,0 +1,17 @@
+// Package pihost embeds the pi-extension host program (pihost.mjs) into the
+// pigo binary. pihost.mjs is a self-contained Node ESM program that loads a pi
+// extension using pi's real runtime and re-exposes it over pigo's JSON-RPC
+// plugin protocol (see docs/superpowers/specs/2026-07-24-pi-extension-host-design.md).
+//
+// At install time, internal/pkgmgr.DistributeExtension writes these bytes next
+// to a pi extension's payload (plugins/<name>.pkg/.pihost.mjs) and points a
+// node-host launcher at them. Embedding keeps the host in lockstep with the
+// pigo binary — there is no separate file to ship or version-skew.
+package pihost
+
+import _ "embed"
+
+// Script is the embedded pihost.mjs source. Callers write it verbatim to disk.
+//
+//go:embed pihost.mjs
+var Script []byte

--- a/internal/pkgmgr/distribute.go
+++ b/internal/pkgmgr/distribute.go
@@ -26,6 +26,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/pihost"
 )
 
 // DistributeExtension copies the extension package at pkgDir into the plugins
@@ -67,6 +70,29 @@ func DistributeExtension(pkgDir, name string) ([]string, error) {
 	}
 
 	launcher := filepath.Join(pluginsDir, name)
+
+	// A pi extension is a JS module loaded by pi's runtime, not a native binary
+	// or JSON-RPC server, so it cannot be exec'd directly. Instead we drop the
+	// embedded Node host next to the payload and point the launcher at it. A
+	// native/JSON-RPC plugin keeps the historical direct-exec launcher.
+	if isPiExtension(pkgDir, binRel) {
+		hostAbs := filepath.Join(payloadDir, ".pihost.mjs")
+		if err := os.WriteFile(hostAbs, pihost.Script, 0o644); err != nil {
+			return nil, fmt.Errorf("pkgmgr: write pi host %q: %w", hostAbs, err)
+		}
+		script := fmt.Sprintf(
+			"#!/bin/sh\n"+
+				"command -v node >/dev/null 2>&1 || { echo \"pigo: node not found on PATH; pi extension %s skipped\" >&2; exit 127; }\n"+
+				"exec node %s %s \"$@\"\n",
+			name, shellQuote(hostAbs), shellQuote(payloadDir),
+		)
+		if err := os.WriteFile(launcher, []byte(script), 0o755); err != nil {
+			return nil, fmt.Errorf("pkgmgr: write launcher %q: %w", launcher, err)
+		}
+		created = append(created, payloadDir, hostAbs, launcher)
+		return created, nil
+	}
+
 	script := fmt.Sprintf("#!/bin/sh\nexec %s \"$@\"\n", shellQuote(binAbs))
 	if err := os.WriteFile(launcher, []byte(script), 0o755); err != nil {
 		return nil, fmt.Errorf("pkgmgr: write launcher %q: %w", launcher, err)
@@ -74,6 +100,33 @@ func DistributeExtension(pkgDir, name string) ([]string, error) {
 
 	created = append(created, payloadDir, launcher)
 	return created, nil
+}
+
+// isPiExtension reports whether the entrypoint should be run under pigo's Node
+// host rather than exec'd directly. The pi.extensions declaration is
+// authoritative and checked first; otherwise the resolved bin extension
+// (.js/.mjs/.cjs) identifies a JS module that needs the host. Native binaries
+// and self-hosted JSON-RPC servers match neither and keep the direct launcher.
+func isPiExtension(pkgDir, binRel string) bool {
+	if data, err := os.ReadFile(filepath.Join(pkgDir, "package.json")); err == nil {
+		var pj struct {
+			Pi struct {
+				Extensions []string `json:"extensions"`
+			} `json:"pi"`
+		}
+		if json.Unmarshal(data, &pj) == nil {
+			for _, p := range pj.Pi.Extensions {
+				if p != "" {
+					return true
+				}
+			}
+		}
+	}
+	switch strings.ToLower(filepath.Ext(binRel)) {
+	case ".js", ".mjs", ".cjs":
+		return true
+	}
+	return false
 }
 
 // extensionBin resolves the package's entrypoint (relative to the package root)

--- a/internal/pkgmgr/distribute_test.go
+++ b/internal/pkgmgr/distribute_test.go
@@ -61,10 +61,15 @@ func TestDistributeExtensionStringBin(t *testing.T) {
 		t.Errorf("created files %v missing launcher", files)
 	}
 
-	// The launcher script should exec the bin path.
+	// A ".js" bin is a pi extension, so the launcher runs the Node host and a
+	// .pihost.mjs is dropped beside the payload.
+	host := filepath.Join(home, "plugins", "pi-demo.pkg", ".pihost.mjs")
+	if _, err := os.Stat(host); err != nil {
+		t.Errorf("expected embedded pi host at %q: %v", host, err)
+	}
 	script, _ := os.ReadFile(launcher)
-	if !contains(string(script), binAbs) {
-		t.Errorf("launcher script = %q, want to exec %q", script, binAbs)
+	if !contains(string(script), "exec node ") || !contains(string(script), host) {
+		t.Errorf("launcher script = %q, want node host exec of %q", script, host)
 	}
 }
 
@@ -135,7 +140,8 @@ func TestDistributeExtensionPiExtensionsEntry(t *testing.T) {
 		"dist/index.js": "#!/usr/bin/env node\nconsole.log('hi')\n",
 	})
 
-	if _, err := DistributeExtension(pkg, "pi-simplify"); err != nil {
+	files, err := DistributeExtension(pkg, "pi-simplify")
+	if err != nil {
 		t.Fatalf("DistributeExtension: %v", err)
 	}
 
@@ -147,9 +153,79 @@ func TestDistributeExtensionPiExtensionsEntry(t *testing.T) {
 	if bi.Mode()&0o111 == 0 {
 		t.Errorf("payload bin not executable: mode %v", bi.Mode())
 	}
-	script, _ := os.ReadFile(filepath.Join(home, "plugins", "pi-simplify"))
+
+	// A pi.extensions package must run under the Node host, dropping .pihost.mjs
+	// and pointing the launcher at `node <host> <pkgDir>`.
+	launcher := filepath.Join(home, "plugins", "pi-simplify")
+	host := filepath.Join(home, "plugins", "pi-simplify.pkg", ".pihost.mjs")
+	pkgDir := filepath.Join(home, "plugins", "pi-simplify.pkg")
+	if _, err := os.Stat(host); err != nil {
+		t.Errorf("expected embedded pi host at %q: %v", host, err)
+	}
+	script, _ := os.ReadFile(launcher)
+	if !contains(string(script), "exec node ") || !contains(string(script), host) || !contains(string(script), pkgDir) {
+		t.Errorf("launcher script = %q, want node host exec of %q with pkgDir %q", script, host, pkgDir)
+	}
+	if !contains(string(script), "node not found") {
+		t.Errorf("launcher script = %q, missing node-absent guard", script)
+	}
+
+	// Both the host and the launcher must be recorded for uninstall.
+	var sawHost, sawLauncher bool
+	for _, f := range files {
+		switch f {
+		case host:
+			sawHost = true
+		case launcher:
+			sawLauncher = true
+		}
+	}
+	if !sawHost || !sawLauncher {
+		t.Errorf("created files %v missing host or launcher", files)
+	}
+}
+
+// TestDistributeExtensionBinaryBinDirectExec verifies a native binary bin (no
+// pi.extensions, non-JS extension) keeps the historical direct-exec launcher —
+// no Node host, no .pihost.mjs.
+func TestDistributeExtensionBinaryBinDirectExec(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("extension install not supported on windows")
+	}
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+
+	pkg := writePkg(t, `{"name":"pi-native","version":"1.0.0","bin":"./server"}`, map[string]string{
+		"server": "#!/usr/bin/env node\n",
+	})
+
+	files, err := DistributeExtension(pkg, "pi-native")
+	if err != nil {
+		t.Fatalf("DistributeExtension: %v", err)
+	}
+
+	launcher := filepath.Join(home, "plugins", "pi-native")
+	binAbs := filepath.Join(home, "plugins", "pi-native.pkg", "server")
+	script, _ := os.ReadFile(launcher)
 	if !contains(string(script), binAbs) {
-		t.Errorf("launcher script = %q, want to exec %q", script, binAbs)
+		t.Errorf("launcher script = %q, want direct exec of %q", script, binAbs)
+	}
+	if contains(string(script), "exec node ") {
+		t.Errorf("binary bin launcher = %q, should not run the Node host", script)
+	}
+	if _, err := os.Stat(filepath.Join(home, "plugins", "pi-native.pkg", ".pihost.mjs")); !os.IsNotExist(err) {
+		t.Errorf("binary bin should not drop .pihost.mjs, err=%v", err)
+	}
+
+	// The launcher and payload dir must be recorded; the host must not be.
+	var sawLauncher bool
+	for _, f := range files {
+		if f == launcher {
+			sawLauncher = true
+		}
+	}
+	if !sawLauncher {
+		t.Errorf("created files %v missing launcher", files)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Embed `pihost.mjs` into the pigo binary via `go:embed` (new `internal/pihost/embed.go`, `var Script []byte`).
- `DistributeExtension` branches on entrypoint kind: a pi extension (non-empty `pi.extensions`, or a `.js/.mjs/.cjs` bin) drops the embedded host to `plugins/<name>.pkg/.pihost.mjs` and writes a launcher execing `node <host> <pkgDir> "$@"`; native/JSON-RPC plugins keep the direct-exec launcher.
- Launcher includes a `command -v node` guard that emits a readable stderr hint and exits 127 when node is absent.
- Both the `.pihost.mjs` and the launcher are recorded in the created-files list for uninstall.

Closes #264

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/pkgmgr/...`
- [x] pi-extension package produces node-host launcher + .pihost.mjs; binary bin keeps direct-exec; both record created files