### PR TITLE
feat: /goal autonomous mode (对标 pi-goal)

### DIFF
--- a/cmd/pigo/color.go
+++ b/cmd/pigo/color.go
@@ -10,12 +10,13 @@ import "os"
 // ANSI SGR escape sequences used by the REPL. Kept unexported and small — this
 // is not a general-purpose styling library.
 const (
-	ansiReset = "\033[0m"
-	ansiBold  = "\033[1m"
-	ansiDim   = "\033[2m"
-	ansiCyan  = "\033[36m"
-	ansiGreen = "\033[32m"
-	ansiRed   = "\033[31m"
+	ansiReset  = "\033[0m"
+	ansiBold   = "\033[1m"
+	ansiDim    = "\033[2m"
+	ansiCyan   = "\033[36m"
+	ansiGreen  = "\033[32m"
+	ansiRed    = "\033[31m"
+	ansiYellow = "\033[33m"
 )
 
 // colorEnabled reports whether ANSI color should be emitted. Color is on only

--- a/cmd/pigo/goal.go
+++ b/cmd/pigo/goal.go
@@ -1,0 +1,392 @@
+// This file implements the /goal command (对标 pi-goal / Claude Code's goal
+// mode): given a high-level objective, pigo runs the agent autonomously —
+// re-prompting it turn after turn from the loop's follow-up seam — until the
+// model declares the goal done (goal_complete), reports a true impasse
+// (goal_blocked), or a safety guard (max turns / no-progress) or the token
+// budget stops it.
+//
+// /goal is intercepted in the REPL loop (see repl.go) rather than routed through
+// a slash Action closure because it must run agent streams and mutate the shared
+// context and goal state — none of which a pure string→string Action can do,
+// exactly like /compact and /fork.
+//
+// Scope: core autonomous continuation plus an optional token budget. Goal state
+// lives only in the session's in-memory GoalState (deps.goal); it is not
+// persisted across process restarts.
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/compaction"
+	"github.com/smallnest/pigo/internal/provider"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// goalMaxAutomaticTurns caps how many autonomous continuations a single /goal
+// run will issue before pausing, a runaway guard (对标 pi-goal's automaticTurns).
+const goalMaxAutomaticTurns = 25
+
+// goalMaxNoProgress pauses the run after this many consecutive tool-free
+// continuations, so a model looping without acting cannot spin forever (对标
+// pi-goal's noProgressTurns).
+const goalMaxNoProgress = 3
+
+// runGoal parses and dispatches a /goal invocation. setCancel publishes the
+// active run's cancel func so the REPL's SIGINT handler can interrupt an
+// autonomous run (same plumbing as a normal turn).
+func runGoal(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, line string) {
+	args := strings.TrimSpace(strings.TrimPrefix(line, "/goal"))
+
+	switch {
+	case args == "":
+		printGoalStatus(out, deps.goal)
+		return
+	case args == "clear":
+		deps.goal.Clear()
+		fmt.Fprintln(out, "goal cleared")
+		return
+	case args == "pause":
+		snap := deps.goal.Snapshot()
+		if snap.Status != agenttool.GoalActive && snap.Status != agenttool.GoalPaused {
+			fmt.Fprintln(out, "no active goal to pause")
+			return
+		}
+		deps.goal.SetStatus(agenttool.GoalPaused)
+		fmt.Fprintln(out, "goal paused — run /goal resume to continue")
+		return
+	case args == "resume":
+		snap := deps.goal.Snapshot()
+		if snap.Status != agenttool.GoalPaused && snap.Status != agenttool.GoalBudgetLimited {
+			fmt.Fprintln(out, "no paused goal to resume")
+			return
+		}
+		deps.goal.Resume()
+		fmt.Fprintf(out, "resuming goal: %s\n", oneLine(snap.Objective))
+		runGoalLoop(setCancel, out, deps)
+		return
+	}
+
+	// Otherwise args is a new objective, optionally prefixed with --tokens N.
+	objective, budget, err := parseGoalObjective(args)
+	if err != nil {
+		fmt.Fprintf(out, "pigo: %v\n", err)
+		return
+	}
+	if strings.TrimSpace(objective) == "" {
+		fmt.Fprintln(out, "usage: /goal [--tokens N] <objective>")
+		return
+	}
+	deps.goal.Start(newGoalID(), objective, budget)
+	if budget > 0 {
+		fmt.Fprintf(out, "goal set (token budget %d): %s\n", budget, oneLine(objective))
+	} else {
+		fmt.Fprintf(out, "goal set: %s\n", oneLine(objective))
+	}
+	runGoalLoop(setCancel, out, deps)
+}
+
+// newGoalID returns a short unique id for a goal (used to key goal_complete's
+// exact-id contract in a future extension; here it just labels the goal).
+func newGoalID() string { return "goal-" + strconv.FormatInt(time.Now().UnixNano(), 36) }
+
+// parseGoalObjective splits an optional leading "--tokens N" flag from the
+// objective text. N accepts a bare integer or a k/m suffix (100k, 1m). The flag
+// must lead; anything after it (or the whole string when absent) is the
+// objective.
+func parseGoalObjective(args string) (objective string, budget int, err error) {
+	rest := args
+	if strings.HasPrefix(rest, "--tokens") {
+		rest = strings.TrimSpace(strings.TrimPrefix(rest, "--tokens"))
+		// The value is the next whitespace-delimited token.
+		var valTok string
+		if i := strings.IndexAny(rest, " \t"); i >= 0 {
+			valTok = rest[:i]
+			rest = strings.TrimSpace(rest[i+1:])
+		} else {
+			valTok = rest
+			rest = ""
+		}
+		budget, err = parseTokenBudget(valTok)
+		if err != nil {
+			return "", 0, err
+		}
+	}
+	return rest, budget, nil
+}
+
+// parseTokenBudget parses a token count with an optional k/m (×1000/×1000000)
+// suffix, case-insensitive. It rejects a non-positive or malformed value.
+func parseTokenBudget(s string) (int, error) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return 0, fmt.Errorf("--tokens requires a value (e.g. --tokens 100k)")
+	}
+	mult := 1
+	switch {
+	case strings.HasSuffix(s, "k"):
+		mult = 1000
+		s = strings.TrimSuffix(s, "k")
+	case strings.HasSuffix(s, "m"):
+		mult = 1000000
+		s = strings.TrimSuffix(s, "m")
+	}
+	n, convErr := strconv.Atoi(s)
+	if convErr != nil || n <= 0 {
+		return 0, fmt.Errorf("invalid --tokens value %q (want a positive number, optionally with k/m)", s)
+	}
+	return n * mult, nil
+}
+
+// goalContinuationPrompt is the follow-up injected each autonomous turn to keep
+// the model working toward the goal. The objective itself is re-stated every
+// turn by the GoalReminderProvider, so this only nudges continuation.
+const goalContinuationPrompt = "Continue working toward the goal. When every requirement is " +
+	"verifiably met, call goal_complete with a summary. If you hit a true impasse you cannot work " +
+	"around, call goal_blocked with concrete evidence. Otherwise keep going — do not stop or ask " +
+	"the user whether to continue."
+
+// goalFollowUpDecision decides, from a goal snapshot, whether the autonomous
+// loop should issue another continuation turn. It is pure so the branch logic
+// (complete/blocked terminal states, token budget, turn cap, no-progress guard)
+// can be unit-tested without running a real agent stream. The returned status is
+// the terminal status to record when cont is false (GoalIdle means "leave the
+// status as-is" — used for the already-terminal complete/blocked cases).
+func goalFollowUpDecision(snap agenttool.GoalSnapshot) (cont bool, terminal agenttool.GoalStatus) {
+	switch snap.Status {
+	case agenttool.GoalComplete, agenttool.GoalBlocked:
+		// A goal tool already ended the run; nothing to continue.
+		return false, agenttool.GoalIdle
+	}
+	if snap.TokenBudget > 0 && snap.TokensUsed >= snap.TokenBudget {
+		return false, agenttool.GoalBudgetLimited
+	}
+	if snap.Iterations >= goalMaxAutomaticTurns {
+		return false, agenttool.GoalPaused
+	}
+	if snap.NoProgress >= goalMaxNoProgress {
+		return false, agenttool.GoalPaused
+	}
+	return true, agenttool.GoalIdle
+}
+
+// runGoalLoop drives the autonomous goal run. It assembles a run just like
+// streamRun but with the goal tools (goal_complete/goal_blocked) added, the goal
+// reminder wired alongside the todo reminder, and a GetFollowUpMessages hook that
+// re-prompts the model each time the inner loop settles — until a goal tool ends
+// the run or goalFollowUpDecision trips a guard. On return it prints the outcome
+// and persists the turn. The run reuses the REPL's SIGINT cancel plumbing via
+// setCancel.
+func runGoalLoop(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps) {
+	goalReg := goalToolRegistry(deps.reg, deps.goal)
+	reminders := goalReminders(deps.reg, deps.goal)
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	setCancel(cancel)
+	defer func() {
+		cancel()
+		setCancel(nil)
+	}()
+
+	// lastSeen tracks how many messages we have already accounted for, so each
+	// settle folds in only the assistant turns produced since the previous one:
+	// their output tokens (budget) and whether any tool ran (no-progress guard).
+	lastSeen := len(deps.agentCtx.Messages)
+
+	cfg := runtime.RunConfig{
+		LoopConfig: runtime.LoopConfig{
+			Model:         deps.live.model,
+			Provider:      deps.live.providerName,
+			ThinkingLevel: deps.live.thinkingLevel,
+			Stream:        provider.StreamFnFromProvider(deps.live.provider),
+			GetAPIKey:     deps.creds.GetAPIKey,
+			ContextWindow: deps.live.contextWindow,
+			Compaction:    compaction.DefaultCompactionSettings,
+		},
+		Batch: agenttool.BatchConfig{
+			ToolExecutorConfig: agenttool.ToolExecutorConfig{
+				Registry:       goalReg,
+				BeforeToolCall: trustBeforeToolCall(deps.trust, deps.cwd, deps.in, out, deps.confirmMu),
+			},
+		},
+		Reminders: reminders,
+		GetFollowUpMessages: func(ctx context.Context, agentCtx *agentcore.AgentContext) []agentcore.AgentMessage {
+			// Account for the turns produced since the last settle. Auto-compaction
+			// can shrink agentCtx.Messages in place (summary + tail) between settles,
+			// dropping its length below lastSeen; clamp so the slice never goes out
+			// of bounds. The compacted turn's tokens are then under-counted, which is
+			// acceptable for a soft budget guard (a crash is not).
+			if lastSeen > len(agentCtx.Messages) {
+				lastSeen = len(agentCtx.Messages)
+			}
+			outputTokens, hadTool := goalTurnActivity(agentCtx.Messages[lastSeen:])
+			lastSeen = len(agentCtx.Messages)
+			deps.goal.RecordIteration(outputTokens, hadTool)
+
+			cont, terminal := goalFollowUpDecision(deps.goal.Snapshot())
+			if !cont {
+				if terminal != agenttool.GoalIdle {
+					deps.goal.SetStatus(terminal)
+				}
+				return nil
+			}
+			return []agentcore.AgentMessage{agentcore.UserMessage{
+				RoleField: agentcore.RoleUser,
+				Content:   agentcore.ContentList{agentcore.NewTextContent(goalContinuationPrompt)},
+			}}
+		},
+	}
+
+	// The first turn is driven by the goal reminder alone (the objective is
+	// injected as background context); no explicit user prompt is appended so the
+	// objective is not duplicated in the durable history.
+	stream := runtime.StartRun(runCtx, deps.agentCtx, cfg)
+	drainGoalStream(runCtx, out, deps, stream)
+
+	printGoalOutcome(out, deps.goal.Snapshot())
+	persistTurn(out, deps)
+}
+
+// goalToolRegistry returns a registry holding every tool from base plus the two
+// goal-control tools, so the autonomous run can invoke goal_complete/goal_blocked
+// while keeping all the normal tools available. The base registry is left
+// unchanged (the goal tools are only present for the goal run).
+func goalToolRegistry(base *agenttool.ToolRegistry, state *agenttool.GoalState) *agenttool.ToolRegistry {
+	reg := agenttool.NewToolRegistry()
+	if base != nil {
+		for _, t := range base.List() {
+			_ = reg.Register(t)
+		}
+	}
+	_ = reg.Register(&agenttool.GoalCompleteTool{State: state})
+	_ = reg.Register(&agenttool.GoalBlockedTool{State: state})
+	return reg
+}
+
+// goalReminders builds the per-turn reminder registry for a goal run: the goal
+// reminder (re-stating the objective every turn) plus the todo reminder when a
+// todo tool is present, so an autonomous run keeps both its objective and its
+// task list in view.
+func goalReminders(base *agenttool.ToolRegistry, state *agenttool.GoalState) *runtime.ReminderRegistry {
+	reg := runtime.NewReminderRegistry(&runtime.GoalReminderProvider{State: state})
+	if base != nil {
+		if t, ok := base.Get("todo"); ok {
+			if tt, ok := t.(*agenttool.TodoTool); ok && tt.Store != nil {
+				reg.Register(&runtime.TodoReminderProvider{Store: tt.Store})
+			}
+		}
+	}
+	return reg
+}
+
+// goalTurnActivity sums the output tokens across the assistant messages in tail
+// and reports whether any tool ran in that window (an assistant tool call or a
+// tool result). It feeds RecordIteration's token-budget and no-progress inputs.
+func goalTurnActivity(tail []agentcore.AgentMessage) (outputTokens int, hadTool bool) {
+	for _, m := range tail {
+		switch msg := m.(type) {
+		case agentcore.AssistantMessage:
+			if msg.Usage != nil {
+				outputTokens += msg.Usage.OutputTokens
+			}
+			if len(msg.ToolCalls()) > 0 {
+				hadTool = true
+			}
+		case agentcore.ToolResultMessage:
+			hadTool = true
+		}
+	}
+	return outputTokens, hadTool
+}
+
+// drainGoalStream prints the streamed assistant text and tool activity of a goal
+// run to out, mirroring streamRun's rendering. It blocks until the run ends.
+func drainGoalStream(ctx context.Context, out io.Writer, deps *replDeps, stream *runtime.LoopEventStream) {
+	var reply strings.Builder
+	flushReply := func() {
+		if reply.Len() == 0 {
+			return
+		}
+		rendered := renderMarkdown(reply.String())
+		fmt.Fprint(out, rendered)
+		if !strings.HasSuffix(rendered, "\n") {
+			fmt.Fprintln(out)
+		}
+		reply.Reset()
+	}
+	_, err := runtime.DrainStream(ctx, stream, runtime.StreamHandler{
+		OnEvent: deps.notifierHandle(),
+		OnText: func(delta string) {
+			reply.WriteString(delta)
+		},
+		OnTurnEnd: func(msg agentcore.AssistantMessage, results []agentcore.ToolResultMessage) {
+			flushReply()
+			for _, c := range msg.ToolCalls() {
+				fmt.Fprintf(out, "  %s %s\n", colorize(colorEnabled(), ansiGreen, "→ tool:"), toolCallLabel(c))
+			}
+			for _, tr := range results {
+				renderToolResult(out, tr)
+			}
+		},
+	})
+	flushReply()
+	if err != nil {
+		if ctx.Err() != nil {
+			fmt.Fprintln(out, "^C interrupted — goal paused (run /goal resume to continue)")
+			deps.goal.SetStatus(agenttool.GoalPaused)
+		} else {
+			fmt.Fprintf(out, "error: %v\n", err)
+		}
+	}
+}
+
+// printGoalOutcome prints a one-line result banner after a goal run settles,
+// keyed on the terminal status the run reached.
+func printGoalOutcome(out io.Writer, snap agenttool.GoalSnapshot) {
+	color := colorEnabled()
+	switch snap.Status {
+	case agenttool.GoalComplete:
+		fmt.Fprintf(out, "%s goal complete: %s\n", colorize(color, ansiGreen, "✓"), snap.Summary)
+	case agenttool.GoalBlocked:
+		fmt.Fprintf(out, "%s goal blocked: %s\n", colorize(color, ansiRed, "⚠"), snap.BlockReason)
+	case agenttool.GoalBudgetLimited:
+		fmt.Fprintf(out, "%s goal paused — token budget reached (%d / %d). Run /goal resume to continue.\n",
+			colorize(color, ansiYellow, "⏸"), snap.TokensUsed, snap.TokenBudget)
+	case agenttool.GoalPaused:
+		fmt.Fprintf(out, "%s goal paused after %d turns. Run /goal resume to continue, or /goal clear to drop it.\n",
+			colorize(color, ansiYellow, "⏸"), snap.Iterations)
+	}
+}
+
+// printGoalStatus prints a summary of the current goal state for a bare /goal.
+func printGoalStatus(out io.Writer, goal *agenttool.GoalState) {
+	snap := goal.Snapshot()
+	if snap.Status == agenttool.GoalIdle {
+		fmt.Fprintln(out, "no goal set — run /goal <objective> to start one")
+		return
+	}
+	fmt.Fprintf(out, "goal:       %s\n", snap.Objective)
+	fmt.Fprintf(out, "status:     %s\n", snap.Status)
+	fmt.Fprintf(out, "iterations: %d\n", snap.Iterations)
+	if snap.TokenBudget > 0 {
+		fmt.Fprintf(out, "tokens:     %d / %d\n", snap.TokensUsed, snap.TokenBudget)
+	} else {
+		fmt.Fprintf(out, "tokens:     %d (no budget)\n", snap.TokensUsed)
+	}
+	if !snap.StartedAt.IsZero() {
+		fmt.Fprintf(out, "elapsed:    %s\n", time.Since(snap.StartedAt).Round(time.Second))
+	}
+	if snap.Summary != "" {
+		fmt.Fprintf(out, "summary:    %s\n", snap.Summary)
+	}
+	if snap.BlockReason != "" {
+		fmt.Fprintf(out, "blocked:    %s\n", snap.BlockReason)
+	}
+}

