### PR TITLE
feat: /btw model/thinking override config

### DIFF
--- a/cmd/pigo/btw.go
+++ b/cmd/pigo/btw.go
@@ -16,8 +16,9 @@
 //
 // Scope: /btw is intercepted in the REPL loop and runs a side question against a
 // copy of the main context (#279); it supports multi-turn follow-ups in the same
-// ephemeral thread (#280) and bare-/btw reopen of the most recent side thread
-// this process (#281). A model/thinking override config lands in #282.
+// ephemeral thread (#280), bare-/btw reopen of the most recent side thread this
+// process (#281), and an optional model/thinking override config (#282, see
+// btw_config.go) that affects only the side thread.
 package main
 
 import (
@@ -59,6 +60,10 @@ const btwPrompt = "btw> "
 // it, but it is never written to disk — restarting pigo discards it.
 func runBtw(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, editor *replLineEditor, line string) {
 	question := strings.TrimSpace(strings.TrimPrefix(line, "/btw"))
+	// Resolve the side thread's model/thinking once per invocation from the
+	// session defaults overlaid with btw.json (#282). Re-read each call so an
+	// edit takes effect next time with no restart.
+	settings := resolveBtwSettings(out, deps)
 	if question == "" {
 		// Bare /btw: reopen the most recent side thread if one exists this process,
 		// replaying its history; otherwise guide the user to supply a question.
@@ -69,7 +74,7 @@ func runBtw(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, e
 		printBtwHeader(out)
 		replaySideHistory(out, deps.lastBtw, deps.lastBtwBase)
 		if editor != nil {
-			btwFollowUpLoop(setCancel, out, deps, editor, deps.lastBtw)
+			btwFollowUpLoop(setCancel, out, deps, editor, deps.lastBtw, settings)
 		}
 		return
 	}
@@ -81,12 +86,12 @@ func runBtw(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, e
 	deps.lastBtw = side
 	deps.lastBtwBase = len(side.Messages)
 	printBtwHeader(out)
-	askSide(setCancel, out, deps, side, question)
+	askSide(setCancel, out, deps, side, settings, question)
 	// Follow-up loop: keep answering in the same ephemeral thread until the user
 	// exits. A nil editor (direct test callers that only ask one question) skips
 	// the loop entirely, so a single /btw asks exactly one question and returns.
 	if editor != nil {
-		btwFollowUpLoop(setCancel, out, deps, editor, side)
+		btwFollowUpLoop(setCancel, out, deps, editor, side, settings)
 	}
 }
 
@@ -120,7 +125,7 @@ func replaySideHistory(out io.Writer, side *agentcore.AgentContext, base int) {
 // /quit, EOF, or an idle Ctrl+C (errLineInterrupted) — the same exit affordances
 // as the main REPL, but confined to the side thread (FR-5). A blank line is
 // ignored (stays in the thread). Nothing here touches the main context.
-func btwFollowUpLoop(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, editor *replLineEditor, side *agentcore.AgentContext) {
+func btwFollowUpLoop(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, editor *replLineEditor, side *agentcore.AgentContext, settings btwRunSettings) {
 	for {
 		raw, err := editor.readLine(btwPrompt)
 		if errors.Is(err, errLineInterrupted) {
@@ -142,7 +147,7 @@ func btwFollowUpLoop(setCancel func(context.CancelFunc), out io.Writer, deps *re
 		if q == "" {
 			continue
 		}
-		askSide(setCancel, out, deps, side, q)
+		askSide(setCancel, out, deps, side, settings, q)
 	}
 }
 
@@ -169,8 +174,10 @@ func printBtwHeader(out io.Writer) {
 // askSide appends the question to the side context and streams one answer,
 // mirroring streamRun's rendering but targeting the side context so nothing is
 // written back to the main conversation or to disk. It reuses the REPL's SIGINT
-// cancel plumbing via setCancel.
-func askSide(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, side *agentcore.AgentContext, question string) {
+// cancel plumbing via setCancel. The model/provider/thinking come from settings
+// (session defaults overlaid with btw.json, #282), never from deps.live, so a
+// /btw override cannot leak into the main session.
+func askSide(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, side *agentcore.AgentContext, settings btwRunSettings, question string) {
 	content, err := buildUserContent(question)
 	if err != nil {
 		fmt.Fprintf(out, "pigo: %v\n", err)
@@ -194,10 +201,10 @@ func askSide(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, 
 
 	cfg := runtime.RunConfig{
 		LoopConfig: runtime.LoopConfig{
-			Model:         deps.live.model,
-			Provider:      deps.live.providerName,
-			ThinkingLevel: deps.live.thinkingLevel,
-			Stream:        provider.StreamFnFromProvider(deps.live.provider),
+			Model:         settings.model,
+			Provider:      settings.providerName,
+			ThinkingLevel: settings.thinkingLevel,
+			Stream:        provider.StreamFnFromProvider(settings.provider),
 			GetAPIKey:     deps.creds.GetAPIKey,
 			ContextWindow: deps.live.contextWindow,
 			Compaction:    compaction.DefaultCompactionSettings,

--- a/cmd/pigo/btw_config.go
+++ b/cmd/pigo/btw_config.go
@@ -1,0 +1,135 @@
+// This file implements the /btw model/thinking override config (US-005, #282):
+// an optional per-command config that lets a side thread use a different model
+// and/or reasoning effort than the main session, without touching the main
+// session's settings (对标 pi-btw's pi-btw.json).
+//
+// The config lives at $PIGO_HOME/btw.json (or ~/.pigo/btw.json). It is read
+// fresh on every /btw invocation, so editing it takes effect on the next call
+// with no restart. A missing file, an empty object, or an absent field all mean
+// "inherit the session default" silently — only a malformed file or an
+// unusable model override produces a (non-fatal) warning.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+// btwConfig is the on-disk shape of ~/.pigo/btw.json. Both fields are optional;
+// an absent field (nil / empty) inherits the session default. Pointers/empty
+// strings distinguish "not set" from a real value so a partial file still falls
+// back per-field.
+type btwConfig struct {
+	Model         string `json:"model,omitempty"`
+	ThinkingLevel string `json:"thinkingLevel,omitempty"`
+}
+
+// btwRunSettings is the resolved model/provider/thinking a side run uses. It is
+// computed once per /btw invocation from the session defaults overlaid with
+// btw.json, and passed down to askSide so every turn of that invocation uses
+// the same settings.
+type btwRunSettings struct {
+	model         string
+	providerName  string
+	provider      provider.Provider
+	thinkingLevel agentcore.ThinkingLevel
+}
+
+// btwConfigPath returns the path to the /btw override config, or "" when the
+// config directory cannot be resolved (then the config is treated as absent).
+func btwConfigPath() string {
+	dir := configDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "btw.json")
+}
+
+// loadBtwConfig reads and parses btw.json. A missing file returns a zero config
+// with no error (inherit everything). A malformed file returns an error so the
+// caller can warn and fall back. An empty object parses to a zero config.
+func loadBtwConfig(path string) (btwConfig, error) {
+	if path == "" {
+		return btwConfig{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return btwConfig{}, nil
+		}
+		return btwConfig{}, err
+	}
+	var cfg btwConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return btwConfig{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return cfg, nil
+}
+
+// resolveBtwSettings computes the model/provider/thinking a side run should use.
+// It starts from the session defaults (deps.live) and overlays btw.json:
+//
+//   - No config / empty object / absent fields → inherit the session values.
+//   - thinkingLevel set → validate and override (invalid value warns, falls back).
+//   - model set → resolve its provider (reusing resolveProvider like /model);
+//     if the model cannot be resolved/authenticated, warn on one line and fall
+//     back to the session model+provider.
+//
+// A malformed config file warns once and inherits everything. Nothing here
+// mutates deps.live, so the override is confined to the side thread (FR-8).
+func resolveBtwSettings(out io.Writer, deps *replDeps) btwRunSettings {
+	s := btwRunSettings{
+		model:         deps.live.model,
+		providerName:  deps.live.providerName,
+		provider:      deps.live.provider,
+		thinkingLevel: deps.live.thinkingLevel,
+	}
+
+	cfg, err := loadBtwConfig(btwConfigPath())
+	if err != nil {
+		fmt.Fprintf(out, "%s\n", colorize(colorEnabled(), ansiDim, "btw: ignoring invalid btw.json: "+err.Error()))
+		return s
+	}
+
+	if lvl := strings.TrimSpace(cfg.ThinkingLevel); lvl != "" {
+		if v, ok := validThinkingLevel(lvl); ok {
+			s.thinkingLevel = v
+		} else {
+			fmt.Fprintf(out, "%s\n", colorize(colorEnabled(), ansiDim, fmt.Sprintf("btw: ignoring invalid thinkingLevel %q, using %q", lvl, s.thinkingLevel)))
+		}
+	}
+
+	if model := strings.TrimSpace(cfg.Model); model != "" && model != s.model {
+		prov, providerName, perr := resolveProvider(model, deps.live.baseURL, deps.live.protocol, "")
+		if perr != nil {
+			fmt.Fprintf(out, "%s\n", colorize(colorEnabled(), ansiDim, fmt.Sprintf("btw: cannot use model %q (%v), falling back to %q", model, perr, s.model)))
+		} else {
+			s.model = model
+			s.providerName = providerName
+			s.provider = prov
+		}
+	}
+
+	return s
+}
+
+// validThinkingLevel reports whether s is one of the known reasoning-effort
+// levels and returns the typed value. It mirrors the enum in agentcore so an
+// invalid btw.json value can be rejected without importing the config layer.
+func validThinkingLevel(s string) (agentcore.ThinkingLevel, bool) {
+	switch agentcore.ThinkingLevel(s) {
+	case agentcore.ThinkingOff, agentcore.ThinkingMinimal, agentcore.ThinkingLow,
+		agentcore.ThinkingMedium, agentcore.ThinkingHigh, agentcore.ThinkingXHigh:
+		return agentcore.ThinkingLevel(s), true
+	default:
+		return "", false
+	}
+}

--- a/cmd/pigo/btw_config_test.go
+++ b/cmd/pigo/btw_config_test.go
@@ -1,0 +1,133 @@
+package main
+
+// Tests for the /btw model/thinking override config (#282, US-005): btw.json
+// overlays the session defaults for the side thread only, is read fresh each
+// call, and falls back silently on missing/empty/partial config.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// withBtwConfig points PIGO_HOME at a temp dir and writes btw.json with the
+// given contents (or removes it when contents is ""), returning nothing — the
+// temp dir is cleaned up by t.TempDir. It restores PIGO_HOME after the test.
+func withBtwConfig(t *testing.T, contents string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("PIGO_HOME", dir)
+	if contents != "" {
+		if err := os.WriteFile(filepath.Join(dir, "btw.json"), []byte(contents), 0o644); err != nil {
+			t.Fatalf("write btw.json: %v", err)
+		}
+	}
+}
+
+// TestBtwConfigAbsentInherits verifies that with no btw.json the side settings
+// equal the session defaults.
+func TestBtwConfigAbsentInherits(t *testing.T) {
+	withBtwConfig(t, "") // no file
+	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
+	deps.live.thinkingLevel = agentcore.ThinkingMedium
+
+	var warn bytes.Buffer
+	s := resolveBtwSettings(&warn, &deps)
+	if s.model != deps.live.model || s.providerName != deps.live.providerName {
+		t.Errorf("absent config must inherit model/provider, got %q/%q", s.model, s.providerName)
+	}
+	if s.thinkingLevel != agentcore.ThinkingMedium {
+		t.Errorf("absent config must inherit thinkingLevel, got %q", s.thinkingLevel)
+	}
+	if warn.Len() != 0 {
+		t.Errorf("absent config must not warn, got %q", warn.String())
+	}
+}
+
+// TestBtwConfigEmptyObjectInherits verifies that an empty JSON object inherits
+// everything without warning.
+func TestBtwConfigEmptyObjectInherits(t *testing.T) {
+	withBtwConfig(t, "{}")
+	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
+	deps.live.thinkingLevel = agentcore.ThinkingLow
+
+	var warn bytes.Buffer
+	s := resolveBtwSettings(&warn, &deps)
+	if s.model != deps.live.model || s.thinkingLevel != agentcore.ThinkingLow {
+		t.Errorf("empty object must inherit, got model=%q thinking=%q", s.model, s.thinkingLevel)
+	}
+	if warn.Len() != 0 {
+		t.Errorf("empty object must not warn, got %q", warn.String())
+	}
+}
+
+// TestBtwConfigThinkingOverride verifies a valid thinkingLevel is applied while
+// the model still inherits (partial config falls back per-field).
+func TestBtwConfigThinkingOverride(t *testing.T) {
+	withBtwConfig(t, `{"thinkingLevel":"high"}`)
+	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
+	deps.live.thinkingLevel = agentcore.ThinkingLow
+
+	var warn bytes.Buffer
+	s := resolveBtwSettings(&warn, &deps)
+	if s.thinkingLevel != agentcore.ThinkingHigh {
+		t.Errorf("expected thinkingLevel override 'high', got %q", s.thinkingLevel)
+	}
+	if s.model != deps.live.model {
+		t.Errorf("model must still inherit when only thinkingLevel is set, got %q", s.model)
+	}
+	if warn.Len() != 0 {
+		t.Errorf("valid override must not warn, got %q", warn.String())
+	}
+}
+
+// TestBtwConfigInvalidThinkingWarnsAndFallsBack verifies an invalid thinkingLevel
+// warns on one line and keeps the session value.
+func TestBtwConfigInvalidThinkingWarnsAndFallsBack(t *testing.T) {
+	withBtwConfig(t, `{"thinkingLevel":"bogus"}`)
+	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
+	deps.live.thinkingLevel = agentcore.ThinkingMedium
+
+	var warn bytes.Buffer
+	s := resolveBtwSettings(&warn, &deps)
+	if s.thinkingLevel != agentcore.ThinkingMedium {
+		t.Errorf("invalid thinkingLevel must fall back to session value, got %q", s.thinkingLevel)
+	}
+	if !strings.Contains(warn.String(), "thinkingLevel") {
+		t.Errorf("expected a warning about the invalid thinkingLevel, got %q", warn.String())
+	}
+}
+
+// TestBtwConfigMalformedWarnsAndInherits verifies a malformed JSON file warns
+// once and inherits every field (never crashes /btw).
+func TestBtwConfigMalformedWarnsAndInherits(t *testing.T) {
+	withBtwConfig(t, `{not json`)
+	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
+	deps.live.thinkingLevel = agentcore.ThinkingLow
+
+	var warn bytes.Buffer
+	s := resolveBtwSettings(&warn, &deps)
+	if s.model != deps.live.model || s.thinkingLevel != agentcore.ThinkingLow {
+		t.Errorf("malformed config must inherit, got model=%q thinking=%q", s.model, s.thinkingLevel)
+	}
+	if !strings.Contains(warn.String(), "invalid btw.json") {
+		t.Errorf("expected a malformed-config warning, got %q", warn.String())
+	}
+}
+
+// TestBtwConfigDoesNotMutateSession verifies resolveBtwSettings never mutates
+// deps.live, so a /btw override cannot leak into the main session (FR-8).
+func TestBtwConfigDoesNotMutateSession(t *testing.T) {
+	withBtwConfig(t, `{"thinkingLevel":"xhigh"}`)
+	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
+	deps.live.thinkingLevel = agentcore.ThinkingLow
+
+	_ = resolveBtwSettings(&bytes.Buffer{}, &deps)
+	if deps.live.thinkingLevel != agentcore.ThinkingLow {
+		t.Errorf("session thinkingLevel must be unchanged by /btw config, got %q", deps.live.thinkingLevel)
+	}
+}

--- a/cmd/pigo/btw_test.go
+++ b/cmd/pigo/btw_test.go
@@ -139,9 +139,10 @@ func TestBtwFollowUpLoopAccumulates(t *testing.T) {
 	side := &agentcore.AgentContext{}
 	deps, _ := newTestDeps(t, &replProvider{reply: "a"})
 	setCancel := func(context.CancelFunc) {}
-	askSide(setCancel, &bytes.Buffer{}, &deps, side, "q1")
+	settings := resolveBtwSettings(&bytes.Buffer{}, &deps)
+	askSide(setCancel, &bytes.Buffer{}, &deps, side, settings, "q1")
 	n1 := len(side.Messages)
-	askSide(setCancel, &bytes.Buffer{}, &deps, side, "q2")
+	askSide(setCancel, &bytes.Buffer{}, &deps, side, settings, "q2")
 	if len(side.Messages) <= n1 {
 		t.Fatalf("side context should accumulate across follow-ups: %d then %d", n1, len(side.Messages))
 	}

--- a/docs/issue#0282.html
+++ b/docs/issue#0282.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #282</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/282">#282</a> &mdash; /btw: 独立的 model / thinking 覆盖配置 &mdash; 2026-07-24</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 配置文件路径复用 <code>configDir()</code>，落在 <code>$PIGO_HOME/btw.json</code></h3>
+      <p><strong>Ambiguity:</strong> Issue 要求"对标 pi-btw.json 的覆盖配置"，但未规定文件名与目录。</p>
+      <p><strong>Choice:</strong> <code>btwConfigPath()</code> 复用既有 <code>configDir()</code>（<code>$PIGO_HOME</code> 或 <code>~/.pigo</code>），文件名 <code>btw.json</code>；<code>configDir()</code> 返回空时视为"无配置"。</p>
+      <p><strong>Rationale:</strong> 与 pigo 其它配置同目录，用户心智一致；命名对齐 pi-btw；空目录静默降级避免在无 HOME 环境崩溃。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 每次 <code>/btw</code> 调用重新读取配置</h3>
+      <p><strong>Ambiguity:</strong> 未规定配置的读取时机（启动时一次 vs 每次调用）。</p>
+      <p><strong>Choice:</strong> <code>runBtw</code> 开头调用 <code>resolveBtwSettings(out, deps)</code>，每次 <code>/btw</code> 都重读 <code>btw.json</code>。</p>
+      <p><strong>Rationale:</strong> 编辑配置后无需重启 pigo，下次 <code>/btw</code> 即生效；配置文件极小，重读成本可忽略。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 逐字段降级（partial config）</h3>
+      <p><strong>Ambiguity:</strong> "部分配置"如何处理未规定。</p>
+      <p><strong>Choice:</strong> <code>btwRunSettings</code> 先以 <code>deps.live</code> 会话默认填满，再逐字段用 btw.json 覆盖；只设 <code>thinkingLevel</code> 时 model 仍继承会话，反之亦然。</p>
+      <p><strong>Rationale:</strong> 用户可只覆盖关心的一项；空字段/缺字段一律"继承默认"，语义直观。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 无效值只警告一行并降级，从不使 <code>/btw</code> 失败</h3>
+      <p><strong>Spec:</strong> Issue 要求"覆盖 model/thinking"，未明确错误处理策略。</p>
+      <p><strong>Implemented:</strong> 畸形 JSON → 一行 <code>invalid btw.json</code> 警告后整体继承；非法 <code>thinkingLevel</code> → 一行警告后保留会话值；model 无法 resolve/鉴权 → 一行警告后回退会话 model+provider。全部非致命。</p>
+      <p><strong>Why:</strong> 侧线程是"随手一问"的辅助功能，配置错误不应阻断提问；一行 dim 警告足以提示用户而不打断心流。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 通过 <code>btwRunSettings</code> 传参，而非临时改写 <code>deps.live</code></h3>
+      <p><strong>Alternatives:</strong> (A) 把解析后的 model/thinking 打包成 <code>btwRunSettings</code>，穿过 <code>askSide</code>/<code>btwFollowUpLoop</code> 显式传递；(B) 进入 <code>/btw</code> 时临时改 <code>deps.live</code>，退出时还原。</p>
+      <p><strong>Chosen:</strong> A。<strong>Pros:</strong> <code>deps.live</code> 永不被侧线程触碰，覆盖绝无可能泄漏进主会话（FR-8）；无需 defer 还原、无 panic 泄漏风险；可测（<code>TestBtwConfigDoesNotMutateSession</code>）。<strong>Cons:</strong> 三个函数签名各加一个 <code>settings</code> 参数，调用点略啰嗦。</p>
+      <p><strong>Rationale:</strong> 隔离正确性 &gt; 签名简洁；B 的"改了再还原"在 Ctrl+C/异常路径下极易漏还原，风险不值当。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> model 覆盖复用 <code>resolveProvider</code> 而非新解析逻辑</h3>
+      <p><strong>Alternatives:</strong> (A) 复用 <code>/model</code> 用的 <code>resolveProvider(model, baseURL, protocol, "")</code>；(B) 为 btw 写独立的 provider 解析。</p>
+      <p><strong>Chosen:</strong> A。<strong>Pros:</strong> 与 <code>/model</code> 行为完全一致（preset 目录、ollama 前缀、协议推断），零重复。<strong>Cons:</strong> 沿用会话的 <code>baseURL</code>/<code>protocol</code>，btw.json 无法单独覆盖 base URL —— 但本 issue 只要求 model/thinking，未超范围。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> btw.json 是否需要支持覆盖 baseURL / protocol / provider</h3>
+      <p><strong>Assumption:</strong> 本 issue 仅覆盖 <code>model</code> 与 <code>thinkingLevel</code>；model 的 provider 由 <code>resolveProvider</code> 从会话的 baseURL/protocol 推断。</p>
+      <p><strong>Verify:</strong> 确认"侧线程用另一 provider/自定义 base URL"不在需求内。若将来需要跨 provider 的侧线程（如主用 anthropic、侧用本地 ollama），需扩展 <code>btwConfig</code> 增加 baseURL/protocol 字段。</p>
+    </div>
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add optional `$PIGO_HOME/btw.json` (`model` + `thinkingLevel`) that overrides settings for the `/btw` side thread only
- Read fresh on every `/btw` call — editing takes effect next call, no restart
- Missing / empty / partial config inherits session defaults silently; malformed JSON, invalid `thinkingLevel`, or unresolvable `model` warn one dim line and fall back per-field
- Resolved into `btwRunSettings` and threaded through `askSide`/`btwFollowUpLoop`, so the override never mutates `deps.live` and cannot leak into the main session

Closes #282

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/pigo/`
- [x] `go test ./cmd/pigo/` (new btw_config_test.go: absent/empty/partial/invalid/malformed/no-mutation)
- [x] gofmt clean