### PR TITLE
feat(runtime): tiered priority for slash-command registry

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -294,8 +294,12 @@ func buildSlashRegistry(live *liveRunConfig, skills []*runtime.Skill, mgr *plugi
 	for _, s := range skills {
 		reg.AddSkill(s.SlashCommand())
 	}
-	if shadowed := reg.Shadowed(); len(shadowed) > 0 {
-		fmt.Fprintf(os.Stderr, "pigo: user commands shadowed by built-ins (rename to use): %v\n", shadowed)
+	if sh := reg.Shadowed(); len(sh) > 0 {
+		parts := make([]string, len(sh))
+		for i, e := range sh {
+			parts[i] = e.String()
+		}
+		fmt.Fprintf(os.Stderr, "pigo: commands shadowed by higher-priority source (rename to use): %v\n", parts)
 	}
 	return reg, nil
 }

--- a/cmd/pigo/plugin_commands_test.go
+++ b/cmd/pigo/plugin_commands_test.go
@@ -186,7 +186,7 @@ func TestBuiltinWinsOverPluginCommand(t *testing.T) {
 	})
 	registerPluginCommands(reg, mgr)
 
-	if names := reg.Shadowed(); len(names) != 1 || names[0] != "hello" {
+	if names := reg.Shadowed(); len(names) != 1 || names[0].Name != "hello" {
 		t.Fatalf("plugin command should be shadowed by built-in, shadowed=%v", names)
 	}
 	out, err := reg.ResolveOutcome("/hello there")

--- a/docs/issue#0335.html
+++ b/docs/issue#0335.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes - Issue #0335</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/335">#335</a> &mdash; SlashRegistry 分层优先级解析 &mdash; 2026-07-27</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Tier constants declared ascending (CLI=0 &hellip; Builtin=5) so &ldquo;higher value wins&rdquo;</h3>
+      <p><strong>Ambiguity:</strong> The spec defined the priority order (built-in &gt; project &gt; global &gt; package &gt; settings &gt; CLI) but not how to encode it numerically.</p>
+      <p><strong>Choice:</strong> <code>TierCLI = iota &hellip; TierBuiltin</code> (ascending), so a higher numeric value is higher priority and the resolver's <code>existing.Tier &gt; cmd.Tier</code> reads naturally as &ldquo;existing wins&rdquo;.</p>
+      <p><strong>Rationale:</strong> The first draft declared Builtin first (=0, lowest), which silently inverted the rule and failed every test. Ascending order makes the <code>&gt;</code> comparison self-evident; the prose docs still list the human-readable order &ldquo;built-in &gt; &hellip; &gt; CLI&rdquo;.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Changed <code>Shadowed()</code> from <code>[]string</code> to <code>[]ShadowedEntry</code> (Name+Tier+Source)</h3>
+      <p><strong>Ambiguity:</strong> The spec required <code>Shadowed()</code> to include the loser's tier; the old API returned only names.</p>
+      <p><strong>Choice:</strong> New <code>ShadowedEntry{Name Name, Tier, Source}</code> with a <code>String() -&gt; "name (tier)"</code>; updated all 3 in-repo callers (interactive.go + 2 tests).</p>
+      <p><strong>Rationale:</strong> <code>internal/runtime</code> is internal-only, so no external API break. The richer entry lets <code>/help</code> (#341) and the startup warning name which source tier was shadowed.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Skills/plugins map to <code>TierGlobal</code>; Source label preserved for display</h3>
+      <p><strong>Ambiguity:</strong> The spec said skills/plugins keep their source label but their tier is Global.</p>
+      <p><strong>Choice:</strong> <code>AddSkill</code>/<code>AddPlugin</code> set <code>Tier=TierGlobal</code> and keep <code>Source=SourceSkill</code>/<code>SourcePlugin</code>.</p>
+      <p><strong>Rationale:</strong> Priority-wise they compete equally with global user templates (last-write-wins within Global); the source tag still lets <code>/status</code> distinguish them.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> New prompt-template sources reuse <code>SourceUser</code>; <code>Tier</code> carries the distinction</h3>
+      <p><strong>Ambiguity:</strong> What <code>Source</code> label for project/settings/CLI/package templates?</p>
+      <p><strong>Choice:</strong> <code>AddProject/AddSettings/AddCLI/AddPackage</code> all set <code>Source=SourceUser</code> and a distinct <code>Tier</code>.</p>
+      <p><strong>Rationale:</strong> Avoids bloating the <code>SlashCommandSource</code> enum. <code>/help</code> (#341) renders <code>source: &lt;tier&gt;</code>, so Tier is the display key; Source remains the coarse builtin/user/skill/plugin tag.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None &mdash; implementation followed US-009 as written. The Tier enum, central <code>add()</code> resolver, <code>ShadowedEntry</code>, the four new <code>AddX</code> methods, and the test matrix (project&gt;global, global&gt;settings, built-in&gt;project, same-tier last-write-wins, full ladder) all match the acceptance criteria.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Central <code>add()</code> resolver vs per-method conflict checks</h3>
+      <p><strong>Alternatives:</strong> Keep the old per-method pattern (each <code>AddX</code> inlines its own built-in-wins check and <code>shadowed</code> append).</p>
+      <p><strong>Pros/cons:</strong> Per-method duplicates the conflict rule across 4+ methods and is easy to get inconsistent. A central <code>add()</code> encodes the tier rule once.</p>
+      <p><strong>Why it won:</strong> Single source of truth for priority; adding a new source tier is one new <code>AddX</code> wrapper, no conflict-logic duplication.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> <code>Tier</code> as an <code>int</code> enum vs a struct with name+priority</h3>
+      <p><strong>Alternatives:</strong> A <code>struct{Priority int; Name string}</code> per tier.</p>
+      <p><strong>Pros/cons:</strong> A struct is more self-documenting but heavier and not directly comparable with <code>&gt;</code>. An <code>int</code> enum is lightweight, comparable, and idiomatic Go.</p>
+      <p><strong>Why it won:</strong> The <code>&gt;</code> comparison is the hot path in <code>add()</code>; an int keeps it trivial, and <code>String()</code> + the ascending-order comment document the meaning.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Same-tier override is silent (no <code>Shadowed</code> entry)</h3>
+      <p><strong>Alternatives:</strong> Record same-tier overrides in <code>Shadowed</code> too.</p>
+      <p><strong>Pros/cons:</strong> Recording same-tier overrides would noise up <code>Shadowed()</code> with ordinary re-loads (e.g. re-reading ~/.pigo/prompts). The AC explicitly tests &ldquo;同级后写覆盖&rdquo; as a non-shadow case.</p>
+      <p><strong>Why it won:</strong> <code>Shadowed()</code> stays a signal for real cross-tier conflicts only; same-tier re-load is normal and expected.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> The Package tier is currently unused by any caller</h3>
+      <p><strong>Assumption:</strong> <code>AddPackage</code> exists for completeness, but pigo's package manager copies installed templates into <code>~/.pigo/prompts</code> (global), so they load via <code>AddUser</code> (TierGlobal), not <code>AddPackage</code>.</p>
+      <p><strong>Verify:</strong> Should #342 install to a separate dir and load via <code>AddPackage</code> so the package tier is real, or is merging into global acceptable? (This is the PRD's Open Question on the package tier.)</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> <code>Shadowed()</code> ordering is insertion-order, not sorted</h3>
+      <p><strong>Assumption:</strong> Shadowed entries append in conflict-resolution order (the order <code>AddX</code> is called), which is deterministic but not alphabetical.</p>
+      <p><strong>Verify:</strong> <code>/help</code> (#341) may want them sorted by name; fine to sort at display time in #341 rather than here.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Tier zero-value is <code>TierCLI</code> (lowest)</h3>
+      <p><strong>Assumption:</strong> Every command reaches the registry via an <code>AddX</code> method that sets its Tier, so no command is ever installed with an unset (zero) Tier. A future caller that bypasses <code>AddX</code> and writes <code>r.commands</code> directly would silently get lowest priority.</p>
+      <p><strong>Verify:</strong> Ensure future source-loading code always goes through the matching <code>AddX</code>; consider a lint/test guard if direct-map writes proliferate.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/runtime/orchestration_test.go
+++ b/internal/runtime/orchestration_test.go
@@ -487,7 +487,7 @@ func TestSlashBuiltinWinsOverUser(t *testing.T) {
 		t.Errorf("expanded %q, want BUILTIN (built-in wins)", got)
 	}
 	shadowed := r.Shadowed()
-	if len(shadowed) != 1 || shadowed[0] != name {
+	if len(shadowed) != 1 || shadowed[0].Name != name {
 		t.Errorf("shadowed = %v, want [%s]", shadowed, name)
 	}
 }
@@ -581,7 +581,7 @@ func TestAddBuiltinWinsOverUser(t *testing.T) {
 	if !ok || cmd.Source != SourceBuiltin {
 		t.Errorf("instance built-in must win, got ok=%v source=%v", ok, cmd.Source)
 	}
-	if len(r.Shadowed()) != 1 || r.Shadowed()[0] != "x" {
+	if len(r.Shadowed()) != 1 || r.Shadowed()[0].Name != "x" {
 		t.Errorf("shadowed = %v, want [x]", r.Shadowed())
 	}
 }

--- a/internal/runtime/slashcommand.go
+++ b/internal/runtime/slashcommand.go
@@ -8,10 +8,10 @@
 //     (对标 the .../commands/*.md convention): the file name is the command
 //     name and the body is a prompt template that may reference $ARGUMENTS.
 //
-// Conflict rule: a built-in command wins over a user command of the same name
-// (built-ins are load-bearing and must not be silently shadowed). Loading a
-// user command whose name collides with a built-in is reported so the user can
-// rename it, but the built-in stays in effect.
+// Conflict rule: same-name commands resolve by priority tier (built-in >
+// project > global > package > settings > CLI); the higher tier wins and the
+// loser is reported via Shadowed. Built-ins are load-bearing and always win.
+// Within a tier, the last-added command overrides earlier ones (a re-load).
 //
 // There is deliberately no standalone plugin mechanism: a fork adds built-ins
 // via init() registration, and external extensions go through MCP (deferred).
@@ -60,6 +60,64 @@ func (s SlashCommandSource) String() string {
 	}
 }
 
+// Tier is the priority tier of a command, used to resolve same-name conflicts
+// across sources (对标 pi prompt-templates discovery priority). Higher tiers
+// win; the loser is recorded in Shadowed. Within the same tier the last-added
+// command wins (a re-load overrides). Skills and plugins are treated as
+// Global-tier for priority - their finer Source label is for display only.
+type Tier int
+
+const (
+	// Tier values are ordered lowest-to-highest priority: in a same-name
+	// conflict the higher Tier value wins, so TierBuiltin always wins and
+	// TierCLI always loses. Declared ascending so the natural > comparison
+	// matches "higher priority wins".
+	TierCLI Tier = iota
+	// TierSettings is a prompt template referenced by the config.toml prompts array.
+	TierSettings
+	// TierPackage is a prompt template discovered from an installed package
+	// source (distinct from one copied into the global dir).
+	TierPackage
+	// TierGlobal is a global user prompt template (e.g. ~/.pigo/prompts or the
+	// legacy ~/.pigo/commands); also the tier used for skills and plugins.
+	TierGlobal
+	// TierProject is a project-local prompt template (e.g. .pigo/prompts).
+	TierProject
+	// TierBuiltin is a compile-time or instance built-in command (highest).
+	TierBuiltin
+)
+
+func (t Tier) String() string {
+	switch t {
+	case TierBuiltin:
+		return "builtin"
+	case TierProject:
+		return "project"
+	case TierGlobal:
+		return "global"
+	case TierPackage:
+		return "package"
+	case TierSettings:
+		return "settings"
+	case TierCLI:
+		return "cli"
+	default:
+		return "unknown"
+	}
+}
+
+// ShadowedEntry records a command that lost a same-name conflict to a higher-
+// tier command, for diagnostics. It carries the loser's name, tier, and source
+// label so /help and the startup warning can say which source was shadowed.
+type ShadowedEntry struct {
+	Name   string
+	Tier   Tier
+	Source SlashCommandSource
+}
+
+// String renders a shadowed entry as "name (tier)" for log lines.
+func (e ShadowedEntry) String() string { return fmt.Sprintf("%s (%s)", e.Name, e.Tier) }
+
 // SlashCommand is a resolved command: its name (without the leading "/"), a
 // short description for the command palette, and its source. A command is one
 // of three kinds, distinguished by which callback is set:
@@ -81,6 +139,11 @@ type SlashCommand struct {
 	Name        string
 	Description string
 	Source      SlashCommandSource
+	// Tier is the priority tier used to resolve same-name conflicts across
+	// sources (built-in > project > global > package > settings > CLI). It is
+	// set by the AddX method matching the command's source; callers should not
+	// set it directly.
+	Tier Tier
 	// Expand maps the argument string (everything after "/name ") to the prompt
 	// text the command produces. For a built-in it may be arbitrary Go; for a
 	// user template it substitutes $ARGUMENTS into the markdown body. Nil for an
@@ -155,6 +218,7 @@ func RegisterBuiltin(cmd SlashCommand) {
 		panic(fmt.Sprintf("agent: duplicate built-in slash command %q", cmd.Name))
 	}
 	cmd.Source = SourceBuiltin
+	cmd.Tier = TierBuiltin
 	builtinCommands[cmd.Name] = cmd
 }
 
@@ -162,9 +226,10 @@ func RegisterBuiltin(cmd SlashCommand) {
 // commands, applying the built-in-wins priority rule.
 type SlashRegistry struct {
 	commands map[string]SlashCommand
-	// shadowed records user command names that collided with a built-in (and so
-	// were not installed), for diagnostics.
-	shadowed []string
+	// shadowed records commands that lost a same-name conflict to a higher-tier
+	// command, with their tier and source for diagnostics. Same-tier overrides
+	// (last-write-wins) are not recorded.
+	shadowed []ShadowedEntry
 }
 
 // NewSlashRegistry builds a registry seeded with all registered built-ins.
@@ -191,49 +256,95 @@ func (r *SlashRegistry) AddBuiltin(cmd SlashCommand) {
 		panic(fmt.Sprintf("agent: duplicate built-in slash command %q", cmd.Name))
 	}
 	cmd.Source = SourceBuiltin
-	r.commands[cmd.Name] = cmd
+	cmd.Tier = TierBuiltin
+	r.add(cmd)
 }
 
-// AddUser installs a user command unless a built-in already owns the name, in
-// which case the command is recorded as shadowed and the built-in is kept
-// (built-in-wins). A user command may override another user command of the same
-// name (last write wins), matching a re-load.
+// AddUser installs a user command (TierGlobal), e.g. a prompt template from
+// ~/.pigo/prompts or the legacy ~/.pigo/commands. A same-named built-in or
+// project-tier command wins; same-tier (global) adds override silently.
 func (r *SlashRegistry) AddUser(cmd SlashCommand) {
-	if existing, ok := r.commands[cmd.Name]; ok && existing.Source == SourceBuiltin {
-		r.shadowed = append(r.shadowed, cmd.Name)
-		return
-	}
 	cmd.Source = SourceUser
-	r.commands[cmd.Name] = cmd
+	cmd.Tier = TierGlobal
+	r.add(cmd)
 }
 
-// AddSkill installs a skill command (loaded from ~/.agents/skills). It follows
-// the same built-in-wins rule as AddUser - a built-in owning the name shadows
-// the skill - only the source tag differs, so /status can report skills
-// separately from user templates and plugins.
+// AddSkill installs a skill command (loaded from ~/.agents/skills) at TierGlobal.
+// It follows the same tier rule as AddUser - a built-in or project-tier command
+// wins - only the source tag differs, so /status can report skills separately.
 func (r *SlashRegistry) AddSkill(cmd SlashCommand) {
-	if existing, ok := r.commands[cmd.Name]; ok && existing.Source == SourceBuiltin {
-		r.shadowed = append(r.shadowed, cmd.Name)
-		return
-	}
 	cmd.Source = SourceSkill
-	r.commands[cmd.Name] = cmd
+	cmd.Tier = TierGlobal
+	r.add(cmd)
 }
 
-// AddPlugin installs a plugin-declared command, mirroring AddUser with a
-// SourcePlugin tag for display.
+// AddPlugin installs a plugin-declared command at TierGlobal, mirroring AddUser
+// with a SourcePlugin tag for display.
 func (r *SlashRegistry) AddPlugin(cmd SlashCommand) {
-	if existing, ok := r.commands[cmd.Name]; ok && existing.Source == SourceBuiltin {
-		r.shadowed = append(r.shadowed, cmd.Name)
+	cmd.Source = SourcePlugin
+	cmd.Tier = TierGlobal
+	r.add(cmd)
+}
+
+// Shadowed returns the commands that lost a same-name conflict to a higher-tier
+// command, with their tier and source for diagnostics. Same-tier overrides
+// (last-write-wins) are not recorded here.
+func (r *SlashRegistry) Shadowed() []ShadowedEntry { return r.shadowed }
+
+// AddProject installs a project-local prompt template (TierProject), which
+// overrides a same-named global/package/settings/CLI template but loses to a
+// built-in.
+func (r *SlashRegistry) AddProject(cmd SlashCommand) {
+	cmd.Source = SourceUser
+	cmd.Tier = TierProject
+	r.add(cmd)
+}
+
+// AddPackage installs a package-discovered prompt template (TierPackage).
+func (r *SlashRegistry) AddPackage(cmd SlashCommand) {
+	cmd.Source = SourceUser
+	cmd.Tier = TierPackage
+	r.add(cmd)
+}
+
+// AddSettings installs a prompt template referenced by config.toml (TierSettings).
+func (r *SlashRegistry) AddSettings(cmd SlashCommand) {
+	cmd.Source = SourceUser
+	cmd.Tier = TierSettings
+	r.add(cmd)
+}
+
+// AddCLI installs a prompt template referenced by --prompt-template (TierCLI,
+// the lowest priority).
+func (r *SlashRegistry) AddCLI(cmd SlashCommand) {
+	cmd.Source = SourceUser
+	cmd.Tier = TierCLI
+	r.add(cmd)
+}
+
+// add installs cmd with tier-based conflict resolution. If a same-named command
+// already exists, the higher tier wins and the loser is appended to shadowed;
+// within the same tier the new command replaces the old (last-write-wins, no
+// shadow entry). A built-in always wins because TierBuiltin is highest.
+func (r *SlashRegistry) add(cmd SlashCommand) {
+	existing, ok := r.commands[cmd.Name]
+	if !ok {
+		r.commands[cmd.Name] = cmd
 		return
 	}
-	cmd.Source = SourcePlugin
-	r.commands[cmd.Name] = cmd
+	switch {
+	case existing.Tier > cmd.Tier:
+		// New command is lower tier: it loses and is shadowed.
+		r.shadowed = append(r.shadowed, ShadowedEntry{Name: cmd.Name, Tier: cmd.Tier, Source: cmd.Source})
+	case existing.Tier < cmd.Tier:
+		// New command is higher tier: it wins; the old one is shadowed.
+		r.shadowed = append(r.shadowed, ShadowedEntry{Name: existing.Name, Tier: existing.Tier, Source: existing.Source})
+		r.commands[cmd.Name] = cmd
+	default:
+		// Same tier: last-write-wins (a re-load), no shadow entry.
+		r.commands[cmd.Name] = cmd
+	}
 }
-
-// Shadowed returns the names of user commands that were dropped because a
-// built-in owns the name.
-func (r *SlashRegistry) Shadowed() []string { return r.shadowed }
 
 // Lookup returns the command bound to name (without the leading "/").
 func (r *SlashRegistry) Lookup(name string) (SlashCommand, bool) {

--- a/internal/runtime/slashcommand_test.go
+++ b/internal/runtime/slashcommand_test.go
@@ -1,0 +1,100 @@
+package runtime
+
+// Tests for tiered priority resolution (US-009, #335): same-name commands
+// across sources resolve by tier (built-in > project > global > package >
+// settings > CLI), the loser is shadowed with its tier recorded, and same-tier
+// adds override silently (last-write-wins, no shadow entry).
+
+import "testing"
+
+// TestSlashTierProjectOverridesGlobal: a project-tier template added after a
+// global one wins; the global entry is shadowed with TierGlobal.
+func TestSlashTierProjectOverridesGlobal(t *testing.T) {
+	r := NewSlashRegistry()
+	r.AddUser(SlashCommand{Name: "t", Expand: func(string) string { return "global" }})
+	r.AddProject(SlashCommand{Name: "t", Expand: func(string) string { return "project" }})
+	cmd, ok := r.Lookup("t")
+	if !ok {
+		t.Fatalf("command %q not found", "t")
+	}
+	if got := cmd.Expand(""); got != "project" {
+		t.Errorf("project must override global, got %q", got)
+	}
+	sh := r.Shadowed()
+	if len(sh) != 1 || sh[0].Name != "t" || sh[0].Tier != TierGlobal {
+		t.Errorf("global should be shadowed, got %v", sh)
+	}
+}
+
+// TestSlashTierGlobalOverridesSettings: a global template added after a
+// settings-tier one wins; the settings entry is shadowed with TierSettings.
+func TestSlashTierGlobalOverridesSettings(t *testing.T) {
+	r := NewSlashRegistry()
+	r.AddSettings(SlashCommand{Name: "t", Expand: func(string) string { return "settings" }})
+	r.AddUser(SlashCommand{Name: "t", Expand: func(string) string { return "global" }})
+	cmd, ok := r.Lookup("t")
+	if !ok {
+		t.Fatalf("command %q not found", "t")
+	}
+	if got := cmd.Expand(""); got != "global" {
+		t.Errorf("global must override settings, got %q", got)
+	}
+	sh := r.Shadowed()
+	if len(sh) != 1 || sh[0].Name != "t" || sh[0].Tier != TierSettings {
+		t.Errorf("settings should be shadowed, got %v", sh)
+	}
+}
+
+// TestSlashTierBuiltinOverridesProject: a built-in added after a project-tier
+// template wins; the project entry is shadowed with TierProject.
+func TestSlashTierBuiltinOverridesProject(t *testing.T) {
+	r := NewSlashRegistry()
+	r.AddProject(SlashCommand{Name: "t", Expand: func(string) string { return "project" }})
+	r.AddBuiltin(SlashCommand{Name: "t", Action: func(string) string { return "builtin" }})
+	cmd, ok := r.Lookup("t")
+	if !ok || cmd.Source != SourceBuiltin {
+		t.Fatalf("built-in must override project, got ok=%v source=%v", ok, cmd.Source)
+	}
+	sh := r.Shadowed()
+	if len(sh) != 1 || sh[0].Name != "t" || sh[0].Tier != TierProject {
+		t.Errorf("project should be shadowed, got %v", sh)
+	}
+}
+
+// TestSlashTierSameTierLastWriteWins: two same-tier (global) adds resolve to the
+// last one, with no shadow entry recorded.
+func TestSlashTierSameTierLastWriteWins(t *testing.T) {
+	r := NewSlashRegistry()
+	r.AddUser(SlashCommand{Name: "t", Expand: func(string) string { return "first" }})
+	r.AddUser(SlashCommand{Name: "t", Expand: func(string) string { return "second" }})
+	cmd, ok := r.Lookup("t")
+	if !ok {
+		t.Fatalf("command %q not found", "t")
+	}
+	if got := cmd.Expand(""); got != "second" {
+		t.Errorf("same-tier last-write-wins, got %q", got)
+	}
+	if len(r.Shadowed()) != 0 {
+		t.Errorf("same-tier override must not shadow, got %v", r.Shadowed())
+	}
+}
+
+// TestSlashTierFullOrdering exercises the full tier ladder: adding lowest-first
+// up to built-in, the built-in wins and every lower tier is shadowed.
+func TestSlashTierFullOrdering(t *testing.T) {
+	r := NewSlashRegistry()
+	r.AddCLI(SlashCommand{Name: "t", Expand: func(string) string { return "cli" }})
+	r.AddSettings(SlashCommand{Name: "t", Expand: func(string) string { return "settings" }})
+	r.AddPackage(SlashCommand{Name: "t", Expand: func(string) string { return "package" }})
+	r.AddUser(SlashCommand{Name: "t", Expand: func(string) string { return "global" }})
+	r.AddProject(SlashCommand{Name: "t", Expand: func(string) string { return "project" }})
+	r.AddBuiltin(SlashCommand{Name: "t", Action: func(string) string { return "builtin" }})
+	cmd, ok := r.Lookup("t")
+	if !ok || cmd.Source != SourceBuiltin {
+		t.Fatalf("built-in must win the full ladder, got ok=%v source=%v", ok, cmd.Source)
+	}
+	// Five lower-tier commands (cli, settings, package, global, project) lost.
+	if len(r.Shadowed()) != 5 {
+		t.Errorf("expected 5 shadowed entries, got %d: %v", len(r.Shadowed()), r.Shadowed())
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Tier` enum to `SlashCommand` (cli < settings < package < global < project < builtin) and a central `add()` resolver: higher tier wins a same-name conflict, loser recorded in `Shadowed` with its tier; same-tier adds override silently (last-write-wins)
- Add `AddProject`/`AddPackage`/`AddSettings`/`AddCLI` for the upcoming prompt-template sources (#336-#339)
- Change `Shadowed()` to `[]ShadowedEntry` (name+tier+source); update the 3 in-repo callers
- Skills/plugins map to `TierGlobal` (Source label preserved for display)

Closes #335

## Test plan
- [x] `go test ./internal/runtime/` passes (5 new tier tests + existing slash tests updated)
- [x] `go test ./cmd/pigo/` passes
- [x] `go vet ./...` clean, `go build ./...` clean