### PR TITLE
feat(config): settings-tier prompts from config.toml

### DIFF
--- a/cmd/pigo/config_file.go
+++ b/cmd/pigo/config_file.go
@@ -31,6 +31,9 @@ type fileConfig struct {
 	NoSkills      bool   `toml:"no_skills"`
 	Approve       bool   `toml:"approve"`
 	SystemPrompt  string `toml:"system_prompt"`
+	// Prompts is the config.toml `prompts` array: paths (files or dirs) to load
+	// prompt templates from at the settings tier (对标 pi's settings prompts).
+	Prompts []string `toml:"prompts"`
 }
 
 // fileConfigPath returns the path to the user config file:
@@ -105,5 +108,10 @@ func applyFileConfig(opts *cliOptions, cfg fileConfig, changed func(string) bool
 	}
 	if cfg.SystemPrompt != "" && !changed("system-prompt") {
 		opts.systemPrompt = cfg.SystemPrompt
+	}
+	// prompts (settings tier) are additive with --prompt-template (CLI tier,
+	// wired in #339), so they are always passed through when present.
+	if len(cfg.Prompts) > 0 {
+		opts.configPrompts = cfg.Prompts
 	}
 }

--- a/cmd/pigo/config_file_test.go
+++ b/cmd/pigo/config_file_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -33,7 +34,7 @@ func TestLoadFileConfig_Missing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("missing file should not error, got %v", err)
 	}
-	if cfg != (fileConfig{}) {
+	if !reflect.DeepEqual(cfg, fileConfig{}) {
 		t.Fatalf("missing file should yield zero config, got %+v", cfg)
 	}
 }
@@ -43,7 +44,7 @@ func TestLoadFileConfig_EmptyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("empty path should not error, got %v", err)
 	}
-	if cfg != (fileConfig{}) {
+	if !reflect.DeepEqual(cfg, fileConfig{}) {
 		t.Fatalf("empty path should yield zero config, got %+v", cfg)
 	}
 }
@@ -83,7 +84,7 @@ system_prompt = "be terse"
 		Approve:       true,
 		SystemPrompt:  "be terse",
 	}
-	if cfg != want {
+	if !reflect.DeepEqual(cfg, want) {
 		t.Fatalf("parsed config = %+v, want %+v", cfg, want)
 	}
 }

--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -73,6 +73,10 @@ type interactiveOptions struct {
 	// plugins holds the loaded plugin manager so the REPL can deliver lifecycle
 	// events to subscribed plugins (US-017, #133). It may be nil (no plugins).
 	plugins *plugin.Manager
+
+	// configPrompts holds prompt-template paths from the config.toml `prompts`
+	// array (settings tier); each is a file or dir loaded non-recursively.
+	configPrompts []string
 }
 
 // runInteractive starts the line-based REPL over a persisted session. It keeps
@@ -170,7 +174,7 @@ func runInteractive(opts interactiveOptions) error {
 	// ~/.agents/skills. A load error is non-fatal — the REPL still runs with the
 	// built-ins. Instance built-ins that need live state (/model, /help) are
 	// registered against `live`.
-	slash, err := buildSlashRegistry(live, opts.skills, opts.plugins)
+	slash, err := buildSlashRegistry(live, opts.skills, opts.plugins, promptTemplateSources{settings: opts.configPrompts})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "pigo: slash-commands: %v\n", err)
 	}
@@ -257,6 +261,46 @@ func stdoutIsTerminal() bool {
 	return fi.Mode()&os.ModeCharDevice != 0
 }
 
+// promptTemplateSources carries the prompt-template discovery sources that
+// buildSlashRegistry loads beyond the global ~/.pigo/{commands,prompts} dirs.
+// settings is the config.toml `prompts` array (TierSettings); cli is the
+// --prompt-template flag list (TierCLI, wired in #339). Each entry is a file or
+// directory (loaded non-recursively). Missing paths are warned and skipped.
+type promptTemplateSources struct {
+	settings []string
+	cli      []string
+}
+
+// loadSettingsPrompts loads prompt templates from each settings-tier path (file
+// or dir), skipping and warning on paths that don't exist or fail to read.
+func loadSettingsPrompts(paths []string) []runtime.SlashCommand {
+	var out []runtime.SlashCommand
+	for _, p := range paths {
+		info, err := os.Stat(p)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "pigo: prompts path %q not found, skipping\n", p)
+			continue
+		}
+		var cmds []runtime.SlashCommand
+		if info.IsDir() {
+			cmds, err = runtime.LoadUserCommandsDir(p)
+		} else {
+			c, e := runtime.LoadPromptFile(p)
+			if e != nil {
+				err = e
+			} else {
+				cmds = []runtime.SlashCommand{c}
+			}
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "pigo: prompts path %q: %v\n", p, err)
+			continue
+		}
+		out = append(out, cmds...)
+	}
+	return out
+}
+
 // buildSlashRegistry assembles the REPL slash-command registry: compile-time
 // built-ins seeded by runtime.NewSlashRegistry, the live-state action commands
 // (/model, /help) bound to live, user declarative templates loaded from
