### PR TITLE
fix: allow file tools to reach the advertised skills dir

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -263,15 +263,28 @@ func builtinTools(cwd string, disabled bool) []agentcore.AgentTool {
 		return nil
 	}
 	return []agentcore.AgentTool{
-		&agenttool.ReadTool{Root: cwd},
-		&agenttool.WriteTool{Root: cwd},
-		&agenttool.EditTool{Root: cwd},
+		&agenttool.ReadTool{Root: cwd, ExtraRoots: readableExtraRoots()},
+		&agenttool.WriteTool{Root: cwd, ExtraRoots: readableExtraRoots()},
+		&agenttool.EditTool{Root: cwd, ExtraRoots: readableExtraRoots()},
 		&agenttool.GrepTool{Root: cwd},
 		&agenttool.FindTool{Root: cwd},
 		&agenttool.BashTool{Dir: cwd},
 		&agenttool.TodoTool{Store: agenttool.NewTodoStore()},
 		&agenttool.WebFetchTool{},
 	}
+}
+
+// readableExtraRoots returns trusted directories the file tools may reach beyond
+// the workspace root. The skills directory is included so the model can load the
+// absolute SKILL.md paths pigo advertises in the system prompt, and author or
+// update skills there (they otherwise resolve outside the workspace and are
+// rejected). An empty skills dir is dropped, so this stays a no-op when the home
+// directory cannot be resolved.
+func readableExtraRoots() []string {
+	if dir := skillsDir(); dir != "" {
+		return []string{dir}
+	}
+	return nil
 }
 
 // toolRegistry builds a registry from the given tools (skipping any that fail

--- a/internal/agenttool/edit_tool.go
+++ b/internal/agenttool/edit_tool.go
@@ -20,6 +20,10 @@ type EditTool struct {
 	// Root bounds all edits; a path resolving outside Root is rejected. Empty
 	// Root defaults to the current working directory.
 	Root string
+	// ExtraRoots are additional trusted directories an edit may target even though
+	// they lie outside Root. It exists for the skills directory so the model can
+	// modify existing skills that live outside the workspace.
+	ExtraRoots []string
 }
 
 // editToolArgs is the decoded argument shape for EditTool.
@@ -59,10 +63,14 @@ func (t *EditTool) ExecutionMode() agentcore.ToolExecutionMode {
 	return agentcore.ToolExecutionSequential
 }
 
-// resolvePath resolves p against Root via the shared resolveWithin boundary
-// policy, so every file tool enforces the same workspace-escape guard.
+// resolvePath resolves p against Root (or any ExtraRoots) via the shared
+// resolveWithin boundary policy, so every file tool enforces the same
+// workspace-escape guard while edits can also reach trusted extra roots.
 func (t *EditTool) resolvePath(p string) (string, error) {
-	return resolveWithin(t.Root, p)
+	if len(t.ExtraRoots) == 0 {
+		return resolveWithin(t.Root, p)
+	}
+	return resolveWithinAny(append([]string{t.Root}, t.ExtraRoots...), p)
 }
 
 // Execute implements AgentTool. Edit failures (no match, non-unique match,

--- a/internal/agenttool/edit_tool_test.go
+++ b/internal/agenttool/edit_tool_test.go
@@ -118,6 +118,36 @@ func TestEditToolPathTraversal(t *testing.T) {
 	}
 }
 
