### PR TITLE
Retain telemetry across runs on REPL state (closes #291)

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -205,6 +205,7 @@ func runInteractive(opts interactiveOptions) error {
 		persisted: len(history),
 		notifier:  plugin.NewEventNotifier(opts.plugins, os.Stderr),
 		goal:      agenttool.NewGoalState(),
+		telemetry: NewTelemetryHolder(),
 	})
 }
 

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -105,6 +105,12 @@ type replDeps struct {
 	// is everything from this index on. Reopening replays only Messages[base:] so
 	// the whole main transcript is not reprinted.
 	lastBtwBase int
+
+	// telemetry holds the retained per-run telemetry events (US-001, #291) and
+	// the cumulative accumulator that sums metrics across all runs in the session.
+	// It is reset to "no telemetry yet" on any session switch (/fork, /clone,
+	// /import).
+	telemetry *TelemetryHolder
 }
 
 // replScanBufInit is the initial size of the shared input reader. A REPL user
@@ -418,7 +424,16 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 		reply.Reset()
 	}
 	_, err = runtime.DrainStream(ctx, stream, runtime.StreamHandler{
-		OnEvent: deps.notifierHandle(),
+		OnEvent: func(ev agentcore.AgentEvent) {
+			// First call the notifier if present.
+			if notifier := deps.notifierHandle(); notifier != nil {
+				notifier(ev)
+			}
+			// Capture TelemetryEvent and fold it into the holder.
+			if telemetry, ok := ev.(agentcore.TelemetryEvent); ok && deps.telemetry != nil {
+				deps.telemetry.Fold(telemetry)
+			}
+		},
 		OnText: func(delta string) {
 			reply.WriteString(delta)
 		},
@@ -545,6 +560,11 @@ func runForkClone(out io.Writer, deps *replDeps, line string) {
 	// new branch, so drop it (#281).
 	deps.lastBtw = nil
 	deps.lastBtwBase = 0
+	// Reset telemetry for the new session, since cumulative stats should not bleed
+	// across conversations.
+	if deps.telemetry != nil {
+		deps.telemetry.Reset()
+	}
 
 	action := "cloned"
 	if cmd == "/fork" {
@@ -678,6 +698,11 @@ func runImport(out io.Writer, deps *replDeps, line string) {
 	// the imported one, so drop it (#281).
 	deps.lastBtw = nil
 	deps.lastBtwBase = 0
+	// Reset telemetry for the imported session, since cumulative stats should not
+	// bleed across conversations.
+	if deps.telemetry != nil {
+		deps.telemetry.Reset()
+	}
 	fmt.Fprintf(out, "imported %d entries from %s → session %s\n", len(entries), path, newHeader.ID)
 }
 

--- a/cmd/pigo/telemetry_state.go
+++ b/cmd/pigo/telemetry_state.go
@@ -1,0 +1,133 @@
+// This file implements the telemetry holder that retains per-run telemetry
+// events (US-001, #291) and folds them into a cumulative accumulator for the
+// /status command to display.
+package main
+
+import (
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// TelemetryHolder holds the most recent run's telemetry event and a cumulative
+// accumulator that sums metrics across all runs in the session.
+type TelemetryHolder struct {
+	// last is the telemetry event from the most recent completed run, or nil if
+	// no run has completed yet.
+	last *agentcore.TelemetryEvent
+	// cumulative is the accumulator that sums metrics across all runs.
+	cumulative cumulativeTelemetry
+}
+
+// cumulativeTelemetry holds the accumulated metrics from all runs in the session.
+type cumulativeTelemetry struct {
+	// turns is the total number of turns across all runs.
+	turns int
+	// toolDurationsMs maps tool name to aggregated count and total milliseconds
+	// across all runs.
+	toolDurationsMs map[string]agentcore.ToolTiming
+	// truncationCount is the total number of truncations across all runs.
+	truncationCount int
+	// compactionCount is the total number of compactions across all runs.
+	compactionCount int
+	// contextTokens is the most recent observed context token count.
+	contextTokens int
+	// contextWindow is the most recent observed context window size.
+	contextWindow int
+}
+
+// NewTelemetryHolder creates a new, empty TelemetryHolder with no telemetry yet.
+func NewTelemetryHolder() *TelemetryHolder {
+	return &TelemetryHolder{
+		last: nil,
+		cumulative: cumulativeTelemetry{
+			toolDurationsMs: make(map[string]agentcore.ToolTiming),
+		},
+	}
+}
+
+// Reset clears the holder to "no telemetry yet", as if the session had just
+// started. It is called when switching sessions (/fork, /clone, /import).
+func (h *TelemetryHolder) Reset() {
+	h.last = nil
+	h.cumulative = cumulativeTelemetry{
+		toolDurationsMs: make(map[string]agentcore.ToolTiming),
+	}
+}
+
+// Fold incorporates a new TelemetryEvent into the holder: it becomes the new
+// "last run" event, and its metrics are added to the cumulative accumulator.
+func (h *TelemetryHolder) Fold(ev agentcore.TelemetryEvent) {
+	// Store the new event as the last run.
+	h.last = &ev
+
+	// Add its metrics to the cumulative accumulator.
+	h.cumulative.turns += ev.Turns
+	h.cumulative.truncationCount += ev.TruncationCount
+	h.cumulative.compactionCount += ev.CompactionCount
+
+	// Update the latest context tokens and window (always use the most recent).
+	h.cumulative.contextTokens = ev.ContextTokens
+	h.cumulative.contextWindow = ev.ContextWindow
+
+	// Sum the per-tool timings.
+	for name, timing := range ev.ToolDurationsMs {
+		agg := h.cumulative.toolDurationsMs[name]
+		agg.Count += timing.Count
+		agg.TotalMs += timing.TotalMs
+		h.cumulative.toolDurationsMs[name] = agg
+	}
+}
+
+// HasTelemetry returns true if at least one run has completed and telemetry is
+// available.
+func (h *TelemetryHolder) HasTelemetry() bool {
+	return h.last != nil
+}
+
+// Last returns the most recent TelemetryEvent, or nil if no run has completed.
+func (h *TelemetryHolder) Last() *agentcore.TelemetryEvent {
+	return h.last
+}
+
+// CumulativeTurns returns the total number of turns across all runs.
+func (h *TelemetryHolder) CumulativeTurns() int {
+	return h.cumulative.turns
+}
+
+// CumulativeTruncationCount returns the total number of truncations across all runs.
+func (h *TelemetryHolder) CumulativeTruncationCount() int {
+	return h.cumulative.truncationCount
+}
+
+// CumulativeCompactionCount returns the total number of compactions across all runs.
+func (h *TelemetryHolder) CumulativeCompactionCount() int {
+	return h.cumulative.compactionCount
+}
+
+// CumulativeToolDurations returns the aggregated tool timings across all runs.
+func (h *TelemetryHolder) CumulativeToolDurations() map[string]agentcore.ToolTiming {
+	// Return a copy to prevent mutation of the internal state.
+	result := make(map[string]agentcore.ToolTiming, len(h.cumulative.toolDurationsMs))
+	for name, timing := range h.cumulative.toolDurationsMs {
+		result[name] = timing
+	}
+	return result
+}
+
+// LatestContextTokens returns the most recent observed context token count.
+func (h *TelemetryHolder) LatestContextTokens() int {
+	return h.cumulative.contextTokens
+}
+
+// LatestContextWindow returns the most recent observed context window size.
+func (h *TelemetryHolder) LatestContextWindow() int {
+	return h.cumulative.contextWindow
+}
+
+// CumulativeContextUtilization returns the latest utilization ratio, or 0 if no
+// window is known.
+func (h *TelemetryHolder) CumulativeContextUtilization() float64 {
+	if h.cumulative.contextWindow <= 0 {
+		return 0
+	}
+	return float64(h.cumulative.contextTokens) / float64(h.cumulative.contextWindow)
+}

--- a/cmd/pigo/telemetry_state_test.go
+++ b/cmd/pigo/telemetry_state_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// TestTelemetryHolderReset verifies that Reset clears the holder to "no telemetry yet".
+func TestTelemetryHolderReset(t *testing.T) {
+	h := NewTelemetryHolder()
+	if h.HasTelemetry() {
+		t.Fatal("expected HasTelemetry() = false on new holder")
+	}
+
+	// Fold an event and verify it's present.
+	h.Fold(agentcore.TelemetryEvent{
+		Turns:           1,
+		TruncationCount: 1,
+		CompactionCount: 1,
+		ContextTokens:   100,
+		ContextWindow:   1000,
+	})
+	if !h.HasTelemetry() {
+		t.Fatal("expected HasTelemetry() = true after Fold")
+	}
+	if h.Last() == nil {
+		t.Fatal("expected Last() != nil after Fold")
+	}
+	if h.CumulativeTurns() != 1 {
+		t.Fatalf("expected CumulativeTurns() = 1, got %d", h.CumulativeTurns())
+	}
+
+	// Reset and verify it's cleared.
+	h.Reset()
+	if h.HasTelemetry() {
+		t.Fatal("expected HasTelemetry() = false after Reset")
+	}
+	if h.Last() != nil {
+		t.Fatal("expected Last() = nil after Reset")
+	}
+	if h.CumulativeTurns() != 0 {
+		t.Fatalf("expected CumulativeTurns() = 0 after Reset, got %d", h.CumulativeTurns())
+	}
+	if h.CumulativeTruncationCount() != 0 {
+		t.Fatalf("expected CumulativeTruncationCount() = 0 after Reset, got %d", h.CumulativeTruncationCount())
+	}
+	if h.CumulativeCompactionCount() != 0 {
+		t.Fatalf("expected CumulativeCompactionCount() = 0 after Reset, got %d", h.CumulativeCompactionCount())
+	}
+	if h.LatestContextTokens() != 0 {
+		t.Fatalf("expected LatestContextTokens() = 0 after Reset, got %d", h.LatestContextTokens())
+	}
+	if h.LatestContextWindow() != 0 {
+		t.Fatalf("expected LatestContextWindow() = 0 after Reset, got %d", h.LatestContextWindow())
+	}
+}
+
+// TestTelemetryHolderFoldTwoEvents verifies that folding two synthetic TelemetryEvents
+// sums the metrics correctly.
+func TestTelemetryHolderFoldTwoEvents(t *testing.T) {
+	h := NewTelemetryHolder()
+
+	// Fold first event.
+	h.Fold(agentcore.TelemetryEvent{
+		Turns:           2,
+		TruncationCount: 1,
+		CompactionCount: 3,
+		ContextTokens:   100,
+		ContextWindow:   1000,
+		ToolDurationsMs: map[string]agentcore.ToolTiming{
+			"foo": {Count: 1, TotalMs: 100},
+			"bar": {Count: 2, TotalMs: 200},
+		},
+	})
+
+	// Verify the first event is the last one.
+	if !h.HasTelemetry() {
+		t.Fatal("expected HasTelemetry() = true after first Fold")
+	}
+	last1 := h.Last()
+	if last1 == nil {
+		t.Fatal("expected Last() != nil after first Fold")
+	}
+	if last1.Turns != 2 {
+		t.Fatalf("expected Last().Turns = 2, got %d", last1.Turns)
+	}
+
+	// Verify cumulative after first event.
+	if h.CumulativeTurns() != 2 {
+		t.Fatalf("expected CumulativeTurns() = 2 after first Fold, got %d", h.CumulativeTurns())
+	}
+	if h.CumulativeTruncationCount() != 1 {
+		t.Fatalf("expected CumulativeTruncationCount() = 1 after first Fold, got %d", h.CumulativeTruncationCount())
+	}
+	if h.CumulativeCompactionCount() != 3 {
+		t.Fatalf("expected CumulativeCompactionCount() = 3 after first Fold, got %d", h.CumulativeCompactionCount())
+	}
+	if h.LatestContextTokens() != 100 {
+		t.Fatalf("expected LatestContextTokens() = 100 after first Fold, got %d", h.LatestContextTokens())
+	}
+	if h.LatestContextWindow() != 1000 {
+		t.Fatalf("expected LatestContextWindow() = 1000 after first Fold, got %d", h.LatestContextWindow())
+	}
+	tools1 := h.CumulativeToolDurations()
+	if tools1["foo"].Count != 1 || tools1["foo"].TotalMs != 100 {
+		t.Fatalf("expected foo tool timing {1, 100}, got %+v", tools1["foo"])
+	}
+	if tools1["bar"].Count != 2 || tools1["bar"].TotalMs != 200 {
+		t.Fatalf("expected bar tool timing {2, 200}, got %+v", tools1["bar"])
+	}
+
+	// Fold second event.
+	h.Fold(agentcore.TelemetryEvent{
+		Turns:           3,
+		TruncationCount: 2,
+		CompactionCount: 1,
+		ContextTokens:   150,
+		ContextWindow:   1000,
+		ToolDurationsMs: map[string]agentcore.ToolTiming{
+			"foo": {Count: 2, TotalMs: 250},
+			"baz": {Count: 1, TotalMs: 50},
+		},
+	})
+
+	// Verify the second event is now the last one.
+	last2 := h.Last()
+	if last2 == nil {
+		t.Fatal("expected Last() != nil after second Fold")
+	}
+	if last2.Turns != 3 {
+		t.Fatalf("expected Last().Turns = 3, got %d", last2.Turns)
+	}
+
+	// Verify cumulative after second event (sums of both).
+	if h.CumulativeTurns() != 5 {
+		t.Fatalf("expected CumulativeTurns() = 5 after second Fold, got %d", h.CumulativeTurns())
+	}
+	if h.CumulativeTruncationCount() != 3 {
+		t.Fatalf("expected CumulativeTruncationCount() = 3 after second Fold, got %d", h.CumulativeTruncationCount())
+	}
+	if h.CumulativeCompactionCount() != 4 {
+		t.Fatalf("expected CumulativeCompactionCount() = 4 after second Fold, got %d", h.CumulativeCompactionCount())
+	}
+	if h.LatestContextTokens() != 150 {
+		t.Fatalf("expected LatestContextTokens() = 150 after second Fold, got %d", h.LatestContextTokens())
+	}
+	if h.LatestContextWindow() != 1000 {
+		t.Fatalf("expected LatestContextWindow() = 1000 after second Fold, got %d", h.LatestContextWindow())
+	}
+	tools2 := h.CumulativeToolDurations()
+	if tools2["foo"].Count != 3 || tools2["foo"].TotalMs != 350 {
+		t.Fatalf("expected foo tool timing {3, 350} after sum, got %+v", tools2["foo"])
+	}
+	if tools2["bar"].Count != 2 || tools2["bar"].TotalMs != 200 {
+		t.Fatalf("expected bar tool timing {2, 200} unchanged, got %+v", tools2["bar"])
+	}
+	if tools2["baz"].Count != 1 || tools2["baz"].TotalMs != 50 {
+		t.Fatalf("expected baz tool timing {1, 50} after sum, got %+v", tools2["baz"])
+	}
+}
+
+// TestTelemetryHolderCumulativeContextUtilization verifies context utilization calculation.
+func TestTelemetryHolderCumulativeContextUtilization(t *testing.T) {
+	h := NewTelemetryHolder()
+
+	// With unknown window (0), utilization should be 0.
+	h.Fold(agentcore.TelemetryEvent{
+		ContextTokens: 100,
+		ContextWindow: 0,
+	})
+	if h.CumulativeContextUtilization() != 0 {
+		t.Fatalf("expected utilization = 0 with unknown window, got %f", h.CumulativeContextUtilization())
+	}
+
+	// With known window, utilization should be tokens/window.
+	h.Fold(agentcore.TelemetryEvent{
+		ContextTokens: 500,
+		ContextWindow: 1000,
+	})
+	if h.CumulativeContextUtilization() != 0.5 {
+		t.Fatalf("expected utilization = 0.5, got %f", h.CumulativeContextUtilization())
+	}
+}
+
+// TestTelemetryHolderToolDurationsImmutable verifies that CumulativeToolDurations returns
+// a copy to prevent external mutation.
+func TestTelemetryHolderToolDurationsImmutable(t *testing.T) {
+	h := NewTelemetryHolder()
+	h.Fold(agentcore.TelemetryEvent{
+		ToolDurationsMs: map[string]agentcore.ToolTiming{
+			"test": {Count: 1, TotalMs: 100},
+		},
+	})
+
+	// Get the tool durations and mutate the returned map.
+	tools := h.CumulativeToolDurations()
+	tools["test"] = agentcore.ToolTiming{Count: 999, TotalMs: 9999}
+	tools["new"] = agentcore.ToolTiming{Count: 1, TotalMs: 1}
+
+	// Verify the internal state was not modified.
+	tools2 := h.CumulativeToolDurations()
+	if tools2["test"].Count != 1 || tools2["test"].TotalMs != 100 {
+		t.Fatalf("expected internal tool timing to remain {1, 100}, got %+v", tools2["test"])
+	}
+	if _, ok := tools2["new"]; ok {
+		t.Fatal("expected 'new' tool not to be present in internal state")
+	}
+}


### PR DESCRIPTION
This PR implements node #291, retaining telemetry across runs on REPL state.

## Changes

- **cmd/pigo/telemetry_state.go**: New file with `TelemetryHolder` struct that stores the most recent `TelemetryEvent` and a cumulative accumulator
- **cmd/pigo/telemetry_state_test.go**: Unit tests for telemetry retention and accumulation
- **cmd/pigo/repl.go**: 
  - Add `telemetry` field to `replDeps`
  - Wrap the `OnEvent` callback in `streamRun` to capture and fold `TelemetryEvent`
  - Reset telemetry on /fork, /clone, /import (matching lastBtw reset semantics)
- **cmd/pigo/interactive.go**: Initialize the telemetry holder when creating replDeps

## Accumulated metrics

The cumulative accumulator tracks:
- Total turns (`Turns`)
- Total truncations (`TruncationCount`)
- Total compactions (`CompactionCount`)
- Per-tool call counts and total durations (`ToolDurationsMs`)
- Most recent context tokens and window (`ContextTokens`, `ContextWindow`)

## Testing

- `go build ./...`: ✅ Passes
- `go vet ./...`: ✅ Passes
- `go test ./cmd/pigo`: ✅ All tests pass, including new telemetry tests
- `go test ./internal/runtime`: ✅ All telemetry-related tests pass

Closes #291