### PR TITLE
feat(repl): project-level .pigo/prompts loaded when trusted

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -181,9 +181,11 @@ func runInteractive(opts interactiveOptions) error {
 	// built-ins. Instance built-ins that need live state (/model, /help) are
 	// registered against `live`.
 	slash, err := buildSlashRegistry(live, opts.skills, opts.plugins, promptTemplateSources{
-		settings: opts.configPrompts,
-		cli:      opts.cliPrompts,
-		disable:  opts.noPromptTemplates,
+		settings:       opts.configPrompts,
+		cli:            opts.cliPrompts,
+		disable:        opts.noPromptTemplates,
+		projectDir:     filepath.Join(cwd, ".pigo", "prompts"),
+		projectTrusted: mgr != nil && mgr.IsTrusted(cwd),
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "pigo: slash-commands: %v\n", err)
@@ -280,8 +282,15 @@ type promptTemplateSources struct {
 	settings []string
 	cli      []string
 	// disable (--no-prompt-templates) turns off all prompt-template discovery
-	// (global, settings, CLI); built-ins and skills are unaffected.
+	// (global, project, settings, CLI); built-ins and skills are unaffected.
 	disable bool
+	// projectDir is the project-local prompts dir (.pigo/prompts in the working
+	// dir), loaded at the project tier only when projectTrusted is true.
+	projectDir string
+	// projectTrusted reports whether the working directory is trusted; project
+	// templates load only then (对标 pi: project prompts after the project is
+	// trusted).
+	projectTrusted bool
 }
 
 // loadPromptPaths loads prompt templates from each path (file or dir), skipping
@@ -363,6 +372,18 @@ func buildSlashRegistry(live *liveRunConfig, skills []*runtime.Skill, mgr *plugi
 		}
 		for _, c := range loadPromptPaths(srcs.cli) {
 			reg.AddCLI(c)
+		}
+		// Project-tier templates from .pigo/prompts in the working directory,
+		// loaded only when the project is trusted (对标 pi). A missing dir is
+		// not an error. Overrides global/settings/CLI (project tier is higher).
+		if srcs.projectTrusted && srcs.projectDir != "" {
+			cmds, err := runtime.LoadUserCommandsDir(srcs.projectDir)
+			if err != nil {
+				return reg, err
+			}
+			for _, c := range cmds {
+				reg.AddProject(c)
+			}
 		}
 	}
 	// Register skills as /skill-name commands from the pre-loaded set (shared with

--- a/cmd/pigo/prompts_project_test.go
+++ b/cmd/pigo/prompts_project_test.go
@@ -1,0 +1,137 @@
+package main
+
+// Tests for project-level .pigo/prompts (US-006, #337): loaded at the project
+// tier only when the project is trusted, overrides global same-name templates,
+// and is suppressed by --no-prompt-templates.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// TestBuildSlashRegistryLoadsProjectPromptsTrusted: with the project trusted,
+// .pigo/prompts/*.md loads at the project tier.
+func TestBuildSlashRegistryLoadsProjectPromptsTrusted(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home) // empty global
+	cwdTmp := t.TempDir()
+	writePrompt(t, cwdTmp, filepath.Join(".pigo", "prompts"), "review.md", "Review: $ARGUMENTS")
+
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+		promptTemplateSources{
+			projectDir:     filepath.Join(cwdTmp, ".pigo", "prompts"),
+			projectTrusted: true,
+		})
+	if err != nil {
+		t.Fatalf("buildSlashRegistry: %v", err)
+	}
+	out, err := reg.ResolveOutcome("/review diff")
+	if err != nil {
+		t.Fatalf("ResolveOutcome: %v", err)
+	}
+	if !out.Handled || out.Prompt != "Review: diff" {
+		t.Errorf("/review = handled=%v prompt=%q, want \"Review: diff\"", out.Handled, out.Prompt)
+	}
+}
+
+// TestBuildSlashRegistryProjectPromptsUntrustedSkipped: when the project is not
+// trusted, .pigo/prompts is not loaded.
+func TestBuildSlashRegistryProjectPromptsUntrustedSkipped(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+	cwdTmp := t.TempDir()
+	writePrompt(t, cwdTmp, filepath.Join(".pigo", "prompts"), "review.md", "Review: $ARGUMENTS")
+
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+		promptTemplateSources{
+			projectDir:     filepath.Join(cwdTmp, ".pigo", "prompts"),
+			projectTrusted: false,
+		})
+	if err != nil {
+		t.Fatalf("buildSlashRegistry: %v", err)
+	}
+	if _, ok := reg.Lookup("review"); ok {
+		t.Error("/review should NOT load from an untrusted project")
+	}
+}
+
+// TestBuildSlashRegistryProjectMissingDirNoError: a missing .pigo/prompts is
+// not an error (most projects don't have one).
+func TestBuildSlashRegistryProjectMissingDirNoError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+	cwdTmp := t.TempDir() // no .pigo/prompts created
+
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+		promptTemplateSources{
+			projectDir:     filepath.Join(cwdTmp, ".pigo", "prompts"),
+			projectTrusted: true,
+		})
+	if err != nil {
+		t.Fatalf("missing .pigo/prompts should not error, got %v", err)
+	}
+	if reg == nil {
+		t.Fatal("registry is nil")
+	}
+}
+
+// TestBuildSlashRegistryProjectOverridesGlobal: a project template overrides a
+// same-named global one (project tier wins, global shadowed).
+func TestBuildSlashRegistryProjectOverridesGlobal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+	// global
+	writePrompt(t, home, "prompts", "dup.md", "FROM GLOBAL")
+	// project
+	cwdTmp := t.TempDir()
+	writePrompt(t, cwdTmp, filepath.Join(".pigo", "prompts"), "dup.md", "FROM PROJECT")
+
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+		promptTemplateSources{
+			projectDir:     filepath.Join(cwdTmp, ".pigo", "prompts"),
+			projectTrusted: true,
+		})
+	if err != nil {
+		t.Fatalf("buildSlashRegistry: %v", err)
+	}
+	cmd, ok := reg.Lookup("dup")
+	if !ok {
+		t.Fatal("/dup not found")
+	}
+	if got := cmd.Expand(""); got != "FROM PROJECT" {
+		t.Errorf("project should override global, got %q", got)
+	}
+	found := false
+	for _, e := range reg.Shadowed() {
+		if e.Name == "dup" && e.Tier == runtime.TierGlobal {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("global dup should be shadowed with TierGlobal, got %v", reg.Shadowed())
+	}
+}
+
+// TestBuildSlashRegistryNoPromptTemplatesDisablesProject: --no-prompt-templates
+// suppresses project prompts too.
+func TestBuildSlashRegistryNoPromptTemplatesDisablesProject(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+	cwdTmp := t.TempDir()
+	writePrompt(t, cwdTmp, filepath.Join(".pigo", "prompts"), "review.md", "Review: $ARGUMENTS")
+
+	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+		promptTemplateSources{
+			disable:        true,
+			projectDir:     filepath.Join(cwdTmp, ".pigo", "prompts"),
+			projectTrusted: true,
+		})
+	if err != nil {
+		t.Fatalf("buildSlashRegistry: %v", err)
+	}
+	if _, ok := reg.Lookup("review"); ok {
+		t.Error("/review should NOT load under --no-prompt-templates")
+	}
+}

