### PR TITLE
feat: 插件命令注册为 slash 命令并注入 prompt

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -7,6 +7,8 @@ package main
 
 import (
 	"bufio"
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -165,7 +167,7 @@ func runInteractive(opts interactiveOptions) error {
 	// ~/.agents/skills. A load error is non-fatal — the REPL still runs with the
 	// built-ins. Instance built-ins that need live state (/model, /help) are
 	// registered against `live`.
-	slash, err := buildSlashRegistry(live, opts.noSkills)
+	slash, err := buildSlashRegistry(live, opts.noSkills, opts.plugins)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "pigo: slash-commands: %v\n", err)
 	}
@@ -253,16 +255,18 @@ func stdoutIsTerminal() bool {
 // buildSlashRegistry assembles the REPL slash-command registry: compile-time
 // built-ins seeded by runtime.NewSlashRegistry, the live-state action commands
 // (/model, /help) bound to live, user declarative templates loaded from
-// ~/.pigo/commands (or $PIGO_HOME/commands), plus skills loaded from
-// ~/.agents/skills — each surfaced as a "/skill-name" command (对标 Claude
-// Code's /skill invocation). A missing directory is not an error. Names that
-// collide with a built-in are shadowed (the built-in wins) and reported on
-// stderr. When noSkills is true, skill discovery is skipped entirely (对标 pi
-// 的 --no-skills): user command templates still load, but no /skill-name
-// commands are registered.
-func buildSlashRegistry(live *liveRunConfig, noSkills bool) (*runtime.SlashRegistry, error) {
+// ~/.pigo/commands (or $PIGO_HOME/commands), plugin-declared commands from the
+// loaded Manager, plus skills loaded from ~/.agents/skills — each surfaced as a
+// "/skill-name" command (对标 Claude Code's /skill invocation). A missing
+// directory is not an error. Names that collide with a built-in are shadowed
+// (the built-in wins) and reported on stderr. When noSkills is true, skill
+// discovery is skipped entirely (对标 pi 的 --no-skills): user command
+// templates and plugin commands still load, but no /skill-name commands are
+// registered. mgr may be nil (no plugins loaded).
+func buildSlashRegistry(live *liveRunConfig, noSkills bool, mgr *plugin.Manager) (*runtime.SlashRegistry, error) {
 	reg := runtime.NewSlashRegistry()
 	registerLiveCommands(reg, live)
+	registerPluginCommands(reg, mgr)
 	dir := os.Getenv("PIGO_HOME")
 	if dir == "" {
 		home, err := os.UserHomeDir()
@@ -359,6 +363,66 @@ type liveRunConfig struct {
 // on genuinely long sessions (threshold = window - ReserveTokens), never on
 // ordinary short exchanges.
 const defaultContextWindow = 128000
+
+// registerPluginCommands installs each plugin-declared slash command
+// (Manager.Commands()) into the registry as a hybrid (Run) command. Invoking it
+// RPCs the owning plugin (Plugin.CallCommand), returns the plugin's
+// notifications as the outcome Message, and returns the plugin's Prompt to run
+// as the next turn. Plugin commands are registered with AddUser so a same-named
+// built-in still wins (existing precedence preserved) and a collision is
+// reported as shadowed. mgr may be nil (no plugins), in which case this is a
+// no-op.
+//
+// The args passed to CallCommand are the invocation's raw argument text encoded
+// as a JSON string (json.RawMessage of a quoted string), never null: the host
+// (node #263) expects a JSON string for a no-arg command, so a bare "/cmd"
+// sends `""` rather than nil. Each command captures its own plugin and spec name
+// (loop variables copied per-iteration).
+func registerPluginCommands(reg *runtime.SlashRegistry, mgr *plugin.Manager) {
+	if mgr == nil {
+		return
+	}
+	for _, pc := range mgr.Commands() {
+		pc := pc // capture per iteration
+		reg.AddUser(runtime.SlashCommand{
+			Name:        pc.Spec.Name,
+			Description: pc.Spec.Description,
+			Run: func(args string) (message, prompt string) {
+				// Encode the raw arg text as a JSON string (""for no args), matching
+				// the host's CommandCallParams.Args contract (a JSON string, never
+				// null). json.Marshal of a Go string always succeeds.
+				raw, _ := json.Marshal(args)
+				res, err := pc.Plugin.CallCommand(context.Background(), pc.Spec.Name, json.RawMessage(raw))
+				if err != nil {
+					return fmt.Sprintf("plugin command %q failed: %v", pc.Spec.Name, err), ""
+				}
+				return formatNotifications(res.Notifications), res.Prompt
+			},
+		})
+	}
+}
+
+// formatNotifications renders a plugin command's notifications into a single
+// block to surface to the user, one per line, prefixed by their type (when set)
+// so severity is visible. Returns "" when there are none.
+func formatNotifications(notes []plugin.CommandNotification) string {
+	if len(notes) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, n := range notes {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		if n.Type != "" {
+			b.WriteString("[")
+			b.WriteString(n.Type)
+			b.WriteString("] ")
+		}
+		b.WriteString(n.Message)
+	}
+	return b.String()
+}
 
 // registerLiveCommands installs the built-in action commands that need live
 // runtime state. /model views or switches the active model; /help lists the

--- a/cmd/pigo/plugin_commands_test.go
+++ b/cmd/pigo/plugin_commands_test.go
@@ -1,0 +1,252 @@
+package main
+
+// Tests for plugin slash-command wiring (#265): a plugin-declared command
+// (Manager.Commands()) is registered into the REPL slash registry as a hybrid
+// (Run) command, and invoking it calls Plugin.CallCommand, surfaces the
+// returned notifications, and runs the returned prompt as the next turn. A real
+// plugin subprocess is compiled and Discover-loaded so the JSON-RPC transport,
+// handshake and commands/call round-trip are exercised end to end.
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/plugin"
+	"github.com/smallnest/pigo/internal/provider"
+	rt "github.com/smallnest/pigo/internal/runtime"
+	"github.com/smallnest/pigo/internal/session"
+)
+
+// cmdPluginMain is a standalone plugin that declares one "hello" slash command
+// and answers commands/call by echoing back a prompt built from the command's
+// args plus one notification. It lets the test assert registration, notification
+// surfacing, and prompt injection. It also records the raw arguments it received
+// so the test can confirm a bare invocation sends a JSON string ("") not null.
+const cmdPluginMain = `package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type req struct {
+	ID     *json.RawMessage ` + "`json:\"id\"`" + `
+	Method string           ` + "`json:\"method\"`" + `
+	Params json.RawMessage  ` + "`json:\"params\"`" + `
+}
+
+func main() {
+	sc := bufio.NewScanner(os.Stdin)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	w := bufio.NewWriter(os.Stdout)
+	for sc.Scan() {
+		var r req
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			continue
+		}
+		switch r.Method {
+		case "initialize":
+			reply(w, r.ID, json.RawMessage(` + "`" + `{"name":"greeter","commands":[{"name":"hello","description":"say hello"}]}` + "`" + `))
+		case "commands/call":
+			var p struct {
+				Name string          ` + "`json:\"name\"`" + `
+				Args json.RawMessage ` + "`json:\"arguments\"`" + `
+			}
+			json.Unmarshal(r.Params, &p)
+			// args is a JSON string (never null); decode it to prove the contract.
+			var argText string
+			json.Unmarshal(p.Args, &argText)
+			res, _ := json.Marshal(map[string]any{
+				"prompt": "please greet " + argText,
+				"notifications": []map[string]any{
+					{"message": "invoked hello", "type": "info"},
+				},
+			})
+			reply(w, r.ID, res)
+		case "shutdown":
+			return
+		}
+	}
+}
+
+func reply(w *bufio.Writer, id *json.RawMessage, result json.RawMessage) {
+	if id == nil {
+		return
+	}
+	out, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "result": result})
+	fmt.Fprintf(w, "%s\n", out)
+	w.Flush()
+}
+`
+
+// buildPluginInDir compiles src into an executable named bin inside dir and
+// returns nothing (the executable path is dir/bin). Discover loads any
+// executable regular file directly under dir.
+func buildPluginInDir(t *testing.T, dir, bin, src string) {
+	t.Helper()
+	srcPath := filepath.Join(dir, "plugin_main.go")
+	if err := os.WriteFile(srcPath, []byte(src), 0o644); err != nil {
+		t.Fatalf("write plugin source: %v", err)
+	}
+	binPath := filepath.Join(dir, bin)
+	if runtime.GOOS == "windows" {
+		binPath += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", binPath, srcPath)
+	cmd.Env = os.Environ()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build plugin: %v\n%s", err, out)
+	}
+	// Remove the source so Discover only sees the executable (a .go file is not
+	// executable, but keeping the dir clean avoids any ambiguity).
+	_ = os.Remove(srcPath)
+}
+
+// loadTestManager compiles the greeter plugin into a fresh dir and Discover-loads
+// it, returning a Manager with exactly that one plugin. The caller must Close it.
+func loadTestManager(t *testing.T) *plugin.Manager {
+	t.Helper()
+	// Build in a build dir, then move only the binary into the plugins dir so
+	// Discover (which loads every executable file in the dir) sees just the one
+	// plugin executable.
+	buildDir := t.TempDir()
+	buildPluginInDir(t, buildDir, "greeter", cmdPluginMain)
+	pluginsDir := t.TempDir()
+	binName := "greeter"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	if err := os.Rename(filepath.Join(buildDir, binName), filepath.Join(pluginsDir, binName)); err != nil {
+		t.Fatalf("move plugin binary: %v", err)
+	}
+	mgr, err := plugin.Discover(pluginsDir, os.Stderr, os.Stderr)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(mgr.Commands()) != 1 || mgr.Commands()[0].Spec.Name != "hello" {
+		t.Fatalf("expected one discovered command 'hello', got %+v", mgr.Commands())
+	}
+	return mgr
+}
+
+// TestBuildSlashRegistryRegistersPluginCommand verifies a discovered plugin
+// command is registered as a resolvable slash command in the registry.
+func TestBuildSlashRegistryRegistersPluginCommand(t *testing.T) {
+	t.Setenv("PIGO_HOME", t.TempDir())
+	mgr := loadTestManager(t)
+	defer mgr.Close()
+
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "faux", providerName: "faux"}, true, mgr)
+	if err != nil {
+		t.Fatalf("buildSlashRegistry: %v", err)
+	}
+	if _, ok := reg.Lookup("hello"); !ok {
+		t.Fatalf("plugin command /hello was not registered in the slash registry")
+	}
+
+	// Resolving it must run the plugin (side effect), surface its notification,
+	// and yield the plugin's prompt to run.
+	out, err := reg.ResolveOutcome("/hello world")
+	if err != nil {
+		t.Fatalf("ResolveOutcome(/hello): %v", err)
+	}
+	if !out.Handled || out.Kind != rt.SlashPrompt {
+		t.Fatalf("outcome = %+v, want handled SlashPrompt", out)
+	}
+	if !strings.Contains(out.Message, "invoked hello") {
+		t.Errorf("notification not surfaced in Message: %q", out.Message)
+	}
+	if out.Prompt != "please greet world" {
+		t.Errorf("Prompt = %q, want plugin-returned prompt", out.Prompt)
+	}
+}
+
+// TestBuiltinWinsOverPluginCommand verifies a built-in command of the same name
+// wins over a plugin command (existing precedence preserved): the plugin command
+// is shadowed and the built-in's behavior is what resolves.
+func TestBuiltinWinsOverPluginCommand(t *testing.T) {
+	t.Setenv("PIGO_HOME", t.TempDir())
+	mgr := loadTestManager(t)
+	defer mgr.Close()
+
+	reg := rt.NewSlashRegistry()
+	reg.AddBuiltin(rt.SlashCommand{
+		Name:   "hello",
+		Action: func(string) string { return "builtin hello" },
+	})
+	registerPluginCommands(reg, mgr)
+
+	if names := reg.Shadowed(); len(names) != 1 || names[0] != "hello" {
+		t.Fatalf("plugin command should be shadowed by built-in, shadowed=%v", names)
+	}
+	out, err := reg.ResolveOutcome("/hello there")
+	if err != nil {
+		t.Fatalf("ResolveOutcome: %v", err)
+	}
+	if out.Kind != rt.SlashAction || out.Message != "builtin hello" {
+		t.Errorf("built-in must win: outcome = %+v", out)
+	}
+}
+
+// TestREPLPluginCommandInjectsPrompt drives the full REPL: invoking a plugin
+// slash command prints its notification and runs the returned prompt as the next
+// agent turn (so the fake provider is called once and the injected prompt lands
+// in the conversation history).
+func TestREPLPluginCommandInjectsPrompt(t *testing.T) {
+	t.Setenv("PIGO_HOME", t.TempDir())
+	mgr := loadTestManager(t)
+	defer mgr.Close()
+
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "faux", providerName: "faux"}, true, mgr)
+	if err != nil {
+		t.Fatalf("buildSlashRegistry: %v", err)
+	}
+
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	p := &replProvider{reply: "hi there"}
+	live := &liveRunConfig{model: "faux", providerName: "faux", provider: p}
+	deps := replDeps{
+		store:    store,
+		header:   session.SessionHeader{ID: session.NewID(time.Now().UTC()), Model: "faux", Provider: "faux"},
+		agentCtx: &agentcore.AgentContext{},
+		live:     live,
+		reg:      agenttool.NewToolRegistry(),
+		slash:    reg,
+		creds:    provider.NewCredentialStore(nil),
+	}
+
+	var out bytes.Buffer
+	if err := runREPL(strings.NewReader("/hello world\n/exit\n"), &out, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+
+	// The plugin's notification must have been printed.
+	if !strings.Contains(out.String(), "invoked hello") {
+		t.Errorf("plugin notification not printed, out=%q", out.String())
+	}
+	// The returned prompt must have run exactly one turn.
+	if p.calls != 1 {
+		t.Fatalf("plugin command should inject and run exactly 1 turn, got %d", p.calls)
+	}
+	// The injected prompt must be the user message that started the turn.
+	if len(deps.agentCtx.Messages) == 0 {
+		t.Fatal("expected messages in context after the injected turn")
+	}
+	u0, ok := deps.agentCtx.Messages[0].(agentcore.UserMessage)
+	if !ok || agentcore.ContentToText(u0.Content) != "please greet world" {
+		t.Errorf("injected prompt not run as the turn: %+v", deps.agentCtx.Messages[0])
+	}
+}

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -242,8 +242,10 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 		}
 
 		// Resolve slash-commands: an action command runs and prints its message
