### PR TITLE
feat(runtime): argument-hint frontmatter + description fallback

### DIFF
--- a/docs/issue#0334.html
+++ b/docs/issue#0334.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes - Issue #0334</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/334">#334</a> &mdash; frontmatter argument-hint + description 回退 &mdash; 2026-07-27</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Description fallback uses the body <em>after</em> frontmatter removal; for no-frontmatter templates it uses the whole content</h3>
+      <p><strong>Ambiguity:</strong> Which text does the &ldquo;first non-empty line&rdquo; fallback scan &mdash; the raw file or the body after the frontmatter fence?</p>
+      <p><strong>Choice:</strong> Scan <code>body</code> (the content after <code>splitFrontmatter</code>), which equals the whole file when there is no frontmatter.</p>
+      <p><strong>Rationale:</strong> pi says &ldquo;the first non-empty line is used&rdquo; &mdash; that line is part of the prompt body, not the frontmatter. Scanning post-frontmatter body avoids ever picking up a YAML key as the description.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>ArgumentHint</code> is stored verbatim with no format validation</h3>
+      <p><strong>Ambiguity:</strong> Should the <code>&lt;angle&gt;</code>/<code>[square]</code> convention be enforced?</p>
+      <p><strong>Choice:</strong> Store the hint as-is; the <code>&lt;angle&gt;</code>/<code>[square]</code> convention is display-only (per the PRD&rsquo;s Design Considerations: &ldquo;仅展示约定，不做语义校验&rdquo;).</p>
+      <p><strong>Rationale:</strong> The hint is free-form text rendered in autocomplete; validating it would reject legitimate hints and add no behavior.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None &mdash; implementation follows US-004 as written. <code>argument-hint</code> is parsed from frontmatter, <code>SlashCommand.ArgumentHint</code> carries it, description falls back to the first non-empty body line, both fields are optional, and the <code>name</code> override is preserved. The four test cases (only-description, only-hint, both, neither) match the acceptance criteria.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> <code>firstNonEmptyLine</code> as a named helper vs inline</h3>
+      <p><strong>Alternatives:</strong> Inline the loop where the fallback is computed.</p>
+      <p><strong>Pros/cons:</strong> A named helper is reusable and independently testable; inlining saves one function but mixes concerns.</p>
+      <p><strong>Why it won:</strong> The fallback is a distinct, testable rule; a helper documents its contract (&ldquo;first trimmed non-empty line&rdquo;) in one place.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> No markdown stripping in the description fallback</h3>
+      <p><strong>Alternatives:</strong> Strip a leading <code>#</code> from the first line so a heading isn&rsquo;t used verbatim as the description.</p>
+      <p><strong>Pros/cons:</strong> Stripping is friendlier for bodies that start with a heading; but pi&rsquo;s spec just says &ldquo;first non-empty line&rdquo; with no mention of markdown stripping.</p>
+      <p><strong>Why it won:</strong> Match the spec literally; avoid guessing pi&rsquo;s markdown handling. Revisit if descriptions render poorly in autocomplete.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should the description fallback strip a leading markdown heading?</h3>
+      <p><strong>Assumption:</strong> The first non-empty body line is used verbatim, so a body starting with <code># Review</code> yields description <code>"# Review"</code>.</p>
+      <p><strong>Verify:</strong> If pi strips leading <code>#</code> / markup for the description, align. Low-risk to leave as-is for now.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> <code>argument-hint</code> rendering in autocomplete</h3>
+      <p><strong>Assumption:</strong> The hint is rendered verbatim (e.g. <code>&lt;PR-URL&gt;</code>) in the Tab autocomplete, which #340 implements.</p>
+      <p><strong>Verify:</strong> #340 must read <code>SlashCommand.ArgumentHint</code> and render <code>name &lt;hint&gt; - description</code>; this issue only stores the field.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/runtime/slashcommand.go
+++ b/internal/runtime/slashcommand.go
@@ -138,7 +138,11 @@ func (e ShadowedEntry) String() string { return fmt.Sprintf("%s (%s)", e.Name, e
 type SlashCommand struct {
 	Name        string
 	Description string
-	Source      SlashCommandSource
+	// ArgumentHint is an optional frontmatter hint shown before the description
+	// in autocomplete (e.g. "<PR-URL>"). Convention: <angle> for required args,
+	// [square] for optional. Empty when not set; display-only, not enforced.
+	ArgumentHint string
+	Source       SlashCommandSource
 	// Tier is the priority tier used to resolve same-name conflicts across
 	// sources (built-in > project > global > package > settings > CLI). It is
 	// set by the AddX method matching the command's source; callers should not
@@ -417,6 +421,18 @@ func (r *SlashRegistry) ResolveOutcome(input string) (SlashOutcome, error) {
 	return SlashOutcome{Handled: true, Kind: SlashPrompt, Prompt: cmd.Expand(args)}, nil
 }
 
+// firstNonEmptyLine returns the first line of s whose trimmed form is non-empty,
+// itself trimmed. It is the description fallback for templates whose frontmatter
+// omits a description (对标 pi: "If missing, the first non-empty line is used").
+func firstNonEmptyLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
 // LoadUserCommandsDir loads declarative markdown command templates from dir
 // (non-recursively). Each "*.md" file defines a command named after the file
 // (without extension). The file may carry an optional YAML frontmatter block
@@ -460,6 +476,7 @@ func LoadUserCommandsDir(dir string) ([]SlashCommand, error) {
 func ParseUserCommand(name string, content []byte) (SlashCommand, error) {
 	body := string(content)
 	description := ""
+	hint := ""
 	// Reuse the skills frontmatter splitter when a fence is present; otherwise
 	// treat the whole file as the template body.
 	if strings.HasPrefix(strings.TrimLeft(strings.TrimPrefix(body, "\ufeff"), "\r\n"), "---") {
@@ -468,23 +485,31 @@ func ParseUserCommand(name string, content []byte) (SlashCommand, error) {
 			return SlashCommand{}, fmt.Errorf("command %s: %w", name, splitErr)
 		}
 		var meta struct {
-			Description string `yaml:"description"`
-			Name        string `yaml:"name"`
+			Description  string `yaml:"description"`
+			Name         string `yaml:"name"`
+			ArgumentHint string `yaml:"argument-hint"`
 		}
 		if err := yaml.Unmarshal(fm, &meta); err != nil {
 			return SlashCommand{}, fmt.Errorf("command %s: parse frontmatter: %w", name, err)
 		}
 		description = meta.Description
+		hint = meta.ArgumentHint
 		if meta.Name != "" {
 			name = meta.Name
 		}
 		body = string(rest)
 	}
+	// When the frontmatter omits a description, fall back to the first non-empty
+	// line of the body (\u5bf9\u6807 pi: "If missing, the first non-empty line is used").
+	if description == "" {
+		description = firstNonEmptyLine(body)
+	}
 	template := strings.TrimSpace(body)
 	return SlashCommand{
-		Name:        name,
-		Description: description,
-		Source:      SourceUser,
+		Name:         name,
+		Description:  description,
+		ArgumentHint: hint,
+		Source:       SourceUser,
 		Expand: func(args string) string {
 			tokens, err := SplitArgs(args)
 			if err != nil {

--- a/internal/runtime/slashcommand_test.go
+++ b/internal/runtime/slashcommand_test.go
@@ -139,3 +139,44 @@ func TestParseUserCommandSplitFailureFallback(t *testing.T) {
 		t.Errorf("no-placeholder split failure: got %q", got)
 	}
 }
+
+// TestParseUserCommandArgumentHintAndDescriptionFallback (US-004, #334):
+// argument-hint is parsed from frontmatter, and description falls back to the
+// first non-empty body line when absent.
+func TestParseUserCommandArgumentHintAndDescriptionFallback(t *testing.T) {
+	// Both description and argument-hint.
+	cmd, err := ParseUserCommand("pr", []byte("---\ndescription: review PR\nargument-hint: \"<PR-URL>\"\n---\nReview the PR"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd.Description != "review PR" {
+		t.Errorf("description = %q, want \"review PR\"", cmd.Description)
+	}
+	if cmd.ArgumentHint != "<PR-URL>" {
+		t.Errorf("argument-hint = %q, want \"<PR-URL>\"", cmd.ArgumentHint)
+	}
+	// Only argument-hint: description falls back to first non-empty body line.
+	hintOnly, _ := ParseUserCommand("wr", []byte("---\nargument-hint: \"[instructions]\"\n---\nFinish the current task\nend-to-end"))
+	if hintOnly.Description != "Finish the current task" {
+		t.Errorf("description fallback = %q, want first body line", hintOnly.Description)
+	}
+	if hintOnly.ArgumentHint != "[instructions]" {
+		t.Errorf("argument-hint = %q, want \"[instructions]\"", hintOnly.ArgumentHint)
+	}
+	// Only description: argument-hint stays empty.
+	descOnly, _ := ParseUserCommand("cl", []byte("---\ndescription: audit changelog\n---\nAudit changelog entries"))
+	if descOnly.Description != "audit changelog" {
+		t.Errorf("description = %q", descOnly.Description)
+	}
+	if descOnly.ArgumentHint != "" {
+		t.Errorf("argument-hint should be empty, got %q", descOnly.ArgumentHint)
+	}
+	// No frontmatter at all: description falls back to first non-empty line.
+	neither, _ := ParseUserCommand("bare", []byte("First line is the desc\nSecond line is body"))
+	if neither.Description != "First line is the desc" {
+		t.Errorf("no-frontmatter fallback = %q, want first line", neither.Description)
+	}
+	if neither.ArgumentHint != "" {
+		t.Errorf("argument-hint should be empty, got %q", neither.ArgumentHint)
+	}
+}


### PR DESCRIPTION
## Summary
- Parse optional `argument-hint` from YAML frontmatter; store on new `SlashCommand.ArgumentHint` field (display-only, no format validation)
- When `description` is absent, fall back to the first non-empty line of the body (对标 pi: "If missing, the first non-empty line is used")
- Both fields optional; the existing `name` frontmatter override is preserved

Closes #334

## Test plan
- [x] `TestParseUserCommandArgumentHintAndDescriptionFallback` covers only-description, only-hint, both, neither (no-frontmatter fallback)
- [x] `TestParseUserCommand` + `TestLoadUserCommandsDir` regression pass
- [x] `go test ./internal/runtime/` passes, `go vet`/`go build` clean