### PR TITLE
Wire skills into system prompt at run assembly

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -65,9 +65,10 @@ type interactiveOptions struct {
 	// run so the first-launch trust prompt is skipped and side-effect tools run
 	// without per-call confirmation (对标 pi 的 --approve/-a).
 	approve bool
-	// noSkills, when true, skips skill discovery so no /skill-name commands are
-	// registered from ~/.agents/skills (对标 pi 的 --no-skills).
-	noSkills bool
+	// skills is the pre-loaded skill set (loaded once by setupAgentEnv, shared
+	// with prompt injection). Each is registered as a /skill-name command. Empty
+	// under --no-skills, so nothing is registered.
+	skills []*runtime.Skill
 
 	// plugins holds the loaded plugin manager so the REPL can deliver lifecycle
 	// events to subscribed plugins (US-017, #133). It may be nil (no plugins).
@@ -169,7 +170,7 @@ func runInteractive(opts interactiveOptions) error {
 	// ~/.agents/skills. A load error is non-fatal — the REPL still runs with the
 	// built-ins. Instance built-ins that need live state (/model, /help) are
 	// registered against `live`.
-	slash, err := buildSlashRegistry(live, opts.noSkills, opts.plugins)
+	slash, err := buildSlashRegistry(live, opts.skills, opts.plugins)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "pigo: slash-commands: %v\n", err)
 	}