--- a/cmd/pigo/goal_test.go
+++ b/cmd/pigo/goal_test.go
@@ -1,0 +1,141 @@
+// Tests for the /goal command's pure helpers: goalFollowUpDecision's branch
+// logic (terminal states, token budget, turn cap, no-progress guard),
+// parseGoalObjective / parseTokenBudget flag parsing, and goalTurnActivity's
+// token/tool accounting.
+package main
+
+import (
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+)
+
+func TestGoalFollowUpDecision(t *testing.T) {
+	tests := []struct {
+		name     string
+		snap     agenttool.GoalSnapshot
+		wantCont bool
+		wantTerm agenttool.GoalStatus
+	}{
+		{
+			name:     "active continues",
+			snap:     agenttool.GoalSnapshot{Status: agenttool.GoalActive, Iterations: 1},
+			wantCont: true,
+			wantTerm: agenttool.GoalIdle,
+		},
+		{
+			name:     "complete stops",
+			snap:     agenttool.GoalSnapshot{Status: agenttool.GoalComplete},
+			wantCont: false,
+			wantTerm: agenttool.GoalIdle,
+		},
+		{
+			name:     "blocked stops",
+			snap:     agenttool.GoalSnapshot{Status: agenttool.GoalBlocked},
+			wantCont: false,
+			wantTerm: agenttool.GoalIdle,
+		},
+		{
+			name:     "budget exhausted",
+			snap:     agenttool.GoalSnapshot{Status: agenttool.GoalActive, TokenBudget: 100, TokensUsed: 100},
+			wantCont: false,
+			wantTerm: agenttool.GoalBudgetLimited,
+		},
+		{
+			name:     "budget under limit continues",
+			snap:     agenttool.GoalSnapshot{Status: agenttool.GoalActive, TokenBudget: 100, TokensUsed: 50},
+			wantCont: true,
+			wantTerm: agenttool.GoalIdle,
+		},
+		{
+			name:     "turn cap",
+			snap:     agenttool.GoalSnapshot{Status: agenttool.GoalActive, Iterations: goalMaxAutomaticTurns},
+			wantCont: false,
+			wantTerm: agenttool.GoalPaused,
+		},
+		{
+			name:     "no progress guard",
+			snap:     agenttool.GoalSnapshot{Status: agenttool.GoalActive, NoProgress: goalMaxNoProgress},
+			wantCont: false,
+			wantTerm: agenttool.GoalPaused,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cont, term := goalFollowUpDecision(tt.snap)
+			if cont != tt.wantCont {
+				t.Errorf("cont = %v, want %v", cont, tt.wantCont)
+			}
+			if term != tt.wantTerm {
+				t.Errorf("terminal = %q, want %q", term, tt.wantTerm)
+			}
+		})
+	}
+}
+
+func TestParseGoalObjective(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    string
+		wantObj string
+		wantBud int
+		wantErr bool
+	}{
+		{name: "no flag", args: "create hello.txt", wantObj: "create hello.txt", wantBud: 0},
+		{name: "tokens k", args: "--tokens 100k build the thing", wantObj: "build the thing", wantBud: 100000},
+		{name: "tokens m", args: "--tokens 1m do it", wantObj: "do it", wantBud: 1000000},
+		{name: "tokens bare", args: "--tokens 5000 go", wantObj: "go", wantBud: 5000},
+		{name: "flag only no objective", args: "--tokens 50k", wantObj: "", wantBud: 50000},
+		{name: "bad value", args: "--tokens abc do it", wantErr: true},
+		{name: "zero value", args: "--tokens 0 do it", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj, bud, err := parseGoalObjective(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got obj=%q bud=%d", obj, bud)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if obj != tt.wantObj {
+				t.Errorf("objective = %q, want %q", obj, tt.wantObj)
+			}
+			if bud != tt.wantBud {
+				t.Errorf("budget = %d, want %d", bud, tt.wantBud)
+			}
+		})
+	}
+}
+
+func TestGoalTurnActivity(t *testing.T) {
+	tail := []agentcore.AgentMessage{
+		agentcore.AssistantMessage{
+			RoleField: agentcore.RoleAssistant,
+			Usage:     &agentcore.Usage{OutputTokens: 40},
+		},
+		agentcore.AssistantMessage{
+			RoleField: agentcore.RoleAssistant,
+			Usage:     &agentcore.Usage{OutputTokens: 60},
+		},
+	}
+	tokens, hadTool := goalTurnActivity(tail)
+	if tokens != 100 {
+		t.Errorf("tokens = %d, want 100", tokens)
+	}
+	if hadTool {
+		t.Error("hadTool = true, want false (no tool calls or results)")
+	}
+
+	withTool := []agentcore.AgentMessage{
+		agentcore.ToolResultMessage{ToolName: "bash"},
+	}
+	_, hadTool = goalTurnActivity(withTool)
+	if !hadTool {
+		t.Error("hadTool = false, want true (tool result present)")
+	}
+}