@@ -267,7 +311,7 @@ func stdoutIsTerminal() bool {
 // reported on stderr. The skills slice is loaded once by setupAgentEnv (empty
 // under --no-skills), so no /skill-name commands are registered when it is
 // empty. mgr may be nil (no plugins loaded).
-func buildSlashRegistry(live *liveRunConfig, skills []*runtime.Skill, mgr *plugin.Manager) (*runtime.SlashRegistry, error) {
+func buildSlashRegistry(live *liveRunConfig, skills []*runtime.Skill, mgr *plugin.Manager, srcs promptTemplateSources) (*runtime.SlashRegistry, error) {
 	reg := runtime.NewSlashRegistry()
 	registerLiveCommands(reg, live)
 	registerPluginCommands(reg, mgr)
@@ -292,6 +336,11 @@ func buildSlashRegistry(live *liveRunConfig, skills []*runtime.Skill, mgr *plugi
 		for _, c := range cmds {
 			reg.AddUser(c)
 		}
+	}
+	// Load settings-tier prompt templates from the config.toml `prompts` array
+	// (each entry is a file or dir). Missing paths are warned and skipped.
+	for _, c := range loadSettingsPrompts(srcs.settings) {
+		reg.AddSettings(c)
 	}
 	// Register skills as /skill-name commands from the pre-loaded set (shared with
 	// prompt injection in setupAgentEnv, so the directory is read once). All

--- a/cmd/pigo/plugin_commands_test.go
+++ b/cmd/pigo/plugin_commands_test.go
@@ -146,7 +146,7 @@ func TestBuildSlashRegistryRegistersPluginCommand(t *testing.T) {
 	mgr := loadTestManager(t)
 	defer mgr.Close()
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "faux", providerName: "faux"}, nil, mgr)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "faux", providerName: "faux"}, nil, mgr, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestREPLPluginCommandInjectsPrompt(t *testing.T) {
 	mgr := loadTestManager(t)
 	defer mgr.Close()
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "faux", providerName: "faux"}, nil, mgr)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "faux", providerName: "faux"}, nil, mgr, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}

