### PR TITLE
Register /status and render runtime config + context sections

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -487,9 +487,9 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 			return b.String()
 		},
 	})
-	// /exit, /quit, /compact, /fork, /clone, /tree, /export, /import, /copy and
-	// /session are intercepted by the REPL loop before slash resolution (they must
-	// return from the loop, run an agent stream, or read/swap the active
+	// /exit, /quit, /compact, /fork, /clone, /tree, /export, /import, /copy,
+	// /session and /status are intercepted by the REPL loop before slash resolution
+	// (they must return from the loop, run an agent stream, or read/swap the active
 	// session/leaf — none of which an Action closure can do). They are registered
 	// here only so /help lists them; their Action is never actually reached.
 	for _, c := range []struct{ name, desc string }{
@@ -503,6 +503,7 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 		{"import", "import a JSONL export as a new session: /import <path.jsonl>"},
 		{"copy", "copy the most recent assistant reply to the clipboard"},
 		{"session", "show session stats: messages, tokens, model, compactions"},
+		{"status", "show runtime config, context usage, and session status"},
 		{"goal", "run autonomously toward a goal: /goal [--tokens N] <objective> | pause | resume | clear"},
 		{"btw", "ask a quick side question without touching the main conversation: /btw <question> (bare /btw reopens the last one)"},
 	} {

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -272,6 +272,14 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 			runSession(out, &deps)
 			continue
 		}
+		if line == "/status" || strings.HasPrefix(line, "/status ") {
+			// /status prints a colored multi-section status report with runtime
+			// config, context usage, and more — state a pure string→string Action
+			// closure cannot see. The exact-or-space-prefix guard keeps "/statusfoo"
+			// from being mistaken for "/status".
+			runStatus(out, &deps)
+			continue
+		}
 		if line == "/goal" || strings.HasPrefix(line, "/goal ") {
 			// /goal is intercepted here (like /compact) because it must run one or
 			// more agent streams and mutate the shared context/goal state — none of

--- a/cmd/pigo/status.go
+++ b/cmd/pigo/status.go
@@ -1,0 +1,123 @@
+// This file implements the /status slash command (US-002, #292) that prints a
+// colored multi-section status report with runtime config, context usage, and more.
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/compaction"
+)
+
+// runStatus prints a colored multi-section status report to out using data
+// from deps. It shows runtime config, context usage, and (later) credentials
+// and telemetry.
+func runStatus(out io.Writer, deps *replDeps) {
+	color := colorEnabled()
+
+	fmt.Fprintln(out)
+	printRuntimeConfig(out, color, deps)
+	fmt.Fprintln(out)
+	printContextStatus(out, color, deps)
+}
+
+// printRuntimeConfig prints the runtime model configuration section.
+func printRuntimeConfig(out io.Writer, color bool, deps *replDeps) {
+	model := deps.live.model
+	providerName := deps.live.providerName
+	baseURL := deps.live.baseURL
+	protocol := deps.live.protocol
+	thinkingLevel := string(deps.live.thinkingLevel)
+	contextWindow := deps.live.contextWindow
+
+	if model == "" {
+		model = deps.header.Model
+	}
+	if providerName == "" {
+		providerName = deps.header.Provider
+	}
+	if baseURL == "" {
+		baseURL = "(default)"
+	}
+	if protocol == "" {
+		protocol = "(default)"
+	}
+	if thinkingLevel == "" {
+		thinkingLevel = "(default)"
+	}
+
+	fmt.Fprintf(out, "%s\n", colorize(color, ansiBold, "runtime config:"))
+	fmt.Fprintf(out, "  %s %s\n", colorize(color, ansiDim, "model:"), model)
+	fmt.Fprintf(out, "  %s %s\n", colorize(color, ansiDim, "provider:"), providerName)
+	fmt.Fprintf(out, "  %s %s\n", colorize(color, ansiDim, "base URL:"), baseURL)
+	fmt.Fprintf(out, "  %s %s\n", colorize(color, ansiDim, "protocol:"), protocol)
+	fmt.Fprintf(out, "  %s %s\n", colorize(color, ansiDim, "thinking:"), thinkingLevel)
+	if contextWindow > 0 {
+		fmt.Fprintf(out, "  %s %d tokens\n", colorize(color, ansiDim, "context window:"), contextWindow)
+	} else {
+		fmt.Fprintf(out, "  %s unknown\n", colorize(color, ansiDim, "context window:"))
+	}
+}
+
+// printContextStatus prints the current context usage and compaction section.
+func printContextStatus(out io.Writer, color bool, deps *replDeps) {
+	msgs := deps.agentCtx.Messages
+	tokens := compaction.EstimateContextTokens(msgs).Tokens
+	contextWindow := deps.live.contextWindow
+
+	compactions := 0
+	for _, m := range msgs {
+		if _, ok := m.(agentcore.CompactionMessage); ok {
+			compactions++
+		}
+	}
+
+	fmt.Fprintf(out, "%s\n", colorize(color, ansiBold, "context:"))
+	fmt.Fprintf(out, "  %s %d / %d tokens\n", colorize(color, ansiDim, "current:"), tokens, contextWindow)
+
+	// Calculate utilization percentage if possible
+	if contextWindow > 0 {
+		utilization := int(float64(tokens) / float64(contextWindow) * 100)
+		utilColor := ""
+		if utilization >= 90 {
+			utilColor = ansiRed
+		} else if utilization >= 70 {
+			utilColor = ansiYellow
+		} else {
+			utilColor = ansiGreen
+		}
+		fmt.Fprintf(out, "  %s %s\n", colorize(color, ansiDim, "utilization:"), colorize(color, utilColor, fmt.Sprintf("%d%%", utilization)))
+	} else {
+		fmt.Fprintf(out, "  %s %s\n", colorize(color, ansiDim, "utilization:"), colorize(color, ansiYellow, "unknown"))
+	}
+
+	fmt.Fprintf(out, "  %s %d\n", colorize(color, ansiDim, "compactions:"), compactions)
+
+	// Calculate remaining tokens before auto-compaction
+	if contextWindow > 0 {
+		reserve := compaction.DefaultCompactionSettings.ReserveTokens
+		threshold := contextWindow - reserve
+		remaining := threshold - tokens
+		if remaining < 0 {
+			fmt.Fprintf(out, "  %s %s (threshold: %d, reserve: %d)\n",
+				colorize(color, ansiDim, "before compact:"),
+				colorize(color, ansiRed, fmt.Sprintf("%d over threshold", -remaining)),
+				threshold,
+				reserve,
+			)
+		} else {
+			fmt.Fprintf(out, "  %s %s (threshold: %d, reserve: %d)\n",
+				colorize(color, ansiDim, "before compact:"),
+				colorize(color, ansiGreen, fmt.Sprintf("%d tokens remaining", remaining)),
+				threshold,
+				reserve,
+			)
+		}
+	} else {
+		fmt.Fprintf(out, "  %s %s\n",
+			colorize(color, ansiDim, "before compact:"),
+			colorize(color, ansiYellow, "auto-compaction disabled (unknown window)"),
+		)
+	}
+}