+func TestEditToolExtraRootsAllowsSkillModification(t *testing.T) {
+	work := t.TempDir()
+	skills := t.TempDir()
+	skillFile := filepath.Join(skills, "weather", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skillFile), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(skillFile, []byte("old body\n"), 0o644); err != nil {
+		t.Fatalf("seed skill: %v", err)
+	}
+
+	// Without ExtraRoots the out-of-workspace skill edit is rejected.
+	bounded := &EditTool{Root: work}
+	res := runEdit(t, bounded, map[string]any{"path": skillFile, "old_string": "old body", "new_string": "new body"})
+	if !strings.Contains(resultText(res), "outside the workspace root") {
+		t.Fatalf("expected boundary rejection without ExtraRoots, got %q", resultText(res))
+	}
+
+	// With the skills dir as an extra root the edit applies.
+	tool := &EditTool{Root: work, ExtraRoots: []string{skills}}
+	res = runEdit(t, tool, map[string]any{"path": skillFile, "old_string": "old body", "new_string": "new body"})
+	if strings.Contains(resultText(res), "outside the workspace root") {
+		t.Fatalf("edit still blocked with ExtraRoots: %q", resultText(res))
+	}
+	got, _ := os.ReadFile(skillFile)
+	if !strings.Contains(string(got), "new body") {
+		t.Fatalf("skill not modified, content = %q", got)
+	}
+}
+
 func TestEditToolMode(t *testing.T) {
 	tool := &EditTool{}
 	if tool.Name() != "edit" {

--- a/internal/agenttool/read_tool.go
+++ b/internal/agenttool/read_tool.go
@@ -45,6 +45,12 @@ type ReadTool struct {
 	// Root is the directory that bounds all reads. A path resolving outside Root
 	// is rejected. Empty Root defaults to the current working directory.
 	Root string
+	// ExtraRoots are additional trusted directories a read may target even though
+	// they lie outside Root. It exists for the skills directory: pigo advertises
+	// each skill's absolute SKILL.md path in the system prompt and tells the model
+	// to read it, so the read tool must permit those paths (they are otherwise
+	// outside the workspace and rejected).
+	ExtraRoots []string
 }
 
 // readToolArgs is the decoded argument shape for ReadTool.
@@ -85,10 +91,14 @@ func (t *ReadTool) ExecutionMode() agentcore.ToolExecutionMode {
 	return agentcore.ToolExecutionParallel
 }
 
-// resolvePath resolves p against Root via the shared resolveWithin boundary
-// policy, so every file tool enforces the same workspace-escape guard.
+// resolvePath resolves p against Root (or any ExtraRoots) via the shared
+// resolveWithin boundary policy, so every file tool enforces the same
+// workspace-escape guard while the read tool can also reach trusted extra roots.
 func (t *ReadTool) resolvePath(p string) (string, error) {
-	return resolveWithin(t.Root, p)
+	if len(t.ExtraRoots) == 0 {
+		return resolveWithin(t.Root, p)
+	}
+	return resolveWithinAny(append([]string{t.Root}, t.ExtraRoots...), p)
 }
 
 // Execute implements AgentTool. It never returns a Go error for a read failure

--- a/internal/agenttool/read_tool_test.go
+++ b/internal/agenttool/read_tool_test.go
@@ -141,6 +141,54 @@ func TestReadToolMissingPathArg(t *testing.T) {
 	}
 }
 
+func TestReadToolExtraRootsAllowsTrustedOutsidePath(t *testing.T) {
+	work := t.TempDir()
+	// A skill file lives OUTSIDE the workspace root (mirrors ~/.agents/skills).
+	skills := t.TempDir()
+	skillFile := filepath.Join(skills, "weather", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skillFile), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(skillFile, []byte("skill body"), 0o644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	// Without ExtraRoots the absolute skill path is rejected as out-of-workspace.
+	bounded := &ReadTool{Root: work}
+	res, _ := runRead(t, bounded, map[string]any{"path": skillFile})
+	if !strings.Contains(resultText(res), "outside the workspace root") {
+		t.Fatalf("expected boundary rejection without ExtraRoots, got %q", resultText(res))
+	}
+
+	// With the skills dir as an extra root the same read succeeds.
+	tool := &ReadTool{Root: work, ExtraRoots: []string{skills}}
+	res, _ = runRead(t, tool, map[string]any{"path": skillFile})
+	if !strings.Contains(resultText(res), "skill body") {
+		t.Fatalf("expected skill contents with ExtraRoots, got %q", resultText(res))
+	}
+}
+
+func TestReadToolExtraRootsStillBlocksUntrustedPath(t *testing.T) {
+	work := t.TempDir()
+	skills := t.TempDir()
+	// A secret sits outside BOTH the workspace root and the extra root.
+	other := t.TempDir()
+	secret := filepath.Join(other, "secret.txt")
+	if err := os.WriteFile(secret, []byte("top secret"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	tool := &ReadTool{Root: work, ExtraRoots: []string{skills}}
+	res, _ := runRead(t, tool, map[string]any{"path": secret})
+	text := resultText(res)
+	if strings.Contains(text, "top secret") {
+		t.Fatal("read escaped both roots!")
+	}
+	if !strings.Contains(text, "outside the workspace root") {
+		t.Errorf("expected boundary error for untrusted path, got %q", text)
+	}
+}
+
 func TestReadToolSchemaAndMode(t *testing.T) {
 	tool := &ReadTool{}
 	if tool.Name() != "read" {

--- a/internal/agenttool/search_tool.go
+++ b/internal/agenttool/search_tool.go
@@ -52,6 +52,32 @@ func resolveWithin(root, p string) (string, error) {
 	return full, nil
 }
 
+// resolveWithinAny resolves p against the first root that contains it, trying
+// roots in order. It exists so the file tools can additionally permit trusted
+// out-of-workspace roots (the skills directory) whose absolute SKILL.md paths
+// pigo itself advertises in the system prompt: without this, the workspace guard
+// would reject the very paths the model is instructed to read or author. Empty
+// roots are skipped; if none contain p, the standard workspace-escape error is
+// returned.
+func resolveWithinAny(roots []string, p string) (string, error) {
+	var lastErr error
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		full, err := resolveWithin(root, p)
+		if err == nil {
+			return full, nil
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		return "", lastErr
+	}
+	// No usable roots supplied: fall back to the default (cwd) policy.
+	return resolveWithin("", p)
+}
+
 // gitignore is a minimal .gitignore matcher. It supports the common subset:
 // blank lines and #-comments are skipped; a leading "/" anchors to the root;
 // a trailing "/" matches directories only; "!" negation re-includes; and plain

--- a/internal/agenttool/write_tool.go
+++ b/internal/agenttool/write_tool.go
@@ -19,6 +19,11 @@ type WriteTool struct {
 	// Root bounds all writes; a path resolving outside Root is rejected. Empty
 	// Root defaults to the current working directory.
 	Root string
+	// ExtraRoots are additional trusted directories a write may target even though
+	// they lie outside Root. It exists for the skills directory so the model can
+	// author or update skills (create a new SKILL.md, edit an existing one) that
+	// live outside the workspace.
+	ExtraRoots []string
 }
 
 // writeToolArgs is the decoded argument shape for WriteTool.
@@ -57,10 +62,14 @@ func (t *WriteTool) ExecutionMode() agentcore.ToolExecutionMode {
 	return agentcore.ToolExecutionSequential
 }
 
-// resolvePath resolves p against Root via the shared resolveWithin boundary
-// policy, so every file tool enforces the same workspace-escape guard.
+// resolvePath resolves p against Root (or any ExtraRoots) via the shared
+// resolveWithin boundary policy, so every file tool enforces the same
+// workspace-escape guard while writes can also reach trusted extra roots.
 func (t *WriteTool) resolvePath(p string) (string, error) {
-	return resolveWithin(t.Root, p)
+	if len(t.ExtraRoots) == 0 {
+		return resolveWithin(t.Root, p)
+	}
+	return resolveWithinAny(append([]string{t.Root}, t.ExtraRoots...), p)
 }
 
 // Execute implements AgentTool. Write failures are encoded as error results;

--- a/internal/agenttool/write_tool_test.go
+++ b/internal/agenttool/write_tool_test.go
@@ -84,6 +84,50 @@ func TestWriteToolPathTraversal(t *testing.T) {
 	}
 }
 
+func TestWriteToolExtraRootsAllowsSkillAuthoring(t *testing.T) {
+	work := t.TempDir()
+	skills := t.TempDir()
+
+	// Without ExtraRoots, authoring a skill outside the workspace is rejected.
+	target := filepath.Join(skills, "newskill", "SKILL.md")
+	bounded := &WriteTool{Root: work}
+	res := runWrite(t, bounded, map[string]any{"path": target, "content": "x"})
+	if !strings.Contains(resultText(res), "outside the workspace root") {
+		t.Fatalf("expected boundary rejection without ExtraRoots, got %q", resultText(res))
+	}
+	if _, err := os.Stat(target); err == nil {
+		t.Fatal("write escaped the workspace without ExtraRoots!")
+	}
+
+	// With the skills dir as an extra root, the new skill file (and its parent
+	// dirs) is created.
+	tool := &WriteTool{Root: work, ExtraRoots: []string{skills}}
+	res = runWrite(t, tool, map[string]any{"path": target, "content": "skill body"})
+	if strings.Contains(resultText(res), "error") {
+		t.Fatalf("unexpected error authoring skill: %q", resultText(res))
+	}
+	got, err := os.ReadFile(target)
+	if err != nil || string(got) != "skill body" {
+		t.Fatalf("skill file content = %q, err = %v", got, err)
+	}
+}
+
+func TestWriteToolExtraRootsStillBlocksUntrustedPath(t *testing.T) {
+	work := t.TempDir()
+	skills := t.TempDir()
+	other := t.TempDir()
+	target := filepath.Join(other, "escape.txt")
+
+	tool := &WriteTool{Root: work, ExtraRoots: []string{skills}}
+	res := runWrite(t, tool, map[string]any{"path": target, "content": "x"})
+	if !strings.Contains(resultText(res), "outside the workspace root") {
+		t.Errorf("expected boundary error for untrusted path, got %q", resultText(res))
+	}
+	if _, err := os.Stat(target); err == nil {
+		t.Fatal("write escaped both roots!")
+	}
+}
+
 func TestWriteToolDirectoryTarget(t *testing.T) {
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "adir")


### PR DESCRIPTION
## Summary
- Add a trusted-root allowlist (`ExtraRoots`) to the Read/Write/Edit tools via a shared `resolveWithinAny` resolver, scoped to `skillsDir()`
- The model can now `read` skill bodies it is instructed to load, and author/modify skills in that directory
- All other out-of-workspace paths remain blocked — the sandbox is preserved

Closes #327

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/agenttool/ ./cmd/pigo/`
- [x] `go test ./internal/agenttool/ ./cmd/pigo/`
- [x] New tests: ExtraRoots allows trusted skill read/write/edit; untrusted paths still blocked