### PR TITLE
Inject <available_skills> into BuildSystemPrompt

### DIFF
--- a/docs/issue#0303.html
+++ b/docs/issue#0303.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0303</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EDE8; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/303">#303</a> &mdash; 把 skills 注入 BuildSystemPrompt &mdash; 2026-07-27</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Skills block appended after the append-instructions layer</h3>
+      <p><strong>Ambiguity:</strong> PRD says "在 base + 环境块 + AGENTS.md + append 之后追加".</p>
+      <p><strong>Choice:</strong> Inject <code>FormatSkillsForPrompt(cfg.Skills)</code> as the very last write in <code>BuildSystemPrompt</code>, after the <code>AppendInstructions</code> loop.</p>
+      <p><strong>Rationale:</strong> Matches pi (skills appended right before the trailing cwd line) and the PRD ordering; keeps the block visually last so the model reads capability metadata after all behavioral guidance.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Two config fields: <code>Skills</code> + <code>ReadToolAvailable</code></h3>
+      <p><strong>Ambiguity:</strong> How to gate injection on read-tool presence without <code>BuildSystemPrompt</code> knowing the tool set.</p>
+      <p><strong>Choice:</strong> A boolean <code>ReadToolAvailable</code> signal on <code>PromptConfig</code>, decided by the caller (wired in #304).</p>
+      <p><strong>Rationale:</strong> Keeps prompt assembly decoupled from the tool registry; the caller already knows the tool set. Mirrors pi's <code>selectedTools.includes("read")</code> check performed outside the formatter.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None — behavior matches pi: inject only when read tool available and visible skills exist; otherwise prompt is unchanged.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Rely on <code>FormatSkillsForPrompt</code> empty-string contract vs re-check length here</h3>
+      <p><strong>Alternatives:</strong> Guard with <code>len(cfg.Skills) &gt; 0</code> in <code>BuildSystemPrompt</code> vs trust the formatter to return "" when nothing is visible.</p>
+      <p><strong>Chosen:</strong> Only guard on <code>ReadToolAvailable</code>; let the formatter decide visibility.</p>
+      <p><strong>Why it wins:</strong> Single source of truth for "what counts as visible" (all-disabled lists also yield ""). A regression test asserts the empty-list prompt is byte-identical with or without the read tool.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <p class="none">None.</p>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/runtime/prompt.go
+++ b/internal/runtime/prompt.go
@@ -52,6 +52,16 @@ type PromptConfig struct {
 	// ReadFile reads a file's contents. When nil, os.ReadFile is used. Injected
 	// for tests so AGENTS.md layout can be faked without touching disk.
 	ReadFile func(path string) ([]byte, error)
+	// Skills are the model-invocable skills to advertise in an <available_skills>
+	// block at the end of the prompt (对标 pi 的渐进式披露). Only their
+	// name/description/location are injected; the model loads a skill's body with
+	// the read tool on demand. Skills flagged disable-model-invocation are
+	// filtered out by FormatSkillsForPrompt. Empty means no skills block.
+	Skills []*Skill
+	// ReadToolAvailable signals whether the read tool is in the current tool set.
+	// Skills are advertised only when it is true, since the model needs the read
+	// tool to load a skill's body; otherwise the block is omitted entirely.
+	ReadToolAvailable bool
 }
 
 // DefaultBaseInstruction is the leading system-prompt text used when
@@ -129,6 +139,14 @@ func BuildSystemPrompt(cfg PromptConfig) (string, error) {
 		}
 		b.WriteString("\n\n")
 		b.WriteString(extra)
+	}
+
+	// Advertise model-invocable skills last (progressive disclosure), but only
+	// when the read tool is available — the model needs it to load a skill's
+	// body. FormatSkillsForPrompt returns "" when no visible skill remains, so
+	// this leaves a skill-free prompt byte-for-byte unchanged.
+	if cfg.ReadToolAvailable {
+		b.WriteString(FormatSkillsForPrompt(cfg.Skills))
 	}
 
 	return b.String(), nil