--- a/cmd/pigo/status_test.go
+++ b/cmd/pigo/status_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/compaction"
+)
+
+func TestRunStatus(t *testing.T) {
+	// Use the same test setup as other REPL tests
+	p := &replProvider{reply: "unused"}
+	deps, _ := newTestDeps(t, p)
+
+	// Customize the live config for clearer test expectations
+	deps.live.model = "test-model"
+	deps.live.providerName = "test-provider"
+	deps.live.baseURL = "https://api.example.com"
+	deps.live.protocol = "anthropic"
+	deps.live.contextWindow = 128000
+
+	// Add a message to the context
+	deps.agentCtx.Messages = append(deps.agentCtx.Messages,
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("hello")}},
+	)
+
+	// Test with color disabled
+	var buf bytes.Buffer
+	runStatus(&buf, &deps)
+	output := buf.String()
+
+	// Check that the runtime config section appears
+	if !strings.Contains(output, "runtime config:") {
+		t.Error("expected output to contain 'runtime config:'")
+	}
+	if !strings.Contains(output, "model: test-model") {
+		t.Error("expected output to contain 'model: test-model'")
+	}
+	if !strings.Contains(output, "provider: test-provider") {
+		t.Error("expected output to contain 'provider: test-provider'")
+	}
+	if !strings.Contains(output, "base URL: https://api.example.com") {
+		t.Error("expected output to contain 'base URL: https://api.example.com'")
+	}
+	if !strings.Contains(output, "protocol: anthropic") {
+		t.Error("expected output to contain 'protocol: anthropic'")
+	}
+	if !strings.Contains(output, "context window: 128000 tokens") {
+		t.Error("expected output to contain 'context window: 128000 tokens'")
+	}
+
+	// Check that the context section appears
+	if !strings.Contains(output, "context:") {
+		t.Error("expected output to contain 'context:'")
+	}
+	if !strings.Contains(output, "current:") {
+		t.Error("expected output to contain 'current:'")
+	}
+	if !strings.Contains(output, "utilization:") {
+		t.Error("expected output to contain 'utilization:'")
+	}
+	if !strings.Contains(output, "compactions: 0") {
+		t.Error("expected output to contain 'compactions: 0'")
+	}
+	if !strings.Contains(output, "before compact:") {
+		t.Error("expected output to contain 'before compact:'")
+	}
+}
+
+func TestRunStatusWithCompaction(t *testing.T) {
+	p := &replProvider{reply: "unused"}
+	deps, _ := newTestDeps(t, p)
+	deps.live.contextWindow = 128000
+
+	// Add messages including a compaction message
+	deps.agentCtx.Messages = append(deps.agentCtx.Messages,
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("hello")}},
+		agentcore.CompactionMessage{Summary: "compacted history"},
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("more")}},
+	)
+
+	var buf bytes.Buffer
+	runStatus(&buf, &deps)
+	output := buf.String()
+
+	if !strings.Contains(output, "compactions: 1") {
+		t.Error("expected output to contain 'compactions: 1'")
+	}
+}
+
+func TestRunStatusUnknownContextWindow(t *testing.T) {
+	p := &replProvider{reply: "unused"}
+	deps, _ := newTestDeps(t, p)
+	deps.live.contextWindow = 0 // unknown
+
+	var buf bytes.Buffer
+	runStatus(&buf, &deps)
+	output := buf.String()
+
+	if !strings.Contains(output, "context window: unknown") {
+		t.Error("expected output to contain 'context window: unknown'")
+	}
+	if !strings.Contains(output, "auto-compaction disabled") {
+		t.Error("expected output to contain 'auto-compaction disabled'")
+	}
+}
+
+func TestStatusGuard(t *testing.T) {
+	// The guard logic is in the REPL loop: matches "/status" or "/status "
+	// but not "/statusfoo" or "/statusbar"
+	testCases := []struct {
+		line string
+		want bool
+	}{
+		{"/status", true},
+		{"/status ", true},
+		{"/status foo", true},
+		{"/statusbar", false},
+		{"/statusfoo", false},
+		{"/status123", false},
+		{"/stat", false},
+		{"/session", false},
+	}
+
+	for _, tc := range testCases {
+		got := (tc.line == "/status" || strings.HasPrefix(tc.line, "/status "))
+		if got != tc.want {
+			t.Errorf("line %q: got %v, want %v", tc.line, got, tc.want)
+		}
+	}
+}
+
+func TestBeforeCompactCalculation(t *testing.T) {
+	// Test the threshold calculation logic
+	// This tests the logic used in printContextStatus
+	reserve := compaction.DefaultCompactionSettings.ReserveTokens
+	if reserve != 16384 {
+		t.Errorf("expected reserve tokens to be 16384, got %d", reserve)
+	}
+
+	contextWindow := 128000
+	threshold := contextWindow - reserve
+	if threshold != 128000-16384 {
+		t.Errorf("expected threshold to be 128000-16384=%d, got %d", 128000-16384, threshold)
+	}
+}
+
+func TestRunStatusViaREPL(t *testing.T) {
+	// Verify that /status is intercepted in the REPL loop and doesn't invoke the model
+	p := &replProvider{reply: "should not be called"}
+	deps, _ := newTestDeps(t, p)
+
+	var out bytes.Buffer
+	in := strings.NewReader("/status\n/exit\n")
+	if err := runREPL(in, &out, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+
+	// Check that the provider was not called (since /status is intercepted)
+	if p.calls != 0 {
+		t.Errorf("expected 0 model calls for /status, got %d", p.calls)
+	}
+
+	// Check that the status output appears
+	output := out.String()
+	if !strings.Contains(output, "runtime config:") {
+		t.Error("expected REPL /status output to contain 'runtime config:'")
+	}
+	if !strings.Contains(output, "context:") {
+		t.Error("expected REPL /status output to contain 'context:'")
+	}
+}
+
+func TestStatusFooNotIntercepted(t *testing.T) {
+	// Verify that "/statusfoo" is NOT intercepted as "/status"
+	p := &replProvider{reply: "model called"}
+	deps, _ := newTestDeps(t, p)
+
+	var out bytes.Buffer
+	in := strings.NewReader("/statusfoo\n/exit\n")
+	if err := runREPL(in, &out, deps); err != nil {
+		t.Fatalf("runREPL: %v", err)
+	}
+
+	// The provider should NOT be called because "/statusfoo" is treated as a
+	// slash command that doesn't exist, not as a prompt
+	if p.calls != 0 {
+		t.Errorf("expected 0 model calls for /statusfoo, got %d", p.calls)
+	}
+
+	// But the key thing: "/statusfoo" was NOT intercepted as "/status"
+	output := out.String()
+	if strings.Contains(output, "runtime config:") {
+		t.Error("expected /statusfoo to NOT run the status command")
+	}
+}


### PR DESCRIPTION
This implements US-002 from the /status PRD:

- Adds /status command to the REPL loop with exact-or-space-prefix guard (so /statusfoo is not matched)
- Adds status.go with runStatus function that prints a colored multi-section report
- Runtime config section shows model id, provider name, base URL, protocol, thinking level, and context window
- Context section shows current context tokens, utilization percentage, compaction count, and remaining tokens before auto-compact threshold
- /status is listed in /help output
- Comprehensive tests verify all functionality

Closes #292