### PR TITLE
feat(runtime): prompt-template expansion engine

### DIFF
--- a/docs/issue#0332.html
+++ b/docs/issue#0332.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes - Issue #0332</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/332">#332</a> &mdash; 模板参数展开引擎 &mdash; 2026-07-27</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Single left-to-right pass instead of &ldquo;expand ${...} then bare $&rdquo; two-phase</h3>
+      <p><strong>Ambiguity:</strong> The AC says &ldquo;先处理 ${...} 形式，再处理裸 $N/$@/$ARGUMENTS&rdquo; (process braced before bare), which suggests two phases.</p>
+      <p><strong>Choice:</strong> One left-to-right scan that consumes a <code>${...}</code> as a single unit and a bare <code>$N</code>/<code>$@</code>/<code>$ARGUMENTS</code> as encountered.</p>
+      <p><strong>Rationale:</strong> A single pass naturally satisfies the ordering invariant &mdash; because <code>${...}</code> is consumed whole, a bare <code>$1</code> can never match inside <code>${1:-...}</code>, and a default literal containing <code>$</code> is appended verbatim (never re-scanned). Two phases would require shadowing/protecting substituted text to avoid re-expansion &mdash; more error-prone.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>$@</code> expands to ALL args (not &ldquo;the rest after positionals&rdquo;)</h3>
+      <p><strong>Ambiguity:</strong> The pi docs example <code>named $1 with features: $@</code> reads as if <code>$@</code> is &ldquo;the remaining args&rdquo; (features shouldn't include the name), but the AC says &ldquo;全部参数&rdquo; and bash semantics are <code>$@</code> = all positional params.</p>
+      <p><strong>Choice:</strong> <code>$@</code> = all args joined; &ldquo;the rest&rdquo; is expressed with the slice form <code>${@:2}</code>.</p>
+      <p><strong>Rationale:</strong> Matches the AC verbatim and bash convention. The slice form is the correct, explicit tool for &ldquo;remaining args&rdquo;.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> No-placeholder append uses <code>Join(args, " ")</code> (tokenized), not the raw arg string</h3>
+      <p><strong>Ambiguity:</strong> The old <code>ParseUserCommand</code> appended the raw <code>args</code> string (preserving quotes). <code>ExpandTemplate</code> receives tokenized <code>[]string</code>.</p>
+      <p><strong>Choice:</strong> Append <code>strings.Join(args, " ")</code> after a blank line.</p>
+      <p><strong>Rationale:</strong> The existing <code>TestParseUserCommand</code> (e.g. <code>Expand("buy milk")</code> -&gt; <code>"Take a note\n\nbuy milk"</code>) passes because <code>Join(["buy","milk"], " ")</code> == the raw string for unquoted input. Quotes were grouping syntax, so dropping them in the append is the more correct behavior.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None &mdash; implementation follows US-002 as written. All six placeholder forms, the ordering invariant, the no-placeholder append, and the test matrix (including the spec's component/bullets examples) match the acceptance criteria.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Hand-written scanner vs regex-based substitution</h3>
+      <p><strong>Alternatives:</strong> A chain of <code>regexp.ReplaceAllFunc</code> calls, one per form.</p>
+      <p><strong>Pros/cons:</strong> Regex is compact but needs careful negative lookbehind to avoid <code>$1</code> matching inside <code>${1:-...}</code>, and still risks re-expanding substituted text. A scanner gives explicit control over the no-re-expansion guarantee.</p>
+      <p><strong>Why it won:</strong> The ordering/no-re-expand invariant is the acceptance-critical part; an explicit scanner makes it obvious and testable.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Unknown <code>${name}</code> expands to <code>""</code> (shell-like unset var)</h3>
+      <p><strong>Alternatives:</strong> Emit the literal <code>${name}</code> for unknown names.</p>
+      <p><strong>Pros/cons:</strong> Empty matches bash semantics (unset variable); literal passthrough would preserve a typo for the user to notice. The AC has no case for unknown names.</p>
+      <p><strong>Why it won:</strong> Shell consistency; <code>${@:N}</code> on an invalid index already returns <code>""</code>, so unknown -&gt; empty is consistent.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> <code>$@</code> = all-args vs &ldquo;rest&rdquo;: confirm against pi's runtime</h3>
+      <p><strong>Assumption:</strong> <code>$@</code> = all args (per AC &ldquo;全部参数&rdquo;). The pi docs example is ambiguous on this point.</p>
+      <p><strong>Verify:</strong> If a pi parity test or the reference implementation shows <code>$@</code> means &ldquo;remaining after positionals&rdquo;, revisit. For now <code>${@:2}</code> is the documented way to get &ldquo;rest&rdquo;.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> No-placeholder append drops quotes from tokenized args</h3>
+      <p><strong>Assumption:</strong> For a no-placeholder template, appending <code>Join(args, " ")</code> (no quotes) is acceptable and matches the tested behavior.</p>
+      <p><strong>Verify:</strong> #333's <code>ParseUserCommand</code> fallback (split failure -&gt; treat raw arg string as <code>$ARGUMENTS</code>) must preserve the raw string on that path so a genuinely unparseable invocation isn't silently de-quoted.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Unknown <code>${name}</code> silently becomes empty</h3>
+      <p><strong>Assumption:</strong> A typo like <code>${nmae}</code> expands to <code>""</code> with no warning.</p>
+      <p><strong>Verify:</strong> Acceptable for now; consider a debug-mode warning if users report confusion. Not worth a hard error since <code>${...}</code> is also used for valid slice/default forms.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/runtime/template.go
+++ b/internal/runtime/template.go
@@ -1,0 +1,182 @@
+// This file implements the prompt-template expansion engine (US-002, #332): it
+// turns a template body plus tokenized invocation args into the final prompt
+// text, supporting pi's positional/default/slice syntax.
+//
+// Supported placeholders (对标 https://pi.dev/docs/latest/prompt-templates):
+//   - $1, $2, ... $N      : Nth positional arg (1-indexed; out-of-range -> "")
+//   - $@, $ARGUMENTS      : all args joined by a single space
+//   - ${1:-default}       : arg 1 when present and non-empty, else `default`
+//   - ${@:-default}, ${ARGUMENTS:-default} : all args when non-empty, else default
+//   - ${@:N}              : args from the Nth onward (1-indexed), joined
+//   - ${@:N:L}            : L args starting at N, joined
+//
+// A single left-to-right pass expands both braced ${...} and bare $N/$@ forms.
+// Because the pass consumes a ${...} as one unit, a bare $1 never matches inside
+// ${1:-...}, and a default literal containing $ is not re-expanded (the
+// substituted text is appended verbatim and the scan advances past it).
+package runtime
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ExpandTemplate expands template against the tokenized args. A template with no
+// placeholder preserves ParseUserCommand's behavior: with no args it is returned
+// verbatim, with args they are appended after a blank line (joined by spaces).
+func ExpandTemplate(template string, args []string) string {
+	if !hasPlaceholder(template) {
+		if len(args) == 0 {
+			return template
+		}
+		return template + "\n\n" + strings.Join(args, " ")
+	}
+	var b strings.Builder
+	i := 0
+	n := len(template)
+	for i < n {
+		c := template[i]
+		if c == '$' && i+1 < n {
+			next := template[i+1]
+			if next == '{' {
+				end := strings.IndexByte(template[i+2:], '}')
+				if end < 0 {
+					// No closing brace: emit the '$' literally and continue.
+					b.WriteByte(c)
+					i++
+					continue
+				}
+				inner := template[i+2 : i+2+end]
+				b.WriteString(expandBraced(inner, args))
+				i += 2 + end + 1
+				continue
+			}
+			if next == '@' {
+				b.WriteString(strings.Join(args, " "))
+				i += 2
+				continue
+			}
+			if isDigitByte(next) {
+				j := i + 1
+				for j < n && isDigitByte(template[j]) {
+					j++
+				}
+				idx, _ := strconv.Atoi(template[i+1 : j])
+				if idx >= 1 && idx <= len(args) {
+					b.WriteString(args[idx-1])
+				}
+				i = j
+				continue
+			}
+			if strings.HasPrefix(template[i+1:], "ARGUMENTS") {
+				b.WriteString(strings.Join(args, " "))
+				i += 1 + len("ARGUMENTS")
+				continue
+			}
+		}
+		b.WriteByte(c)
+		i++
+	}
+	return b.String()
+}
+
+// hasPlaceholder reports whether s contains any template placeholder: ${...},
+// $@, $<digits>, or $ARGUMENTS. A bare '$' not followed by one of these is not a
+// placeholder (emitted literally), so a template like "price $5" still counts.
+func hasPlaceholder(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] != '$' {
+			continue
+		}
+		if i+1 >= len(s) {
+			return false
+		}
+		next := s[i+1]
+		if next == '{' || next == '@' || isDigitByte(next) {
+			return true
+		}
+		if strings.HasPrefix(s[i+1:], "ARGUMENTS") {
+			return true
+		}
+	}
+	return false
+}
+
+// expandBraced expands the content inside ${...} (without the surrounding
+// braces). It dispatches on the three forms: name:-default, @:N[:L], or plain.
+func expandBraced(inner string, args []string) string {
+	// default form: name:-default
+	if idx := strings.Index(inner, ":-"); idx >= 0 {
+		return expandDefaulted(inner[:idx], inner[idx+2:], args)
+	}
+	// slice form: @:N or @:N:L
+	if idx := strings.Index(inner, ":"); idx >= 0 {
+		if name := inner[:idx]; name != "@" && name != "ARGUMENTS" {
+			return "" // slicing only applies to all-args
+		}
+		return expandSlice(inner[idx+1:], args)
+	}
+	// plain: N, @, or ARGUMENTS
+	return expandPlain(inner, args)
+}
+
+// expandPlain expands a bare braced name (no :- or :): a positional index, @,
+// or ARGUMENTS. An unknown name (e.g. ${foo}) expands to "".
+func expandPlain(name string, args []string) string {
+	if name == "@" || name == "ARGUMENTS" {
+		return strings.Join(args, " ")
+	}
+	if idx, err := strconv.Atoi(name); err == nil {
+		if idx >= 1 && idx <= len(args) {
+			return args[idx-1]
+		}
+		return ""
+	}
+	return ""
+}
+
+// expandDefaulted expands name:-default: the named positional (when in range and
+// non-empty) or all-args (when the join is non-empty), otherwise the literal
+// default. The default is not re-expanded.
+func expandDefaulted(name, def string, args []string) string {
+	if name == "@" || name == "ARGUMENTS" {
+		if joined := strings.Join(args, " "); joined != "" {
+			return joined
+		}
+		return def
+	}
+	if idx, err := strconv.Atoi(name); err == nil {
+		if idx >= 1 && idx <= len(args) && args[idx-1] != "" {
+			return args[idx-1]
+		}
+		return def
+	}
+	return def
+}
+
+// expandSlice expands the N (or N:L) part of ${@:N} / ${@:N:L}: args from the Nth
+// onward (1-indexed), optionally limited to L, joined by spaces. N<1 or beyond
+// the arg list yields "".
+func expandSlice(rest string, args []string) string {
+	parts := strings.SplitN(rest, ":", 2)
+	start, _ := strconv.Atoi(parts[0])
+	if start < 1 {
+		return ""
+	}
+	begin := start - 1
+	if begin >= len(args) {
+		return ""
+	}
+	end := len(args)
+	if len(parts) == 2 {
+		if l, err := strconv.Atoi(parts[1]); err == nil && l >= 0 {
+			end = begin + l
+			if end > len(args) {
+				end = len(args)
+			}
+		}
+	}
+	return strings.Join(args[begin:end], " ")
+}
+
+func isDigitByte(b byte) bool { return b >= '0' && b <= '9' }