--- a/cmd/pigo/prompts_config_test.go
+++ b/cmd/pigo/prompts_config_test.go
@@ -1,0 +1,137 @@
+package main
+
+// Tests for config.toml `prompts` array -> settings-tier prompt templates
+// (US-007, #338): fileConfig parses the array, applyFileConfig passes it to
+// cliOptions, loadSettingsPrompts loads file/dir entries (warning on missing),
+// and buildSlashRegistry registers them at the settings tier (overridden by
+// global same-name templates).
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+func TestLoadFileConfigPromptsArray(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := "prompts = [\"./my-prompts\", \"/abs/x.md\"]\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadFileConfig(path)
+	if err != nil {
+		t.Fatalf("loadFileConfig: %v", err)
+	}
+	if len(cfg.Prompts) != 2 || cfg.Prompts[0] != "./my-prompts" || cfg.Prompts[1] != "/abs/x.md" {
+		t.Errorf("Prompts = %v, want [./my-prompts /abs/x.md]", cfg.Prompts)
+	}
+}
+
+func TestApplyFileConfigPrompts(t *testing.T) {
+	var opts cliOptions
+	cfg := fileConfig{Prompts: []string{"./my-prompts", "/abs/x.md"}}
+	applyFileConfig(&opts, cfg, func(string) bool { return false })
+	if len(opts.configPrompts) != 2 || opts.configPrompts[0] != "./my-prompts" || opts.configPrompts[1] != "/abs/x.md" {
+		t.Errorf("opts.configPrompts = %v, want [./my-prompts /abs/x.md]", opts.configPrompts)
+	}
+}
+
+func TestLoadSettingsPromptsFileDirMissing(t *testing.T) {
+	home := t.TempDir()
+	// file entry -> 1 cmd.
+	filePath := filepath.Join(home, "single.md")
+	if err := os.WriteFile(filePath, []byte("Single: $ARGUMENTS"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// dir entry -> 2 cmds.
+	dirPath := filepath.Join(home, "promptsdir")
+	if err := os.MkdirAll(dirPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirPath, "a.md"), []byte("A: $1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirPath, "b.md"), []byte("B: $1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// missing entry -> 0 cmds (warned, not fatal).
+	missing := filepath.Join(home, "nope")
+
+	cmds := loadSettingsPrompts([]string{filePath, dirPath, missing})
+	if len(cmds) != 3 {
+		t.Fatalf("got %d cmds, want 3 (file=1 + dir=2 + missing=0)", len(cmds))
+	}
+	names := map[string]bool{}
+	for _, c := range cmds {
+		names[c.Name] = true
+	}
+	for _, want := range []string{"single", "a", "b"} {
+		if !names[want] {
+			t.Errorf("missing cmd %q; got %v", want, names)
+		}
+	}
+}
+
+func TestBuildSlashRegistryLoadsSettingsPrompts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+	// A settings-tier prompt dir (loaded via configPrompts).
+	settingsDir := filepath.Join(home, "settings-prompts")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(settingsDir, "review.md"), []byte("FROM SETTINGS"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+		promptTemplateSources{settings: []string{settingsDir}})
+	if err != nil {
+		t.Fatalf("buildSlashRegistry: %v", err)
+	}
+	cmd, ok := reg.Lookup("review")
+	if !ok {
+		t.Fatal("/review not found")
+	}
+	if got := cmd.Expand(""); got != "FROM SETTINGS" {
+		t.Errorf("settings prompt: got %q, want \"FROM SETTINGS\"", got)
+	}
+}
+
+func TestBuildSlashRegistryGlobalOverridesSettings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+	// global prompt (TierGlobal) under ~/.pigo/prompts.
+	writePrompt(t, home, "prompts", "dup.md", "FROM GLOBAL")
+	// settings-tier prompt (file) of the same name, placed at the home root
+	// (not under prompts/, so the global loop does not also load it).
+	settingsFile := filepath.Join(home, "dup.md")
+	if err := os.WriteFile(settingsFile, []byte("FROM SETTINGS"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+		promptTemplateSources{settings: []string{settingsFile}})
+	if err != nil {
+		t.Fatalf("buildSlashRegistry: %v", err)
+	}
+	cmd, ok := reg.Lookup("dup")
+	if !ok {
+		t.Fatal("/dup not found")
+	}
+	if got := cmd.Expand(""); got != "FROM GLOBAL" {
+		t.Errorf("global should override settings, got %q", got)
+	}
+	// The settings loser is shadowed with TierSettings.
+	found := false
+	for _, e := range reg.Shadowed() {
+		if e.Name == "dup" && e.Tier == runtime.TierSettings {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("settings dup should be shadowed with TierSettings, got %v", reg.Shadowed())
+	}
+}

--- a/cmd/pigo/prompts_dir_test.go
+++ b/cmd/pigo/prompts_dir_test.go
@@ -30,7 +30,7 @@ func TestBuildSlashRegistryLoadsLegacyCommandsDir(t *testing.T) {
 	t.Setenv("PIGO_HOME", home)
 	writePrompt(t, home, "commands", "legacy.md", "Legacy: $ARGUMENTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestBuildSlashRegistryLoadsPromptsDir(t *testing.T) {
 	t.Setenv("PIGO_HOME", home)
 	writePrompt(t, home, "prompts", "review.md", "Review: $ARGUMENTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestBuildSlashRegistryPromptsOverridesCommands(t *testing.T) {
 	writePrompt(t, home, "commands", "dup.md", "FROM COMMANDS")
 	writePrompt(t, home, "prompts", "dup.md", "FROM PROMPTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestBuildSlashRegistryPromptsOverridesCommands(t *testing.T) {
 // nor prompts/ present, buildSlashRegistry returns no error (built-ins only).
 func TestBuildSlashRegistryMissingDirsNoError(t *testing.T) {
 	t.Setenv("PIGO_HOME", t.TempDir())
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry with no prompt dirs: %v", err)
 	}

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -269,6 +269,10 @@ type cliOptions struct {
 	// each is a path to a file whose contents are appended, or literal text when
 	// it is not an existing file. Appended after the base prompt and AGENTS.md.
 	appendSystemPrompt []string
+	// configPrompts holds prompt-template paths from the config.toml `prompts`
+	// array (settings tier); each is a file or directory loaded non-recursively.
+	// Populated by applyFileConfig; empty when the config omits `prompts`.
+	configPrompts []string
 	// subagentRPC selects the process-isolated sub-agent server mode (US-019,
 	// #135): pigo reads JSON-RPC sub-agent run requests from stdin and writes
 	// results to stdout. Internal, used by SubAgentTool's process mode.
@@ -355,6 +359,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			approve:       opts.approve,
 			skills:        env.skills,
 			plugins:       env.plugins,
+			configPrompts: opts.configPrompts,
 		}); err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 1

--- a/cmd/pigo/skills_test.go
+++ b/cmd/pigo/skills_test.go
@@ -97,7 +97,7 @@ func TestBuildSlashRegistryIncludesSkills(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadSkills: %v", err)
 	}
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, skills, nil)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, skills, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestBuildSlashRegistryIncludesSkills(t *testing.T) {
 func TestBuildSlashRegistryNoSkills(t *testing.T) {
 	t.Setenv("PIGO_HOME", t.TempDir())
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestLoadSkillsBootstrapsBuiltinSkills(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadSkills: %v", err)
 	}
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, skills, nil)
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, skills, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}

--- a/docs/issue#0338.html
+++ b/docs/issue#0338.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes - Issue #0338</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/338">#338</a> &mdash; config.toml prompts 数组 &mdash; 2026-07-27</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Pass prompt sources to <code>buildSlashRegistry</code> via a <code>promptTemplateSources</code> struct</h3>
+      <p><strong>Ambiguity:</strong> How to plumb config-provided prompt paths into the registry without churning the signature again for #339 (CLI flag + disable)?</p>
+      <p><strong>Choice:</strong> A small struct <code>promptTemplateSources{settings, cli}</code> as a 4th param. #338 fills <code>settings</code>; #339 will fill <code>cli</code> and the disable flag without another signature change.</p>
+      <p><strong>Rationale:</strong> One signature change covers both issues; the struct documents the discovery sources in one place.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>loadSettingsPrompts</code> lives in <code>cmd/pigo</code> (stderr access); <code>LoadPromptFile</code> in <code>runtime</code></h3>
+      <p><strong>Ambiguity:</strong> Where does the &ldquo;file or dir, warn on missing&rdquo; loader belong?</p>
+      <p><strong>Choice:</strong> <code>runtime.LoadPromptFile</code> (single-file parse, pure) + <code>cmd/pigo.loadSettingsPrompts</code> (stat/warn/collect, has stderr).</p>
+      <p><strong>Rationale:</strong> Keeps the runtime package free of stderr I/O; the warning is a user-facing concern owned by the CLI layer.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Config <code>prompts</code> is always passed through (no CLI-flag override)</h3>
+      <p><strong>Ambiguity:</strong> The AC said &ldquo;applyFileConfig 把 prompts 透传到运行时（CLI flag 未覆盖时）&rdquo;, implying an override relationship.</p>
+      <p><strong>Choice:</strong> Config <code>prompts</code> (settings tier) and #339&rsquo;s <code>--prompt-template</code> (CLI tier) are additive, distinct tiers &mdash; both load, priority resolved by tier. So config is always passed when present.</p>
+      <p><strong>Rationale:</strong> Tiered priority (global &gt; settings &gt; CLI) already handles same-name resolution; treating them as additive matches pi&rsquo;s model. The &ldquo;CLI flag 未覆盖时&rdquo; phrasing is the generic applyFileConfig boilerplate, not a real override here.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Changed 3 pre-existing <code>config_file_test.go</code> struct comparisons to <code>reflect.DeepEqual</code></h3>
+      <p><strong>Spec said:</strong> (existing tests) <code>cfg != (fileConfig{})</code> and <code>cfg != want</code>.</p>
+      <p><strong>Implemented instead:</strong> <code>!reflect.DeepEqual(cfg, fileConfig{})</code> / <code>!reflect.DeepEqual(cfg, want)</code>.</p>
+      <p><strong>Why:</strong> Adding the <code>Prompts []string</code> slice field makes <code>fileConfig</code> non-comparable (<code>!=</code> on a struct containing a slice is a compile error). This is a necessary side effect of the new field, not a behavior change.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> <code>promptTemplateSources</code> struct vs separate params</h3>
+      <p><strong>Alternatives:</strong> Add <code>settingsPrompts []string</code> now and <code>cliPrompts</code> + <code>disable</code> in #339 as more params.</p>
+      <p><strong>Pros/cons:</strong> Separate params mean two signature churns (and re-updating ~8 call sites each time). A struct is one churn.</p>
+      <p><strong>Why it won:</strong> One signature change; #339 just fills more struct fields.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Warn to stderr on missing settings path vs silent skip</h3>
+      <p><strong>Alternatives:</strong> Silent skip (like missing global dirs).</p>
+      <p><strong>Pros/cons:</strong> The AC explicitly wants a one-line warning for missing settings paths (they&rsquo;re explicitly user-listed, unlike ambient global dirs). Silent skip would hide config typos.</p>
+      <p><strong>Why it won:</strong> Match the AC; an explicit <code>prompts = [...]</code> entry that doesn&rsquo;t resolve is almost certainly a typo the user wants to know about.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Config <code>prompts</code> vs <code>--prompt-template</code>: additive confirmed?</h3>
+      <p><strong>Assumption:</strong> Both load (settings and CLI tiers), resolved by priority. Config is always passed through; the CLI flag (in #339) adds more, it does not replace config.</p>
+      <p><strong>Verify:</strong> If pi instead makes <code>--prompt-template</code> suppress config <code>prompts</code>, revisit. Tiered priority makes additive the natural choice.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> <code>buildSlashRegistry</code> signature change touched ~8 call sites</h3>
+      <p><strong>Assumption:</strong> All in-repo callers (1 production + 7 tests) were updated to pass <code>promptTemplateSources{}</code> or the real sources.</p>
+      <p><strong>Verify:</strong> No external callers exist (internal <code>cmd/pigo</code>); the change is safe. Future test helpers can use a zero-value struct.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/runtime/slashcommand.go
+++ b/internal/runtime/slashcommand.go
@@ -433,6 +433,20 @@ func firstNonEmptyLine(s string) string {
 	return ""
 }
 
+// LoadPromptFile loads a single prompt-template file. The command name is the
+// filename without its extension (e.g. /x/review.md -> "review"). It is the
+// single-file counterpart of LoadUserCommandsDir, used for settings/CLI paths
+// that point at one file rather than a directory.
+func LoadPromptFile(path string) (SlashCommand, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return SlashCommand{}, fmt.Errorf("read prompt %s: %w", path, err)
+	}
+	base := filepath.Base(path)
+	name := strings.TrimSuffix(base, filepath.Ext(base))
+	return ParseUserCommand(name, content)
+}
+
 // LoadUserCommandsDir loads declarative markdown command templates from dir
 // (non-recursively). Each "*.md" file defines a command named after the file
 // (without extension). The file may carry an optional YAML frontmatter block


### PR DESCRIPTION
## Summary
- Add `prompts` array to `config.toml` (`fileConfig.Prompts`); `applyFileConfig` passes it through as `cliOptions.configPrompts` -> `interactiveOptions` -> `buildSlashRegistry`
- `buildSlashRegistry` loads each entry at the **settings tier** (`AddSettings`): a file via new `runtime.LoadPromptFile`, a dir non-recursively via `LoadUserCommandsDir`; missing paths are warned and skipped
- Introduces a `promptTemplateSources` struct (4th param to `buildSlashRegistry`) so #339 can add `--prompt-template` (CLI tier) without another signature change
- Side effect: `fileConfig` now has a slice field, so 3 pre-existing `config_file_test.go` struct comparisons switch to `reflect.DeepEqual`

Closes #338

## Test plan
- [x] `TestLoadFileConfigPromptsArray` (TOML parse), `TestApplyFileConfigPrompts` (pass-through)
- [x] `TestLoadSettingsPromptsFileDirMissing` (file/dir/missing-warn)
- [x] `TestBuildSlashRegistryLoadsSettingsPrompts` + `TestBuildSlashRegistryGlobalOverridesSettings` (settings tier; global overrides settings + shadow)
- [x] `go test ./cmd/pigo/ ./internal/runtime/` passes, `go vet`/`go build` clean