### PR TITLE
feat: 裸 /btw 重开最近侧线程

### DIFF
--- a/cmd/pigo/btw.go
+++ b/cmd/pigo/btw.go
@@ -14,9 +14,10 @@
 // deps.header.UpdatedAt. Closing the side thread, switching sessions or
 // restarting pigo discards everything.
 //
-// Scope of this file (#279): the interception + isolation skeleton for a single
-// side question. Multi-turn follow-ups, bare-/btw reopen, and a model/thinking
-// override config land in follow-up issues (#280/#281/#282).
+// Scope: /btw is intercepted in the REPL loop and runs a side question against a
+// copy of the main context (#279); it supports multi-turn follow-ups in the same
+// ephemeral thread (#280) and bare-/btw reopen of the most recent side thread
+// this process (#281). A model/thinking override config lands in #282.
 package main
 
 import (
@@ -42,27 +43,43 @@ const btwHeader = "btw · side thread"
 // thread, distinguishing it from the main "pigo(model)>" prompt.
 const btwPrompt = "btw> "
 
-// runBtw handles a /btw invocation. With an argument it asks that side question
-// immediately, then enters a follow-up loop so the user can keep asking in the
-// same ephemeral thread; with no argument it prompts the user to supply one
-// (bare-/btw reopen of a prior side thread lands in #281). setCancel publishes
-// the active run's cancel func so the REPL's SIGINT handler can interrupt the
-// side run, reusing the same plumbing as a normal turn.
+// runBtw handles a /btw invocation. With an argument it starts a fresh side
+// thread, asks that question, then enters a follow-up loop so the user can keep
+// asking in the same ephemeral thread. Bare "/btw" reopens the most recent side
+// thread from this process — replaying its Q&A history — and drops back into the
+// follow-up loop; if none exists yet it guides the user to supply a question
+// (US-004, #281). setCancel publishes the active run's cancel func so the REPL's
+// SIGINT handler can interrupt the side run, reusing the same plumbing as a
+// normal turn.
 //
 // The main context is never mutated: runBtw builds a private side AgentContext
 // seeded with a copy of the main messages, runs every turn against that copy,
-// and returns without touching deps.agentCtx or persisting anything. The whole
-// side thread is discarded when this function returns.
+// and returns without touching deps.agentCtx or persisting anything. The side
+// thread is retained in-process (deps.lastBtw) so a later bare /btw can reopen
+// it, but it is never written to disk — restarting pigo discards it.
 func runBtw(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, editor *replLineEditor, line string) {
 	question := strings.TrimSpace(strings.TrimPrefix(line, "/btw"))
 	if question == "" {
-		// Bare /btw: reopening the most recent side thread is #281; for now guide
-		// the user to supply a question rather than erroring.
-		fmt.Fprintln(out, "usage: /btw <question> — ask a quick side question without touching the main conversation")
+		// Bare /btw: reopen the most recent side thread if one exists this process,
+		// replaying its history; otherwise guide the user to supply a question.
+		if deps.lastBtw == nil {
+			fmt.Fprintln(out, "usage: /btw <question> — ask a quick side question without touching the main conversation")
+			return
+		}
+		printBtwHeader(out)
+		replaySideHistory(out, deps.lastBtw, deps.lastBtwBase)
+		if editor != nil {
+			btwFollowUpLoop(setCancel, out, deps, editor, deps.lastBtw)
+		}
 		return
 	}
 
 	side := newSideContext(deps.agentCtx)
+	// Remember this thread so a later bare /btw can reopen it. lastBtwBase marks
+	// where the copied background ends and the side Q&A begins, so a reopen only
+	// replays the side turns, not the whole main transcript.
+	deps.lastBtw = side
+	deps.lastBtwBase = len(side.Messages)
 	printBtwHeader(out)
 	askSide(setCancel, out, deps, side, question)
 	// Follow-up loop: keep answering in the same ephemeral thread until the user
@@ -70,6 +87,31 @@ func runBtw(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, e
 	// the loop entirely, so a single /btw asks exactly one question and returns.
 	if editor != nil {
 		btwFollowUpLoop(setCancel, out, deps, editor, side)
+	}
+}
+
+// replaySideHistory prints the side thread's own Q&A (everything after the
+// copied main-conversation background at index base) when a bare /btw reopens a
+// prior thread, so the user can browse earlier answers before continuing. Only
+// user questions and assistant text are shown; tool activity is omitted to keep
+// the recap compact.
+func replaySideHistory(out io.Writer, side *agentcore.AgentContext, base int) {
+	if base > len(side.Messages) {
+		base = len(side.Messages)
+	}
+	for _, msg := range side.Messages[base:] {
+		switch m := msg.(type) {
+		case agentcore.UserMessage:
+			fmt.Fprintf(out, "%s %s\n", colorize(colorEnabled(), ansiDim, "you:"), agentcore.ContentToText(m.Content))
+		case agentcore.AssistantMessage:
+			if text := agentcore.ContentToText(m.Content); text != "" {
+				rendered := renderMarkdown(text)
+				fmt.Fprint(out, rendered)
+				if !strings.HasSuffix(rendered, "\n") {
+					fmt.Fprintln(out)
+				}
+			}
+		}
 	}
 }
 

--- a/cmd/pigo/btw_test.go
+++ b/cmd/pigo/btw_test.go
@@ -59,8 +59,8 @@ func TestBtwDoesNotPersist(t *testing.T) {
 	}
 }
 
-// TestBtwBareUsage verifies bare "/btw" does not launch a run and prints usage
-// guidance (reopen of a prior side thread is a follow-up issue).
+// TestBtwBareUsage verifies bare "/btw" with no prior side thread does not
+// launch a run and prints usage guidance.
 func TestBtwBareUsage(t *testing.T) {
 	p := &replProvider{reply: "unused"}
 	deps, _ := newTestDeps(t, p)
@@ -74,6 +74,37 @@ func TestBtwBareUsage(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "usage: /btw") {
 		t.Errorf("expected usage hint for bare /btw, got: %q", out.String())
+	}
+}
+
+// TestBtwBareReopensLastThread verifies that after a side thread exists, a bare
+// "/btw" reopens it, replays the prior side Q&A, and lets the user keep asking
+// in the SAME thread. The main context stays untouched throughout.
+func TestBtwBareReopensLastThread(t *testing.T) {
+	p := &replProvider{reply: "side answer"}
+	deps, _ := newTestDeps(t, p)
+
+	var out bytes.Buffer
+	// Open a side thread and ask once, leave it, then bare /btw reopens it and
+	// asks a follow-up, then leave again and exit the REPL.
+	in := strings.NewReader("/btw first question?\n/exit\n/btw\nsecond question?\n/exit\n/exit\n")
+	if err := runREPL(in, &out, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	if p.calls != 2 {
+		t.Fatalf("expected 2 side runs (1 initial + 1 after reopen), got %d", p.calls)
+	}
+	if len(deps.agentCtx.Messages) != 0 {
+		t.Fatalf("main context must stay untouched, got %d messages", len(deps.agentCtx.Messages))
+	}
+	s := out.String()
+	// The reopen must not print the bare-/btw usage hint (a thread existed).
+	if strings.Contains(s, "usage: /btw") {
+		t.Errorf("bare /btw with an existing thread must not print usage, got: %q", s)
+	}
+	// The replay must echo the earlier question.
+	if !strings.Contains(s, "first question?") {
+		t.Errorf("reopen should replay the earlier side question, got: %q", s)
 	}
 }
 

--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -504,7 +504,7 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 		{"copy", "copy the most recent assistant reply to the clipboard"},
 		{"session", "show session stats: messages, tokens, model, compactions"},
 		{"goal", "run autonomously toward a goal: /goal [--tokens N] <objective> | pause | resume | clear"},
-		{"btw", "ask a quick side question without touching the main conversation: /btw <question>"},
+		{"btw", "ask a quick side question without touching the main conversation: /btw <question> (bare /btw reopens the last one)"},
 	} {
 		reg.AddBuiltin(runtime.SlashCommand{
 			Name:        c.name,

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -92,6 +92,19 @@ type replDeps struct {
 	// the objective is injected each turn and goal_complete/goal_blocked can end
 	// the run.
 	goal *agenttool.GoalState
+
+	// lastBtw holds the most recent /btw side thread from this process (US-004,
+	// #281), so a bare "/btw" reopens it and shows its history. It is nil until
+	// the first /btw and is reset to nil on any session switch (/fork, /clone,
+	// /import) because a side thread branched from the old conversation no longer
+	// makes sense against a different one. It is never persisted: restarting pigo
+	// starts with lastBtw nil again.
+	lastBtw *agentcore.AgentContext
+	// lastBtwBase is the number of leading messages in lastBtw.Messages that were
+	// copied from the main conversation as background — the side thread's own Q&A
+	// is everything from this index on. Reopening replays only Messages[base:] so
+	// the whole main transcript is not reprinted.
+	lastBtwBase int
 }
 
 // replScanBufInit is the initial size of the shared input reader. A REPL user
@@ -528,6 +541,10 @@ func runForkClone(out io.Writer, deps *replDeps, line string) {
 	if len(path) > 0 {
 		deps.curLeaf = path[len(path)-1].ID
 	}
+	// A side thread branched from the old conversation is meaningless against the
+	// new branch, so drop it (#281).
+	deps.lastBtw = nil
+	deps.lastBtwBase = 0
 
 	action := "cloned"
 	if cmd == "/fork" {
@@ -657,6 +674,10 @@ func runImport(out io.Writer, deps *replDeps, line string) {
 	if len(entries) > 0 {
 		deps.curLeaf = entries[len(entries)-1].ID
 	}
+	// A side thread branched from the previous conversation no longer applies to
+	// the imported one, so drop it (#281).
+	deps.lastBtw = nil
+	deps.lastBtwBase = 0
 	fmt.Fprintf(out, "imported %d entries from %s → session %s\n", len(entries), path, newHeader.ID)
 }
 

--- a/docs/issue#0281.html
+++ b/docs/issue#0281.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #281</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/281">#281</a> &mdash; /btw: 裸 /btw 重开最近侧线程 &mdash; 2026-07-24</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 进程级状态存于 <code>replDeps.lastBtw</code> + <code>lastBtwBase</code></h3>
+      <p><strong>Ambiguity:</strong> Issue 要求"维护进程级 <code>lastBtw *agentcore.AgentContext</code>"，但未规定放在哪个结构、如何区分"背景拷贝"与"侧线程问答"。</p>
+      <p><strong>Choice:</strong> 在 <code>replDeps</code> 上加 <code>lastBtw</code>（最近侧线程）与 <code>lastBtwBase</code>（拷贝自主上下文的前缀长度）。REPL 循环以 <code>&amp;deps</code> 调用 <code>runBtw</code>，故跨轮次持久，重启进程即归零。</p>
+      <p><strong>Rationale:</strong> <code>replDeps</code> 已是循环持有的可变状态载体；用一个 base 下标即可在重开时只回放 <code>Messages[base:]</code>（侧问答），不重复打印整段主对话。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 重开只回放 user/assistant 文本，省略工具活动</h3>
+      <p><strong>Ambiguity:</strong> "展示历史问答"未规定回放粒度。</p>
+      <p><strong>Choice:</strong> <code>replaySideHistory</code> 只打印 UserMessage 文本（<code>you:</code> 前缀）与 AssistantMessage 文本，跳过 tool call / tool result。</p>
+      <p><strong>Rationale:</strong> 侧线程重开的目的是"浏览earlier answers"，紧凑回放更可读；工具细节对回顾问答无价值。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 会话切换清空 lastBtw 覆盖 /fork、/clone、/import，未含 /tree</h3>
+      <p><strong>Spec:</strong> AC 写"会话切换（/fork/clone/import）时清空 <code>lastBtw</code>"。</p>
+      <p><strong>Implemented:</strong> 在 <code>runForkClone</code> 与 <code>runImport</code> 成功切换后 <code>deps.lastBtw = nil</code>；<code>/tree</code> 不清空。</p>
+      <p><strong>Why:</strong> <code>/tree</code> 只在<em>同一会话</em>内移动 leaf，不是切换到另一段对话，侧线程背景仍属同一 conversation，无需失效。这与 AC 列举的三个命令一致，未偏离意图。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 重开沿用旧背景快照，不刷新主上下文</h3>
+      <p><strong>Alternatives:</strong> (A) 重开时保留侧线程创建时拷贝的主上下文背景；(B) 重开时用当前最新主上下文重新 seed 背景，再接上旧侧问答。</p>
+      <p><strong>Chosen:</strong> A。<strong>Pros:</strong> 侧线程语义稳定——它是"当时那条支线"，问答与其背景自洽；实现最简。<strong>Cons:</strong> 若主对话在两次 /btw 间大幅推进，重开的侧线程看到的是旧背景。对"快速回顾侧问答"场景可接受；需要最新背景时用户可起新 <code>/btw &lt;q&gt;</code>。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 只保留"最近一个"侧线程，历史侧线程不可回溯</h3>
+      <p><strong>Assumption:</strong> <code>lastBtw</code> 是单槽，起新 <code>/btw &lt;q&gt;</code> 会覆盖上一条侧线程；无侧线程列表/多槽浏览。</p>
+      <p><strong>Verify:</strong> 确认"仅最近一条可重开"符合预期（Claude Code 的 /btw 也是重开 most recent；多侧线程管理未在本 issue 范围）。</p>
+    </div>
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- `replDeps` 增加进程级 `lastBtw *agentcore.AgentContext` 与 `lastBtwBase int`，保存最近一次 /btw 侧线程及其背景/问答分界
- 裸 `/btw`：已有侧线程时重开并回放侧问答（`replaySideHistory`，只回放 user/assistant 文本），随后进入追问循环；无侧线程时仍打印用法提示
- `/fork`、`/clone`、`/import` 切换会话后清空 `lastBtw`（`/tree` 同会话移动 leaf 不清空）
- 侧线程不落盘，重启 pigo 后 `lastBtw` 归零

Closes #281

## Test plan
- [x] TestBtwBareReopensLastThread — 重开后回放 "first question?"、追问再触发 1 次 run、主上下文 0 消息、不打印 usage
- [x] TestBtwBareUsage — 无侧线程时裸 /btw 打印 usage、不 run
- [x] go build / go vet / go test ./cmd/pigo/ 全通过