### PR TITLE
test: /btw context-isolation & zero-pollution tests

### DIFF
--- a/cmd/pigo/btw_isolation_test.go
+++ b/cmd/pigo/btw_isolation_test.go
@@ -1,0 +1,148 @@
+package main
+
+// Isolation / zero-pollution tests for /btw (#284, PRD Success Metrics). These
+// lock the feature's most important correctness guarantee: a side thread's
+// question and answer NEVER touch the main conversation and NEVER hit disk. The
+// tests drive the whole runREPL loop with the fake replProvider and assert, in
+// one place, every observable that a leak would perturb: the main context's
+// message count AND content, the session store on disk, and the persistence
+// bookkeeping (deps.persisted / deps.curLeaf / deps.header.UpdatedAt).
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// snapshotMessages returns the flattened text of every message so a test can
+// assert the main context is byte-for-byte unchanged, not merely the same
+// length (a leak could replace a message without changing the count). Content
+// is a field on the concrete message types, not on the Message interface, so we
+// type-switch on the two kinds /btw could ever append.
+func snapshotMessages(msgs agentcore.MessageList) []string {
+	out := make([]string, len(msgs))
+	for i, m := range msgs {
+		var text string
+		switch v := m.(type) {
+		case agentcore.UserMessage:
+			text = agentcore.ContentToText(v.Content)
+		case agentcore.AssistantMessage:
+			text = agentcore.ContentToText(v.Content)
+		}
+		out[i] = m.Role() + ":" + text
+	}
+	return out
+}
+
+// seedMainContext appends a real user+assistant exchange to the main context so
+// the isolation tests start from a non-empty conversation — proving /btw leaves
+// existing history untouched, not just that it avoids growing an empty slice.
+func seedMainContext(deps *replDeps) {
+	deps.agentCtx.Messages = append(deps.agentCtx.Messages,
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("main question")}},
+		agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant, Content: agentcore.ContentList{agentcore.NewTextContent("main answer")}},
+	)
+}
+
+// TestBtwMainContextZeroGrowth verifies one /btw Q&A leaves the main context's
+// message count AND content exactly as before (AC-1).
+func TestBtwMainContextZeroGrowth(t *testing.T) {
+	p := &replProvider{reply: "side answer"}
+	deps, _ := newTestDeps(t, p)
+	seedMainContext(&deps)
+	before := snapshotMessages(deps.agentCtx.Messages)
+
+	var out bytes.Buffer
+	if err := runREPL(strings.NewReader("/btw a quick question?\n/exit\n"), &out, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	if p.calls != 1 {
+		t.Fatalf("expected exactly 1 side run, got %d", p.calls)
+	}
+	after := snapshotMessages(deps.agentCtx.Messages)
+	if len(after) != len(before) {
+		t.Fatalf("main context grew: %d → %d messages", len(before), len(after))
+	}
+	for i := range before {
+		if after[i] != before[i] {
+			t.Fatalf("main context message %d changed:\n before %q\n after  %q", i, before[i], after[i])
+		}
+	}
+}
+
+// TestBtwNoStoreWrites verifies /btw writes nothing to the session store: no
+// entries are appended for the session on disk (AC-2).
+func TestBtwNoStoreWrites(t *testing.T) {
+	p := &replProvider{reply: "answer"}
+	deps, store := newTestDeps(t, p)
+	seedMainContext(&deps)
+
+	var out bytes.Buffer
+	if err := runREPL(strings.NewReader("/btw does this persist?\n/exit\n"), &out, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	// The main loop persists only on a real turn; /btw must trigger none. Since
+	// the seeded messages were never run through streamRun, the store should hold
+	// no entries for this session at all.
+	if _, entries, err := store.LoadEntries(deps.header.ID); err == nil && len(entries) != 0 {
+		t.Fatalf("/btw must not write to the store, got %d entries", len(entries))
+	}
+}
+
+// TestBtwFollowUpsLeaveContextUnchanged verifies that ≥3 follow-ups in the same
+// side thread still leave the main context's count and content unchanged (AC-3).
+func TestBtwFollowUpsLeaveContextUnchanged(t *testing.T) {
+	p := &replProvider{reply: "ok"}
+	deps, _ := newTestDeps(t, p)
+	seedMainContext(&deps)
+	before := snapshotMessages(deps.agentCtx.Messages)
+
+	var out bytes.Buffer
+	// One /btw plus three bare follow-ups, then leave the thread and exit.
+	in := strings.NewReader("/btw first?\nsecond?\nthird?\nfourth?\n/exit\n/exit\n")
+	if err := runREPL(in, &out, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	if p.calls != 4 {
+		t.Fatalf("expected 4 side runs (1 + 3 follow-ups), got %d", p.calls)
+	}
+	after := snapshotMessages(deps.agentCtx.Messages)
+	if len(after) != len(before) {
+		t.Fatalf("main context grew across follow-ups: %d → %d", len(before), len(after))
+	}
+	for i := range before {
+		if after[i] != before[i] {
+			t.Fatalf("follow-ups changed main message %d: %q → %q", i, before[i], after[i])
+		}
+	}
+}
+
+// TestBtwPersistenceBookkeepingUnchanged verifies /btw does not advance the
+// persistence bookkeeping: deps.persisted, deps.curLeaf and deps.header.UpdatedAt
+// are all identical before and after (AC-4).
+func TestBtwPersistenceBookkeepingUnchanged(t *testing.T) {
+	p := &replProvider{reply: "x"}
+	deps, _ := newTestDeps(t, p)
+	seedMainContext(&deps)
+	// Give the bookkeeping non-zero starting values so the test would catch a
+	// reset-to-zero as well as an increment.
+	deps.persisted = 2
+	deps.curLeaf = "leaf-abc"
+	beforeUpdated := deps.header.UpdatedAt
+
+	var out bytes.Buffer
+	if err := runREPL(strings.NewReader("/btw hi\nmore?\n/exit\n/exit\n"), &out, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+	if deps.persisted != 2 {
+		t.Errorf("deps.persisted changed: 2 → %d", deps.persisted)
+	}
+	if deps.curLeaf != "leaf-abc" {
+		t.Errorf("deps.curLeaf changed: %q → %q", "leaf-abc", deps.curLeaf)
+	}
+	if !deps.header.UpdatedAt.Equal(beforeUpdated) {
+		t.Errorf("deps.header.UpdatedAt changed: %v → %v", beforeUpdated, deps.header.UpdatedAt)
+	}
+}

--- a/docs/issue#0284.html
+++ b/docs/issue#0284.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #284</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/284">#284</a> &mdash; /btw: 上下文隔离与零污染的自动化测试 &mdash; 2026-07-24</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 用非空的种子对话作为测试起点</h3>
+      <p><strong>Ambiguity:</strong> AC 只说"主会话零增长"，未规定测试起始状态。空 slice 的零增长是弱证明。</p>
+      <p><strong>Choice:</strong> <code>seedMainContext</code> 先往主上下文塞一轮真实 user+assistant 对话，再跑 <code>/btw</code>，断言前后 count 与逐条内容都不变。</p>
+      <p><strong>Rationale:</strong> 证明 <code>/btw</code> 不仅"不追加"，更"不改写既有历史"——覆盖 shallow-copy 隔离可能被破坏的真实场景。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 快照比对内容而非仅比长度</h3>
+      <p><strong>Ambiguity:</strong> "数量与内容零增长"——如何比"内容"未规定。</p>
+      <p><strong>Choice:</strong> <code>snapshotMessages</code> 把每条消息拍平成 <code>role:text</code> 字符串数组，逐条对比。</p>
+      <p><strong>Rationale:</strong> 泄漏可能替换某条消息而不改长度；逐条比对能抓到这种"等长但内容变了"的污染。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 持久化簿记用非零初值</h3>
+      <p><strong>Ambiguity:</strong> AC-4 要求 <code>persisted/curLeaf/UpdatedAt</code> 不变，但从零值开始无法区分"未改"与"被重置为零"。</p>
+      <p><strong>Choice:</strong> 测试前置 <code>deps.persisted=2</code>、<code>deps.curLeaf="leaf-abc"</code>，再断言 <code>/btw</code> 后仍是这些值。</p>
+      <p><strong>Rationale:</strong> 同时捕获"增量"与"清零"两类回归。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> <code>snapshotMessages</code> 用类型 switch 取 Content，而非接口方法</h3>
+      <p><strong>Spec:</strong> 无——属实现细节。</p>
+      <p><strong>Implemented:</strong> 初稿写成 <code>m.Content()</code>，编译报错（<code>agentcore.Message</code> 接口只有 <code>Role()</code>/<code>isMessage()</code>，无 <code>Content()</code>）。改为对 <code>UserMessage</code>/<code>AssistantMessage</code> 类型 switch 取 <code>.Content</code> 字段。</p>
+      <p><strong>Why:</strong> <code>/btw</code> 只会向侧上下文追加 user/assistant 两类消息，覆盖这两种足够；避免为测试给 agentcore 接口加方法。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 端到端驱动 <code>runREPL</code> 而非直接调 <code>askSide</code></h3>
+      <p><strong>Alternatives:</strong> (A) 用 <code>strings.NewReader</code> 喂 <code>/btw ...\n/exit</code> 跑完整 REPL 循环；(B) 直接调内部 <code>askSide</code>/<code>runBtw</code> 断言。</p>
+      <p><strong>Chosen:</strong> A（延续 btw_test.go 既有风格）。<strong>Pros:</strong> 覆盖真实拦截路径（repl.go 的 <code>/btw</code> 拦截 → runBtw → askSide → 不落盘），最贴近用户行为；同一测试顺带验证追问循环。<strong>Cons:</strong> 比单元调用慢一点、失败定位略粗——但都是毫秒级 fake provider，可接受。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 是否需要断言 store 文件的 mtime / 字节数不变</h3>
+      <p><strong>Assumption:</strong> 用 <code>store.LoadEntries</code> 断言"该会话零 entry"已足以证明未落盘；不额外检查磁盘文件时间戳/大小。</p>
+      <p><strong>Verify:</strong> 确认"无 entry 写入"是"零污染落盘"的充分证明；若将来 store 有旁路写入（如索引文件），需补充断言。</p>
+    </div>
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `cmd/pigo/btw_isolation_test.go` — 4 tests locking `/btw`'s core correctness guarantee: side threads never touch the main conversation and never hit disk.
- AC-1 main context zero-growth (count + byte-for-byte content), AC-2 no store writes, AC-3 follow-ups leave context unchanged, AC-4 persistence bookkeeping (persisted/curLeaf/UpdatedAt) untouched.
- Drives the real `runREPL` interception path with the fake `replProvider`.

Closes #284

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./cmd/pigo/` clean
- [x] `go test ./cmd/pigo/ -run TestBtw` passes