--- a/internal/runtime/template_test.go
+++ b/internal/runtime/template_test.go
@@ -1,0 +1,170 @@
+package runtime
+
+// Tests for the prompt-template expansion engine (US-002, #332). Covers the
+// positional/default/slice syntax from the acceptance criteria, the
+// ${...}-before-bare-$ ordering invariant, and the no-placeholder append
+// behavior that preserves ParseUserCommand's existing semantics.
+
+import "testing"
+
+func TestExpandTemplateNoPlaceholder(t *testing.T) {
+	// No args: verbatim.
+	if got := ExpandTemplate("Take a note", nil); got != "Take a note" {
+		t.Errorf("no args: got %q", got)
+	}
+	if got := ExpandTemplate("Take a note", []string{}); got != "Take a note" {
+		t.Errorf("empty args: got %q", got)
+	}
+	// With args: appended after a blank line, joined by spaces.
+	if got := ExpandTemplate("Take a note", []string{"buy", "milk"}); got != "Take a note\n\nbuy milk" {
+		t.Errorf("with args: got %q", got)
+	}
+}
+
+func TestExpandTemplatePositional(t *testing.T) {
+	args := []string{"Button", "click", "handler"}
+	if got := ExpandTemplate("$1", args); got != "Button" {
+		t.Errorf("$1 = %q, want Button", got)
+	}
+	if got := ExpandTemplate("$3", args); got != "handler" {
+		t.Errorf("$3 = %q, want handler", got)
+	}
+	// Out of range -> empty.
+	if got := ExpandTemplate("$5", args); got != "" {
+		t.Errorf("$5 = %q, want empty", got)
+	}
+	// Multi-digit.
+	if got := ExpandTemplate("$10", []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}); got != "j" {
+		t.Errorf("$10 = %q, want j", got)
+	}
+}
+
+func TestExpandTemplateAllArgs(t *testing.T) {
+	args := []string{"Button", "click", "handler"}
+	if got := ExpandTemplate("$@", args); got != "Button click handler" {
+		t.Errorf("$@ = %q", got)
+	}
+	if got := ExpandTemplate("$ARGUMENTS", args); got != "Button click handler" {
+		t.Errorf("$ARGUMENTS = %q", got)
+	}
+}
+
+func TestExpandTemplateDefaultPositional(t *testing.T) {
+	// Present and non-empty -> the arg.
+	if got := ExpandTemplate("${1:-default}", []string{"a"}); got != "a" {
+		t.Errorf("present: got %q", got)
+	}
+	// Absent -> default.
+	if got := ExpandTemplate("${1:-default}", nil); got != "default" {
+		t.Errorf("absent: got %q", got)
+	}
+	// Present but empty -> default.
+	if got := ExpandTemplate("${1:-default}", []string{""}); got != "default" {
+		t.Errorf("empty: got %q", got)
+	}
+	// Default containing a $ is not re-expanded.
+	if got := ExpandTemplate("${1:-pay $5}", nil); got != "pay $5" {
+		t.Errorf("default literal $: got %q", got)
+	}
+}
+
+func TestExpandTemplateDefaultAllArgs(t *testing.T) {
+	if got := ExpandTemplate("${@:-default}", []string{"a", "b"}); got != "a b" {
+		t.Errorf("present: got %q", got)
+	}
+	if got := ExpandTemplate("${@:-default}", nil); got != "default" {
+		t.Errorf("absent: got %q", got)
+	}
+	if got := ExpandTemplate("${ARGUMENTS:-default}", []string{"x"}); got != "x" {
+		t.Errorf("ARGUMENTS present: got %q", got)
+	}
+	if got := ExpandTemplate("${ARGUMENTS:-default}", nil); got != "default" {
+		t.Errorf("ARGUMENTS absent: got %q", got)
+	}
+}
+
+func TestExpandTemplateSlice(t *testing.T) {
+	args := []string{"a", "b", "c", "d", "e"}
+	// ${@:N}: from Nth onward.
+	if got := ExpandTemplate("${@:2}", args); got != "b c d e" {
+		t.Errorf("${@:2} = %q", got)
+	}
+	if got := ExpandTemplate("${@:1}", args); got != "a b c d e" {
+		t.Errorf("${@:1} = %q", got)
+	}
+	// ${@:N:L}: L args starting at N.
+	if got := ExpandTemplate("${@:2:2}", args); got != "b c" {
+		t.Errorf("${@:2:2} = %q", got)
+	}
+	if got := ExpandTemplate("${@:1:3}", args); got != "a b c" {
+		t.Errorf("${@:1:3} = %q", got)
+	}
+	// N beyond args -> empty.
+	if got := ExpandTemplate("${@:9}", args); got != "" {
+		t.Errorf("${@:9} = %q, want empty", got)
+	}
+	// L clamps to available.
+	if got := ExpandTemplate("${@:3:100}", args); got != "c d e" {
+		t.Errorf("${@:3:100} = %q, want c d e", got)
+	}
+	// N<1 -> empty.
+	if got := ExpandTemplate("${@:0}", args); got != "" {
+		t.Errorf("${@:0} = %q, want empty", got)
+	}
+}
+
+func TestExpandTemplateOrderingNoDoubleMatch(t *testing.T) {
+	// A bare $1 must NOT match inside ${1:-...}. With args present, ${1:-$2}
+	// uses arg1 ("a"); the $2 default is never consulted nor expanded.
+	if got := ExpandTemplate("${1:-$2}", []string{"a"}); got != "a" {
+		t.Errorf("${1:-$2} with arg1=a: got %q, want a", got)
+	}
+	// With arg1 absent, the default "$2" is taken literally (not expanded to "").
+	if got := ExpandTemplate("${1:-$2}", nil); got != "$2" {
+		t.Errorf("${1:-$2} absent: got %q, want literal $2", got)
+	}
+	// Braced and bare coexist in one pass.
+	if got := ExpandTemplate("${1:-x} and $2", []string{"a", "b"}); got != "a and b" {
+		t.Errorf("coexist: got %q", got)
+	}
+}
+
+func TestExpandTemplateExampleFromSpec(t *testing.T) {
+	// $@ expands to ALL args joined (AC: "全部参数以单空格连接").
+	if got := ExpandTemplate("echo $@", []string{"a", "b", "c"}); got != "echo a b c" {
+		t.Errorf("$@ all-args: got %q", got)
+	}
+	// The pi "component" example: $1 for the name, features are the remaining
+	// args expressed with the slice form ${@:2} (the right tool for "rest").
+	tmpl := "Create a React component named $1 with features: ${@:2}"
+	if got := ExpandTemplate(tmpl, []string{"Button", "click", "handler"}); got != "Create a React component named Button with features: click handler" {
+		t.Errorf("component example: got %q", got)
+	}
+	// "Summarize the current state in ${1:-7} bullet points."
+	bullets := "Summarize the current state in ${1:-7} bullet points."
+	if got := ExpandTemplate(bullets, nil); got != "Summarize the current state in 7 bullet points." {
+		t.Errorf("default bullets: got %q", got)
+	}
+	if got := ExpandTemplate(bullets, []string{"5"}); got != "Summarize the current state in 5 bullet points." {
+		t.Errorf("explicit bullets: got %q", got)
+	}
+}
+
+func TestExpandTemplateLiteralDollar(t *testing.T) {
+	// A '$' not forming a placeholder is emitted literally. Such a template has
+	// no placeholder, so args (if any) are appended per the no-placeholder rule.
+	if got := ExpandTemplate("100$ off", nil); got != "100$ off" {
+		t.Errorf("literal $ mid-string: got %q", got)
+	}
+	if got := ExpandTemplate("trailing$", nil); got != "trailing$" {
+		t.Errorf("trailing $ no args: got %q", got)
+	}
+	// No placeholder + args -> append after a blank line.
+	if got := ExpandTemplate("trailing$", []string{"x"}); got != "trailing$\n\nx" {
+		t.Errorf("trailing $ with args: got %q", got)
+	}
+	// A literal '$' alongside a real placeholder: '$' before a space stays '$'.
+	if got := ExpandTemplate("cost $ and $1", []string{"five"}); got != "cost $ and five" {
+		t.Errorf("literal $ next to placeholder: got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `runtime.ExpandTemplate(template, args []string) string` supporting pi's syntax: `$1`..`$N`, `$@`/`$ARGUMENTS`, `${1:-default}`, `${@:-default}`, `${ARGUMENTS:-default}`, `${@:N}`, `${@:N:L}`
- Single left-to-right pass: `${...}` consumed as one unit so bare `$1` never matches inside `${1:-…}` and default literals are not re-expanded
- No-placeholder templates preserve `ParseUserCommand`'s append behavior (verbatim with no args; joined args appended with a blank line otherwise)
- Out-of-range positional / invalid slice index -> `""`; L is clamped to available args

Closes #332

## Test plan
- [x] `go test ./internal/runtime/ -run TestExpandTemplate` passes (9 test funcs: positional, all-args, defaults, slicing, ordering/no-double-match, spec examples, literal `$`)
- [x] `go test ./internal/runtime/ ./cmd/pigo/` passes
- [x] `go vet ./internal/runtime/` + `go build ./...` clean