-		// (no agent run); a prompt command or skill expands to the text we run; an
-		// unknown command prints an error and returns to the prompt.
+		// (no agent run); a prompt command or skill expands to the text we run; a
+		// hybrid (plugin) command runs its side effect, prints its message
+		// (notifications), then runs the returned prompt if non-empty; an unknown
+		// command prints an error and returns to the prompt.
 		prompt := line
 		if strings.HasPrefix(line, "/") {
 			outcome, err := deps.slash.ResolveOutcome(line)
@@ -255,6 +257,16 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 				if outcome.Message != "" {
 					fmt.Fprintln(out, outcome.Message)
 				}
+				continue
+			}
+			// SlashPrompt. A hybrid command may carry a Message to surface first
+			// (e.g. plugin notifications) alongside the prompt to run.
+			if outcome.Message != "" {
+				fmt.Fprintln(out, outcome.Message)
+			}
+			// A hybrid command with no prompt (only notifications) has nothing to
+			// run; return to the prompt without starting a turn.
+			if outcome.Prompt == "" {
 				continue
 			}
 			prompt = outcome.Prompt

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -345,7 +346,14 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 	if env.plugins != nil {
 		defer env.plugins.Close()
 	}
-	promptContent, err := buildUserContent(opts.prompt)
+	// Best-effort plugin slash-command support in headless mode: if the prompt is
+	// a "/cmd ..." naming a plugin command, invoke it, print its notifications to
+	// errOut, and use the returned prompt for this run (appending the raw args if
+	// the command produced no prompt). Headless has no turn injection, so
+	// appending the returned prompt is the accepted behavior. A non-plugin prompt
+	// or unknown command is left untouched.
+	headlessPrompt := resolveHeadlessPluginCommand(opts.prompt, env.plugins, errOut)
+	promptContent, err := buildUserContent(headlessPrompt)
 	if err != nil {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
 		return 1
@@ -404,6 +412,57 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+// resolveHeadlessPluginCommand gives the headless / print path best-effort
+// support for plugin slash commands. When prompt is a "/cmd ..." naming a
+// plugin command (from mgr.Commands()), it invokes the command, prints each
+// returned notification to notifyOut, and returns the command's returned Prompt
+// as the run's prompt. If the command returns no prompt, the raw argument text
+// is used instead (so a bare "/cmd" with only notifications still runs
+// something sensible rather than an empty prompt). Any other input — a
+// non-command, an unknown command, or a call error — leaves prompt unchanged so
+// the normal headless run proceeds. mgr may be nil (no plugins).
+//
+// Headless has no turn-injection loop, so "inject the returned prompt" degrades
+// to "use the returned prompt for this run", which the acceptance criteria
+// permit.
+func resolveHeadlessPluginCommand(prompt string, mgr *plugin.Manager, notifyOut io.Writer) string {
+	if mgr == nil || !strings.HasPrefix(strings.TrimLeft(prompt, " \t"), "/") {
+		return prompt
+	}
+	trimmed := strings.TrimLeft(prompt, " \t")[1:]
+	name := trimmed
+	args := ""
+	if i := strings.IndexAny(trimmed, " \t"); i >= 0 {
+		name = trimmed[:i]
+		args = strings.TrimSpace(trimmed[i+1:])
+	}
+	for _, pc := range mgr.Commands() {
+		if pc.Spec.Name != name {
+			continue
+		}
+		// Encode the raw arg text as a JSON string (never null), matching the
+		// host's CommandCallParams.Args contract.
+		raw, _ := json.Marshal(args)
+		res, err := pc.Plugin.CallCommand(context.Background(), name, json.RawMessage(raw))
+		if err != nil {
+			fmt.Fprintf(notifyOut, "pigo: plugin command %q failed: %v\n", name, err)
+			return prompt
+		}
+		for _, n := range res.Notifications {
+			if n.Type != "" {
+				fmt.Fprintf(notifyOut, "[%s] %s\n", n.Type, n.Message)
+			} else {
+				fmt.Fprintln(notifyOut, n.Message)
+			}
+		}
+		if res.Prompt != "" {
+			return res.Prompt
+		}
+		return args
+	}
+	return prompt
 }
 
 // parseOutputMode maps the --output-format flag onto a HeadlessMode, erroring on

--- a/cmd/pigo/skills_test.go
+++ b/cmd/pigo/skills_test.go
@@ -71,7 +71,7 @@ func TestBuildSlashRegistryIncludesSkills(t *testing.T) {
 	t.Setenv("PIGO_HOME", t.TempDir())
 	writeSkill(t, dir, "summarize.md", "---\nname: summarize\ndescription: summarize input\n---\nSummarize the following: $ARGUMENTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, false)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, false, nil)
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestBuildSlashRegistryNoSkills(t *testing.T) {
 	t.Setenv("PIGO_HOME", t.TempDir())
 	writeSkill(t, dir, "summarize.md", "---\nname: summarize\ndescription: summarize input\n---\nSummarize the following: $ARGUMENTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, true)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, true, nil)
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}

--- a/internal/runtime/slashcommand.go
+++ b/internal/runtime/slashcommand.go
@@ -47,17 +47,20 @@ func (s SlashCommandSource) String() string {
 
 // SlashCommand is a resolved command: its name (without the leading "/"), a
 // short description for the command palette, and its source. A command is one
-// of two kinds, distinguished by which callback is set:
+// of three kinds, distinguished by which callback is set:
 //
 //   - A prompt command sets Expand: it turns the invocation arguments into the
 //     prompt text fed to the agent (the original slash-command behavior).
 //   - An action command sets Action instead: it performs a side effect (e.g.
 //     switching the runtime model) and returns a status line to show the user,
 //     rather than producing a prompt. No agent run is started.
+//   - A hybrid command sets Run: it performs a side effect AND may return prompt
+//     text to run — used by plugin commands, which RPC their plugin, surface the
+//     returned notifications, then inject the returned prompt as the next turn.
 //
-// Exactly one of Expand/Action should be set. When both are set Action wins
-// (an action command never doubles as a prompt). This split is what lets a
-// control command like "/model" change runtime state — the old design could
+// Exactly one of Expand/Action/Run should be set. Precedence when more than one
+// is set: Action wins over Run, which wins over Expand. This split is what lets
+// a control command like "/model" change runtime state — the old design could
 // only emit prompt text.
 type SlashCommand struct {
 	Name        string
@@ -74,6 +77,16 @@ type SlashCommand struct {
 	// and mutate live runtime state, which Expand (a pure prompt producer)
 	// cannot. Nil for a prompt command.
 	Action func(args string) string
+	// Run is the hybrid of Action and Expand: it performs a side effect AND may
+	// produce prompt text to run as the next agent turn. It returns
+	// (message, prompt): message is shown to the user immediately (like an
+	// Action's status, e.g. plugin notifications), and prompt, when non-empty, is
+	// run as a normal turn (like Expand's output). This is what a plugin command
+	// needs — it RPCs its plugin (side effect), surfaces the returned
+	// notifications (message), then injects the returned prompt (prompt). Set
+	// instead of Expand/Action for such a command; nil otherwise. When Run is set
+	// it takes precedence over Expand (but Action still wins over Run).
+	Run func(args string) (message, prompt string)
 }
 
 // SlashKind classifies how a resolved invocation should be handled by the
@@ -94,6 +107,11 @@ const (
 // to run). When Handled is true, Kind says whether Prompt should be run
 // (SlashPrompt) or an action already ran and Message should be shown without
 // starting a run (SlashAction).
+//
+// A hybrid (Run) command resolves to Kind SlashPrompt with BOTH fields set: its
+// side effect already ran, Message carries the text to show the user first
+// (e.g. plugin notifications), and Prompt, when non-empty, is the turn to run
+// after. The caller shows Message (if any) then runs Prompt (if non-empty).
 type SlashOutcome struct {
 	Handled bool
 	Kind    SlashKind
@@ -216,8 +234,10 @@ func (r *SlashRegistry) Resolve(input string) (prompt string, handled bool, err 
 // non-command it returns {Handled:false, Prompt:input}. For a known prompt
 // command it returns {Handled:true, Kind:SlashPrompt, Prompt:<expanded>}. For a
 // known action command it RUNS the action and returns {Handled:true,
-// Kind:SlashAction, Message:<status>} — no prompt to run. An unknown "/name"
-// yields an error.
+// Kind:SlashAction, Message:<status>} — no prompt to run. For a known hybrid
+// (Run) command it RUNS the side effect and returns {Handled:true,
+// Kind:SlashPrompt, Message:<status>, Prompt:<text>} — the caller shows Message
+// then runs Prompt when non-empty. An unknown "/name" yields an error.
 func (r *SlashRegistry) ResolveOutcome(input string) (SlashOutcome, error) {
 	trimmed := strings.TrimLeft(input, " \t")
 	if !strings.HasPrefix(trimmed, "/") {
@@ -236,6 +256,13 @@ func (r *SlashRegistry) ResolveOutcome(input string) (SlashOutcome, error) {
 	}
 	if cmd.Action != nil {
 		return SlashOutcome{Handled: true, Kind: SlashAction, Message: cmd.Action(args)}, nil
+	}
+	if cmd.Run != nil {
+		// A hybrid command runs its side effect now and may yield prompt text.
+		// The outcome is a prompt (SlashPrompt) that also carries a Message to
+		// surface first; the caller shows Message then runs Prompt if non-empty.
+		message, prompt := cmd.Run(args)
+		return SlashOutcome{Handled: true, Kind: SlashPrompt, Message: message, Prompt: prompt}, nil
 	}
 	return SlashOutcome{Handled: true, Kind: SlashPrompt, Prompt: cmd.Expand(args)}, nil
 }


### PR DESCRIPTION
## Summary
- 新增 `SlashCommand.Run` 混合命令类型：执行副作用并可返回 prompt 作为下一轮（介于 Action 与 Expand 之间，优先级 Action > Run > Expand）
- `registerPluginCommands` 将 `Manager.Commands()` 每个 `PluginCommand` 以 `AddUser` 注册进 slash 注册表，内建命令名冲突时仍优先（shadowed 上报）
- 调用插件命令走 `Plugin.CallCommand`，打印返回的 notifications，再把非空 Prompt 作为下一轮 agent turn 运行
- headless 路径 best-effort 支持：识别 `/cmd`，打印通知并用返回的 prompt 运行本次（无 turn 注入则退化为用返回 prompt）
- 无参 `/cmd` 按 host 契约传 JSON 空串 `""`（非 null）

Closes #265

## Test plan
- [x] go build ./... && go vet ./cmd/pigo/... ./internal/runtime/...
- [x] go test ./cmd/pigo/... ./internal/runtime/...
- [x] 新增 cmd/pigo 测试：断言发现的插件命令被注册且调用时注入返回的 prompt；内建命令优先；REPL 端到端注入