### PR TITLE
feat(repl): argument-hint + description in slash autocomplete

### DIFF
--- a/cmd/pigo/autocomplete_label_test.go
+++ b/cmd/pigo/autocomplete_label_test.go
@@ -1,0 +1,62 @@
+package main
+
+// Tests for formatSlashAutocompleteLabel (US-010, #340): the Tab-completion
+// label renders as "name <argument-hint> - description", omitting the hint
+// segment when absent and falling back to the first body line for description.
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+func TestFormatSlashAutocompleteLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  runtime.SlashCommand
+		want string
+	}{
+		{"hint+desc", runtime.SlashCommand{Name: "review", ArgumentHint: "<PR-URL>", Description: "Review PRs"}, "review <PR-URL> - Review PRs"},
+		{"desc only", runtime.SlashCommand{Name: "review", Description: "Review PRs"}, "review - Review PRs"},
+		{"hint only", runtime.SlashCommand{Name: "wr", ArgumentHint: "[instructions]"}, "wr [instructions]"},
+		{"neither", runtime.SlashCommand{Name: "model"}, "model"},
+	}
+	for _, c := range cases {
+		if got := formatSlashAutocompleteLabel(c.cmd); got != c.want {
+			t.Errorf("%s: got %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// TestFormatSlashAutocompleteLabelDescriptionFallback verifies the description
+// fallback from #334 (first non-empty body line) flows through to the label.
+func TestFormatSlashAutocompleteLabelDescriptionFallback(t *testing.T) {
+	cmd, err := runtime.ParseUserCommand("bare", []byte("First line is the desc\nbody"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := formatSlashAutocompleteLabel(cmd); got != "bare - First line is the desc" {
+		t.Errorf("fallback label = %q, want \"bare - First line is the desc\"", got)
+	}
+}
+
+// TestSlashAutocompleteSuggestionStillCompletesName verifies that a slash
+// command with an argument-hint is still completable by name (Tab inserts
+// "/name"); the label is a display annotation, not the inserted text.
+func TestSlashAutocompleteSuggestionStillCompletesName(t *testing.T) {
+	reg := runtime.NewSlashRegistry()
+	reg.AddBuiltin(runtime.SlashCommand{Name: "model", Action: func(string) string { return "" }})
+	reg.AddUser(runtime.SlashCommand{
+		Name:          "review",
+		ArgumentHint:  "<PR-URL>",
+		Description:   "Review PRs",
+		Expand:        func(string) string { return "" },
+	})
+	e := newREPLLineEditor(strings.NewReader(""), bufio.NewReader(strings.NewReader("")), io.Discard, reg, nil)
+	if got := e.suggestion("/rev"); got != "/review" {
+		t.Errorf("suggestion(/rev) = %q, want /review (name, not the label)", got)
+	}
+}

--- a/cmd/pigo/line_editor.go
+++ b/cmd/pigo/line_editor.go
@@ -301,6 +301,22 @@ func (e *replLineEditor) remember(line string) {
 	}
 }
 
+// formatSlashAutocompleteLabel renders a slash command for the Tab-completion
+// hint as "name <argument-hint> - description" (对标 pi's autocomplete). The
+// argument-hint is shown verbatim (frontmatter supplies its own <angle>/
+// [square] brackets); it and the description are omitted when absent, so a
+// bare command renders as just its name.
+func formatSlashAutocompleteLabel(cmd runtime.SlashCommand) string {
+	label := cmd.Name
+	if cmd.ArgumentHint != "" {
+		label += " " + cmd.ArgumentHint
+	}
+	if cmd.Description != "" {
+		label += " - " + cmd.Description
+	}
+	return label
+}
+
 // suggestion returns the single best completion for input, or "" when there is
 // none. It is the head of the ordered candidate list (see suggestions).
 func (e *replLineEditor) suggestion(input string) string {
@@ -501,7 +517,15 @@ func (e *replLineEditor) editLoop(prompt string) (string, error) {
 		if buf.single() && buf.col == utf8.RuneCountInString(buf.lines[0]) {
 			if s := visible(); s != "" {
 				input := buf.lines[0]
-				if strings.HasPrefix(s, input) {
+				if strings.HasPrefix(s, "/") {
+					// Slash command: render the argument-hint + description label
+					// (对标 pi autocomplete) instead of the bare name suffix.
+					label := s
+					if cmd, ok := e.slash.Lookup(s[1:]); ok {
+						label = formatSlashAutocompleteLabel(cmd)
+					}
+					fmt.Fprintf(e.out, "\033[2m -> %s\033[0m", label)
+				} else if strings.HasPrefix(s, input) {
 					fmt.Fprintf(e.out, "\033[2m%s\033[0m", s[len(input):])
 				} else {
 					fmt.Fprintf(e.out, "\033[2m → %s\033[0m", s)

--- a/docs/issue#0340.html
+++ b/docs/issue#0340.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes - Issue #0340</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/340">#340</a> &mdash; REPL Tab 补全展示 argument-hint + description &mdash; 2026-07-27</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Label format: <code>name &lt;argument-hint&gt; - description</code>, segments omitted when absent</h3>
+      <p><strong>Ambiguity:</strong> How to combine name, hint, and description?</p>
+      <p><strong>Choice:</strong> <code>name</code> + (<code>" " + hint</code> if hint) + (<code>" - " + description</code> if description). The hint is shown verbatim &mdash; frontmatter supplies its own <code>&lt;angle&gt;</code>/<code>[square]</code> brackets, so no extra wrapping.</p>
+      <p><strong>Rationale:</strong> Matches pi&rsquo;s autocomplete rendering. Omitting empty segments keeps bare commands readable as just <code>name</code>.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Slash commands render as <code> -&gt; {label}</code> inline (existing arrow convention); Tab still inserts <code>/name</code></h3>
+      <p><strong>Ambiguity:</strong> Where to show the label given pigo&rsquo;s inline-cycling autocomplete (no columnar dropdown)?</p>
+      <p><strong>Choice:</strong> In <code>render()</code>, slash-command candidates take a dedicated branch that prints <code> -&gt; {label}</code> dimly (reusing the existing <code> -&gt; </code> suggestion form). Non-slash candidates (history, models) keep the prior suffix/arrow behavior. The inserted candidate is still <code>/name</code>.</p>
+      <p><strong>Rationale:</strong> Reuses the existing single-line render; the label is a display annotation, not the inserted text, so Tab completion keeps inserting the bare command name.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> &ldquo;列按现有补全列宽对齐&rdquo; (columnar alignment) not implemented</h3>
+      <p><strong>Spec said:</strong> Render with column alignment, referencing &ldquo;现有 /model 目录补全的排版&rdquo;.</p>
+      <p><strong>Implemented instead:</strong> Inline <code> -&gt; {label}</code> rendering, because pigo&rsquo;s autocomplete is inline-cycling (arrow keys cycle candidates, Tab accepts) &mdash; there is no columnar candidate list to align. The <code>/model</code> catalog uses the same inline-cycling mechanism, not a columnar layout.</p>
+      <p><strong>Why:</strong> A columnar dropdown would be a separate UX feature (e.g. double-Tab to list all). The inline label delivers the hint+description information the AC asks for within the existing architecture.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Inline label vs a columnar candidate list</h3>
+      <p><strong>Alternatives:</strong> Add a multi-candidate columnar display (print all matching commands in aligned columns when several match).</p>
+      <p><strong>Pros/cons:</strong> A columnar list shows more at once but is a larger UX change (row accounting in <code>render</code>, double-Tab trigger). The inline label is a minimal, low-risk change that surfaces the hint+description.</p>
+      <p><strong>Why it won:</strong> Minimal risk; the AC&rsquo;s testable core (the label rendering, 4 cases) is delivered and unit-tested. A columnar list can be added later as a follow-up.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Label replaces the inline name-suffix for slash commands</h3>
+      <p><strong>Alternatives:</strong> Show both the inline suffix (e.g. <code>iew</code> completing <code>/rev</code>-&gt;<code>/review</code>) and the label.</p>
+      <p><strong>Pros/cons:</strong> Both would repeat the name (<code>/review  review &lt;PR-URL&gt; - &hellip;</code>). The label alone is cleaner and more informative.</p>
+      <p><strong>Why it won:</strong> The label already starts with the full name; the bare suffix adds no information the label doesn&rsquo;t.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should pigo add a columnar candidate list?</h3>
+      <p><strong>Assumption:</strong> The inline <code> -&gt; {label}</code> rendering satisfies the AC&rsquo;s intent (show hint+description) within the existing architecture.</p>
+      <p><strong>Verify:</strong> If users want a bash-style multi-candidate columnar list (double-Tab), that&rsquo;s a follow-up feature. The column-alignment wording in the AC likely assumed a list UI pigo doesn&rsquo;t have.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> &ldquo;在 REPL 中验证&rdquo; is manual, not auto-verified</h3>
+      <p><strong>Assumption:</strong> The label function (4 cases + fallback) is unit-tested, and the render wiring is type/vet-checked, but the actual terminal render (<code> -&gt; {label}</code> dim) is not captured by an automated test.</p>
+      <p><strong>Verify:</strong> A manual REPL check (type <code>/</code>, Tab) confirms the dim label appears. An automated terminal-render test would require capturing <code>e.out</code> bytes &mdash; deferred.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `formatSlashAutocompleteLabel(cmd)` rendering `name <argument-hint> - description` (hint verbatim with its own brackets; segments omitted when absent)
- Wire it into the Tab-completion `render()`: slash-command candidates show ` -> {label}` dimly (reusing the existing suggestion form); Tab still inserts `/name`. History/model candidates keep prior behavior
- Prompt templates, built-ins, skills, and plugins share one candidate list sorted by name (already the case in `suggestions()`)

Closes #340

## Test plan
- [x] `TestFormatSlashAutocompleteLabel` (4 cases: hint+desc, desc only, hint only, neither)
- [x] `TestFormatSlashAutocompleteLabelDescriptionFallback` (description fallback from #334 flows through)
- [x] `TestSlashAutocompleteSuggestionStillCompletesName` (Tab still inserts `/name`, not the label)
- [x] existing `TestLineEditor*` regression passes; `go vet`/`go build` clean

## Note
The AC&rsquo;s &ldquo;列按现有补全列宽对齐&rdquo; assumes a columnar candidate list; pigo&rsquo;s autocomplete is inline-cycling, so slash commands render the label inline as ` -> {label}`. A columnar list is a possible follow-up. See docs/issue#0340.html.