### PR TITLE
feat(pkgmgr): install prompt packages to ~/.pigo/prompts

### DIFF
--- a/docs/issue#0342.html
+++ b/docs/issue#0342.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes - Issue #0342</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/342">#342</a> &mdash; 包管理器识别 prompts/ 约定并安装到 ~/.pigo/prompts &mdash; 2026-07-27</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Source-dir lookup order: prompts/ &gt; commands/ &gt; root</h3>
+      <p><strong>Ambiguity:</strong> Which subdir does a prompt package ship its templates in?</p>
+      <p><strong>Choice:</strong> Try <code>prompts/</code> first (the pi convention), then the legacy <code>commands/</code>, then root-level <code>*.md</code>.</p>
+      <p><strong>Rationale:</strong> pi packages use <code>prompts/</code>; pigo&rsquo;s legacy convention was <code>commands/</code>. Supporting both (with prompts preferred) maximizes compatibility while aligning with pi.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Install target is <code>PromptsDir()</code> (~/.pigo/prompts); <code>CommandsDir()</code> retained for back-compat</h3>
+      <p><strong>Ambiguity:</strong> Where do newly installed prompt templates land?</p>
+      <p><strong>Choice:</strong> New installs go to <code>$PIGO_HOME/prompts</code> (new <code>PromptsDir()</code> in layout.go). <code>CommandsDir()</code> is kept because pre-#342 installs live in <code>commands/</code> and their lockfile entries point there (uninstall must still find them).</p>
+      <p><strong>Rationale:</strong> runtime.LoadUserCommandsDir loads both <code>prompts/</code> and <code>commands/</code> (per #336), so old installs keep working and new installs use the pi-aligned location.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> No migration of existing commands/ installs</h3>
+      <p><strong>Ambiguity:</strong> Should existing <code>~/.pigo/commands/*.md</code> be moved to <code>prompts/</code>?</p>
+      <p><strong>Choice:</strong> Leave them in place; they still load (back-compat) and their lockfile entries still point to <code>commands/</code> for clean uninstall.</p>
+      <p><strong>Rationale:</strong> Moving user files on upgrade is risky and unnecessary since both dirs are loaded. New installs use <code>prompts/</code>; old ones age out naturally.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None &mdash; implementation follows US-012 as written. The prompts/ &gt; commands/ &gt; root lookup, install to PromptsDir, README.md skip at root, and the lockfile-path/uninstall tests match the acceptance criteria.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> prompts/ wins outright when both prompts/ and commands/ exist</h3>
+      <p><strong>Alternatives:</strong> Merge templates from both subdirs.</p>
+      <p><strong>Pros/cons:</strong> Picking prompts/ only is simpler and matches pi (one canonical subdir). Merging would install duplicate/legacy templates the package author likely didn&rsquo;t intend.</p>
+      <p><strong>Why it won:</strong> A package shipping both is rare; prompts/ is the canonical source. commands/ is a fallback for packages that haven&rsquo;t migrated.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Keep CommandsDir() vs remove it</h3>
+      <p><strong>Alternatives:</strong> Remove CommandsDir() now that installs go to PromptsDir().</p>
+      <p><strong>Pros/cons:</strong> Removing would orphan pre-#342 lockfile entries (uninstall couldn&rsquo;t resolve <code>commands/</code> paths). Keeping it costs one small function.</p>
+      <p><strong>Why it won:</strong> Back-compat for existing installs and their lockfile entries; CommandsDir() is still referenced by the loader and uninstall paths.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> <code>pigo update</code> on a pre-#342 package</h3>
+      <p><strong>Assumption:</strong> An existing package installed to <code>commands/</code> has lockfile entries pointing there. A <code>pigo update</code> would re-install to <code>prompts/</code> (new target), but the old <code>commands/</code> copies are removed by uninstall (which uses the old lockfile entries) before re-install.</p>
+      <p><strong>Verify:</strong> Confirm the update flow uninstalls the old entries (removing <code>commands/</code> copies) before distributing to <code>prompts/</code>, so no orphaned <code>commands/</code> files remain. Not tested here; the lockfile-path test only checks new installs land under <code>prompts/</code>.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Uninstall of a package with prompts/ + commands/ both</h3>
+      <p><strong>Assumption:</strong> Only the prompts/ templates were installed (commands/ ignored), so the lockfile records only prompts/ paths; uninstall removes exactly those.</p>
+      <p><strong>Verify:</strong> Confirmed by <code>TestDistributePromptPromptsDirPreferred</code> (1 file installed) + <code>TestDistributePromptReturnsPromptsPaths</code> (paths under prompts/). Uninstall uses these paths.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/pkgmgr/distribute_prompt.go
+++ b/internal/pkgmgr/distribute_prompt.go
@@ -1,15 +1,15 @@
 // This file distributes a classified pi prompt/command package into pigo's
-// commands directory so runtime.LoadUserCommandsDir picks it up (#160).
+// prompts directory so runtime.LoadUserCommandsDir picks it up (#160, #342).
 //
-// pigo loads declarative slash commands from $PIGO_HOME/commands/*.md
-// (non-recursively): each markdown file defines a "/name" command, named after
-// the file, whose body is the prompt template. A pi prompt package ships one or
-// more such templates, conventionally under a "commands/" subdirectory (the
-// same convention pigo's loader mirrors); some packages place the .md files at
-// the package root.
+// pigo loads declarative slash commands from $PIGO_HOME/prompts/*.md (and the
+// legacy $PIGO_HOME/commands/*.md) non-recursively: each markdown file defines
+// a "/name" command, named after the file, whose body is the prompt template.
+// A pi prompt package ships one or more such templates, conventionally under a
+// "prompts/" subdirectory (the pi convention); the legacy "commands/" subdir is
+// a fallback, and some packages place the .md files at the package root.
 //
 // Distribution copies those .md files (flattened, since the loader is
-// non-recursive) into $PIGO_HOME/commands/. Every file laid down is returned so
+// non-recursive) into $PIGO_HOME/prompts/. Every file laid down is returned so
 // the lockfile can remove precisely what was installed.
 package pkgmgr
 
@@ -26,13 +26,21 @@ import (
 // every file it created, for the lockfile. An unresolvable commands dir, or a
 // package with no command templates, is an error.
 func DistributePrompt(pkgDir, name string) ([]string, error) {
-	commandsDir := CommandsDir()
-	if commandsDir == "" {
-		return nil, fmt.Errorf("pkgmgr: cannot resolve commands dir (PIGO_HOME/home unavailable)")
+	promptsDir := PromptsDir()
+	if promptsDir == "" {
+		return nil, fmt.Errorf("pkgmgr: cannot resolve prompts dir (PIGO_HOME/home unavailable)")
 	}
 
-	srcDir := filepath.Join(pkgDir, "commands")
-	if !dirExists(srcDir) {
+	// Prefer the pi-aligned prompts/ subdir, then the legacy commands/ subdir,
+	// then root-level *.md as a last resort.
+	srcDir := ""
+	for _, sub := range []string{"prompts", "commands"} {
+		if dirExists(filepath.Join(pkgDir, sub)) {
+			srcDir = filepath.Join(pkgDir, sub)
+			break
+		}
+	}
+	if srcDir == "" {
 		srcDir = pkgDir // fall back to root-level *.md
 	}
 	entries, err := os.ReadDir(srcDir)
@@ -53,17 +61,17 @@ func DistributePrompt(pkgDir, name string) ([]string, error) {
 		mds = append(mds, e.Name())
 	}
 	if len(mds) == 0 {
-		return nil, fmt.Errorf("pkgmgr: prompt %q has no command templates (*.md)", name)
+		return nil, fmt.Errorf("pkgmgr: prompt %q has no prompt templates (*.md)", name)
 	}
 
-	if err := os.MkdirAll(commandsDir, 0o755); err != nil {
-		return nil, fmt.Errorf("pkgmgr: create commands dir: %w", err)
+	if err := os.MkdirAll(promptsDir, 0o755); err != nil {
+		return nil, fmt.Errorf("pkgmgr: create prompts dir: %w", err)
 	}
 
 	created := make([]string, 0, len(mds))
 	for _, md := range mds {
 		src := filepath.Join(srcDir, md)
-		dst := filepath.Join(commandsDir, md)
+		dst := filepath.Join(promptsDir, md)
 		info, statErr := os.Stat(src)
 		if statErr != nil {
 			return created, fmt.Errorf("pkgmgr: stat command %q: %w", src, statErr)

--- a/internal/pkgmgr/distribute_prompt_test.go
+++ b/internal/pkgmgr/distribute_prompt_test.go
@@ -6,9 +6,36 @@ import (
 	"testing"
 )
 
-// TestDistributePromptCommandsDir verifies *.md under the package's commands/
-// dir land in $PIGO_HOME/commands, discoverable by LoadUserCommandsDir.
-func TestDistributePromptCommandsDir(t *testing.T) {
+// TestDistributePromptPromptsDirPreferred verifies the pi-aligned prompts/
+// subdir is preferred over the legacy commands/ subdir (#342): only the
+// prompts/ templates are installed.
+func TestDistributePromptPromptsDirPreferred(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+
+	pkg := writePkg(t, `{"name":"pi-prompts","version":"1.0.0","pi":{"type":"prompt"}}`, map[string]string{
+		"prompts/review.md":  "---\ndescription: review\n---\nReview $ARGUMENTS",
+		"commands/legacy.md": "Legacy $ARGUMENTS",
+	})
+
+	files, err := DistributePrompt(pkg, "pi-prompts")
+	if err != nil {
+		t.Fatalf("DistributePrompt: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("created %d files, want 1 (prompts/ preferred over commands/): %v", len(files), files)
+	}
+	if _, err := os.Stat(filepath.Join(home, "prompts", "review.md")); err != nil {
+		t.Errorf("review.md not placed in prompts/: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, "prompts", "legacy.md")); !os.IsNotExist(err) {
+		t.Errorf("legacy.md from commands/ should not be installed when prompts/ exists: %v", err)
+	}
+}
+
+// TestDistributePromptCommandsDirFallback verifies the legacy commands/ subdir
+// is used when prompts/ is absent, installing into ~/.pigo/prompts.
+func TestDistributePromptCommandsDirFallback(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PIGO_HOME", home)
 
@@ -26,19 +53,19 @@ func TestDistributePromptCommandsDir(t *testing.T) {
 		t.Errorf("created %d files, want 2: %v", len(files), files)
 	}
 	for _, want := range []string{"review.md", "explain.md"} {
-		if _, err := os.Stat(filepath.Join(home, "commands", want)); err != nil {
-			t.Errorf("%s not placed: %v", want, err)
+		if _, err := os.Stat(filepath.Join(home, "prompts", want)); err != nil {
+			t.Errorf("%s not placed in prompts/: %v", want, err)
 		}
 	}
-	// README.md under commands/ isn't special — but it's not present here; the
-	// root README.md must NOT be copied (we used the commands/ dir).
-	if _, err := os.Stat(filepath.Join(home, "commands", "README.md")); !os.IsNotExist(err) {
-		t.Errorf("root README.md leaked into commands: %v", err)
+	// Root README.md is not copied (commands/ was used, not root).
+	if _, err := os.Stat(filepath.Join(home, "prompts", "README.md")); !os.IsNotExist(err) {
+		t.Errorf("root README.md leaked into prompts: %v", err)
 	}
 }
 
-// TestDistributePromptRootFallback verifies root-level *.md are used when there
-// is no commands/ dir, skipping README.md.
+// TestDistributePromptRootFallback verifies root-level *.md are used when
+// neither prompts/ nor commands/ exists, skipping README.md, installing into
+// ~/.pigo/prompts.
 func TestDistributePromptRootFallback(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PIGO_HOME", home)
@@ -55,19 +82,40 @@ func TestDistributePromptRootFallback(t *testing.T) {
 	if len(files) != 1 {
 		t.Fatalf("created %d files, want 1: %v", len(files), files)
 	}
-	if _, err := os.Stat(filepath.Join(home, "commands", "summarize.md")); err != nil {
-		t.Errorf("summarize.md not placed: %v", err)
+	if _, err := os.Stat(filepath.Join(home, "prompts", "summarize.md")); err != nil {
+		t.Errorf("summarize.md not placed in prompts/: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(home, "commands", "README.md")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(home, "prompts", "README.md")); !os.IsNotExist(err) {
 		t.Errorf("README.md should be skipped at root fallback: %v", err)
 	}
 }
 
-// TestDistributePromptNone verifies a package with no command templates errors.
+// TestDistributePromptNone verifies a package with no prompt templates errors.
 func TestDistributePromptNone(t *testing.T) {
 	t.Setenv("PIGO_HOME", t.TempDir())
 	pkg := writePkg(t, `{"name":"pi-empty","version":"1.0.0"}`, nil)
 	if _, err := DistributePrompt(pkg, "pi-empty"); err == nil {
 		t.Fatal("DistributePrompt with no templates = nil error, want error")
+	}
+}
+
+// TestDistributePromptReturnsPromptsPaths verifies the returned paths (recorded
+// in the lockfile) are under ~/.pigo/prompts, so uninstall removes precisely
+// what was installed.
+func TestDistributePromptReturnsPromptsPaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+	pkg := writePkg(t, `{"name":"pi-p","version":"1.0.0","pi":{"type":"prompt"}}`, map[string]string{
+		"prompts/x.md": "X $ARGUMENTS",
+	})
+	files, err := DistributePrompt(pkg, "pi-p")
+	if err != nil {
+		t.Fatalf("DistributePrompt: %v", err)
+	}
+	wantDir := filepath.Join(home, "prompts")
+	for _, f := range files {
+		if filepath.Dir(f) != wantDir {
+			t.Errorf("installed path %q not under %s", f, wantDir)
+		}
 	}
 }

--- a/internal/pkgmgr/layout.go
+++ b/internal/pkgmgr/layout.go
@@ -43,15 +43,28 @@ func PluginsDir() string {
 	return filepath.Join(h, "plugins")
 }
 
-// CommandsDir returns $PIGO_HOME/commands, where installed prompt/command
-// templates are laid down for runtime.LoadUserCommandsDir. It returns "" when
-// Home is unavailable.
+// CommandsDir returns $PIGO_HOME/commands, the legacy location for installed
+// prompt/command templates (still loaded by runtime.LoadUserCommandsDir for
+// back-compat). New installs go to PromptsDir. It returns "" when Home is
+// unavailable.
 func CommandsDir() string {
 	h := Home()
 	if h == "" {
 		return ""
 	}
 	return filepath.Join(h, "commands")
+}
+
+// PromptsDir returns $PIGO_HOME/prompts, the pi-aligned location where installed
+// prompt templates are laid down for runtime.LoadUserCommandsDir (which loads
+// both prompts/ and the legacy commands/). It returns "" when Home is
+// unavailable.
+func PromptsDir() string {
+	h := Home()
+	if h == "" {
+		return ""
+	}
+	return filepath.Join(h, "prompts")
 }
 
 // ThemesDir returns $PIGO_HOME/themes, where installed themes are stored. pigo


### PR DESCRIPTION
## Summary
- `DistributePrompt` looks for templates in `prompts/` (pi convention) first, then the legacy `commands/`, then root `*.md`; installs them into `$PIGO_HOME/prompts` (new `PromptsDir()` in layout.go) instead of `commands/`
- Root `README.md` is still skipped on the root fallback
- `CommandsDir()` retained for back-compat (pre-#342 installs live in `commands/` and their lockfile entries point there; runtime still loads both dirs per #336)

Closes #342

## Test plan
- [x] `TestDistributePromptPromptsDirPreferred` (prompts/ wins over commands/)
- [x] `TestDistributePromptCommandsDirFallback` (commands/ used when no prompts/, installs to ~/.pigo/prompts)
- [x] `TestDistributePromptRootFallback` (root *.md, README skipped, installs to ~/.pigo/prompts)
- [x] `TestDistributePromptReturnsPromptsPaths` (lockfile paths under prompts/ for clean uninstall)
- [x] `go test ./internal/pkgmgr/` passes, `go vet`/`go build` clean