### PR TITLE
docs: document /status in /help listing and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ pigo --resume 20260720-1530-abcd  # 续跑指定会话（无头/REPL 均可）
 pigo --continue                   # 续跑最近一次会话
 ```
 
-REPL 中的内置斜杠命令包括 `/model`、`/models`、`/help`、`/compact`、`/fork`、`/clone`、`/tree`、`/export`、`/import`、`/copy`、`/session`、`/exit` 等。
+REPL 中的内置斜杠命令包括 `/model`、`/models`、`/help`、`/compact`、`/fork`、`/clone`、`/tree`、`/export`、`/import`、`/copy`、`/session`、`/status`、`/exit` 等。其中 `/status` 一次性展示运行时模型配置、上下文占用与压缩、项目环境（信任 / 技能 / 插件）、凭据连通性，以及遥测数据（累计与最近一次 run 的轮次、工具耗时、上下文利用率）。
 
 在交互终端输入时，pigo 会用灰色文字提示最近匹配的输入或斜杠命令；
 输入 `/model ` 时还会从最近使用的模型和内置模型目录中匹配。按 `Tab`

--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -504,7 +504,7 @@ func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
 		{"import", "import a JSONL export as a new session: /import <path.jsonl>"},
 		{"copy", "copy the most recent assistant reply to the clipboard"},
 		{"session", "show session stats: messages, tokens, model, compactions"},
-		{"status", "show runtime config, context usage, and session status"},
+		{"status", "show session status: runtime config, context, telemetry, credentials, environment"},
 		{"goal", "run autonomously toward a goal: /goal [--tokens N] <objective> | pause | resume | clear"},
 		{"btw", "ask a quick side question without touching the main conversation: /btw <question> (bare /btw reopens the last one)"},
 	} {


### PR DESCRIPTION
Follow-up to the /status feature (#291-#295, all merged).

- `/help` one-liner: `show runtime config, context usage, and session status` -> `show session status: runtime config, context, telemetry, credentials, environment` (the old line omitted telemetry/credentials/environment).
- README: add `/status` to the built-in slash-command list with a one-line description of the five sections.

`go build`/`go test ./cmd/pigo/` green.