@@ -260,14 +261,13 @@ func stdoutIsTerminal() bool {
 // built-ins seeded by runtime.NewSlashRegistry, the live-state action commands
 // (/model, /help) bound to live, user declarative templates loaded from
 // ~/.pigo/commands (or $PIGO_HOME/commands), plugin-declared commands from the
-// loaded Manager, plus skills loaded from ~/.agents/skills — each surfaced as a
-// "/skill-name" command (对标 Claude Code's /skill invocation). A missing
-// directory is not an error. Names that collide with a built-in are shadowed
-// (the built-in wins) and reported on stderr. When noSkills is true, skill
-// discovery is skipped entirely (对标 pi 的 --no-skills): user command
-// templates and plugin commands still load, but no /skill-name commands are
-// registered. mgr may be nil (no plugins loaded).
-func buildSlashRegistry(live *liveRunConfig, noSkills bool, mgr *plugin.Manager) (*runtime.SlashRegistry, error) {
+// loaded Manager, plus the pre-loaded skills — each surfaced as a "/skill-name"
+// command (对标 Claude Code's /skill invocation). A missing directory is not an
+// error. Names that collide with a built-in are shadowed (the built-in wins) and
+// reported on stderr. The skills slice is loaded once by setupAgentEnv (empty
+// under --no-skills), so no /skill-name commands are registered when it is
+// empty. mgr may be nil (no plugins loaded).
+func buildSlashRegistry(live *liveRunConfig, skills []*runtime.Skill, mgr *plugin.Manager) (*runtime.SlashRegistry, error) {
 	reg := runtime.NewSlashRegistry()
 	registerLiveCommands(reg, live)
 	registerPluginCommands(reg, mgr)
@@ -286,33 +286,13 @@ func buildSlashRegistry(live *liveRunConfig, noSkills bool, mgr *plugin.Manager)
 	for _, c := range cmds {
 		reg.AddUser(c)
 	}
-	// Load skills from ~/.agents/skills and register each as a /skill-name
-	// command, unless discovery is disabled. A skill invocation expands to the
-	// skill's instructions as the next prompt. A partial parse error is
-	// non-fatal: the skills that DID load are still registered, and the error is
-	// only reported on stderr — so one malformed skill file cannot hide every
-	// other skill.
-	if !noSkills {
-		// First-run bootstrap: copy the built-in skill collections into the
-		// skills directory so they load as /skill-name commands out of the box.
-		// It is silent and best-effort — a failure never blocks the REPL — and
-		// runs before loadSkillCommands so freshly installed skills are picked up
-		// this launch. Skipped entirely under --no-skills, matching the "don't
-		// load ⇒ don't install" expectation. Debug output goes to stderr only
-		// when PIGO_DEBUG is set, keeping normal launches quiet.
-		var blog io.Writer
-		if os.Getenv("PIGO_DEBUG") != "" {
-			blog = os.Stderr
-		}
-		builtinskills.Bootstrap(configDir(), skillsDir(), blog)
-
-		skillCmds, serr := loadSkillCommands()
-		for _, c := range skillCmds {
-			reg.AddSkill(c)
-		}
-		if serr != nil {
-			fmt.Fprintf(os.Stderr, "pigo: skills: some skills failed to load: %v\n", serr)
-		}
+	// Register skills as /skill-name commands from the pre-loaded set (shared with
+	// prompt injection in setupAgentEnv, so the directory is read once). All
+	// skills — including disable-model-invocation ones — get a slash command; the
+	// prompt-injection side filters the disabled ones. Under --no-skills the set
+	// is empty, so nothing is registered.
+	for _, s := range skills {
+		reg.AddSkill(s.SlashCommand())
 	}
 	if shadowed := reg.Shadowed(); len(shadowed) > 0 {
 		fmt.Fprintf(os.Stderr, "pigo: user commands shadowed by built-ins (rename to use): %v\n", shadowed)
@@ -335,23 +315,28 @@ func skillsDir() string {
 	return filepath.Join(home, ".agents", "skills")
 }
 
-// loadSkillCommands loads skills from skillsDir() and returns each as a
-// /skill-name slash command. A missing directory yields no commands and no
-// error (skills are optional). A partial parse error is returned alongside the
-// skills that DID load — callers should register the returned commands and
-// treat the error as a non-fatal warning, so one malformed skill file does not
-// suppress every other skill.
-func loadSkillCommands() ([]runtime.SlashCommand, error) {
+// loadSkills discovers skills from skillsDir() once, for both prompt injection
+// (setupAgentEnv) and /skill-name registration (buildSlashRegistry), so the
+// directory is read a single time. It first bootstraps the built-in skill
+// collections into the skills dir (best-effort, first-run) so freshly installed
+// skills are picked up this launch, then loads every skill. --no-skills disables
+// discovery entirely: no bootstrap, no load, nil result. A partial parse error
+// is returned alongside the skills that DID load, so one malformed file cannot
+// hide the rest; callers treat it as a non-fatal warning.
+func loadSkills(noSkills bool) ([]*runtime.Skill, error) {
+	if noSkills {
+		return nil, nil
+	}
+	var blog io.Writer
+	if os.Getenv("PIGO_DEBUG") != "" {
+		blog = os.Stderr
+	}
+	builtinskills.Bootstrap(configDir(), skillsDir(), blog)
 	dir := skillsDir()
 	if dir == "" {
 		return nil, nil
 	}
-	skills, err := runtime.LoadSkillsDir(dir)
-	cmds := make([]runtime.SlashCommand, 0, len(skills))
-	for _, s := range skills {
-		cmds = append(cmds, s.SlashCommand())
-	}
-	return cmds, err
+	return runtime.LoadSkillsDir(dir)
 }
 
 // liveRunConfig is the mutable run configuration a control command may change

--- a/cmd/pigo/plugin_commands_test.go
+++ b/cmd/pigo/plugin_commands_test.go
@@ -146,7 +146,7 @@ func TestBuildSlashRegistryRegistersPluginCommand(t *testing.T) {
 	mgr := loadTestManager(t)
 	defer mgr.Close()
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "faux", providerName: "faux"}, true, mgr)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "faux", providerName: "faux"}, nil, mgr)
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestREPLPluginCommandInjectsPrompt(t *testing.T) {
 	mgr := loadTestManager(t)
 	defer mgr.Close()
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "faux", providerName: "faux"}, true, mgr)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "faux", providerName: "faux"}, nil, mgr)
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -33,6 +33,12 @@ type agentEnv struct {
 	providerName string
 	sysPrompt    string
 
+	// skills is the discovered skill set (loaded once here, empty under
+	// --no-skills). It is threaded into the REPL so each skill is registered as a
+	// /skill-name command, and the model-invocable subset is already injected into
+	// sysPrompt.
+	skills []*runtime.Skill
+
 	// plugins holds any loaded external plugins so the caller can Close them
 	// when the run ends. It is nil when no plugins were discovered.
 	plugins *plugin.Manager
@@ -46,22 +52,13 @@ type agentEnv struct {
 // read, otherwise the value is literal text) and layered onto the end of the
 // prompt (对标 pi 的 --append-system-prompt). It returns an error rather than
 // exiting so the caller owns exit-code mapping.
-func setupAgentEnv(model, baseURL, protocol, providerName string, noTools bool, systemPrompt string, appendSystemPrompt []string) (agentEnv, error) {
+func setupAgentEnv(model, baseURL, protocol, providerName string, noTools, noSkills bool, systemPrompt string, appendSystemPrompt []string) (agentEnv, error) {
 	cwd, _ := os.Getwd()
 	prov, resolvedName, err := resolveProvider(model, baseURL, protocol, providerName)
 	if err != nil {
 		return agentEnv{}, err
 	}
 	appends, err := resolveAppendInstructions(appendSystemPrompt)
-	if err != nil {
-		return agentEnv{}, err
-	}
-	sysPrompt, err := runtime.BuildSystemPrompt(runtime.PromptConfig{
-		BaseInstruction:    systemPrompt,
-		WorkingDir:         cwd,
-		Root:               cwd,
-		AppendInstructions: appends,
-	})
 	if err != nil {
 		return agentEnv{}, err
 	}
@@ -78,14 +75,47 @@ func setupAgentEnv(model, baseURL, protocol, providerName string, noTools bool, 
 			fmt.Fprintf(os.Stderr, "pigo: plugin discovery failed: %v\n", err)
 		}
 	}
+	// Load skills once (shared between prompt injection and /skill-name
+	// registration). A partial parse error still yields the skills that DID load,
+	// so one malformed file is a non-fatal warning rather than a hard failure.
+	skills, err := loadSkills(noSkills)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pigo: skills: %v\n", err)
+	}
+	// The model can only load a skill's body when the read tool is present, so
+	// advertise skills in the prompt only then (对标 pi 的 selectedTools check).
+	sysPrompt, err := runtime.BuildSystemPrompt(runtime.PromptConfig{
+		BaseInstruction:    systemPrompt,
+		WorkingDir:         cwd,
+		Root:               cwd,
+		AppendInstructions: appends,
+		Skills:             skills,
+		ReadToolAvailable:  hasReadTool(tools),
+	})
+	if err != nil {
+		return agentEnv{}, err
+	}
 	return agentEnv{
 		cwd:          cwd,
 		tools:        tools,
 		provider:     prov,
 		providerName: resolvedName,
 		sysPrompt:    sysPrompt,
+		skills:       skills,
 		plugins:      mgr,
 	}, nil
+}
+
+// hasReadTool reports whether the read tool is present in the tool set. Skills
+// are advertised in the system prompt only when it is, since the model needs
+// the read tool to load a skill's body on demand.
+func hasReadTool(tools []agentcore.AgentTool) bool {
+	for _, t := range tools {
+		if t.Name() == "read" {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveAppendInstructions maps each --append-system-prompt value to the text
@@ -298,7 +328,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			fmt.Fprintln(errOut, "pigo: no prompt (use -p \"...\" or positional args)")
 			return 2
 		}
-		env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.noTools, opts.systemPrompt, opts.appendSystemPrompt)
+		env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt)
 		if err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 1
@@ -323,7 +353,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			sysPrompt:     env.sysPrompt,
 			resumeID:      resumeID,
 			approve:       opts.approve,
-			noSkills:      opts.noSkills,
+			skills:        env.skills,
 			plugins:       env.plugins,
 		}); err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
