### PR TITLE
feat(runtime): wire ParseUserCommand to expansion engine

### DIFF
--- a/docs/issue#0333.html
+++ b/docs/issue#0333.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes - Issue #0333</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/333">#333</a> &mdash; 接入 ParseUserCommand：新引擎替换 $ARGUMENTS &mdash; 2026-07-27</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> On split failure, fall back to <code>[]string{args}</code> (raw string as $ARGUMENTS)</h3>
+      <p><strong>Ambiguity:</strong> When <code>SplitArgs</code> errors (e.g. an unterminated quote), what should the expander receive?</p>
+      <p><strong>Choice:</strong> Use a single-element token slice holding the raw arg string, so <code>$ARGUMENTS</code> expands to the raw input.</p>
+      <p><strong>Rationale:</strong> <code>Expand</code> returns only a string (no error path), so the fallback must be silent. Treating the raw string as <code>$ARGUMENTS</code> keeps a bad invocation usable and matches the old <code>strings.ReplaceAll</code> behavior for <code>$ARGUMENTS</code> templates; no-placeholder templates still append the raw string.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Removed the <code>$ARGUMENTS</code>-only fast path; all templates go through <code>ExpandTemplate</code></h3>
+      <p><strong>Ambiguity:</strong> Keep a special-case <code>strings.Contains(template, "$ARGUMENTS")</code> branch for parity with the old code?</p>
+      <p><strong>Choice:</strong> A single code path: <code>SplitArgs</code> then <code>ExpandTemplate</code> for every template.</p>
+      <p><strong>Rationale:</strong> One path is easier to reason about; <code>ExpandTemplate</code> already handles <code>$ARGUMENTS</code>, the no-placeholder append, and the new positional/default/slice forms. The existing <code>TestParseUserCommand</code> regression test passes unchanged.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None &mdash; implementation follows US-003 as written. <code>Expand</code> now does <code>SplitArgs</code> + <code>ExpandTemplate</code> with the documented raw-<code>$ARGUMENTS</code> fallback, and the regression + new (no-arg, quoted multi-arg, <code>${1:-7}</code> default, split-failure) tests match the acceptance criteria.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Silent fallback vs surfacing an error</h3>
+      <p><strong>Alternatives:</strong> Change <code>Expand</code> to return an error, or log a warning from inside <code>Expand</code>.</p>
+      <p><strong>Pros/cons:</strong> An error return would ripple through every <code>Expand</code> caller; a warning from <code>Expand</code> mixes I/O into a pure function. Silent fallback keeps <code>Expand</code> pure and the signature stable.</p>
+      <p><strong>Why it won:</strong> The REPL layer (not <code>Expand</code>) is the right place for user-facing warnings; keeping the engine pure matches <code>ExpandTemplate</code>&rsquo;s design.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Fallback sets <code>$1</code> = raw string too (single-element tokens)</h3>
+      <p><strong>Alternatives:</strong> Special-case so only <code>$ARGUMENTS</code> gets the raw string while <code>$1</code> is empty on split failure.</p>
+      <p><strong>Pros/cons:</strong> Single-element tokens are simplest and coherent (one arg = the whole raw input). Special-casing <code>$1</code> differently from <code>$ARGUMENTS</code> would be surprising.</p>
+      <p><strong>Why it won:</strong> Coherence: on split failure the whole input is &ldquo;one arg&rdquo;, so <code>$1</code> and <code>$ARGUMENTS</code> agreeing is the least surprising behavior.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should the REPL warn on a split failure?</h3>
+      <p><strong>Assumption:</strong> An unterminated quote silently falls back to raw-<code>$ARGUMENTS</code> with no user-visible signal.</p>
+      <p><strong>Verify:</strong> Consider a one-line stderr warning in the REPL layer when <code>SplitArgs</code> errors, so users notice their quoting mistake. Not added here to keep <code>Expand</code> pure.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Fallback <code>$1</code> = raw string: confirm against pi</h3>
+      <p><strong>Assumption:</strong> On a split failure, <code>$1</code> expanding to the whole raw input (same as <code>$ARGUMENTS</code>) is acceptable.</p>
+      <p><strong>Verify:</strong> If pi instead leaves <code>$1</code> empty on a parse failure, revisit. The single-element-token model is the simplest coherent choice.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/runtime/slashcommand.go
+++ b/internal/runtime/slashcommand.go
@@ -420,9 +420,9 @@ func (r *SlashRegistry) ResolveOutcome(input string) (SlashOutcome, error) {
 // LoadUserCommandsDir loads declarative markdown command templates from dir
 // (non-recursively). Each "*.md" file defines a command named after the file
 // (without extension). The file may carry an optional YAML frontmatter block
-// with a "description" (对标 skills); the remaining body is the prompt template.
-// $ARGUMENTS in the body is replaced with the invocation arguments at expand
-// time. A missing directory yields no commands and no error.
+// with a "description" (对标 skills); the remaining body is the prompt template,
+// expanded via ExpandTemplate at invoke time. A missing directory yields no
+// commands and no error.
 func LoadUserCommandsDir(dir string) ([]SlashCommand, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -453,8 +453,10 @@ func LoadUserCommandsDir(dir string) ([]SlashCommand, error) {
 }
 
 // ParseUserCommand parses a declarative command template. An optional YAML
-// frontmatter block supplies a description; the body is the prompt template
-// with $ARGUMENTS substitution.
+// frontmatter block supplies a description; the body is the prompt template,
+// expanded at invoke time via ExpandTemplate (positional $N, $@/$ARGUMENTS,
+// ${1:-default}, ${@:N}). If arg tokenization fails (e.g. an unterminated
+// quote) the raw arg string is used as $ARGUMENTS so the invocation still works.
 func ParseUserCommand(name string, content []byte) (SlashCommand, error) {
 	body := string(content)
 	description := ""
@@ -484,15 +486,14 @@ func ParseUserCommand(name string, content []byte) (SlashCommand, error) {
 		Description: description,
 		Source:      SourceUser,
 		Expand: func(args string) string {
-			if strings.Contains(template, "$ARGUMENTS") {
-				return strings.ReplaceAll(template, "$ARGUMENTS", args)
+			tokens, err := SplitArgs(args)
+			if err != nil {
+				// Split failure (e.g. an unterminated quote): treat the raw arg
+				// string as a single $ARGUMENTS rather than feeding a malformed
+				// arg list to the engine, so a bad invocation stays usable.
+				tokens = []string{args}
 			}
-			// No placeholder: append args (if any) so a bare template still
-			// receives the user's input.
-			if args == "" {
-				return template
-			}
-			return template + "\n\n" + args
+			return ExpandTemplate(template, tokens)
 		},
 	}, nil
 }

--- a/internal/runtime/slashcommand_test.go
+++ b/internal/runtime/slashcommand_test.go
@@ -98,3 +98,44 @@ func TestSlashTierFullOrdering(t *testing.T) {
 		t.Errorf("expected 5 shadowed entries, got %d: %v", len(r.Shadowed()), r.Shadowed())
 	}
 }
+
+// Tests for ParseUserCommand wiring to the expansion engine (US-003, #333):
+// Expand tokenizes args via SplitArgs and expands via ExpandTemplate, falling
+// back to the raw arg string as $ARGUMENTS when tokenization fails.
+
+// TestParseUserCommandPositionalAndQuoted verifies multi-arg invocation,
+// quoted-arg preservation, and the ${1:-default} form through ParseUserCommand.
+func TestParseUserCommandPositionalAndQuoted(t *testing.T) {
+	// /review with no args: $ARGUMENTS expands to empty.
+	review, _ := ParseUserCommand("review", []byte("Review: $ARGUMENTS"))
+	if got := review.Expand(""); got != "Review: " {
+		t.Errorf("no args: got %q, want \"Review: \"", got)
+	}
+	// /component Button "click handler": quoted arg stays one token ($2).
+	comp, _ := ParseUserCommand("component", []byte("name=$1 feat=$2"))
+	if got := comp.Expand(`Button "click handler"`); got != "name=Button feat=click handler" {
+		t.Errorf("quoted args: got %q", got)
+	}
+	// ${1:-7} default: no arg -> 7, explicit -> the arg.
+	bul, _ := ParseUserCommand("summarize", []byte("in ${1:-7} bullets"))
+	if got := bul.Expand(""); got != "in 7 bullets" {
+		t.Errorf("default no arg: got %q", got)
+	}
+	if got := bul.Expand("5"); got != "in 5 bullets" {
+		t.Errorf("explicit arg: got %q", got)
+	}
+}
+
+// TestParseUserCommandSplitFailureFallback verifies that an unterminated quote
+// (SplitArgs error) falls back to treating the raw arg string as $ARGUMENTS.
+func TestParseUserCommandSplitFailureFallback(t *testing.T) {
+	cmd, _ := ParseUserCommand("t", []byte("echo $ARGUMENTS"))
+	if got := cmd.Expand(`"unterminated`); got != `echo "unterminated` {
+		t.Errorf("split-failure fallback: got %q, want raw string as $ARGUMENTS", got)
+	}
+	// A no-placeholder template with split failure still appends the raw string.
+	bare, _ := ParseUserCommand("note", []byte("Take a note"))
+	if got := bare.Expand(`"unterminated`); got != "Take a note\n\n\"unterminated" {
+		t.Errorf("no-placeholder split failure: got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- `ParseUserCommand`&rsquo;s `Expand` closure now does `SplitArgs(args)` then `ExpandTemplate(template, tokens)`, replacing the `$ARGUMENTS`-only `ReplaceAll` path
- On split failure (e.g. unterminated quote) it falls back to `[]string{args}` so the raw arg string becomes `$ARGUMENTS` and the invocation stays usable
- Existing `$ARGUMENTS` and no-placeholder template behavior is preserved (regression tests pass unchanged)

Closes #333

## Test plan
- [x] `TestParseUserCommand` (existing regression) passes
- [x] `TestParseUserCommandPositionalAndQuoted` (no-arg, quoted multi-arg, `${1:-7}` default) passes
- [x] `TestParseUserCommandSplitFailureFallback` (unterminated quote -> raw `$ARGUMENTS`) passes
- [x] `go test ./internal/runtime/` passes, `go vet`/`go build` clean