--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/builtinskills"
 	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
@@ -203,6 +204,7 @@ func runInteractive(opts interactiveOptions) error {
 		curLeaf:   curLeaf,
 		persisted: len(history),
 		notifier:  plugin.NewEventNotifier(opts.plugins, os.Stderr),
+		goal:      agenttool.NewGoalState(),
 	})
 }
 
@@ -501,6 +503,7 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 		{"import", "import a JSONL export as a new session: /import <path.jsonl>"},
 		{"copy", "copy the most recent assistant reply to the clipboard"},
 		{"session", "show session stats: messages, tokens, model, compactions"},
+		{"goal", "run autonomously toward a goal: /goal [--tokens N] <objective> | pause | resume | clear"},
 	} {
 		reg.AddBuiltin(runtime.SlashCommand{
 			Name:        c.name,

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -85,6 +85,13 @@ type replDeps struct {
 	// from curLeaf, so switching leaves and continuing grows a real tree instead
 	// of rewriting the file as a single linear chain.
 	persisted int
+
+	// goal holds the session's autonomous-goal state (对标 pi-goal), driven by
+	// the /goal command. It is always non-nil (runInteractive seeds an idle
+	// state); the GoalReminderProvider and the goal tools share this handle so
+	// the objective is injected each turn and goal_complete/goal_blocked can end
+	// the run.
+	goal *agenttool.GoalState
 }
 
 // replScanBufInit is the initial size of the shared input reader. A REPL user
@@ -250,6 +257,15 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 			// derived from deps.header + the in-memory context — state a pure
 			// string→string Action closure cannot see.
 			runSession(out, &deps)
+			continue
+		}
+		if line == "/goal" || strings.HasPrefix(line, "/goal ") {
+			// /goal is intercepted here (like /compact) because it must run one or
+			// more agent streams and mutate the shared context/goal state — none of
+			// which a slash Action closure (string→string) can do. It drives the
+			// autonomous goal loop, reusing the same SIGINT cancel plumbing as a
+			// normal turn via setCancel.
+			runGoal(setCancel, out, &deps, line)
 			continue
 		}
 

--- a/internal/agenttool/goal_tool.go
+++ b/internal/agenttool/goal_tool.go
@@ -1,0 +1,374 @@
+// This file implements the goal state and the two goal-control tools that power
+// the /goal command (对标 pi-goal / Claude Code's goal mode): given a high-level
+// objective, the agent runs autonomously — re-prompted turn after turn — until
+// it either declares the goal done (goal_complete), hits a true impasse
+// (goal_blocked), or a safety guard / token budget stops it.
+//
+// The tools live here (rather than in the REPL) because they are ordinary
+// AgentTools the model invokes, and because the runtime's GoalReminderProvider
+// needs to read the same state — mirroring how TodoTool/TodoStore pairs with
+// TodoReminderProvider. GoalState is the shared, concurrency-safe handle both
+// the tools (which may run in a batch) and the REPL/reminder (which reads it
+// each turn) touch.
+package agenttool
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// GoalStatus is the lifecycle state of the active goal.
+type GoalStatus string
+
+const (
+	// GoalIdle means no goal is set (the zero value).
+	GoalIdle GoalStatus = ""
+	// GoalActive means the agent is autonomously working toward the goal.
+	GoalActive GoalStatus = "active"
+	// GoalPaused means autonomous continuation stopped (a safety guard fired, or
+	// the user paused it); it can be resumed.
+	GoalPaused GoalStatus = "paused"
+	// GoalBlocked means the agent hit a true impasse (goal_blocked was called).
+	GoalBlocked GoalStatus = "blocked"
+	// GoalComplete means the agent declared the goal done (goal_complete).
+	GoalComplete GoalStatus = "complete"
+	// GoalBudgetLimited means the token budget was exhausted before completion.
+	GoalBudgetLimited GoalStatus = "budget_limited"
+)
+
+// GoalState holds the current goal for a REPL session. It is safe for concurrent
+// use so the goal tools (which may run in a batch) and the REPL/reminder reader
+// can touch it without racing. A single state is shared for a session's
+// lifetime; /goal clear resets it to the idle zero value.
+type GoalState struct {
+	mu sync.RWMutex
+
+	id          string
+	objective   string
+	summary     string // set by goal_complete
+	blockReason string // set by goal_blocked
+	status      GoalStatus
+
+	iterations int // autonomous continuations issued so far
+	noProgress int // consecutive settles with no tool activity
+
+	tokenBudget int // 0 = unlimited
+	tokensUsed  int
+
+	startedAt time.Time
+}
+
+// NewGoalState returns an empty (idle) goal state.
+func NewGoalState() *GoalState { return &GoalState{} }
+
+// GoalSnapshot is an immutable copy of the goal state for display/decisions.
+type GoalSnapshot struct {
+	ID          string
+	Objective   string
+	Summary     string
+	BlockReason string
+	Status      GoalStatus
+	Iterations  int
+	NoProgress  int
+	TokenBudget int
+	TokensUsed  int
+	StartedAt   time.Time
+}
+
+// Start (re)initializes the state for a new objective, moving it to active. It
+// resets all counters so a fresh goal never inherits a prior goal's tallies.
+func (s *GoalState) Start(id, objective string, tokenBudget int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.id = id
+	s.objective = objective
+	s.summary = ""
+	s.blockReason = ""
+	s.status = GoalActive
+	s.iterations = 0
+	s.noProgress = 0
+	s.tokenBudget = tokenBudget
+	s.tokensUsed = 0
+	s.startedAt = time.Now()
+}
+
+// Snapshot returns a copy of the current state, safe to read without a lock.
+func (s *GoalState) Snapshot() GoalSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return GoalSnapshot{
+		ID:          s.id,
+		Objective:   s.objective,
+		Summary:     s.summary,
+		BlockReason: s.blockReason,
+		Status:      s.status,
+		Iterations:  s.iterations,
+		NoProgress:  s.noProgress,
+		TokenBudget: s.tokenBudget,
+		TokensUsed:  s.tokensUsed,
+		StartedAt:   s.startedAt,
+	}
+}
+
+// Clear resets the state to idle (no goal). It zeroes the fields individually
+// rather than replacing the whole struct so the embedded mutex (currently held)
+// is preserved — overwriting it while locked would corrupt the lock.
+func (s *GoalState) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.id = ""
+	s.objective = ""
+	s.summary = ""
+	s.blockReason = ""
+	s.status = GoalIdle
+	s.iterations = 0
+	s.noProgress = 0
+	s.tokenBudget = 0
+	s.tokensUsed = 0
+	s.startedAt = time.Time{}
+}
+
+// SetStatus transitions the goal to a new status (used by the REPL when a safety
+// guard fires or the user pauses/resumes).
+func (s *GoalState) SetStatus(status GoalStatus) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status = status
+}
+
+// Resume reactivates a paused or budget-limited goal and clears the transient
+// safety-guard counters (iterations, no-progress) that stopped it, so the run
+// gets a fresh allowance rather than immediately re-tripping the same guard. The
+// token budget is intentionally reset too (tokensUsed → 0): resuming past an
+// exhausted budget is an explicit user decision to grant another window. The
+// objective and id are preserved. It is a no-op-safe wrapper — callers gate on
+// the current status before invoking it.
+func (s *GoalState) Resume() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.status = GoalActive
+	s.iterations = 0
+	s.noProgress = 0
+	s.tokensUsed = 0
+}
+
+// ID returns the current goal id (empty when idle).
+func (s *GoalState) ID() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.id
+}
+
+// RecordIteration increments the autonomous-continuation counter and folds the
+// given output-token delta into the running total. hadToolActivity resets the
+// no-progress counter when true, else increments it — so a run of tool-free
+// turns can trip the no-progress guard.
+func (s *GoalState) RecordIteration(outputTokens int, hadToolActivity bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.iterations++
+	s.tokensUsed += outputTokens
+	if hadToolActivity {
+		s.noProgress = 0
+	} else {
+		s.noProgress++
+	}
+}
+
+// MarkComplete records the completion summary and moves the goal to complete.
+func (s *GoalState) MarkComplete(summary string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.summary = summary
+	s.status = GoalComplete
+}
+
+// MarkBlocked records the block reason and moves the goal to blocked.
+func (s *GoalState) MarkBlocked(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.blockReason = reason
+	s.status = GoalBlocked
+}
+
+// terminate is the shared *bool=true value returned by both goal tools to end
+// the run immediately (the loop terminates when every result in a batch has
+// Terminate=true; a goal tool is expected to be the sole call in its turn).
+func terminatePtr() *bool { b := true; return &b }
+
+// contradictorySummary reports whether a goal_complete summary plainly claims the
+// goal is NOT done — a guard against the model closing a goal it just admitted
+// is unfinished. The check is a conservative substring match on well-known
+// negative phrasings (English + 中文), matching pi-goal's "plainly contradictory
+// summary" rejection.
+func contradictorySummary(summary string) bool {
+	lower := strings.ToLower(summary)
+	for _, bad := range []string{
+		"not complete",
+		"not done",
+		"incomplete",
+		"tests still fail",
+		"tests fail",
+		"still failing",
+		"could not",
+		"couldn't",
+		"unable to",
+		"未完成",
+		"没有完成",
+		"未能",
+		"无法完成",
+		"仍然失败",
+		"测试失败",
+	} {
+		if strings.Contains(lower, bad) || strings.Contains(summary, bad) {
+			return true
+		}
+	}
+	return false
+}
+
+// GoalCompleteTool lets the model declare the active goal finished. It records
+// the summary, moves the state to complete, and terminates the run.
+type GoalCompleteTool struct {
+	// State is the session goal state. Must be non-nil.
+	State *GoalState
+}
+
+type goalCompleteArgs struct {
+	Summary string `json:"summary"`
+}
+
+// Name implements AgentTool.
+func (t *GoalCompleteTool) Name() string { return "goal_complete" }
+
+// Description implements AgentTool.
+func (t *GoalCompleteTool) Description() string {
+	return "Declare the current goal COMPLETE. Call this ONLY after verifying, " +
+		"requirement by requirement, that the objective is fully met — treat the " +
+		"working tree, tests, and actual runtime behavior as authoritative, not " +
+		"the prior conversation. Provide a concise summary of what was accomplished. " +
+		"Do NOT call this if any requirement is unmet, tests fail, or work remains; " +
+		"use goal_blocked for a true impasse instead. Calling this ends the run."
+}
+
+// Schema implements AgentTool.
+func (t *GoalCompleteTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "summary": {"type": "string", "description": "Concise summary of what was accomplished to satisfy the goal."}
+  },
+  "required": ["summary"],
+  "additionalProperties": false
+}`)
+}
+
+// ExecutionMode implements AgentTool. It mutates shared goal state → sequential.
+func (t *GoalCompleteTool) ExecutionMode() agentcore.ToolExecutionMode {
+	return agentcore.ToolExecutionSequential
+}
+
+// Execute implements AgentTool. It validates the summary (non-empty and not
+// plainly contradictory), records completion, and terminates the run. Invalid
+// input degrades to an error result (not a Go error) so the model can retry.
+func (t *GoalCompleteTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+	a, bad := decodeArgs[goalCompleteArgs](args, "goal_complete")
+	if bad != nil {
+		return *bad, nil
+	}
+	if t.State == nil {
+		return errorResult("goal_complete: no active goal"), nil
+	}
+	summary := strings.TrimSpace(a.Summary)
+	if summary == "" {
+		return errorResult("goal_complete: summary must not be empty"), nil
+	}
+	if contradictorySummary(summary) {
+		return errorResult("goal_complete: summary indicates the goal is NOT complete; " +
+			"keep working, or call goal_blocked with evidence if truly stuck"), nil
+	}
+	snap := t.State.Snapshot()
+	if snap.Status == GoalIdle {
+		return errorResult("goal_complete: no active goal"), nil
+	}
+	t.State.MarkComplete(summary)
+	return agentcore.AgentToolResult{
+		Content:   agentcore.ContentList{agentcore.NewTextContent("Goal marked complete: " + summary)},
+		Terminate: terminatePtr(),
+	}, nil
+}
+
+// GoalBlockedTool lets the model report a true impasse it cannot work around. It
+// records the reason, moves the state to blocked, and terminates the run.
+type GoalBlockedTool struct {
+	// State is the session goal state. Must be non-nil.
+	State *GoalState
+}
+
+type goalBlockedArgs struct {
+	Reason   string `json:"reason"`
+	Evidence string `json:"evidence"`
+}
+
+// Name implements AgentTool.
+func (t *GoalBlockedTool) Name() string { return "goal_blocked" }
+
+// Description implements AgentTool.
+func (t *GoalBlockedTool) Description() string {
+	return "Report that the current goal is BLOCKED by a true impasse you cannot " +
+		"resolve (e.g. missing credentials, an external dependency you cannot " +
+		"install, contradictory requirements). Provide a concrete reason and the " +
+		"evidence that establishes the blocker. Use this only as a last resort — " +
+		"prefer trying a different approach first. Calling this ends the run."
+}
+
+// Schema implements AgentTool.
+func (t *GoalBlockedTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "reason":   {"type": "string", "description": "Concise statement of what blocks the goal."},
+    "evidence": {"type": "string", "description": "Concrete evidence establishing the blocker (error output, missing file, etc.)."}
+  },
+  "required": ["reason", "evidence"],
+  "additionalProperties": false
+}`)
+}
+
+// ExecutionMode implements AgentTool. It mutates shared goal state → sequential.
+func (t *GoalBlockedTool) ExecutionMode() agentcore.ToolExecutionMode {
+	return agentcore.ToolExecutionSequential
+}
+
+// Execute implements AgentTool. It validates the reason/evidence, records the
+// block, and terminates the run.
+func (t *GoalBlockedTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+	a, bad := decodeArgs[goalBlockedArgs](args, "goal_blocked")
+	if bad != nil {
+		return *bad, nil
+	}
+	if t.State == nil {
+		return errorResult("goal_blocked: no active goal"), nil
+	}
+	reason := strings.TrimSpace(a.Reason)
+	if reason == "" {
+		return errorResult("goal_blocked: reason must not be empty"), nil
+	}
+	if strings.TrimSpace(a.Evidence) == "" {
+		return errorResult("goal_blocked: evidence must not be empty"), nil
+	}
+	snap := t.State.Snapshot()
+	if snap.Status == GoalIdle {
+		return errorResult("goal_blocked: no active goal"), nil
+	}
+	t.State.MarkBlocked(reason)
+	return agentcore.AgentToolResult{
+		Content:   agentcore.ContentList{agentcore.NewTextContent("Goal marked blocked: " + reason)},
+		Terminate: terminatePtr(),
+	}, nil
+}