--- a/internal/runtime/prompt_test.go
+++ b/internal/runtime/prompt_test.go
@@ -201,3 +201,49 @@ func TestBuildSystemPromptAppendInstructions(t *testing.T) {
 		t.Errorf("appends must follow the env block and keep order (env<first<second), got env=%d first=%d second=%d", iEnv, iFirst, iSecond)
 	}
 }
+
+// TestBuildSystemPromptInjectsSkills verifies the <available_skills> block is
+// appended after the base/env/append layers when the read tool is available.
+func TestBuildSystemPromptInjectsSkills(t *testing.T) {
+	skills := []*Skill{
+		{Frontmatter: SkillFrontmatter{Name: "weather", Description: "get weather"}, Path: "/skills/weather.md"},
+		{Frontmatter: SkillFrontmatter{Name: "secret", Description: "hidden", DisableModelInvocation: true}, Path: "/skills/secret.md"},
+	}
+	got, err := BuildSystemPrompt(PromptConfig{
+		WorkingDir:        "/work/proj",
+		Now:               fixedTime,
+		ReadFile:          func(string) ([]byte, error) { return nil, os.ErrNotExist },
+		Skills:            skills,
+		ReadToolAvailable: true,
+	})
+	if err != nil {
+		t.Fatalf("BuildSystemPrompt: %v", err)
+	}
+	if !strings.Contains(got, "<available_skills>") || !strings.Contains(got, "<name>weather</name>") {
+		t.Errorf("skills block must be injected, got:\n%s", got)
+	}
+	if strings.Contains(got, "secret") {
+		t.Errorf("disable-model-invocation skill must not appear, got:\n%s", got)
+	}
+	iEnv := strings.Index(got, "Working directory")
+	iSkills := strings.Index(got, "<available_skills>")
+	if !(iEnv < iSkills) {
+		t.Errorf("skills block must come after env block, env=%d skills=%d", iEnv, iSkills)
+	}
+}
+
+// TestBuildSystemPromptNoSkillsWithoutReadTool verifies skills are NOT injected
+// when the read tool is unavailable, and that a skill-free prompt is unchanged.
+func TestBuildSystemPromptNoSkillsWithoutReadTool(t *testing.T) {
+	skills := []*Skill{{Frontmatter: SkillFrontmatter{Name: "weather", Description: "d"}, Path: "/s/weather.md"}}
+	withTool, _ := BuildSystemPrompt(PromptConfig{WorkingDir: "/w", Now: fixedTime, ReadFile: func(string) ([]byte, error) { return nil, os.ErrNotExist }, Skills: skills, ReadToolAvailable: false})
+	if strings.Contains(withTool, "available_skills") {
+		t.Errorf("no read tool → no skills block, got:\n%s", withTool)
+	}
+	// A prompt with no skills at all must equal one with read tool but empty list.
+	bare, _ := BuildSystemPrompt(PromptConfig{WorkingDir: "/w", Now: fixedTime, ReadFile: func(string) ([]byte, error) { return nil, os.ErrNotExist }})
+	withReadNoSkills, _ := BuildSystemPrompt(PromptConfig{WorkingDir: "/w", Now: fixedTime, ReadFile: func(string) ([]byte, error) { return nil, os.ErrNotExist }, ReadToolAvailable: true})
+	if bare != withReadNoSkills {
+		t.Errorf("empty skill list must not alter the prompt even with read tool:\n%q\nvs\n%q", bare, withReadNoSkills)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Skills []*Skill` and `ReadToolAvailable bool` to `PromptConfig`
- Append `FormatSkillsForPrompt` output at the end of `BuildSystemPrompt`, after base/env/AGENTS.md/append layers
- Inject only when the read tool is available; skill-free prompts remain byte-identical

Closes #303

## Test plan
- [x] `go build ./...` / `go vet` clean
- [x] `go test ./internal/runtime/ -run BuildSystemPrompt` (inject / no-read-tool / empty-list regression)