### PR TITLE
fix(repl): Ctrl+D/Ctrl+C exit under kitty keyboard protocol

### DIFF
--- a/cmd/pigo/line_editor.go
+++ b/cmd/pigo/line_editor.go
@@ -605,7 +605,9 @@ func (e *replLineEditor) editLoop(prompt string) (string, error) {
 				switch final {
 				case 'u': // CSI-u key report: "<code>[;<mod>]u".
 					code, mod := parseCSIParams(params)
-					if code == 13 {
+					ctrl := (mod-1)&4 != 0
+					switch {
+					case code == 13:
 						if mod >= 2 {
 							buf.newline()
 							selected = 0
@@ -613,6 +615,19 @@ func (e *replLineEditor) editLoop(prompt string) (string, error) {
 						} else if res, done := tryEnter(); done {
 							return res, nil
 						}
+					case ctrl && code == 'd':
+						// Ctrl+D: EOF on an empty line. Under the kitty keyboard
+						// protocol (enabled via \x1b[>1u) the terminal reports it here
+						// as a CSI-u event, not the raw 0x04 byte the case-4 arm handles.
+						if buf.isEmpty() {
+							fmt.Fprint(e.out, "\r\n")
+							return "", io.EOF
+						}
+					case ctrl && code == 'c':
+						// Ctrl+C: same story — delivered as a CSI-u report rather than
+						// the raw 0x03 byte once the kitty keyboard mode is active.
+						fmt.Fprint(e.out, "^C\r\n")
+						return "", errLineInterrupted
 					}
 				case '~': // modifyOtherKeys ("27;<mod>;<code>~") or Home/End ("1~"/"4~").
 					parts := strings.Split(string(params), ";")

--- a/cmd/pigo/line_editor_test.go
+++ b/cmd/pigo/line_editor_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -297,6 +298,39 @@ func TestEditLoopCSIuPlainEnterSubmits(t *testing.T) {
 	}
 	if got != "hi" {
 		t.Fatalf("submitted %q, want %q", got, "hi")
+	}
+}
+
+func TestEditLoopCSIuCtrlDEmptyReturnsEOF(t *testing.T) {
+	// Under the kitty keyboard protocol Ctrl+D on an empty line arrives as the
+	// CSI-u report \x1b[100;5u (code 'd', ctrl modifier) rather than raw 0x04,
+	// and must still exit with io.EOF.
+	e := editorWithInput("\x1b[100;5u")
+	got, err := e.editLoop("")
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("want io.EOF, got err=%v got=%q", err, got)
+	}
+}
+
+func TestEditLoopCSIuCtrlDNonEmptyIgnored(t *testing.T) {
+	// Ctrl+D on a non-empty line is a no-op (matches the raw-byte behavior); the
+	// following Enter submits the typed text.
+	e := editorWithInput("ab\x1b[100;5u\r")
+	got, err := e.editLoop("")
+	if err != nil {
+		t.Fatalf("editLoop error: %v", err)
+	}
+	if got != "ab" {
+		t.Fatalf("submitted %q, want %q", got, "ab")
+	}
+}
+
+func TestEditLoopCSIuCtrlCInterrupts(t *testing.T) {
+	// Ctrl+C reported as CSI-u \x1b[99;5u must interrupt the line.
+	e := editorWithInput("\x1b[99;5u")
+	_, err := e.editLoop("")
+	if !errors.Is(err, errLineInterrupted) {
+		t.Fatalf("want errLineInterrupted, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The REPL enables the kitty keyboard protocol (`\x1b[>1u`); on supporting terminals Ctrl+D/Ctrl+C arrive as CSI-u events (`\x1b[100;5u` / `\x1b[99;5u`), not raw `0x04`/`0x03`
- The `case 'u'` handler only recognized Enter, so Ctrl+D silently did nothing and the REPL couldn't be exited
- Recognize ctrl-modified `'d'`/`'c'` in the CSI-u arm, mirroring the raw-byte handlers: empty-line Ctrl+D → `io.EOF`, Ctrl+C → interrupt

Closes #329

## Test plan
- [x] `go build ./...`
- [x] `go vet ./cmd/pigo/`
- [x] `go test ./cmd/pigo/`
- [x] New CSI-u tests: Ctrl+D empty exits, Ctrl+D non-empty ignored, Ctrl+C interrupts