--- a/internal/agenttool/goal_tool_test.go
+++ b/internal/agenttool/goal_tool_test.go
@@ -1,0 +1,188 @@
+// Tests for the goal tools (对标 pi-goal): goal_complete validation (empty and
+// contradictory summaries are rejected, a valid summary marks complete and
+// terminates the run), goal_blocked validation, and GoalState counter/lifecycle
+// behavior. Mirrors todo_tool_test.go's structure.
+package agenttool
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// execGoalComplete runs the goal_complete tool with the given JSON args.
+func execGoalComplete(t *testing.T, tool *GoalCompleteTool, args string) agentcore.AgentToolResult {
+	t.Helper()
+	res, err := tool.Execute(context.Background(), "call-1", json.RawMessage(args), nil)
+	if err != nil {
+		t.Fatalf("Execute returned Go error: %v", err)
+	}
+	return res
+}
+
+func isErrorResult(res agentcore.AgentToolResult) bool {
+	// An error result carries no Terminate and its text is the error message;
+	// the tools return errorResult(...) which has Terminate=nil.
+	return res.Terminate == nil
+}
+
+func TestGoalToolsRegister(t *testing.T) {
+	reg := NewToolRegistry()
+	st := NewGoalState()
+	if err := reg.Register(&GoalCompleteTool{State: st}); err != nil {
+		t.Fatalf("Register goal_complete: %v", err)
+	}
+	if err := reg.Register(&GoalBlockedTool{State: st}); err != nil {
+		t.Fatalf("Register goal_blocked: %v", err)
+	}
+	if _, ok := reg.Get("goal_complete"); !ok {
+		t.Fatal("goal_complete not found after Register")
+	}
+	if _, ok := reg.Get("goal_blocked"); !ok {
+		t.Fatal("goal_blocked not found after Register")
+	}
+}
+
+func TestGoalCompleteValidSummary(t *testing.T) {
+	st := NewGoalState()
+	st.Start("g1", "do the thing", 0)
+	tool := &GoalCompleteTool{State: st}
+
+	res := execGoalComplete(t, tool, `{"summary":"created hello.txt with the requested contents"}`)
+	if res.Terminate == nil || !*res.Terminate {
+		t.Fatalf("expected Terminate=true, got %v", res.Terminate)
+	}
+	if snap := st.Snapshot(); snap.Status != GoalComplete {
+		t.Errorf("status = %q, want complete", snap.Status)
+	}
+}
+
+func TestGoalCompleteRejectsEmpty(t *testing.T) {
+	st := NewGoalState()
+	st.Start("g1", "do the thing", 0)
+	tool := &GoalCompleteTool{State: st}
+
+	res := execGoalComplete(t, tool, `{"summary":"   "}`)
+	if !isErrorResult(res) {
+		t.Fatal("expected error result for empty summary")
+	}
+	if snap := st.Snapshot(); snap.Status != GoalActive {
+		t.Errorf("status = %q, want still active after rejected summary", snap.Status)
+	}
+}
+
+func TestGoalCompleteRejectsContradictory(t *testing.T) {
+	st := NewGoalState()
+	st.Start("g1", "do the thing", 0)
+	tool := &GoalCompleteTool{State: st}
+
+	for _, summary := range []string{
+		`{"summary":"the goal is not complete yet"}`,
+		`{"summary":"tests still fail but I stopped"}`,
+		`{"summary":"任务未完成"}`,
+	} {
+		res := execGoalComplete(t, tool, summary)
+		if !isErrorResult(res) {
+			t.Fatalf("expected error result for contradictory summary %s", summary)
+		}
+	}
+	if snap := st.Snapshot(); snap.Status != GoalActive {
+		t.Errorf("status = %q, want still active", snap.Status)
+	}
+}
+
+func TestGoalBlockedRecordsReason(t *testing.T) {
+	st := NewGoalState()
+	st.Start("g1", "do the thing", 0)
+	tool := &GoalBlockedTool{State: st}
+
+	res, err := tool.Execute(context.Background(), "c1",
+		json.RawMessage(`{"reason":"missing API key","evidence":"env AUTH_TOKEN is empty"}`), nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Terminate == nil || !*res.Terminate {
+		t.Fatalf("expected Terminate=true, got %v", res.Terminate)
+	}
+	snap := st.Snapshot()
+	if snap.Status != GoalBlocked {
+		t.Errorf("status = %q, want blocked", snap.Status)
+	}
+	if snap.BlockReason != "missing API key" {
+		t.Errorf("block reason = %q", snap.BlockReason)
+	}
+}
+
+func TestGoalBlockedRequiresEvidence(t *testing.T) {
+	st := NewGoalState()
+	st.Start("g1", "do the thing", 0)
+	tool := &GoalBlockedTool{State: st}
+
+	res, err := tool.Execute(context.Background(), "c1",
+		json.RawMessage(`{"reason":"stuck","evidence":""}`), nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !isErrorResult(res) {
+		t.Fatal("expected error result when evidence is empty")
+	}
+	if snap := st.Snapshot(); snap.Status != GoalActive {
+		t.Errorf("status = %q, want still active", snap.Status)
+	}
+}
+
+func TestGoalStateRecordIteration(t *testing.T) {
+	st := NewGoalState()
+	st.Start("g1", "obj", 1000)
+
+	st.RecordIteration(100, true) // tool activity resets no-progress
+	st.RecordIteration(50, false) // no tool activity
+	st.RecordIteration(50, false)
+
+	snap := st.Snapshot()
+	if snap.Iterations != 3 {
+		t.Errorf("iterations = %d, want 3", snap.Iterations)
+	}
+	if snap.TokensUsed != 200 {
+		t.Errorf("tokensUsed = %d, want 200", snap.TokensUsed)
+	}
+	if snap.NoProgress != 2 {
+		t.Errorf("noProgress = %d, want 2", snap.NoProgress)
+	}
+	if snap.TokenBudget != 1000 {
+		t.Errorf("tokenBudget = %d, want 1000", snap.TokenBudget)
+	}
+}
+
+func TestGoalStateClear(t *testing.T) {
+	st := NewGoalState()
+	st.Start("g1", "obj", 0)
+	st.Clear()
+	if snap := st.Snapshot(); snap.Status != GoalIdle || snap.Objective != "" {
+		t.Errorf("after Clear: status=%q objective=%q, want idle/empty", snap.Status, snap.Objective)
+	}
+}
+
+func TestGoalStateResume(t *testing.T) {
+	st := NewGoalState()
+	st.Start("g1", "obj", 1000)
+	// Simulate a run that tripped a safety guard.
+	st.RecordIteration(500, false)
+	st.RecordIteration(500, false)
+	st.SetStatus(GoalPaused)
+
+	st.Resume()
+	snap := st.Snapshot()
+	if snap.Status != GoalActive {
+		t.Errorf("status = %q, want active after Resume", snap.Status)
+	}
+	if snap.Iterations != 0 || snap.NoProgress != 0 || snap.TokensUsed != 0 {
+		t.Errorf("Resume should clear transient counters: iterations=%d noProgress=%d tokensUsed=%d",
+			snap.Iterations, snap.NoProgress, snap.TokensUsed)
+	}
+	if snap.Objective != "obj" || snap.TokenBudget != 1000 {
+		t.Errorf("Resume should preserve objective/budget: objective=%q budget=%d", snap.Objective, snap.TokenBudget)
+	}
+}

--- a/internal/runtime/reminder.go
+++ b/internal/runtime/reminder.go
@@ -24,6 +24,7 @@ package runtime
 
 import (
 	"context"
+	"strings"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
@@ -187,4 +188,34 @@ func (p *TodoReminderProvider) Reminder(ctx context.Context, _ agentcore.Message
 	}
 	return "Your todo list has unfinished items. Keep it up to date with the todo tool.\n\n" +
 		agenttool.RenderTodoList(items), true
+}
+
+// GoalReminderProvider surfaces the active goal as background context each turn
+// so the model keeps working toward it (对标 pi-goal). It reads the same
+// GoalState the /goal command drives, so the reminder always reflects the live
+// objective. It fires only while the goal is active — a paused, blocked, or
+// completed goal (and an idle state) injects nothing.
+type GoalReminderProvider struct {
+	// State is the session goal state. When nil the provider never fires.
+	State *agenttool.GoalState
+}
+
+// Name implements ReminderProvider.
+func (p *GoalReminderProvider) Name() string { return "goal" }
+
+// Reminder implements ReminderProvider. It injects the objective plus a
+// persistence instruction while the goal is active, and stays silent otherwise.
+func (p *GoalReminderProvider) Reminder(ctx context.Context, _ agentcore.MessageList) (string, bool) {
+	if p.State == nil {
+		return "", false
+	}
+	snap := p.State.Snapshot()
+	if snap.Status != agenttool.GoalActive || strings.TrimSpace(snap.Objective) == "" {
+		return "", false
+	}
+	return "You are working autonomously toward this goal:\n\n" + snap.Objective +
+		"\n\nKeep making progress. When every requirement is verifiably met, call the " +
+		"goal_complete tool with a summary. If you hit a true impasse you cannot work " +
+		"around, call goal_blocked with concrete evidence. Do not stop or ask the user " +
+		"to continue — keep going until the goal is done or blocked.", true
 }

--- a/internal/runtime/reminder_test.go
+++ b/internal/runtime/reminder_test.go
@@ -166,3 +166,29 @@ func TestTodoReminderEndToEndInjection(t *testing.T) {
 		t.Fatalf("todo reminder should be injected into the request, saw %v", seen)
 	}
 }
+
+func TestGoalReminderOnlyWhenActive(t *testing.T) {
+	st := agenttool.NewGoalState()
+	p := &GoalReminderProvider{State: st}
+
+	// Idle: no reminder.
+	if _, ok := p.Reminder(context.Background(), nil); ok {
+		t.Fatal("idle goal should not inject a reminder")
+	}
+
+	// Active: injects the objective.
+	st.Start("g1", "build the feature", 0)
+	body, ok := p.Reminder(context.Background(), nil)
+	if !ok {
+		t.Fatal("active goal should inject a reminder")
+	}
+	if !strings.Contains(body, "build the feature") {
+		t.Errorf("reminder body missing objective: %q", body)
+	}
+
+	// Completed: silent again.
+	st.MarkComplete("done")
+	if _, ok := p.Reminder(context.Background(), nil); ok {
+		t.Fatal("completed goal should not inject a reminder")
+	}
+}

--- a/tasks/prd-goal-autonomous-mode.md
+++ b/tasks/prd-goal-autonomous-mode.md
@@ -1,0 +1,91 @@
+# PRD: `/goal` 自主目标模式（对标 pi-goal / Claude Code goal）
+
+## Introduction
+
+pigo 的 REPL 目前每次只跑「一个 prompt → 助手回复（可含多轮工具调用）→ 回到提示符」的单轮闭环。用户希望像 Claude Code / [pi-goal](https://pi.dev/packages/@narumitw/pi-goal) 那样：给一个高层目标后，让 agent **自主续跑**，直到它认为目标达成（显式调用 `goal_complete`）、遇到真正的僵局（`goal_blocked`），或触发安全阀（最大轮次 / 无进展）或 token 预算上限才停下。
+
+技术路线（已确认）：
+- **范围** — 核心自主续跑 **+ token 预算**。不做目标队列、跨扩展 RPC、statusline。
+- **持久化** — 目标状态**仅存活于当前 REPL 会话内存**，退出即清空，无需跨进程持久化。
+- **无需改动核心 agent loop** — 复用现有接缝：`RunConfig.GetFollowUpMessages`（续跑驱动）、`ReminderProvider`（目标注入）、工具 `Terminate`（结束 run）、`AssistantMessage.Usage.OutputTokens`（token 预算）。
+
+## Goals
+
+- 用户在 REPL 输入 `/goal <objective>` 后，agent 自主朝目标推进，无需每轮手动确认。
+- 目标达成由模型显式调用 `goal_complete` 声明；真正僵局由 `goal_blocked` 声明；两者都立即结束 run。
+- 安全阀防止失控：最大自动轮次（默认 25）、连续无工具活动轮次（默认 3）、可选 token 预算。
+- 目标始终作为 `<system-reminder>` 背景上下文每轮注入，不污染持久化历史。
+- 复用 REPL 现有的 SIGINT 取消、会话持久化、Markdown 渲染。
+- 目标状态并发安全（工具可能在 batch 中运行，reminder/REPL 每轮读取）。
+
+## User Stories
+
+### US-001: 目标状态与两个目标控制工具
+**Description:** 作为使用者，我需要一个会话级目标状态，以及 `goal_complete` / `goal_blocked` 两个工具，让模型能声明目标完成或阻塞。
+
+**Acceptance Criteria:**
+- [x] `internal/agenttool/goal_tool.go` 定义 `GoalState`（`sync.RWMutex` 保护）与 `GoalStatus`（idle/active/paused/blocked/complete/budget_limited）
+- [x] `GoalState` 方法：`Start`、`Snapshot`、`Clear`、`SetStatus`、`ID`、`RecordIteration(outputTokens, hadToolActivity)`、`MarkComplete`、`MarkBlocked`
+- [x] `Clear` 逐字段清零（不整体替换 struct，避免覆盖持锁的 mutex）
+- [x] `GoalCompleteTool`：schema 需 `summary`；拒绝空 summary 与"明显矛盾"的 summary（含 `not complete`/`tests still fail`/`未完成` 等英中短语）；成功后 `MarkComplete` 并返回 `Terminate=true`；`ExecutionMode=Sequential`
+- [x] `GoalBlockedTool`：schema 需 `reason`+`evidence`；两者非空校验；`MarkBlocked` 并 `Terminate=true`
+- [x] 复用 `decodeArgs` / `errorResult`；无效输入降级为 error result（非 Go error），模型可重试
+
+### US-002: 目标提醒每轮注入
+**Description:** 作为使用者，我需要目标在自主续跑期间每轮被重新提醒，让模型始终记得目标而不必把目标写进持久化历史。
+
+**Acceptance Criteria:**
+- [x] `internal/runtime/reminder.go` 新增 `GoalReminderProvider{State *agenttool.GoalState}`，实现 `ReminderProvider`
+- [x] 仅当 `Status==active` 且 objective 非空时注入；paused/blocked/complete/idle 一律静默
+- [x] 注入正文含目标 + 持久化指令（"完成后调用 goal_complete，遇僵局调用 goal_blocked，不要停下或询问用户是否继续"）
+- [x] 遵循现有 `<system-reminder>` 语义：背景上下文，非用户指令，仅进入本轮请求，不写回持久化历史
+
+### US-003: `/goal` 命令与自主续跑循环
+**Description:** 作为使用者，我需要一个 `/goal` 命令来设置/查看/暂停/恢复/清空目标，并驱动自主续跑。
+
+**Acceptance Criteria:**
+- [x] `cmd/pigo/goal.go` 实现 `runGoal`，在 `cmd/pigo/repl.go` 主循环里拦截（与 `/compact`、`/fork` 同类，不走 slash Action 闭包），因为要跑 agent stream 且改共享状态
+- [x] `replDeps` 增加 `goal *agenttool.GoalState` 字段；`runInteractive` 初始化为空 idle state
+- [x] `/goal <objective>`：解析可选 `--tokens 100k/1m/N` 前缀（`parseGoalObjective`/`parseTokenBudget`）；`Start` 后调用 `runGoalLoop`
+- [x] `/goal`（裸）：打印状态（objective、status、iterations、tokens used/budget、elapsed、summary/blocked）
+- [x] `/goal pause`：标记 paused；`/goal resume`：从 paused/budget_limited 继续 `runGoalLoop`；`/goal clear`：清空
+- [x] `runGoalLoop`：组装 run（基础工具 + 两个 goal 工具的临时 registry；goal+todo reminder 合并；`GetFollowUpMessages` 续跑），复用 `streamRun` 结构与 SIGINT 取消（`setCancel` + `context.WithCancel`）
+- [x] `/help` 与拦截命令列表登记 `goal`
+
+### US-004: 续跑判定与安全阀
+**Description:** 作为使用者，我需要自主续跑在合适时机停下，避免失控或空转。
+
+**Acceptance Criteria:**
+- [x] `goalFollowUpDecision(snap) (cont bool, terminal GoalStatus)` 为纯函数，便于单测
+- [x] 判定顺序：complete/blocked → 结束（不改状态）；`TokensUsed>=TokenBudget`（预算>0）→ budget_limited 结束；`Iterations>=25` → paused 结束；`NoProgress>=3` → paused 结束；否则续跑
+- [x] 每次 settle 用 `goalTurnActivity(tail)` 累计新助手轮的 `Usage.OutputTokens` 与是否有工具活动，喂给 `RecordIteration`
+- [x] SIGINT 中断时置 paused 并提示 `/goal resume`
+- [x] 结束后按状态打印结果横幅（✓ 完成 / ⚠ 阻塞 / ⏸ 暂停或预算），并 `persistTurn`
+
+## Non-Goals
+
+- 目标队列（多目标排队）。
+- 跨扩展 RPC / 子代理编排。
+- statusline / 全屏进度渲染。
+- 跨进程 / 重启持久化目标状态。
+
+## Design Notes
+
+关键复用点：
+- 续跑驱动：`RunConfig.GetFollowUpMessages`（`internal/runtime/loop.go:232`）—— 内层循环 settle 后被调用，返回消息则继续外层循环，返回 nil 则结束 run。
+- 目标注入：`ReminderProvider` / `TodoReminderProvider`（`internal/runtime/reminder.go`）。
+- run 结束：工具 `Terminate`（`internal/agentcore/tool.go`）+ loop `allTerminate`（`loop.go:219`）。
+- token：`AssistantMessage.Usage.OutputTokens`（`internal/agentcore/message.go:61`）。
+- 命令拦截模式：`runManualCompact` / `runForkClone`（`cmd/pigo/repl.go`）。
+- run 组装：`streamRun`（`cmd/pigo/repl.go`）。
+- 工具骨架：`TodoTool` + `TodoStore`（`internal/agenttool/todo_tool.go`）。
+
+安全阀常量：`goalMaxAutomaticTurns=25`、`goalMaxNoProgress=3`（`cmd/pigo/goal.go`）。
+
+## Testing
+
+- [x] `internal/agenttool/goal_tool_test.go`：goal_complete 拒绝空/矛盾 summary、正常 summary 置 complete+Terminate；goal_blocked 记录 reason、要求 evidence；`RecordIteration` 计数；`Clear` 复位。
+- [x] `internal/runtime/reminder_test.go`：`GoalReminderProvider` 仅 active 时注入。
+- [x] `cmd/pigo/goal_test.go`：`goalFollowUpDecision` 各分支、`parseGoalObjective`/`parseTokenBudget` 解析、`goalTurnActivity` 累计。
+- [x] `go build ./...` + `go vet ./...` + `go test ./...` 全绿。
+- [ ] 端到端手测：REPL `/goal --tokens 50k 在当前目录创建 hello.txt 并写入 hi` → 观察自主续跑、goal_complete 结束、`/goal` 显示 complete、`/goal clear` 清空。


### PR DESCRIPTION
## Summary
- Add a `/goal` slash command that runs the agent autonomously toward a high-level objective, re-prompting each turn until the model declares the goal done (`goal_complete`), reports a true impasse (`goal_blocked`), or a safety guard / token budget stops it.
- `GoalState` + `goal_complete`/`goal_blocked` tools in `internal/agenttool`; `GoalReminderProvider` injects the objective as per-turn `<system-reminder>` background context.
- `/goal set | (bare) status | pause | resume | clear`, with an optional `--tokens 100k/1m/N` budget.
- Reuses existing loop seams (`GetFollowUpMessages`, `Reminders`, tool `Terminate`, `Usage.OutputTokens`) — no core agent-loop changes. Goal state is session-memory only, cleared on exit.
- Safety guards: max automatic turns (25), consecutive no-progress turns (3), optional token budget.

## Notes
- `resume` clears the transient safety counters so it grants a fresh allowance rather than immediately re-tripping the guard that paused the run.
- The follow-up token accounting clamps its message slice, so auto-compaction shrinking the context mid-run cannot panic.
- PRD saved to `tasks/prd-goal-autonomous-mode.md`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (new: goal_tool_test.go, goal_test.go, reminder_test.go goal case)
- [ ] End-to-end REPL smoke test against a live provider (`/goal --tokens 50k ...`)