### PR TITLE
feat: /status env/credentials/telemetry sections

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -308,7 +308,7 @@ func buildSlashRegistry(live *liveRunConfig, noSkills bool, mgr *plugin.Manager)
 
 		skillCmds, serr := loadSkillCommands()
 		for _, c := range skillCmds {
-			reg.AddUser(c)
+			reg.AddSkill(c)
 		}
 		if serr != nil {
 			fmt.Fprintf(os.Stderr, "pigo: skills: some skills failed to load: %v\n", serr)
@@ -385,7 +385,7 @@ const defaultContextWindow = 128000
 // (Manager.Commands()) into the registry as a hybrid (Run) command. Invoking it
 // RPCs the owning plugin (Plugin.CallCommand), returns the plugin's
 // notifications as the outcome Message, and returns the plugin's Prompt to run
-// as the next turn. Plugin commands are registered with AddUser so a same-named
+// as the next turn. Plugin commands are registered with AddPlugin so a same-named
 // built-in still wins (existing precedence preserved) and a collision is
 // reported as shadowed. mgr may be nil (no plugins), in which case this is a
 // no-op.
@@ -401,7 +401,7 @@ func registerPluginCommands(reg *runtime.SlashRegistry, mgr *plugin.Manager) {
 	}
 	for _, pc := range mgr.Commands() {
 		pc := pc // capture per iteration
-		reg.AddUser(runtime.SlashCommand{
+		reg.AddPlugin(runtime.SlashCommand{
 			Name:        pc.Spec.Name,
 			Description: pc.Spec.Description,
 			Run: func(args string) (message, prompt string) {

--- a/cmd/pigo/status.go
+++ b/cmd/pigo/status.go
@@ -3,11 +3,16 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"sort"
+	"strings"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/compaction"
+	"github.com/smallnest/pigo/internal/runtime"
+	"github.com/smallnest/pigo/internal/trust"
 )
 
 // runStatus prints a colored multi-section status report to out using data
@@ -20,6 +25,12 @@ func runStatus(out io.Writer, deps *replDeps) {
 	printRuntimeConfig(out, color, deps)
 	fmt.Fprintln(out)
 	printContextStatus(out, color, deps)
+	fmt.Fprintln(out)
+	printEnvStatus(out, color, deps)
+	fmt.Fprintln(out)
+	printCredentialsStatus(out, color, deps)
+	fmt.Fprintln(out)
+	printTelemetryStatus(out, color, deps)
 }
 
 // printRuntimeConfig prints the runtime model configuration section.
@@ -119,5 +130,153 @@ func printContextStatus(out io.Writer, color bool, deps *replDeps) {
 			colorize(color, ansiDim, "before compact:"),
 			colorize(color, ansiYellow, "auto-compaction disabled (unknown window)"),
 		)
+	}
+}
+
+// printEnvStatus prints the project & environment section: cwd, trust status,
+// and counts of loaded skills and plugins (with names). User command templates
+// are listed separately when present.
+func printEnvStatus(out io.Writer, color bool, deps *replDeps) {
+	fmt.Fprintf(out, "%s\n", colorize(color, ansiBold, "project & environment:"))
+	fmt.Fprintf(out, "  %s %s\n", colorize(color, ansiDim, "cwd:"), deps.cwd)
+	fmt.Fprintf(out, "  %s %s\n", colorize(color, ansiDim, "trust:"), trustStatus(deps.trust, deps.cwd))
+
+	var skills, plugins, userCmds []string
+	if deps.slash != nil {
+		for _, c := range deps.slash.List() {
+			switch c.Source {
+			case runtime.SourceSkill:
+				skills = append(skills, c.Name)
+			case runtime.SourcePlugin:
+				plugins = append(plugins, c.Name)
+			case runtime.SourceUser:
+				userCmds = append(userCmds, c.Name)
+			}
+		}
+	}
+	fmt.Fprintf(out, "  %s %d%s\n", colorize(color, ansiDim, "skills:"), len(skills), namesSuffix(skills))
+	fmt.Fprintf(out, "  %s %d%s\n", colorize(color, ansiDim, "plugins:"), len(plugins), namesSuffix(plugins))
+	if len(userCmds) > 0 {
+		fmt.Fprintf(out, "  %s %d%s\n", colorize(color, ansiDim, "user commands:"), len(userCmds), namesSuffix(userCmds))
+	}
+}
+
+// trustStatus classifies the cwd's trust state for display: disabled when trust
+// is off, trusted when IsTrusted is true (session grant or saved Trusted),
+// untrusted when a saved Untrusted decision applies, else prompt (undecided).
+func trustStatus(mgr *trust.Manager, cwd string) string {
+	if mgr == nil {
+		return "disabled"
+	}
+	if mgr.IsTrusted(cwd) {
+		return "trusted"
+	}
+	if res := mgr.NearestTrustDecision(cwd); res.Found && res.Decision == trust.Untrusted {
+		return "untrusted"
+	}
+	return "prompt"
+}
+
+// namesSuffix renders " (n1, n2, ...)" for a non-empty name list, capping at 8
+// names with "+k more". It returns "" for an empty list.
+func namesSuffix(names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+	sort.Strings(names)
+	const max = 8
+	if len(names) <= max {
+		return " (" + strings.Join(names, ", ") + ")"
+	}
+	return fmt.Sprintf(" (%s, +%d more)", strings.Join(names[:max], ", "), len(names)-max)
+}
+
+// printCredentialsStatus prints the credentials & connectivity section: API key
+// presence (masked, never plaintext) and the provider endpoint URL.
+func printCredentialsStatus(out io.Writer, color bool, deps *replDeps) {
+	fmt.Fprintf(out, "%s\n", colorize(color, ansiBold, "credentials & connectivity:"))
+	provider := deps.live.providerName
+	if deps.creds != nil && deps.creds.HasCredential(context.Background(), provider) {
+		key := deps.creds.GetAPIKey(context.Background(), provider)
+		fmt.Fprintf(out, "  %s %s %s\n",
+			colorize(color, ansiDim, "api key:"),
+			colorize(color, ansiGreen, "set"),
+			colorize(color, ansiDim, maskKey(key)))
+	} else {
+		fmt.Fprintf(out, "  %s %s\n",
+			colorize(color, ansiDim, "api key:"),
+			colorize(color, ansiYellow, "not set"))
+	}
+	endpoint := deps.live.baseURL
+	if endpoint == "" {
+		endpoint = "(default)"
+	}
+	fmt.Fprintf(out, "  %s %s\n", colorize(color, ansiDim, "endpoint:"), endpoint)
+}
+
+// maskKey returns a masked hint of an API key showing only the last 4 chars
+// (e.g. "••••abcd"). A key of 4 chars or fewer is masked entirely. It never
+// returns the full key.
+func maskKey(key string) string {
+	const tail = 4
+	r := []rune(key)
+	if len(r) <= tail {
+		return strings.Repeat("•", len(r))
+	}
+	return strings.Repeat("•", tail) + string(r[len(r)-tail:])
+}
+
+// printTelemetryStatus prints the telemetry section with two sub-blocks -
+// cumulative (since session start) and last run - each showing turn count,
+// truncation/compaction counts, context utilization, and a per-tool table.
+// Both blocks show "no telemetry yet" before any run has completed.
+func printTelemetryStatus(out io.Writer, color bool, deps *replDeps) {
+	fmt.Fprintf(out, "%s\n", colorize(color, ansiBold, "telemetry:"))
+	holder := deps.telemetry
+	if holder == nil || !holder.HasTelemetry() {
+		fmt.Fprintf(out, "  %s %s\n", colorize(color, ansiDim, "since session start:"), colorize(color, ansiDim, "no telemetry yet"))
+		fmt.Fprintf(out, "  %s %s\n", colorize(color, ansiDim, "last run:"), colorize(color, ansiDim, "no telemetry yet"))
+		return
+	}
+	printTelemetryBlock(out, color, "since session start:",
+		holder.CumulativeTurns(),
+		holder.CumulativeTruncationCount(),
+		holder.CumulativeCompactionCount(),
+		holder.CumulativeContextUtilization(),
+		holder.CumulativeToolDurations(),
+	)
+	if last := holder.Last(); last != nil {
+		printTelemetryBlock(out, color, "last run:",
+			last.Turns,
+			last.TruncationCount,
+			last.CompactionCount,
+			last.ContextUtilization,
+			last.ToolDurationsMs,
+		)
+	} else {
+		fmt.Fprintf(out, "  %s %s\n", colorize(color, ansiDim, "last run:"), colorize(color, ansiDim, "no telemetry yet"))
+	}
+}
+
+// printTelemetryBlock renders one telemetry sub-block (cumulative or last run).
+func printTelemetryBlock(out io.Writer, color bool, label string, turns, trunc, compact int, util float64, tools map[string]agentcore.ToolTiming) {
+	fmt.Fprintf(out, "  %s\n", colorize(color, ansiCyan, label))
+	fmt.Fprintf(out, "    %s %d\n", colorize(color, ansiDim, "turns:"), turns)
+	fmt.Fprintf(out, "    %s %d\n", colorize(color, ansiDim, "truncations:"), trunc)
+	fmt.Fprintf(out, "    %s %d\n", colorize(color, ansiDim, "compactions:"), compact)
+	fmt.Fprintf(out, "    %s %s\n", colorize(color, ansiDim, "utilization:"), fmt.Sprintf("%.0f%%", util*100))
+	if len(tools) == 0 {
+		fmt.Fprintf(out, "    %s (none)\n", colorize(color, ansiDim, "tools:"))
+		return
+	}
+	names := make([]string, 0, len(tools))
+	for n := range tools {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	fmt.Fprintf(out, "    %s\n", colorize(color, ansiDim, "tools:"))
+	for _, n := range names {
+		t := tools[n]
+		fmt.Fprintf(out, "      %-12s %3d calls  %dms\n", n, t.Count, t.TotalMs)
 	}
 }

--- a/cmd/pigo/status_test.go
+++ b/cmd/pigo/status_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/compaction"
+	"github.com/smallnest/pigo/internal/runtime"
 )
 
 func TestRunStatus(t *testing.T) {
@@ -194,5 +195,156 @@ func TestStatusFooNotIntercepted(t *testing.T) {
 	output := out.String()
 	if strings.Contains(output, "runtime config:") {
 		t.Error("expected /statusfoo to NOT run the status command")
+	}
+}
+
+func TestRunStatusEnvAndCreds(t *testing.T) {
+	p := &replProvider{reply: "unused"}
+	deps, _ := newTestDeps(t, p)
+	deps.cwd = "/tmp/test-cwd"
+	deps.live.providerName = "test-provider"
+	deps.live.baseURL = "https://api.example.com"
+
+	// Register a skill and a plugin command so /status can count them separately.
+	deps.slash.AddSkill(runtime.SlashCommand{Name: "my-skill", Expand: func(string) string { return "" }})
+	deps.slash.AddPlugin(runtime.SlashCommand{Name: "my-plugin", Run: func(string) (string, string) { return "", "" }})
+
+	// Set an API key for the provider.
+	deps.creds.SetOverride("test-provider", "sk-secretkey-wxyz")
+
+	var buf bytes.Buffer
+	runStatus(&buf, &deps)
+	output := buf.String()
+
+	// project & environment section
+	if !strings.Contains(output, "project & environment:") {
+		t.Error("expected 'project & environment:' section")
+	}
+	if !strings.Contains(output, "cwd: /tmp/test-cwd") {
+		t.Error("expected 'cwd: /tmp/test-cwd'")
+	}
+	if !strings.Contains(output, "trust: disabled") {
+		t.Error("expected 'trust: disabled' when trust manager is nil")
+	}
+	if !strings.Contains(output, "skills: 1 (my-skill)") {
+		t.Error("expected 'skills: 1 (my-skill)'")
+	}
+	if !strings.Contains(output, "plugins: 1 (my-plugin)") {
+		t.Error("expected 'plugins: 1 (my-plugin)'")
+	}
+
+	// credentials & connectivity section
+	if !strings.Contains(output, "credentials & connectivity:") {
+		t.Error("expected 'credentials & connectivity:' section")
+	}
+	if !strings.Contains(output, "api key: set") {
+		t.Error("expected 'api key: set'")
+	}
+	if !strings.Contains(output, "••••wxyz") {
+		t.Error("expected masked key '••••wxyz'")
+	}
+	// The full key must NEVER appear in the output.
+	if strings.Contains(output, "sk-secretkey-wxyz") {
+		t.Error("full API key leaked into /status output")
+	}
+	if !strings.Contains(output, "endpoint: https://api.example.com") {
+		t.Error("expected 'endpoint: https://api.example.com'")
+	}
+}
+
+func TestRunStatusTelemetryNoData(t *testing.T) {
+	p := &replProvider{reply: "unused"}
+	deps, _ := newTestDeps(t, p)
+	// deps.telemetry is nil from newTestDeps.
+
+	var buf bytes.Buffer
+	runStatus(&buf, &deps)
+	output := buf.String()
+
+	if !strings.Contains(output, "telemetry:") {
+		t.Error("expected 'telemetry:' section")
+	}
+	if n := strings.Count(output, "no telemetry yet"); n != 2 {
+		t.Errorf("expected 2 'no telemetry yet' (cumulative + last run), got %d", n)
+	}
+}
+
+func TestRunStatusTelemetryPopulated(t *testing.T) {
+	p := &replProvider{reply: "unused"}
+	deps, _ := newTestDeps(t, p)
+	deps.live.contextWindow = 128000
+
+	holder := NewTelemetryHolder()
+	holder.Fold(agentcore.TelemetryEvent{
+		Turns:              3,
+		TruncationCount:    1,
+		CompactionCount:    0,
+		ContextUtilization: 0.42,
+		ContextTokens:      53760,
+		ContextWindow:      128000,
+		ToolDurationsMs: map[string]agentcore.ToolTiming{
+			"bash": {Count: 2, TotalMs: 150},
+			"read": {Count: 4, TotalMs: 80},
+		},
+	})
+	deps.telemetry = holder
+
+	var buf bytes.Buffer
+	runStatus(&buf, &deps)
+	output := buf.String()
+
+	if strings.Contains(output, "no telemetry yet") {
+		t.Error("did not expect 'no telemetry yet' when telemetry is populated")
+	}
+	if !strings.Contains(output, "since session start:") {
+		t.Error("expected 'since session start:' cumulative block")
+	}
+	if !strings.Contains(output, "last run:") {
+		t.Error("expected 'last run:' block")
+	}
+	if !strings.Contains(output, "turns: 3") {
+		t.Error("expected 'turns: 3' (last run == cumulative after one run)")
+	}
+	if !strings.Contains(output, "bash") || !strings.Contains(output, "2 calls") || !strings.Contains(output, "150ms") {
+		t.Error("expected bash tool row with '2 calls' / '150ms'")
+	}
+	if !strings.Contains(output, "utilization: 42%") {
+		t.Error("expected 'utilization: 42%'")
+	}
+
+	// Fold a second run: cumulative (5) must exceed last run (2).
+	holder.Fold(agentcore.TelemetryEvent{
+		Turns:              2,
+		TruncationCount:    0,
+		CompactionCount:    1,
+		ContextUtilization: 0.5,
+		ContextTokens:      64000,
+		ContextWindow:      128000,
+		ToolDurationsMs: map[string]agentcore.ToolTiming{
+			"bash": {Count: 1, TotalMs: 40},
+		},
+	})
+	buf.Reset()
+	runStatus(&buf, &deps)
+	output = buf.String()
+	if !strings.Contains(output, "turns: 5") {
+		t.Error("expected cumulative 'turns: 5' after two runs")
+	}
+	if !strings.Contains(output, "turns: 2") {
+		t.Error("expected last-run 'turns: 2' after two runs")
+	}
+}
+
+func TestMaskKey(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"sk-secretkey-wxyz", "••••wxyz"},
+		{"abcd", "••••"}, // exactly 4 -> masked entirely
+		{"ab", "••"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := maskKey(c.in); got != c.want {
+			t.Errorf("maskKey(%q) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }

--- a/internal/runtime/slashcommand.go
+++ b/internal/runtime/slashcommand.go
@@ -34,15 +34,30 @@ type SlashCommandSource int
 const (
 	// SourceBuiltin is a compile-time registered command (highest priority).
 	SourceBuiltin SlashCommandSource = iota
-	// SourceUser is a declarative markdown command loaded from disk.
+	// SourceUser is a declarative markdown command template loaded from disk
+	// (e.g. ~/.pigo/commands/*.md).
 	SourceUser
+	// SourceSkill is a skill loaded from ~/.agents/skills and surfaced as a
+	// /skill-name command. It behaves like SourceUser for the built-in-wins
+	// conflict rule; the finer tag is for display only (e.g. /status).
+	SourceSkill
+	// SourcePlugin is a command declared by a loaded plugin. It behaves like
+	// SourceUser for the built-in-wins conflict rule; the finer tag is for
+	// display only.
+	SourcePlugin
 )
 
 func (s SlashCommandSource) String() string {
-	if s == SourceBuiltin {
+	switch s {
+	case SourceBuiltin:
 		return "builtin"
+	case SourceSkill:
+		return "skill"
+	case SourcePlugin:
+		return "plugin"
+	default:
+		return "user"
 	}
-	return "user"
 }
 
 // SlashCommand is a resolved command: its name (without the leading "/"), a
@@ -189,6 +204,30 @@ func (r *SlashRegistry) AddUser(cmd SlashCommand) {
 		return
 	}
 	cmd.Source = SourceUser
+	r.commands[cmd.Name] = cmd
+}
+
+// AddSkill installs a skill command (loaded from ~/.agents/skills). It follows
+// the same built-in-wins rule as AddUser - a built-in owning the name shadows
+// the skill - only the source tag differs, so /status can report skills
+// separately from user templates and plugins.
+func (r *SlashRegistry) AddSkill(cmd SlashCommand) {
+	if existing, ok := r.commands[cmd.Name]; ok && existing.Source == SourceBuiltin {
+		r.shadowed = append(r.shadowed, cmd.Name)
+		return
+	}
+	cmd.Source = SourceSkill
+	r.commands[cmd.Name] = cmd
+}
+
+// AddPlugin installs a plugin-declared command, mirroring AddUser with a
+// SourcePlugin tag for display.
+func (r *SlashRegistry) AddPlugin(cmd SlashCommand) {
+	if existing, ok := r.commands[cmd.Name]; ok && existing.Source == SourceBuiltin {
+		r.shadowed = append(r.shadowed, cmd.Name)
+		return
+	}
+	cmd.Source = SourcePlugin
 	r.commands[cmd.Name] = cmd
 }
 


### PR DESCRIPTION
Implements #293 (US-003) + #294 (US-004) of tasks/prd-status-command.md. Builds on #291 (telemetry holder) and #292 (/status scaffold), both merged.

Adds three sections to `runStatus`:

- **project & environment**: cwd, trust status (`disabled`/`trusted`/`untrusted`/`prompt`), skills count + names, plugins count + names. Extends `SlashCommandSource` with `SourceSkill`/`SourcePlugin` (`AddSkill`/`AddPlugin`) so skills and plugins are counted separately from user templates; built-in-wins conflict rule unchanged.
- **credentials & connectivity**: API key presence (`set`/`not set`) with a masked last-4 hint (`••••abcd`, never plaintext) and the provider endpoint URL.
- **telemetry**: two sub-blocks (`since session start` cumulative + `last run`) showing turn/truncation/compaction counts, context utilization, and a per-tool call-count/total-ms table. Prints `no telemetry yet` before any run completes.

`go build`/`go vet`/`go test ./...` green (the lone `TestCredentialStoreOAuthRefreshFallback` failure is pre-existing on master - environment-local OAuth token - and passes in CI).

Closes #293. Closes #294.