### PR TITLE
docs: document prompt templates in README and book

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ pigo 可以读写文件、执行命令、检索代码、抓取网页，并借助
 - [系统提示词组装](#系统提示词组装)
 - [项目信任](#项目信任)
 - [技能 Skills](#技能-skills)
+- [提示词模板](#提示词模板)
 - [插件](#插件)
 - [包管理](#包管理)
 - [发布release](#发布release)
@@ -46,6 +47,7 @@ pigo 可以读写文件、执行命令、检索代码、抓取网页，并借助
 - **系统提示词分层组装**：base 指令 + 环境块 + `AGENTS.md`（general→specific）+ `--append-system-prompt`。
 - **项目信任**：副作用工具（bash/write/edit）在未信任目录需确认，`--approve` 一次性授权。
 - **技能与插件**：`~/.agents/skills` 下的 `/slash` 命令、`~/.pigo/plugins` 下的外部插件。
+- **提示词模板**：`~/.pigo/prompts`、项目 `.pigo/prompts`（受信任时）、config `prompts`、`--prompt-template` 下的可复用 `/name` 模板，支持 `$1`/`$@`/`${1:-default}`/`${@:N}` 等参数语法。
 - **上下文自动压缩**：接近上下文窗口上限时自动摘要，亦可 `/compact` 手动触发。
 - **包管理**：`pigo install npm:<pkg>` 安装 pi 生态的 extension / skill / prompt / theme。
 
@@ -159,6 +161,8 @@ pigo -m ollama/qwen2.5-coder -u http://localhost:11434/v1 -p "解释 main.go 做
 | `--continue` | `-c` | `false` | 续跑最近一次的会话 |
 | `--approve` | `-a` | `false` | 为本次运行信任工作目录：跳过首次信任提示，副作用工具免逐次确认 |
 | `--no-skills` | | `false` | 禁用技能发现（不加载 `~/.agents/skills` 为 `/skill-name` 命令） |
+| `--no-prompt-templates` | | `false` | 禁用提示词模板发现（不加载 `~/.pigo/{commands,prompts}`、`.pigo/prompts`、config `prompts`、`--prompt-template`）；内置斜杠命令不受影响 |
+| `--prompt-template` | | `nil` | 从文件或目录（非递归）加载提示词模板；可重复（对标 pi `--prompt-template`） |
 | `--system-prompt` | | `""` | 用自定义系统提示词替换默认的 coding-assistant 提示词 |
 | `--append-system-prompt` | | `nil` | 向系统提示词末尾追加文本或文件内容；可重复 |
 | `--version` | `-v` | `false` | 打印版本信息并退出 |
@@ -317,6 +321,62 @@ REPL 中的内置斜杠命令包括 `/model`、`/models`、`/help`、`/compact`�
 
 ---
 
+## 提示词模板
+
+提示词模板是可复用的 Markdown 片段，在 REPL 中输入 `/name` 即可展开为完整 prompt（对标 [pi prompt templates](https://pi.dev/docs/latest/prompt-templates)）。模板可带 YAML frontmatter，支持位置参数、默认值与切片。
+
+### 发现来源与优先级
+
+pigo 从以下来源非递归加载 `*.md` 模板（文件名去掉 `.md` 即命令名）：
+
+| 来源 | 路径 / 配置 | 优先级 tier |
+|------|-------------|-------------|
+| 项目级（受信任时） | `.pigo/prompts/*.md`（仅当项目受信任） | project |
+| 全局 | `~/.pigo/prompts/*.md` 与 legacy `~/.pigo/commands/*.md` | global |
+| 包安装 | `pigo install` 安装到 `~/.pigo/prompts` | global（并入全局） |
+| 配置 | `~/.config/pigo/config.toml` 的 `prompts = ["./my-prompts", "/abs/x.md"]` | settings |
+| CLI | `--prompt-template <path>`（可重复，文件或目录） | cli |
+
+同名模板按 tier 解析：**project > global > settings > cli**，败者丢弃并在启动时报告；built-in 斜杠命令始终胜出。`--no-prompt-templates` 关闭全部模板发现（内置命令与技能不受影响，与 `--no-skills` 互相独立）。
+
+### 模板格式
+
+````markdown
+---
+description: Review PRs from URLs with structured issue and code analysis
+argument-hint: "<PR-URL>"
+---
+Review the PR at $1. Focus on:
+- Bugs and logic errors
+- Security issues
+- Error handling gaps
+````
+
+- `description`：可选；缺省时回退为正文首个非空行。
+- `argument-hint`：可选；在 Tab 补全与 `/help` 中以 `name <hint> - description` 形式展示。用 `<angle>` 表示必选参数、`[square]` 表示可选。
+- 正文是 prompt 模板，支持下面的参数语法。
+
+### 参数语法
+
+| 语法 | 含义 |
+|------|------|
+| `$1`、`$2`、… `$N` | 第 N 个位置参数（1-indexed；越界为空） |
+| `$@` / `$ARGUMENTS` | 全部参数以单空格连接 |
+| `${1:-default}` | arg1 存在且非空则用 arg1，否则用 `default` |
+| `${@:-default}` / `${ARGUMENTS:-default}` | 全部参数非空则用之，否则 `default` |
+| `${@:N}` | 从第 N 个起的所有参数 |
+| `${@:N:L}` | 从第 N 个起的 L 个参数 |
+
+调用示例：
+
+```
+/review https://github.com/owner/repo/pull/123
+/component Button "onClick handler" "disabled support"
+/summarize            # 模板用 ${1:-7} 时回退为 7 条要点
+```
+
+> 分词遵循 shell 引号规则：`Button "click handler"` 被切分为 `["Button", "click handler"]`。未闭合引号会回退为把原始串整体作为 `$ARGUMENTS`，保证可用。
+
 ## 技能 Skills
 
 技能是带 YAML frontmatter（`name`、`description`，可选 `allowed-tools`、`model`、`disable-model-invocation`）的 Markdown 文件，位于 `~/.agents/skills`（可用 `PIGO_SKILLS_DIR` 覆盖）：
@@ -392,11 +452,15 @@ git push origin v0.2.0
 
 | 变量 / 路径 | 用途 |
 |-------------|------|
-| `PIGO_HOME` | 覆盖 `~/.pigo` 基础目录（影响 plugins 与 commands） |
+| `PIGO_HOME` | 覆盖 `~/.pigo` 基础目录（影响 plugins、commands、prompts） |
 | `PIGO_SKILLS_DIR` | 覆盖技能目录（默认 `~/.agents/skills`） |
 | `~/.pigo/sessions` | 会话存储（JSONL） |
 | `~/.pigo/plugins` | 外部插件 |
-| `~/.pigo/commands` | 用户自定义命令模板 |
+| `~/.pigo/prompts` | 提示词模板（pi 对齐；`pigo install` 的安装目标） |
+| `~/.pigo/commands` | 用户自定义命令模板（legacy，仍加载） |
+| `.pigo/prompts` | 项目级提示词模板（仅当项目受信任时加载） |
+| `~/.config/pigo/config.toml` 的 `prompts` | 配置追加的模板来源（settings tier） |
+| `--prompt-template <path>` | CLI 追加的模板来源（cli tier，可重复） |
 | `<PROVIDER>_API_KEY` | 各 Provider 的 API Key（见[模型与 Provider](#模型与-provider)） |
 
 ### 内置 Provider 一览（`--provider`）

--- a/book/chapter10.md
+++ b/book/chapter10.md
@@ -16,7 +16,7 @@
 
 **包管理器**回答"这些扩展怎么分发、安装、版本化"。它把前两者（以及提示词模板、主题）当作发布到 npm 上的包，`pigo install npm:<name>` 负责拉取、判断这是什么类型、分发到对应目录，并记进锁文件以便日后卸载升级。
 
-一条线索贯穿始终：**pigo 不为扩展另造发现机制，而是让每种扩展落到一个它本来就会扫描的目录里**。技能落到技能目录（`LoadSkillsDir` 会扫），提示词落到 `commands` 目录（`LoadUserCommandsDir` 会扫），扩展落到 `plugins` 目录（`plugin.Discover` 会扫）。包管理器的"分发"本质上就是把包里的东西摆到正确的位置，剩下的交给既有的加载逻辑。下面就从最轻的一层说起。
+一条线索贯穿始终：**pigo 不为扩展另造发现机制，而是让每种扩展落到一个它本来就会扫描的目录里**。技能落到技能目录（`LoadSkillsDir` 会扫），提示词落到 `prompts` 目录（legacy `commands` 仍兼容，`LoadUserCommandsDir` 都扫），扩展落到 `plugins` 目录（`plugin.Discover` 会扫）。包管理器的"分发"本质上就是把包里的东西摆到正确的位置，剩下的交给既有的加载逻辑。下面就从最轻的一层说起。
 
 <!--
 生图prompt：
@@ -131,11 +131,11 @@ func (s *Skill) SlashCommand() SlashCommand {
 }
 ```
 
-两种挂法的区别是语义上的：子 Agent 版让技能带着独立上下文另跑一轮、只回结论；斜杠命令版让技能的指令**就地展开**进当前对话，参数通过 `$ARGUMENTS` 占位符替换（没有占位符就把参数追加到末尾）。pigo 在 REPL 里选的是后者——`cmd/pigo/interactive.go` 的 `loadSkillCommands` 把每个技能都注册成一条 `/skill-name`。
+两种挂法的区别是语义上的：子 Agent 版让技能带着独立上下文另跑一轮、只回结论；斜杠命令版让技能的指令**就地展开**进当前对话，参数经 `ExpandTemplate` 展开（`$1`/`$@`/`$ARGUMENTS` 位置参数、`${1:-default}` 默认值、`${@:N}`/`${@:N:L}` 切片）（没有占位符就把参数追加到末尾）。pigo 在 REPL 里选的是后者——`cmd/pigo/interactive.go` 的 `loadSkillCommands` 把每个技能都注册成一条 `/skill-name`。
 
 ### 斜杠命令注册表：内置优先，动作与提示分家
 
-斜杠命令本身是 pigo REPL 的一等公民，定义在 `internal/runtime/slashcommand.go`。它有两个来源，按固定优先级解析：**内置命令**在编译期通过 `RegisterBuiltin`（在 `init()` 里）注册，永远可用；**用户命令**是从目录加载的声明式 Markdown 模板。冲突规则很明确——同名时内置命令赢，因为内置命令是"承重"的、不能被悄悄遮蔽；一个撞名的用户命令会被记进 `shadowed` 列表提示用户改名，但内置的照旧生效。
+斜杠命令本身是 pigo REPL 的一等公民，定义在 `internal/runtime/slashcommand.go`。它有两个来源，按固定优先级解析：**内置命令**在编译期通过 `RegisterBuiltin`（在 `init()` 里）注册，永远可用；**用户命令**是从目录加载的声明式 Markdown 模板。冲突规则很明确——按来源 tier 解析（project > global > settings > cli），内置命令 tier 最高、始终胜出，因为内置命令是"承重"的、不能被悄悄遮蔽；一个撞名的用户命令会被记进 `shadowed` 列表提示用户改名，但内置的照旧生效。
 
 更关键的是一条命令有两种"性格"，由设置哪个回调决定：
 
@@ -174,7 +174,7 @@ Constraints: One image explains only one core structure. Main subject 40%-60% of
 
 `ResolveOutcome` 是解析一行输入的统一入口。它区分三种结局：不是斜杠命令，原样返回让调用方直接运行；是已知的提示命令，返回展开后的提示文本；是已知的动作命令，**当场执行动作**并返回状态消息、不启动运行。未知的 `/name` 则报错。这三态被打包进 `SlashOutcome`，REPL 据此决定"跑一轮"还是"只显示一行"。
 
-装配这一切的是 `cmd/pigo/interactive.go` 的 `buildSlashRegistry`：先用 `NewSlashRegistry` 播种全部编译期内置命令，再挂上 `/model`、`/help` 这类需要捕获活状态的实例内置命令，然后从 `~/.pigo/commands`（或 `$PIGO_HOME/commands`）加载用户声明式模板，最后——除非带了 `--no-skills`——从 `~/.agents/skills` 加载技能并各自注册成一条 `/skill-name`。技能加载遵循前面说的容错约定：加载成功的照常注册，出错的只在 stderr 上报一句警告。这条 `--no-skills` 开关，我们在第 1 章 `dispatch` 的标志里就见过它的名字，这里才落到实处。
+装配这一切的是 `cmd/pigo/interactive.go` 的 `buildSlashRegistry`：先用 `NewSlashRegistry` 播种全部编译期内置命令，再挂上 `/model`、`/help` 这类需要捕获活状态的实例内置命令，然后从 `~/.pigo/prompts` 与 legacy `~/.pigo/commands`（或 `$PIGO_HOME` 下同名子目录）加载用户声明式模板（另有项目 `.pigo/prompts`、config `prompts`、`--prompt-template` 等来源，`--no-prompt-templates` 可整体关闭），最后——除非带了 `--no-skills`——从 `~/.agents/skills` 加载技能并各自注册成一条 `/skill-name`。技能加载遵循前面说的容错约定：加载成功的照常注册，出错的只在 stderr 上报一句警告。这条 `--no-skills` 开关，我们在第 1 章 `dispatch` 的标志里就见过它的名字，这里才落到实处。
 
 ## Plugin 系统：进程隔离的外部工具
 
@@ -357,7 +357,7 @@ if dirExists(filepath.Join(pkgDir, "commands")) {
 
 这套靠结构兜底的判断，让一个"没好好声明元数据、但明摆着是某类型"的包也能被认出来；什么都匹配不上时它宁可报错也不瞎猜，好让 `pigo install` 在一个根本不是 pi 包的东西上清清楚楚地失败。
 
-**分发**（`distribute.go` 及同族文件）。这是包管理器最能体现全章那条线索的地方——分发不是别的，就是**把包里的东西摆到 pigo 本来就会扫描的目录**。`install.go` 的 `distribute` 按类型路由到四个分发器，各自的目标目录由 `layout.go` 定义：扩展进 `$PIGO_HOME/plugins`（`plugin.Discover` 扫）、提示词进 `$PIGO_HOME/commands`（`LoadUserCommandsDir` 扫）、技能进 `~/.agents/skills`（`LoadSkillsDir` 扫）、主题进 `$PIGO_HOME/themes`（暂无运行时消费者，只是先存着）。
+**分发**（`distribute.go` 及同族文件）。这是包管理器最能体现全章那条线索的地方——分发不是别的，就是**把包里的东西摆到 pigo 本来就会扫描的目录**。`install.go` 的 `distribute` 按类型路由到四个分发器，各自的目标目录由 `layout.go` 定义：扩展进 `$PIGO_HOME/plugins`（`plugin.Discover` 扫）、提示词进 `$PIGO_HOME/prompts`（`LoadUserCommandsDir` 扫，legacy `commands` 仍兼容）、技能进 `~/.agents/skills`（`LoadSkillsDir` 扫）、主题进 `$PIGO_HOME/themes`（暂无运行时消费者，只是先存着）。
 
 技能分发最直白：`DistributeSkill` 就是把包整棵树拷进 `<skillsDir>/<name>/`，因为一个 npm 技能包恰好就是 `LoadSkillsDir` 认得的那种"一个目录一个 `SKILL.md`"布局。扩展分发要多一道弯：`plugin.Discover` 只跑目录里"直接的可执行文件"，可一个 npm 扩展是整棵包树、入口还依赖同级文件，没法只丢一个文件进去。`DistributeExtension` 的解法是摆两样东西——`<name>.pkg/` 放完整包树（是目录，Discover 会跳过），`<name>` 放一个 tiny 的 shell 启动脚本 `exec` 真正的 bin 入口（是文件，Discover 会跑）。每个分发器都会先清掉自己上一次的旧产物再写，所以分发是幂等的，重跑一次 install 不会留下陈货。
 

--- a/docs/issue#0343.html
+++ b/docs/issue#0343.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes - Issue #0343</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/343">#343</a> &mdash; 文档更新：README + 电子书 &mdash; 2026-07-27</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Added a dedicated &ldquo;## 提示词模板&rdquo; README section</h3>
+      <p><strong>Ambiguity:</strong> Document prompt templates inline in existing sections, or as a new section?</p>
+      <p><strong>Choice:</strong> A new section with: a discovery-sources table (path + tier), the template format (frontmatter + example), and an argument-syntax cheat sheet (<code>$1</code>/<code>$@</code>/<code>${1:-default}</code>/<code>${@:N}</code>/<code>${@:N:L}</code>) with a usage example.</p>
+      <p><strong>Rationale:</strong> Prompt templates are a substantial feature (6 sources, tiered priority, full arg syntax) deserving a self-contained reference; scattering would undersell it.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Synced chapter10.md (the extensibility book chapter) at 5 factual points</h3>
+      <p><strong>Ambiguity:</strong> How much of the book to rewrite?</p>
+      <p><strong>Choice:</strong> Surgical edits at 5 points: discovery dir (<code>commands</code> -&gt; <code>prompts</code>), the expansion engine (<code>$ARGUMENTS</code> -&gt; <code>ExpandTemplate</code> with full syntax), the tiered conflict rule, <code>buildSlashRegistry</code> loading sources, and the distribute target (<code>commands</code> -&gt; <code>prompts</code>).</p>
+      <p><strong>Rationale:</strong> The book is a narrative; surgical edits keep the prose intact while correcting the now-changed facts. A full rewrite would disrupt the chapter.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Updated 目录与环境变量 table, CLI args table, feature line, and TOC</h3>
+      <p><strong>Ambiguity:</strong> Where else to surface the new flags/paths?</p>
+      <p><strong>Choice:</strong> Added <code>--no-prompt-templates</code>/<code>--prompt-template</code> rows to the CLI args table; added <code>~/.pigo/prompts</code>, <code>.pigo/prompts</code>, config <code>prompts</code>, <code>--prompt-template</code> rows to the env/paths table; updated the <code>PIGO_HOME</code> row and the feature bullet; added a TOC entry for the new section.</p>
+      <p><strong>Rationale:</strong> These are the surfaces users scan for flags and paths; keeping them current is the AC&rsquo;s core.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None &mdash; documentation follows US-013 as written. README records all required paths/flags, the CLI args table has both new rows, the arg-syntax cheat sheet + example are present, chapter10 is synced, and markdown anchors/links verify (TOC <code>#提示词模板</code> matches the heading; the pi.dev link is well-formed).</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Dedicated README section vs inline mentions</h3>
+      <p><strong>Alternatives:</strong> Mention prompts briefly under &ldquo;技能与插件&rdquo; and the env table only.</p>
+      <p><strong>Pros/cons:</strong> A dedicated section is comprehensive (discovery, format, syntax, example) but adds length. Inline is terse but hides the arg syntax users need.</p>
+      <p><strong>Why it won:</strong> The arg syntax (<code>${@:N:L}</code> etc.) is non-obvious; a reference table is the usable form.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Surgical chapter10 edits vs a full rewrite</h3>
+      <p><strong>Alternatives:</strong> Rewrite the Skills/斜杠命令 and 分发 sections to fully incorporate prompt templates.</p>
+      <p><strong>Pros/cons:</strong> A rewrite would be more thorough but risks the narrative flow and is disproportionate to a docs-sync issue. Surgical edits correct the facts that changed (#336-#342) without restructuring.</p>
+      <p><strong>Why it won:</strong> The AC says &ldquo;同步更新&rdquo; (sync), not &ldquo;rewrite&rdquo;. Correcting the 5 changed facts is the right scope.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> The PDF eBook is not regenerated</h3>
+      <p><strong>Assumption:</strong> Only the markdown source (<code>book/chapter10.md</code>) is updated; the published <code>write_pi_agent_in_go.pdf</code> is built separately via <code>book/build_pdf.sh</code> and not run here.</p>
+      <p><strong>Verify:</strong> The PDF regen is a separate release step; the markdown is the source of truth. Confirm the book build pipeline picks up these edits on next PDF release.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> <code>argument-hint</code> rendering documented consistently with #340/#341</h3>
+      <p><strong>Assumption:</strong> The README documents <code>argument-hint</code> as shown in Tab autocomplete (<code>name &lt;hint&gt; - description</code>) and <code>/help</code>, matching the #340/#341 implementations.</p>
+      <p><strong>Verify:</strong> Cross-check the documented format against the actual <code>formatSlashAutocompleteLabel</code> (#340) and <code>formatHelpLine</code> (#341) output.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add a **提示词模板** README section: discovery-sources table (path + tier), template format (frontmatter + `argument-hint`), argument-syntax cheat sheet (`$1`/`$@`/`${1:-default}`/`${@:N}`/`${@:N:L}`), and a usage example
- Add `--prompt-template` and `--no-prompt-templates` rows to the CLI args table; add `~/.pigo/prompts`, `.pigo/prompts`, config `prompts`, `--prompt-template` rows to the 目录与环境变量 table; update `PIGO_HOME` row, feature bullet, and TOC
- Sync `book/chapter10.md` at 5 factual points: prompts/ discovery dir, `ExpandTemplate` expansion, tiered conflict rule, `buildSlashRegistry` loading sources, distribute target

Closes #343

## Verification
- [x] TOC anchor `#提示词模板` matches the `## 提示词模板` heading
- [x] pi.dev doc link well-formed; CLI table rows have 4 columns
- [x] `go build ./...` / `go vet ./...` clean (docs-only)