--- a/docs/issue#0337.html
+++ b/docs/issue#0337.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes - Issue #0337</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/337">#337</a> &mdash; 项目级 .pigo/prompts（受信任时加载）&mdash; 2026-07-27</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Caller computes <code>projectTrusted</code>; <code>buildSlashRegistry</code> receives a bool, not the trust manager</h3>
+      <p><strong>Ambiguity:</strong> Should <code>buildSlashRegistry</code> take the trust manager and check trust itself, or receive a pre-computed decision?</p>
+      <p><strong>Choice:</strong> The call site computes <code>projectTrusted = mgr != nil &amp;&amp; mgr.IsTrusted(cwd)</code> and passes it (plus <code>projectDir</code>) via <code>promptTemplateSources</code>.</p>
+      <p><strong>Rationale:</strong> Decouples <code>buildSlashRegistry</code> from the trust package; the registry only needs the decision, not the manager. The call site already has <code>mgr</code> and <code>cwd</code>.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Project loading sits inside the <code>--no-prompt-templates</code> gate</h3>
+      <p><strong>Ambiguity:</strong> Should <code>--no-prompt-templates</code> suppress project prompts too?</p>
+      <p><strong>Choice:</strong> Yes &mdash; the project <code>AddProject</code> block is inside <code>if !srcs.disable</code>, alongside global/settings/CLI.</p>
+      <p><strong>Rationale:</strong> The #339 AC says disable closes &ldquo;global/project/settings/CLI&rdquo;; the #339 notes flagged this as a follow-up. Project is now covered.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Missing <code>.pigo/prompts</code> is silent (no warning)</h3>
+      <p><strong>Ambiguity:</strong> Should a missing project dir warn (like settings/CLI paths) or stay silent (like global dirs)?</p>
+      <p><strong>Choice:</strong> Silent &mdash; use <code>LoadUserCommandsDir</code> (returns nil, nil for <code>IsNotExist</code>), not <code>loadPromptPaths</code> (which warns).</p>
+      <p><strong>Rationale:</strong> Most projects don&rsquo;t have <code>.pigo/prompts</code>; warning on every launch would be noise. Settings/CLI paths are user-explicit (typos matter), but the project dir is ambient.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None &mdash; implementation follows US-006 as written. <code>.pigo/prompts/*.md</code> loads non-recursively at the project tier only when trusted (untrusted/undecided skip silently), reuses <code>trust.Manager.IsTrusted</code>, and the trusted/untrusted/missing tests match the acceptance criteria.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Pass <code>projectTrusted</code> bool vs pass the trust <code>Manager</code></h3>
+      <p><strong>Alternatives:</strong> Add a <code>*trust.Manager</code> + <code>cwd</code> param to <code>buildSlashRegistry</code>.</p>
+      <p><strong>Pros/cons:</strong> A bool keeps the registry free of the trust dependency and its tests don&rsquo;t need to construct a real trust store. Passing the manager would let the registry re-check trust, but that&rsquo;s not needed (trust is static for a session).</p>
+      <p><strong>Why it won:</strong> Simpler, testable without trust-store setup; trust is decided once at launch.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Re-read <code>.pigo/prompts</code> every launch vs cache</h3>
+      <p><strong>Alternatives:</strong> Cache the project templates for the session.</p>
+      <p><strong>Pros/cons:</strong> Re-reading is simple and picks up edits between sessions; caching would be faster but stale within a session. The dir is tiny (a few .md files).</p>
+      <p><strong>Why it won:</strong> Simplicity; the cost of reading a few small files at launch is negligible.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Undecided projects skip loading (confirmed)</h3>
+      <p><strong>Assumption:</strong> <code>IsTrusted(cwd)</code> returns true only for <code>Trusted</code>; both <code>Untrusted</code> and <code>Undecided</code> skip project prompts. The AC says &ldquo;untrusted/undecided 时静默跳过&rdquo;.</p>
+      <p><strong>Verify:</strong> This matches the AC. A first-launch (undecided) project won&rsquo;t see its own templates until trusted &mdash; consistent with pi.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Project dir resolved from launch cwd only</h3>
+      <p><strong>Assumption:</strong> <code>projectDir = cwd/.pigo/prompts</code>, where cwd is captured once at launch (pigo doesn&rsquo;t <code>cd</code> during a session).</p>
+      <p><strong>Verify:</strong> If a future feature changes cwd mid-session, project templates would be stale. Acceptable for now.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- `buildSlashRegistry` loads `.pigo/prompts/*.md` (non-recursive) at the **project tier** (`AddProject`, overrides global) when the working directory is trusted (`mgr.IsTrusted(cwd)`)
- Untrusted/undecided projects skip it silently; a missing `.pigo/prompts` is not an error (most projects don&rsquo;t have one)
- Honors `--no-prompt-templates` (project loading sits inside the disable gate)
- Caller computes `projectTrusted` and passes `projectDir`/`projectTrusted` via `promptTemplateSources` (keeps `buildSlashRegistry` free of the trust dependency)

Closes #337

## Test plan
- [x] `TestBuildSlashRegistryLoadsProjectPromptsTrusted` (trusted -> loads)
- [x] `TestBuildSlashRegistryProjectPromptsUntrustedSkipped` (untrusted -> not loaded)
- [x] `TestBuildSlashRegistryProjectMissingDirNoError` (missing dir -> no error)
- [x] `TestBuildSlashRegistryProjectOverridesGlobal` (project wins, global shadowed TierGlobal)
- [x] `TestBuildSlashRegistryNoPromptTemplatesDisablesProject` (disable covers project)
- [x] `go test ./cmd/pigo/ ./internal/runtime/` passes, `go vet`/`go build` clean