@@ -338,7 +368,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		return 2
 	}
 
-	env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.noTools, opts.systemPrompt, opts.appendSystemPrompt)
+	env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt)
 	if err != nil {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
 		return 1

--- a/cmd/pigo/skills_test.go
+++ b/cmd/pigo/skills_test.go
@@ -20,21 +20,33 @@ func writeSkill(t *testing.T, dir, name, content string) {
 	}
 }
 
-// TestLoadSkillCommandsFromDir verifies skills in PIGO_SKILLS_DIR are loaded and
-// exposed as /skill-name commands whose expansion is the skill body.
-func TestLoadSkillCommandsFromDir(t *testing.T) {
+// findSkill returns the skill with the given name from the set, or nil.
+func findSkill(skills []*runtime.Skill, name string) *runtime.Skill {
+	for _, s := range skills {
+		if s.Frontmatter.Name == name {
+			return s
+		}
+	}
+	return nil
+}
+
+// TestLoadSkillsFromDir verifies skills in PIGO_SKILLS_DIR are loaded and expose
+// a /skill-name slash command whose expansion is the skill body.
+func TestLoadSkillsFromDir(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("PIGO_SKILLS_DIR", dir)
+	t.Setenv("PIGO_HOME", t.TempDir())
 	writeSkill(t, dir, "greet.md", "---\nname: greet\ndescription: say hello\n---\nYou are a friendly greeter.")
 
-	cmds, err := loadSkillCommands()
+	skills, err := loadSkills(false)
 	if err != nil {
-		t.Fatalf("loadSkillCommands: %v", err)
+		t.Fatalf("loadSkills: %v", err)
 	}
-	if len(cmds) != 1 {
-		t.Fatalf("got %d commands, want 1", len(cmds))
+	s := findSkill(skills, "greet")
+	if s == nil {
+		t.Fatal("greet skill not loaded")
 	}
-	c := cmds[0]
+	c := s.SlashCommand()
 	if c.Name != "greet" {
 		t.Errorf("Name = %q, want greet", c.Name)
 	}
@@ -49,21 +61,31 @@ func TestLoadSkillCommandsFromDir(t *testing.T) {
 	}
 }
 
-// TestLoadSkillCommandsMissingDir verifies a missing skills directory yields no
-// commands and no error (skills are optional).
-func TestLoadSkillCommandsMissingDir(t *testing.T) {
-	t.Setenv("PIGO_SKILLS_DIR", filepath.Join(t.TempDir(), "does-not-exist"))
-	cmds, err := loadSkillCommands()
+// TestLoadSkillsNoSkills verifies --no-skills skips discovery entirely: no
+// skills are loaded and the skills dir is left untouched (no bootstrap).
+func TestLoadSkillsNoSkills(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PIGO_SKILLS_DIR", dir)
+	t.Setenv("PIGO_HOME", t.TempDir())
+
+	skills, err := loadSkills(true)
 	if err != nil {
-		t.Fatalf("missing dir must not error: %v", err)
+		t.Fatalf("loadSkills(true): %v", err)
 	}
-	if len(cmds) != 0 {
-		t.Errorf("got %d commands, want 0", len(cmds))
+	if len(skills) != 0 {
+		t.Errorf("got %d skills, want 0 under --no-skills", len(skills))
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read skills dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("--no-skills must not bootstrap; skills dir has %d entries", len(entries))
 	}
 }
 
-// TestBuildSlashRegistryIncludesSkills verifies buildSlashRegistry wires loaded
-// skills into the registry so /skill-name resolves.
+// TestBuildSlashRegistryIncludesSkills verifies buildSlashRegistry wires the
+// pre-loaded skills into the registry so /skill-name resolves.
 func TestBuildSlashRegistryIncludesSkills(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("PIGO_SKILLS_DIR", dir)
@@ -71,7 +93,11 @@ func TestBuildSlashRegistryIncludesSkills(t *testing.T) {
 	t.Setenv("PIGO_HOME", t.TempDir())
 	writeSkill(t, dir, "summarize.md", "---\nname: summarize\ndescription: summarize input\n---\nSummarize the following: $ARGUMENTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, false, nil)
+	skills, err := loadSkills(false)
+	if err != nil {
+		t.Fatalf("loadSkills: %v", err)
+	}
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, skills, nil)
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -90,36 +116,36 @@ func TestBuildSlashRegistryIncludesSkills(t *testing.T) {
 	}
 }
 
-// TestBuildSlashRegistryNoSkills verifies that when noSkills is true, skill
-// discovery is skipped so a /skill-name command is not registered even though a
-// skill file exists on disk (对标 pi 的 --no-skills).
+// TestBuildSlashRegistryNoSkills verifies that when no skills are passed (as
+// under --no-skills, where loadSkills returns nil), a /skill-name command is not
+// registered even though a skill file exists on disk (对标 pi 的 --no-skills).
 func TestBuildSlashRegistryNoSkills(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("PIGO_SKILLS_DIR", dir)
 	t.Setenv("PIGO_HOME", t.TempDir())
-	writeSkill(t, dir, "summarize.md", "---\nname: summarize\ndescription: summarize input\n---\nSummarize the following: $ARGUMENTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, true, nil)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil)
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
-	// With discovery disabled, /summarize was never registered, so the registry
-	// treats it as an unknown command (an error) rather than a handled one.
+	// With no skills registered, /summarize is an unknown command (an error)
+	// rather than a handled one.
 	if _, err := reg.ResolveOutcome("/summarize hello world"); err == nil {
-		t.Error("/summarize must be unknown when --no-skills disables discovery")
+		t.Error("/summarize must be unknown when no skills are registered")
 	}
 }
 
-// TestBuildSlashRegistryBootstrapsBuiltinSkills verifies that on a fresh
-// PIGO_SKILLS_DIR the built-in skills are installed and registered as
-// /skill-name commands (first-run bootstrap), so e.g. /prd resolves without any
-// manual install.
-func TestBuildSlashRegistryBootstrapsBuiltinSkills(t *testing.T) {
+// TestLoadSkillsBootstrapsBuiltinSkills verifies that on a fresh
+// PIGO_SKILLS_DIR the built-in skills are installed and loaded (first-run
+// bootstrap), so e.g. /prd resolves without any manual install.
+func TestLoadSkillsBootstrapsBuiltinSkills(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("PIGO_SKILLS_DIR", dir)
 	t.Setenv("PIGO_HOME", t.TempDir())
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, false, nil)
+	skills, err := loadSkills(false)
+	if err != nil {
+		t.Fatalf("loadSkills: %v", err)
+	}
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, skills, nil)
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -132,24 +158,5 @@ func TestBuildSlashRegistryBootstrapsBuiltinSkills(t *testing.T) {
 		if !out.Handled {
 			t.Errorf("%s should be handled by the registry after bootstrap", name)
 		}
-	}
-}
-
-// TestBuildSlashRegistryNoSkillsSkipsBootstrap verifies --no-skills skips the
-// first-run bootstrap entirely: nothing is written to the skills dir.
-func TestBuildSlashRegistryNoSkillsSkipsBootstrap(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("PIGO_SKILLS_DIR", dir)
-	t.Setenv("PIGO_HOME", t.TempDir())
-
-	if _, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, true, nil); err != nil {
-		t.Fatalf("buildSlashRegistry: %v", err)
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("read skills dir: %v", err)
-	}
-	if len(entries) != 0 {
-		t.Errorf("--no-skills must not bootstrap; skills dir has %d entries", len(entries))
 	}
 }

--- a/docs/issue#0304.html
+++ b/docs/issue#0304.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0304</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EDE8; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/304">#304</a> &mdash; 在 run/repl 装配层加载 skills 并注入 prompt &mdash; 2026-07-27</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Load skills once in <code>setupAgentEnv</code>, share between prompt and slash commands</h3>
+      <p><strong>Ambiguity:</strong> Skills are needed in two places — the system prompt's <code>&lt;available_skills&gt;</code> block and the REPL's <code>/skill-name</code> registry. The spec didn't say where to load them.</p>
+      <p><strong>Choice:</strong> Introduced <code>loadSkills(noSkills)</code> (bootstrap + <code>LoadSkillsDir</code>) called once in <code>setupAgentEnv</code>; the result is stored on <code>agentEnv.skills</code>, injected into the prompt, and threaded through <code>interactiveOptions.skills</code> into <code>buildSlashRegistry</code>.</p>
+      <p><strong>Rationale:</strong> The skills directory is read a single time per launch. <code>buildSlashRegistry</code> shrinks to a pure registration loop over the pre-loaded set — no disk I/O, no bootstrap side effect buried in the REPL wiring.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Reorder <code>setupAgentEnv</code>: build tools before the prompt</h3>
+      <p><strong>Ambiguity:</strong> <code>BuildSystemPrompt</code> now needs <code>ReadToolAvailable</code>, but the prompt was previously built before the tool set existed.</p>
+      <p><strong>Choice:</strong> Moved tool + plugin assembly above <code>BuildSystemPrompt</code>, then computed <code>hasReadTool(tools)</code> and passed it plus the loaded skills into <code>PromptConfig</code>.</p>
+      <p><strong>Rationale:</strong> The read-tool signal is derived from the actual resolved tool set (respecting <code>--no-tools</code>), not guessed. Mirrors pi's <code>selectedTools.includes("read")</code> check performed at assembly time.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Built-in skill bootstrap now also runs in headless mode</h3>
+      <p><strong>Spec:</strong> Bootstrap was previously REPL-only (it lived inside <code>buildSlashRegistry</code>, reached only from <code>runInteractive</code>).</p>
+      <p><strong>Implemented:</strong> Bootstrap moved into <code>loadSkills</code>, which <code>setupAgentEnv</code> calls on both the REPL and headless (<code>-p</code>) paths.</p>
+      <p><strong>Why better:</strong> Model-invocable skills must be advertised in the prompt in every mode, including headless. Bootstrap stays silent unless <code>PIGO_DEBUG</code> is set, so no new output noise. Consistent with the feature goal that headless runs also see skills.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Removed the now-dead <code>interactiveOptions.noSkills</code> field</h3>
+      <p><strong>Alternatives:</strong> Keep the field for symmetry with the CLI flag, vs delete it since <code>buildSlashRegistry</code> no longer gates on it.</p>
+      <p><strong>Chosen:</strong> Deleted it (surfaced during review — it was set but never read after the refactor).</p>
+      <p><strong>Why it wins:</strong> <code>--no-skills</code> is already honored upstream in <code>loadSkills(noSkills)</code>, so an empty <code>skills</code> slice fully expresses the disabled state. A set-but-unread field would mislead future readers into thinking the REPL re-checks the flag.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <p class="none">None — build, vet, and <code>go test ./cmd/pigo/ ./internal/runtime/</code> all pass; behavior matches the PRD (skills loaded once, injected when read tool present, slash commands preserved).</p>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `loadSkills(noSkills)` (bootstrap + LoadSkillsDir); call it once in `setupAgentEnv` and share the result between prompt injection and `/skill-name` registration
- Reorder `setupAgentEnv` to build the tool set before the prompt, then gate the `<available_skills>` block on `hasReadTool(tools)`
- Thread the loaded skills through `agentEnv` → `interactiveOptions` → `buildSlashRegistry`; drop the now-dead `interactiveOptions.noSkills` field

Closes #304

## Test plan
- [x] go build ./...
- [x] go vet ./cmd/pigo/
- [x] go test ./cmd/pigo/ ./internal/runtime/