### PR TITLE
feat(cli): establish internal/cli skeleton and Host contract

### DIFF
--- a/cmd/pigo/btw.go
+++ b/cmd/pigo/btw.go
@@ -206,7 +206,7 @@ func askSide(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, 
 			ThinkingLevel: settings.thinkingLevel,
 			Stream:        provider.StreamFnFromProvider(settings.provider),
 			GetAPIKey:     deps.creds.GetAPIKey,
-			ContextWindow: deps.live.contextWindow,
+			ContextWindow: deps.live.ContextWindow,
 			Compaction:    compaction.DefaultCompactionSettings,
 		},
 		Batch: agenttool.BatchConfig{

--- a/cmd/pigo/btw_config.go
+++ b/cmd/pigo/btw_config.go
@@ -87,10 +87,10 @@ func loadBtwConfig(path string) (btwConfig, error) {
 // mutates deps.live, so the override is confined to the side thread (FR-8).
 func resolveBtwSettings(out io.Writer, deps *replDeps) btwRunSettings {
 	s := btwRunSettings{
-		model:         deps.live.model,
-		providerName:  deps.live.providerName,
-		provider:      deps.live.provider,
-		thinkingLevel: deps.live.thinkingLevel,
+		model:         deps.live.Model,
+		providerName:  deps.live.ProviderName,
+		provider:      deps.live.Provider,
+		thinkingLevel: deps.live.ThinkingLevel,
 	}
 
 	cfg, err := loadBtwConfig(btwConfigPath())
@@ -108,7 +108,7 @@ func resolveBtwSettings(out io.Writer, deps *replDeps) btwRunSettings {
 	}
 
 	if model := strings.TrimSpace(cfg.Model); model != "" && model != s.model {
-		prov, providerName, perr := resolveProvider(model, deps.live.baseURL, deps.live.protocol, "")
+		prov, providerName, perr := resolveProvider(model, deps.live.BaseURL, deps.live.Protocol, "")
 		if perr != nil {
 			fmt.Fprintf(out, "%s\n", colorize(colorEnabled(), ansiDim, fmt.Sprintf("btw: cannot use model %q (%v), falling back to %q", model, perr, s.model)))
 		} else {

--- a/cmd/pigo/btw_config_test.go
+++ b/cmd/pigo/btw_config_test.go
@@ -33,11 +33,11 @@ func withBtwConfig(t *testing.T, contents string) {
 func TestBtwConfigAbsentInherits(t *testing.T) {
 	withBtwConfig(t, "") // no file
 	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
-	deps.live.thinkingLevel = agentcore.ThinkingMedium
+	deps.live.ThinkingLevel = agentcore.ThinkingMedium
 
 	var warn bytes.Buffer
 	s := resolveBtwSettings(&warn, &deps)
-	if s.model != deps.live.model || s.providerName != deps.live.providerName {
+	if s.model != deps.live.Model || s.providerName != deps.live.ProviderName {
 		t.Errorf("absent config must inherit model/provider, got %q/%q", s.model, s.providerName)
 	}
 	if s.thinkingLevel != agentcore.ThinkingMedium {
@@ -53,11 +53,11 @@ func TestBtwConfigAbsentInherits(t *testing.T) {
 func TestBtwConfigEmptyObjectInherits(t *testing.T) {
 	withBtwConfig(t, "{}")
 	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
-	deps.live.thinkingLevel = agentcore.ThinkingLow
+	deps.live.ThinkingLevel = agentcore.ThinkingLow
 
 	var warn bytes.Buffer
 	s := resolveBtwSettings(&warn, &deps)
-	if s.model != deps.live.model || s.thinkingLevel != agentcore.ThinkingLow {
+	if s.model != deps.live.Model || s.thinkingLevel != agentcore.ThinkingLow {
 		t.Errorf("empty object must inherit, got model=%q thinking=%q", s.model, s.thinkingLevel)
 	}
 	if warn.Len() != 0 {
@@ -70,14 +70,14 @@ func TestBtwConfigEmptyObjectInherits(t *testing.T) {
 func TestBtwConfigThinkingOverride(t *testing.T) {
 	withBtwConfig(t, `{"thinkingLevel":"high"}`)
 	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
-	deps.live.thinkingLevel = agentcore.ThinkingLow
+	deps.live.ThinkingLevel = agentcore.ThinkingLow
 
 	var warn bytes.Buffer
 	s := resolveBtwSettings(&warn, &deps)
 	if s.thinkingLevel != agentcore.ThinkingHigh {
 		t.Errorf("expected thinkingLevel override 'high', got %q", s.thinkingLevel)
 	}
-	if s.model != deps.live.model {
+	if s.model != deps.live.Model {
 		t.Errorf("model must still inherit when only thinkingLevel is set, got %q", s.model)
 	}
 	if warn.Len() != 0 {
@@ -90,7 +90,7 @@ func TestBtwConfigThinkingOverride(t *testing.T) {
 func TestBtwConfigInvalidThinkingWarnsAndFallsBack(t *testing.T) {
 	withBtwConfig(t, `{"thinkingLevel":"bogus"}`)
 	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
-	deps.live.thinkingLevel = agentcore.ThinkingMedium
+	deps.live.ThinkingLevel = agentcore.ThinkingMedium
 
 	var warn bytes.Buffer
 	s := resolveBtwSettings(&warn, &deps)
@@ -107,11 +107,11 @@ func TestBtwConfigInvalidThinkingWarnsAndFallsBack(t *testing.T) {
 func TestBtwConfigMalformedWarnsAndInherits(t *testing.T) {
 	withBtwConfig(t, `{not json`)
 	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
-	deps.live.thinkingLevel = agentcore.ThinkingLow
+	deps.live.ThinkingLevel = agentcore.ThinkingLow
 
 	var warn bytes.Buffer
 	s := resolveBtwSettings(&warn, &deps)
-	if s.model != deps.live.model || s.thinkingLevel != agentcore.ThinkingLow {
+	if s.model != deps.live.Model || s.thinkingLevel != agentcore.ThinkingLow {
 		t.Errorf("malformed config must inherit, got model=%q thinking=%q", s.model, s.thinkingLevel)
 	}
 	if !strings.Contains(warn.String(), "invalid btw.json") {
@@ -124,10 +124,10 @@ func TestBtwConfigMalformedWarnsAndInherits(t *testing.T) {
 func TestBtwConfigDoesNotMutateSession(t *testing.T) {
 	withBtwConfig(t, `{"thinkingLevel":"xhigh"}`)
 	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
-	deps.live.thinkingLevel = agentcore.ThinkingLow
+	deps.live.ThinkingLevel = agentcore.ThinkingLow
 
 	_ = resolveBtwSettings(&bytes.Buffer{}, &deps)
-	if deps.live.thinkingLevel != agentcore.ThinkingLow {
-		t.Errorf("session thinkingLevel must be unchanged by /btw config, got %q", deps.live.thinkingLevel)
+	if deps.live.ThinkingLevel != agentcore.ThinkingLow {
+		t.Errorf("session thinkingLevel must be unchanged by /btw config, got %q", deps.live.ThinkingLevel)
 	}
 }

--- a/cmd/pigo/btw_help_test.go
+++ b/cmd/pigo/btw_help_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/runtime"
 )
 
@@ -16,7 +17,7 @@ import (
 // any consumer of reg.List()) surfaces it with a usage description.
 func TestBtwListedInHelp(t *testing.T) {
 	reg := runtime.NewSlashRegistry()
-	registerLiveCommands(reg, &liveRunConfig{})
+	registerLiveCommands(reg, &cli.LiveConfig{})
 
 	var btw *runtime.SlashCommand
 	for _, c := range reg.List() {
@@ -39,7 +40,7 @@ func TestBtwListedInHelp(t *testing.T) {
 // completion, so registration is all that's needed.
 func TestBtwSlashCompletion(t *testing.T) {
 	reg := runtime.NewSlashRegistry()
-	registerLiveCommands(reg, &liveRunConfig{})
+	registerLiveCommands(reg, &cli.LiveConfig{})
 	e := newREPLLineEditor(nil, nil, nil, reg, nil)
 
 	cands := e.suggestions("/bt")

--- a/cmd/pigo/color_test.go
+++ b/cmd/pigo/color_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/runtime"
 )
 
@@ -13,10 +14,9 @@ import (
 func runtimeHelpRegistry(t *testing.T) *runtime.SlashRegistry {
 	t.Helper()
 	reg := runtime.NewSlashRegistry()
-	registerLiveCommands(reg, &liveRunConfig{model: "faux", providerName: "faux"})
+	registerLiveCommands(reg, &cli.LiveConfig{Model: "faux", ProviderName: "faux"})
 	return reg
 }
-
 
 // TestColorizeGating verifies colorize wraps text in SGR codes only when
 // enabled, returns text unchanged when disabled, and treats an empty code as a

--- a/cmd/pigo/goal.go
+++ b/cmd/pigo/goal.go
@@ -202,12 +202,12 @@ func runGoalLoop(setCancel func(context.CancelFunc), out io.Writer, deps *replDe
 
 	cfg := runtime.RunConfig{
 		LoopConfig: runtime.LoopConfig{
-			Model:         deps.live.model,
-			Provider:      deps.live.providerName,
-			ThinkingLevel: deps.live.thinkingLevel,
-			Stream:        provider.StreamFnFromProvider(deps.live.provider),
+			Model:         deps.live.Model,
+			Provider:      deps.live.ProviderName,
+			ThinkingLevel: deps.live.ThinkingLevel,
+			Stream:        provider.StreamFnFromProvider(deps.live.Provider),
 			GetAPIKey:     deps.creds.GetAPIKey,
-			ContextWindow: deps.live.contextWindow,
+			ContextWindow: deps.live.ContextWindow,
 			Compaction:    compaction.DefaultCompactionSettings,
 		},
 		Batch: agenttool.BatchConfig{

--- a/cmd/pigo/help_line_test.go
+++ b/cmd/pigo/help_line_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/runtime"
 )
 
@@ -35,7 +36,7 @@ func TestFormatHelpLine(t *testing.T) {
 // prompt template with its argument-hint, description, and source tier.
 func TestHelpActionIncludesTemplateLabelAndTier(t *testing.T) {
 	reg := runtime.NewSlashRegistry()
-	registerLiveCommands(reg, &liveRunConfig{model: "test", providerName: "test"})
+	registerLiveCommands(reg, &cli.LiveConfig{Model: "test", ProviderName: "test"})
 	reg.AddUser(runtime.SlashCommand{
 		Name:         "review",
 		ArgumentHint: "<PR-URL>",

--- a/cmd/pigo/host.go
+++ b/cmd/pigo/host.go
@@ -1,0 +1,49 @@
+// This file makes replDeps satisfy cli.Host: the accessor and mutator methods
+// let the /goal, /btw, /status and REPL logic reach the session's collaborators
+// and mutable state through the cli.Host contract rather than the concrete
+// aggregate. The compile-time assertion below fails the build if replDeps drifts
+// out of conformance.
+package main
+
+import (
+	"bufio"
+	"sync"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/plugin"
+	"github.com/smallnest/pigo/internal/provider"
+	"github.com/smallnest/pigo/internal/runtime"
+	"github.com/smallnest/pigo/internal/session"
+	"github.com/smallnest/pigo/internal/trust"
+)
+
+var _ cli.Host = (*replDeps)(nil)
+
+func (d *replDeps) Store() *session.Store                      { return d.store }
+func (d *replDeps) Header() session.SessionHeader              { return d.header }
+func (d *replDeps) AgentCtx() *agentcore.AgentContext          { return d.agentCtx }
+func (d *replDeps) Live() *cli.LiveConfig                      { return d.live }
+func (d *replDeps) Registry() *agenttool.ToolRegistry          { return d.reg }
+func (d *replDeps) Reminders() *runtime.ReminderRegistry       { return d.reminders }
+func (d *replDeps) Slash() *runtime.SlashRegistry              { return d.slash }
+func (d *replDeps) Creds() *provider.CredentialStore           { return d.creds }
+func (d *replDeps) Notifier() *plugin.EventNotifier            { return d.notifier }
+func (d *replDeps) NotifierHandle() func(agentcore.AgentEvent) { return d.notifierHandle() }
+func (d *replDeps) Trust() *trust.Manager                      { return d.trust }
+func (d *replDeps) Goal() *agenttool.GoalState                 { return d.goal }
+func (d *replDeps) Telemetry() *cli.TelemetryHolder            { return d.telemetry }
+func (d *replDeps) Cwd() string                                { return d.cwd }
+func (d *replDeps) Input() *bufio.Reader                       { return d.in }
+func (d *replDeps) ConfirmMu() *sync.Mutex                     { return d.confirmMu }
+
+func (d *replDeps) CurLeaf() string      { return d.curLeaf }
+func (d *replDeps) SetCurLeaf(id string) { d.curLeaf = id }
+func (d *replDeps) Persisted() int       { return d.persisted }
+func (d *replDeps) SetPersisted(n int)   { d.persisted = n }
+
+func (d *replDeps) LastBtw() *agentcore.AgentContext       { return d.lastBtw }
+func (d *replDeps) SetLastBtw(ctx *agentcore.AgentContext) { d.lastBtw = ctx }
+func (d *replDeps) LastBtwBase() int                       { return d.lastBtwBase }
+func (d *replDeps) SetLastBtwBase(n int)                   { d.lastBtwBase = n }

--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/builtinskills"
+	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
@@ -144,14 +145,14 @@ func runInteractive(opts interactiveOptions) error {
 	// mutate mid-session. streamRun reads it on each prompt so a model switch
 	// takes effect on the next turn; header is updated so the switch is persisted
 	// with the session.
-	live := &liveRunConfig{
-		model:         opts.model,
-		providerName:  opts.providerName,
-		provider:      opts.provider,
-		baseURL:       opts.baseURL,
-		protocol:      opts.protocol,
-		thinkingLevel: opts.thinkingLevel,
-		contextWindow: defaultContextWindow,
+	live := &cli.LiveConfig{
+		Model:         opts.model,
+		ProviderName:  opts.providerName,
+		Provider:      opts.provider,
+		BaseURL:       opts.baseURL,
+		Protocol:      opts.protocol,
+		ThinkingLevel: opts.thinkingLevel,
+		ContextWindow: cli.DefaultContextWindow,
 	}
 
 	// Project trust (US-018, #134): load the persisted trust store for the
@@ -222,7 +223,7 @@ func runInteractive(opts interactiveOptions) error {
 		persisted: len(history),
 		notifier:  plugin.NewEventNotifier(opts.plugins, os.Stderr),
 		goal:      agenttool.NewGoalState(),
-		telemetry: NewTelemetryHolder(),
+		telemetry: cli.NewTelemetryHolder(),
 	})
 }
 
@@ -334,7 +335,7 @@ func loadPromptPaths(paths []string) []runtime.SlashCommand {
 // reported on stderr. The skills slice is loaded once by setupAgentEnv (empty
 // under --no-skills), so no /skill-name commands are registered when it is
 // empty. mgr may be nil (no plugins loaded).
-func buildSlashRegistry(live *liveRunConfig, skills []*runtime.Skill, mgr *plugin.Manager, srcs promptTemplateSources) (*runtime.SlashRegistry, error) {
+func buildSlashRegistry(live *cli.LiveConfig, skills []*runtime.Skill, mgr *plugin.Manager, srcs promptTemplateSources) (*runtime.SlashRegistry, error) {
 	reg := runtime.NewSlashRegistry()
 	registerLiveCommands(reg, live)
 	registerPluginCommands(reg, mgr)
@@ -443,33 +444,6 @@ func loadSkills(noSkills bool) ([]*runtime.Skill, error) {
 	return runtime.LoadSkillsDir(dir)
 }
 
-// liveRunConfig is the mutable run configuration a control command may change
-// mid-session. The run closure reads it on every prompt, so a /model switch
-// takes effect on the next turn. It carries no lock: it is read and written
-// only on the REPL's single main goroutine (slash actions and the run are both
-// invoked synchronously from runREPL's loop, never concurrently).
-type liveRunConfig struct {
-	model        string
-	providerName string
-	provider     provider.Provider
-	baseURL      string
-	protocol     string
-	// thinkingLevel is the reasoning-effort level applied to each turn. It is
-	// seeded from the resolved config chain and read by streamRun on every prompt.
-	thinkingLevel agentcore.ThinkingLevel
-	// contextWindow is the model's total context-token budget, used to gate
-	// automatic compaction. When 0 the window is unknown and auto-compaction is
-	// disabled; the REPL seeds it with a conservative default so long sessions
-	// still compact rather than overflow.
-	contextWindow int
-}
-
-// defaultContextWindow is the fallback context-token budget used when a model's
-// true window is unknown. It is deliberately large so auto-compaction only fires
-// on genuinely long sessions (threshold = window - ReserveTokens), never on
-// ordinary short exchanges.
-const defaultContextWindow = 128000
-
 // registerPluginCommands installs each plugin-declared slash command
 // (Manager.Commands()) into the registry as a hybrid (Run) command. Invoking it
 // RPCs the owning plugin (Plugin.CallCommand), returns the plugin's
@@ -551,22 +525,22 @@ func formatHelpLine(c runtime.SlashCommand) string {
 // available commands. These are instance built-ins (AddBuiltin) because their
 // closures must capture live and the registry — state unreachable from an
 // init()-time global registration.
-func registerLiveCommands(reg *runtime.SlashRegistry, live *liveRunConfig) {
+func registerLiveCommands(reg *runtime.SlashRegistry, live *cli.LiveConfig) {
 	reg.AddBuiltin(runtime.SlashCommand{
 		Name:        "model",
 		Description: "view or switch the active model: /model [model-id] (see /models for presets)",
 		Action: func(args string) string {
 			id := strings.TrimSpace(args)
 			if id == "" {
-				return fmt.Sprintf("model: %s (provider: %s)\nrun /models to see presets, or /model <id> to switch", live.model, live.providerName)
+				return fmt.Sprintf("model: %s (provider: %s)\nrun /models to see presets, or /model <id> to switch", live.Model, live.ProviderName)
 			}
-			prov, providerName, err := resolveProvider(id, live.baseURL, live.protocol, "")
+			prov, providerName, err := resolveProvider(id, live.BaseURL, live.Protocol, "")
 			if err != nil {
 				return fmt.Sprintf("model: cannot switch to %q: %v", id, err)
 			}
-			live.model = id
-			live.providerName = providerName
-			live.provider = prov
+			live.Model = id
+			live.ProviderName = providerName
+			live.Provider = prov
 			return fmt.Sprintf("model switched to %s (provider: %s)", id, providerName)
 		},
 	})

--- a/cmd/pigo/plugin_commands_test.go
+++ b/cmd/pigo/plugin_commands_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	rt "github.com/smallnest/pigo/internal/runtime"
@@ -146,7 +147,7 @@ func TestBuildSlashRegistryRegistersPluginCommand(t *testing.T) {
 	mgr := loadTestManager(t)
 	defer mgr.Close()
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "faux", providerName: "faux"}, nil, mgr, promptTemplateSources{})
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "faux", ProviderName: "faux"}, nil, mgr, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -207,7 +208,7 @@ func TestREPLPluginCommandInjectsPrompt(t *testing.T) {
 	mgr := loadTestManager(t)
 	defer mgr.Close()
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "faux", providerName: "faux"}, nil, mgr, promptTemplateSources{})
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "faux", ProviderName: "faux"}, nil, mgr, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -217,7 +218,7 @@ func TestREPLPluginCommandInjectsPrompt(t *testing.T) {
 		t.Fatalf("new store: %v", err)
 	}
 	p := &replProvider{reply: "hi there"}
-	live := &liveRunConfig{model: "faux", providerName: "faux", provider: p}
+	live := &cli.LiveConfig{Model: "faux", ProviderName: "faux", Provider: p}
 	deps := replDeps{
 		store:    store,
 		header:   session.SessionHeader{ID: session.NewID(time.Now().UTC()), Model: "faux", Provider: "faux"},

--- a/cmd/pigo/prompts_cli_test.go
+++ b/cmd/pigo/prompts_cli_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/testutil"
 	"github.com/smallnest/pigo/internal/runtime"
 )
 
@@ -30,7 +32,7 @@ func TestBuildSlashRegistryLoadsCLIPrompts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
 		promptTemplateSources{cli: []string{filePath, dirPath}})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
@@ -55,14 +57,14 @@ func TestBuildSlashRegistryNoPromptTemplatesDisables(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PIGO_HOME", home)
 	// A global prompt that should NOT load under --no-prompt-templates.
-	writePrompt(t, home, "prompts", "review.md", "Review: $ARGUMENTS")
+	testutil.WritePrompt(t, home, "prompts", "review.md", "Review: $ARGUMENTS")
 	// A CLI path that should also be ignored under --no-prompt-templates.
 	cliFile := filepath.Join(home, "cli.md")
 	if err := os.WriteFile(cliFile, []byte("CLI: $ARGUMENTS"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
 		promptTemplateSources{disable: true, cli: []string{cliFile}})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
@@ -83,14 +85,14 @@ func TestBuildSlashRegistryGlobalOverridesCLI(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PIGO_HOME", home)
 	// global prompt (TierGlobal) under ~/.pigo/prompts.
-	writePrompt(t, home, "prompts", "dup.md", "FROM GLOBAL")
+	testutil.WritePrompt(t, home, "prompts", "dup.md", "FROM GLOBAL")
 	// CLI-tier file of the same name at the home root (not under prompts/).
 	cliFile := filepath.Join(home, "dup.md")
 	if err := os.WriteFile(cliFile, []byte("FROM CLI"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
 		promptTemplateSources{cli: []string{cliFile}})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)

--- a/cmd/pigo/prompts_config_test.go
+++ b/cmd/pigo/prompts_config_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/testutil"
 	"github.com/smallnest/pigo/internal/runtime"
 )
 
@@ -86,7 +88,7 @@ func TestBuildSlashRegistryLoadsSettingsPrompts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
 		promptTemplateSources{settings: []string{settingsDir}})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
@@ -104,7 +106,7 @@ func TestBuildSlashRegistryGlobalOverridesSettings(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PIGO_HOME", home)
 	// global prompt (TierGlobal) under ~/.pigo/prompts.
-	writePrompt(t, home, "prompts", "dup.md", "FROM GLOBAL")
+	testutil.WritePrompt(t, home, "prompts", "dup.md", "FROM GLOBAL")
 	// settings-tier prompt (file) of the same name, placed at the home root
 	// (not under prompts/, so the global loop does not also load it).
 	settingsFile := filepath.Join(home, "dup.md")
@@ -112,7 +114,7 @@ func TestBuildSlashRegistryGlobalOverridesSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
 		promptTemplateSources{settings: []string{settingsFile}})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)

--- a/cmd/pigo/prompts_dir_test.go
+++ b/cmd/pigo/prompts_dir_test.go
@@ -6,31 +6,20 @@ package main
 // the one in commands/ (last-write-wins within the global tier).
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
-)
 
-// writePrompt writes a prompt-template .md at home/<sub>/<name>.
-func writePrompt(t *testing.T, home, sub, name, body string) {
-	t.Helper()
-	d := filepath.Join(home, sub)
-	if err := os.MkdirAll(d, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(d, name), []byte(body), 0o644); err != nil {
-		t.Fatal(err)
-	}
-}
+	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/testutil"
+)
 
 // TestBuildSlashRegistryLoadsLegacyCommandsDir verifies the legacy
 // ~/.pigo/commands directory still loads templates (regression).
 func TestBuildSlashRegistryLoadsLegacyCommandsDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PIGO_HOME", home)
-	writePrompt(t, home, "commands", "legacy.md", "Legacy: $ARGUMENTS")
+	testutil.WritePrompt(t, home, "commands", "legacy.md", "Legacy: $ARGUMENTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil, promptTemplateSources{})
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -48,9 +37,9 @@ func TestBuildSlashRegistryLoadsLegacyCommandsDir(t *testing.T) {
 func TestBuildSlashRegistryLoadsPromptsDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PIGO_HOME", home)
-	writePrompt(t, home, "prompts", "review.md", "Review: $ARGUMENTS")
+	testutil.WritePrompt(t, home, "prompts", "review.md", "Review: $ARGUMENTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil, promptTemplateSources{})
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -69,10 +58,10 @@ func TestBuildSlashRegistryLoadsPromptsDir(t *testing.T) {
 func TestBuildSlashRegistryPromptsOverridesCommands(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PIGO_HOME", home)
-	writePrompt(t, home, "commands", "dup.md", "FROM COMMANDS")
-	writePrompt(t, home, "prompts", "dup.md", "FROM PROMPTS")
+	testutil.WritePrompt(t, home, "commands", "dup.md", "FROM COMMANDS")
+	testutil.WritePrompt(t, home, "prompts", "dup.md", "FROM PROMPTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil, promptTemplateSources{})
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -92,7 +81,7 @@ func TestBuildSlashRegistryPromptsOverridesCommands(t *testing.T) {
 // nor prompts/ present, buildSlashRegistry returns no error (built-ins only).
 func TestBuildSlashRegistryMissingDirsNoError(t *testing.T) {
 	t.Setenv("PIGO_HOME", t.TempDir())
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil, promptTemplateSources{})
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry with no prompt dirs: %v", err)
 	}

--- a/cmd/pigo/prompts_project_test.go
+++ b/cmd/pigo/prompts_project_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/testutil"
 	"github.com/smallnest/pigo/internal/runtime"
 )
 
@@ -17,9 +19,9 @@ func TestBuildSlashRegistryLoadsProjectPromptsTrusted(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PIGO_HOME", home) // empty global
 	cwdTmp := t.TempDir()
-	writePrompt(t, cwdTmp, filepath.Join(".pigo", "prompts"), "review.md", "Review: $ARGUMENTS")
+	testutil.WritePrompt(t, cwdTmp, filepath.Join(".pigo", "prompts"), "review.md", "Review: $ARGUMENTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
 		promptTemplateSources{
 			projectDir:     filepath.Join(cwdTmp, ".pigo", "prompts"),
 			projectTrusted: true,
@@ -42,9 +44,9 @@ func TestBuildSlashRegistryProjectPromptsUntrustedSkipped(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PIGO_HOME", home)
 	cwdTmp := t.TempDir()
-	writePrompt(t, cwdTmp, filepath.Join(".pigo", "prompts"), "review.md", "Review: $ARGUMENTS")
+	testutil.WritePrompt(t, cwdTmp, filepath.Join(".pigo", "prompts"), "review.md", "Review: $ARGUMENTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
 		promptTemplateSources{
 			projectDir:     filepath.Join(cwdTmp, ".pigo", "prompts"),
 			projectTrusted: false,
@@ -64,7 +66,7 @@ func TestBuildSlashRegistryProjectMissingDirNoError(t *testing.T) {
 	t.Setenv("PIGO_HOME", home)
 	cwdTmp := t.TempDir() // no .pigo/prompts created
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
 		promptTemplateSources{
 			projectDir:     filepath.Join(cwdTmp, ".pigo", "prompts"),
 			projectTrusted: true,
@@ -83,12 +85,12 @@ func TestBuildSlashRegistryProjectOverridesGlobal(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PIGO_HOME", home)
 	// global
-	writePrompt(t, home, "prompts", "dup.md", "FROM GLOBAL")
+	testutil.WritePrompt(t, home, "prompts", "dup.md", "FROM GLOBAL")
 	// project
 	cwdTmp := t.TempDir()
-	writePrompt(t, cwdTmp, filepath.Join(".pigo", "prompts"), "dup.md", "FROM PROJECT")
+	testutil.WritePrompt(t, cwdTmp, filepath.Join(".pigo", "prompts"), "dup.md", "FROM PROJECT")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
 		promptTemplateSources{
 			projectDir:     filepath.Join(cwdTmp, ".pigo", "prompts"),
 			projectTrusted: true,
@@ -120,9 +122,9 @@ func TestBuildSlashRegistryNoPromptTemplatesDisablesProject(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PIGO_HOME", home)
 	cwdTmp := t.TempDir()
-	writePrompt(t, cwdTmp, filepath.Join(".pigo", "prompts"), "review.md", "Review: $ARGUMENTS")
+	testutil.WritePrompt(t, cwdTmp, filepath.Join(".pigo", "prompts"), "review.md", "Review: $ARGUMENTS")
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil,
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
 		promptTemplateSources{
 			disable:        true,
 			projectDir:     filepath.Join(cwdTmp, ".pigo", "prompts"),

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/clipboard"
 	"github.com/smallnest/pigo/internal/compaction"
 	"github.com/smallnest/pigo/internal/plugin"
@@ -41,7 +42,7 @@ type replDeps struct {
 	store    *session.Store
 	header   session.SessionHeader
 	agentCtx *agentcore.AgentContext
-	live     *liveRunConfig
+	live     *cli.LiveConfig
 	reg      *agenttool.ToolRegistry
 	// reminders holds the per-turn system-reminder providers (US-002). It is nil
 	// when no todo tool is present; when set, streamRun wires it so ephemeral
@@ -110,7 +111,7 @@ type replDeps struct {
 	// the cumulative accumulator that sums metrics across all runs in the session.
 	// It is reset to "no telemetry yet" on any session switch (/fork, /clone,
 	// /import).
-	telemetry *TelemetryHolder
+	telemetry *cli.TelemetryHolder
 }
 
 // replScanBufInit is the initial size of the shared input reader. A REPL user
@@ -157,7 +158,7 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 		}
 	}
 	editor := newREPLLineEditor(in, deps.in, out, deps.slash, priorInputs)
-	editor.models = append([]string{deps.live.model}, editor.models...)
+	editor.models = append([]string{deps.live.Model}, editor.models...)
 
 	// A SIGINT during a run cancels only that run; the handler is installed for
 	// the whole REPL and targets whichever run is active via runCancel. runCancel
@@ -188,7 +189,7 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 
 	for {
 		fmt.Fprintln(out)
-		raw, err := editor.readLine(fmt.Sprintf("pigo(%s)> ", deps.live.model))
+		raw, err := editor.readLine(fmt.Sprintf("pigo(%s)> ", deps.live.Model))
 		if errors.Is(err, errLineInterrupted) {
 			continue
 		}
@@ -348,8 +349,8 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 		// Persist the turn as a branch descending from the active leaf, so a
 		// prior /tree leaf-switch produces a real sibling branch on disk rather
 		// than a truncated linear rewrite.
-		deps.header.Model = deps.live.model
-		deps.header.Provider = deps.live.providerName
+		deps.header.Model = deps.live.Model
+		deps.header.Provider = deps.live.ProviderName
 		persistTurn(out, &deps)
 	}
 }
@@ -396,12 +397,12 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 	})
 	cfg := runtime.RunConfig{
 		LoopConfig: runtime.LoopConfig{
-			Model:         deps.live.model,
-			Provider:      deps.live.providerName,
-			ThinkingLevel: deps.live.thinkingLevel,
-			Stream:        provider.StreamFnFromProvider(deps.live.provider),
+			Model:         deps.live.Model,
+			Provider:      deps.live.ProviderName,
+			ThinkingLevel: deps.live.ThinkingLevel,
+			Stream:        provider.StreamFnFromProvider(deps.live.Provider),
 			GetAPIKey:     deps.creds.GetAPIKey,
-			ContextWindow: deps.live.contextWindow,
+			ContextWindow: deps.live.ContextWindow,
 			Compaction:    compaction.DefaultCompactionSettings,
 		},
 		Batch: agenttool.BatchConfig{
@@ -763,8 +764,8 @@ func runSession(out io.Writer, deps *replDeps) {
 	fmt.Fprintf(out, "session:      %s\n", deps.header.ID)
 	fmt.Fprintf(out, "messages:     %d\n", len(msgs))
 	fmt.Fprintf(out, "tokens (est): %d\n", tokens)
-	model := deps.live.model
-	providerName := deps.live.providerName
+	model := deps.live.Model
+	providerName := deps.live.ProviderName
 	if model == "" {
 		model = deps.header.Model
 	}
@@ -788,15 +789,15 @@ func runManualCompact(out io.Writer, deps replDeps) {
 	settings := compaction.DefaultCompactionSettings
 	before := compaction.EstimateContextTokens(msgs).Tokens
 
-	stream := provider.StreamFnFromProvider(deps.live.provider)
-	model := provider.Model{Provider: deps.live.providerName, ID: deps.live.model, ContextWindow: deps.live.contextWindow}
+	stream := provider.StreamFnFromProvider(deps.live.Provider)
+	model := provider.Model{Provider: deps.live.ProviderName, ID: deps.live.Model, ContextWindow: deps.live.ContextWindow}
 
 	// Resolve the API key like a normal turn so summarization authenticates
 	// against auth-requiring providers (otherwise Compact fails with
 	// "missing API key" and /compact would always report a non-fatal failure).
 	scfg := provider.StreamConfig{}
 	if deps.creds != nil {
-		scfg.APIKey = deps.creds.GetAPIKey(context.Background(), deps.live.providerName)
+		scfg.APIKey = deps.creds.GetAPIKey(context.Background(), deps.live.ProviderName)
 	}
 	res, err := compaction.Compact(context.Background(), stream, model, msgs, settings, -1, nil, "", scfg)
 	if err != nil {

--- a/cmd/pigo/repl_test.go
+++ b/cmd/pigo/repl_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 	"github.com/smallnest/pigo/internal/session"
@@ -63,7 +64,7 @@ func newTestDeps(t *testing.T, p *replProvider) (replDeps, *session.Store) {
 	if err != nil {
 		t.Fatalf("new store: %v", err)
 	}
-	live := &liveRunConfig{model: "faux", providerName: "faux", provider: p}
+	live := &cli.LiveConfig{Model: "faux", ProviderName: "faux", Provider: p}
 	reg := runtime.NewSlashRegistry()
 	reg.AddBuiltin(runtime.SlashCommand{
 		Name:   "ping",
@@ -231,8 +232,8 @@ func TestREPLModelSwitchTakesEffect(t *testing.T) {
 	if p.calls != 0 {
 		t.Errorf("/model actions must not launch a run, got %d calls", p.calls)
 	}
-	if deps.live.model != "ollama/llama3.3" || deps.live.providerName != "ollama" {
-		t.Errorf("live not switched: model=%q provider=%q", deps.live.model, deps.live.providerName)
+	if deps.live.Model != "ollama/llama3.3" || deps.live.ProviderName != "ollama" {
+		t.Errorf("live not switched: model=%q provider=%q", deps.live.Model, deps.live.ProviderName)
 	}
 	s := out.String()
 	if !strings.Contains(s, "faux") {

--- a/cmd/pigo/skills_test.go
+++ b/cmd/pigo/skills_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/runtime"
 )
 
@@ -97,7 +98,7 @@ func TestBuildSlashRegistryIncludesSkills(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadSkills: %v", err)
 	}
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, skills, nil, promptTemplateSources{})
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, skills, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -122,7 +123,7 @@ func TestBuildSlashRegistryIncludesSkills(t *testing.T) {
 func TestBuildSlashRegistryNoSkills(t *testing.T) {
 	t.Setenv("PIGO_HOME", t.TempDir())
 
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, nil, nil, promptTemplateSources{})
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}
@@ -145,7 +146,7 @@ func TestLoadSkillsBootstrapsBuiltinSkills(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadSkills: %v", err)
 	}
-	reg, err := buildSlashRegistry(&liveRunConfig{model: "test", providerName: "test"}, skills, nil, promptTemplateSources{})
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, skills, nil, promptTemplateSources{})
 	if err != nil {
 		t.Fatalf("buildSlashRegistry: %v", err)
 	}

--- a/cmd/pigo/status.go
+++ b/cmd/pigo/status.go
@@ -35,12 +35,12 @@ func runStatus(out io.Writer, deps *replDeps) {
 
 // printRuntimeConfig prints the runtime model configuration section.
 func printRuntimeConfig(out io.Writer, color bool, deps *replDeps) {
-	model := deps.live.model
-	providerName := deps.live.providerName
-	baseURL := deps.live.baseURL
-	protocol := deps.live.protocol
-	thinkingLevel := string(deps.live.thinkingLevel)
-	contextWindow := deps.live.contextWindow
+	model := deps.live.Model
+	providerName := deps.live.ProviderName
+	baseURL := deps.live.BaseURL
+	protocol := deps.live.Protocol
+	thinkingLevel := string(deps.live.ThinkingLevel)
+	contextWindow := deps.live.ContextWindow
 
 	if model == "" {
 		model = deps.header.Model
@@ -75,7 +75,7 @@ func printRuntimeConfig(out io.Writer, color bool, deps *replDeps) {
 func printContextStatus(out io.Writer, color bool, deps *replDeps) {
 	msgs := deps.agentCtx.Messages
 	tokens := compaction.EstimateContextTokens(msgs).Tokens
-	contextWindow := deps.live.contextWindow
+	contextWindow := deps.live.ContextWindow
 
 	compactions := 0
 	for _, m := range msgs {
@@ -195,7 +195,7 @@ func namesSuffix(names []string) string {
 // presence (masked, never plaintext) and the provider endpoint URL.
 func printCredentialsStatus(out io.Writer, color bool, deps *replDeps) {
 	fmt.Fprintf(out, "%s\n", colorize(color, ansiBold, "credentials & connectivity:"))
-	provider := deps.live.providerName
+	provider := deps.live.ProviderName
 	if deps.creds != nil && deps.creds.HasCredential(context.Background(), provider) {
 		key := deps.creds.GetAPIKey(context.Background(), provider)
 		fmt.Fprintf(out, "  %s %s %s\n",
@@ -207,7 +207,7 @@ func printCredentialsStatus(out io.Writer, color bool, deps *replDeps) {
 			colorize(color, ansiDim, "api key:"),
 			colorize(color, ansiYellow, "not set"))
 	}
-	endpoint := deps.live.baseURL
+	endpoint := deps.live.BaseURL
 	if endpoint == "" {
 		endpoint = "(default)"
 	}

--- a/cmd/pigo/status_e2e_test.go
+++ b/cmd/pigo/status_e2e_test.go
@@ -12,6 +12,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/cli"
 )
 
 // TestStatusFreshSessionAllSections verifies /status renders every section on a
@@ -41,13 +42,13 @@ func TestStatusFreshSessionAllSections(t *testing.T) {
 }
 
 // TestStatusReflectsModelSwitch verifies /status reads the live run config each
-// invocation, so a /model switch (which mutates live.model/providerName) is
+// invocation, so a /model switch (which mutates live.Model/providerName) is
 // reflected on the next /status without a restart.
 func TestStatusReflectsModelSwitch(t *testing.T) {
 	p := &replProvider{reply: "unused"}
 	deps, _ := newTestDeps(t, p)
-	deps.live.model = "model-a"
-	deps.live.providerName = "prov-a"
+	deps.live.Model = "model-a"
+	deps.live.ProviderName = "prov-a"
 
 	var buf bytes.Buffer
 	runStatus(&buf, &deps)
@@ -56,8 +57,8 @@ func TestStatusReflectsModelSwitch(t *testing.T) {
 	}
 
 	// Simulate a /model switch mutating the live config.
-	deps.live.model = "model-b"
-	deps.live.providerName = "prov-b"
+	deps.live.Model = "model-b"
+	deps.live.ProviderName = "prov-b"
 	buf.Reset()
 	runStatus(&buf, &deps)
 	out := buf.String()
@@ -77,7 +78,7 @@ func TestStatusTelemetryResetOnFork(t *testing.T) {
 	p := &replProvider{reply: "unused"}
 	deps, _ := newTestDeps(t, p)
 
-	holder := NewTelemetryHolder()
+	holder := cli.NewTelemetryHolder()
 	holder.Fold(agentcore.TelemetryEvent{
 		Turns:              3,
 		TruncationCount:    1,
@@ -125,11 +126,11 @@ func TestStatusTiming(t *testing.T) {
 	p := &replProvider{reply: "unused"}
 	deps, _ := newTestDeps(t, p)
 	deps.cwd = "/tmp/e2e-timing"
-	deps.live.contextWindow = 128000
+	deps.live.ContextWindow = 128000
 	deps.agentCtx.Messages = append(deps.agentCtx.Messages,
 		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("hello")}},
 	)
-	holder := NewTelemetryHolder()
+	holder := cli.NewTelemetryHolder()
 	holder.Fold(agentcore.TelemetryEvent{
 		Turns:              5,
 		ContextUtilization: 0.5,
@@ -158,9 +159,9 @@ func TestStatusE2EViaREPL(t *testing.T) {
 	p := &replProvider{reply: "should not be called"}
 	deps, _ := newTestDeps(t, p)
 	deps.cwd = "/tmp/e2e-repl"
-	deps.live.model = "e2e-model"
-	deps.live.providerName = "e2e-prov"
-	deps.live.contextWindow = 128000
+	deps.live.Model = "e2e-model"
+	deps.live.ProviderName = "e2e-prov"
+	deps.live.ContextWindow = 128000
 
 	var out bytes.Buffer
 	in := strings.NewReader("/status\n/exit\n")

--- a/cmd/pigo/status_test.go
+++ b/cmd/pigo/status_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/compaction"
 	"github.com/smallnest/pigo/internal/runtime"
 )
@@ -16,11 +17,11 @@ func TestRunStatus(t *testing.T) {
 	deps, _ := newTestDeps(t, p)
 
 	// Customize the live config for clearer test expectations
-	deps.live.model = "test-model"
-	deps.live.providerName = "test-provider"
-	deps.live.baseURL = "https://api.example.com"
-	deps.live.protocol = "anthropic"
-	deps.live.contextWindow = 128000
+	deps.live.Model = "test-model"
+	deps.live.ProviderName = "test-provider"
+	deps.live.BaseURL = "https://api.example.com"
+	deps.live.Protocol = "anthropic"
+	deps.live.ContextWindow = 128000
 
 	// Add a message to the context
 	deps.agentCtx.Messages = append(deps.agentCtx.Messages,
@@ -73,7 +74,7 @@ func TestRunStatus(t *testing.T) {
 func TestRunStatusWithCompaction(t *testing.T) {
 	p := &replProvider{reply: "unused"}
 	deps, _ := newTestDeps(t, p)
-	deps.live.contextWindow = 128000
+	deps.live.ContextWindow = 128000
 
 	// Add messages including a compaction message
 	deps.agentCtx.Messages = append(deps.agentCtx.Messages,
@@ -94,7 +95,7 @@ func TestRunStatusWithCompaction(t *testing.T) {
 func TestRunStatusUnknownContextWindow(t *testing.T) {
 	p := &replProvider{reply: "unused"}
 	deps, _ := newTestDeps(t, p)
-	deps.live.contextWindow = 0 // unknown
+	deps.live.ContextWindow = 0 // unknown
 
 	var buf bytes.Buffer
 	runStatus(&buf, &deps)
@@ -202,8 +203,8 @@ func TestRunStatusEnvAndCreds(t *testing.T) {
 	p := &replProvider{reply: "unused"}
 	deps, _ := newTestDeps(t, p)
 	deps.cwd = "/tmp/test-cwd"
-	deps.live.providerName = "test-provider"
-	deps.live.baseURL = "https://api.example.com"
+	deps.live.ProviderName = "test-provider"
+	deps.live.BaseURL = "https://api.example.com"
 
 	// Register a skill and a plugin command so /status can count them separately.
 	deps.slash.AddSkill(runtime.SlashCommand{Name: "my-skill", Expand: func(string) string { return "" }})
@@ -272,9 +273,9 @@ func TestRunStatusTelemetryNoData(t *testing.T) {
 func TestRunStatusTelemetryPopulated(t *testing.T) {
 	p := &replProvider{reply: "unused"}
 	deps, _ := newTestDeps(t, p)
-	deps.live.contextWindow = 128000
+	deps.live.ContextWindow = 128000
 
-	holder := NewTelemetryHolder()
+	holder := cli.NewTelemetryHolder()
 	holder.Fold(agentcore.TelemetryEvent{
 		Turns:              3,
 		TruncationCount:    1,

--- a/docs/issue#0357.html
+++ b/docs/issue#0357.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0357</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/357">#357</a> &mdash; 建立 internal/cli 骨架与 Host 契约 &mdash; 2026-07-28</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Host 接口方法集从实际字段访问面反推</h3>
+      <p><strong>Ambiguity:</strong> Spec 未给出 Host 契约的确切方法列表。</p>
+      <p><strong>Choice:</strong> 扫描 goal/btw/status 对 replDeps 的字段访问（agentCtx、confirmMu、creds、cwd、goal、in、live、notifierHandle、reg、trust、curLeaf、header、lastBtw、lastBtwBase、persisted、reminders、slash、telemetry、store），据此定义 getter；对会被 mid-session 修改的字段（curLeaf、persisted、lastBtw、lastBtwBase）配对 setter。</p>
+      <p><strong>Rationale:</strong> 契约恰好覆盖真实使用面，避免过度暴露内部字段；后续 issue 迁移消费者时接口即为稳定 seam。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> replDeps 用指针接收者实现 Host</h3>
+      <p><strong>Ambiguity:</strong> 值接收者还是指针接收者未指定。</p>
+      <p><strong>Choice:</strong> 指针接收者 <code>*replDeps</code>，断言 <code>var _ cli.Host = (*replDeps)(nil)</code>。</p>
+      <p><strong>Rationale:</strong> setter 需要修改聚合体字段，值接收者无法生效。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> testutil 仅收纳可复用且不依赖 main 内部类型的 helper</h3>
+      <p><strong>Ambiguity:</strong> 哪些测试 helper 应迁到共享 testutil 包。</p>
+      <p><strong>Choice:</strong> 仅将 <code>writePrompt</code> → <code>testutil.WritePrompt</code> 上移。</p>
+      <p><strong>Rationale:</strong> 它不引用 package-main 类型，可被多个测试文件复用；构建 replDeps 的 helper 必须留在拥有该类型的包内。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> newTestDeps 未上移到 testutil</h3>
+      <p><strong>Spec:</strong> 隐含期望测试 helper 集中到共享 testutil。</p>
+      <p><strong>Implemented:</strong> <code>newTestDeps</code> 保留在 cmd/pigo 包内。</p>
+      <p><strong>Why:</strong> 它返回 package-main 的 <code>replDeps</code> 类型，无法从外部包导入构造；强行上移会造成循环导入或类型泄露。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> telemetry 测试重定位为 package cli</h3>
+      <p><strong>Spec:</strong> 未明确测试文件归属。</p>
+      <p><strong>Implemented:</strong> telemetry_state_test.go 随实现迁到 <code>internal/cli/telemetry_test.go</code>，改为 <code>package cli</code> 并去掉 cli. 前缀。</p>
+      <p><strong>Why:</strong> 测试须与被测类型同包，实现已移入 internal/cli。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 骨架阶段引入接口但暂不迁移消费者</h3>
+      <p><strong>Alternatives:</strong> (A) 本 PR 一并迁移 goal/btw/status；(B) 仅立骨架 + 编译期断言，消费者留待后续 issue。</p>
+      <p><strong>Pros/Cons:</strong> A 一次到位但 diff 巨大、审查困难、易夹带回归；B 每个 PR 聚焦、可增量验证，但接口暂时"无消费者"。</p>
+      <p><strong>Chosen:</strong> B。#357 定位即"骨架"，编译期断言保证 replDeps 持续符合契约，后续 #358+ 逐个迁移。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Header() 返回值拷贝是否需要可变访问</h3>
+      <p><strong>Assumption:</strong> 消费者只读 header。</p>
+      <p><strong>Verify:</strong> repl.go 目前直接在 replDeps 上写 <code>header.Model/Provider</code>；若后续 status/run 需经 Host 修改 header，需补 SetHeader 或返回指针。当前无消费者，暂不加。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 无 PRD/SPEC 文件</h3>
+      <p><strong>Assumption:</strong> 接口契约由代码实际使用面推导，正确性由 build/vet/test + golden 输出把关。</p>
+      <p><strong>Verify:</strong> tasks/prd-*.md 缺失（用户已授权 "Infer from code, proceed"）；如有正式 spec 请对照复核方法集完整性。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -1,0 +1,23 @@
+// Package cli is the contract and shared-type layer for pigo's command-line
+// surface. It holds the interfaces and value types that the cmd/pigo entry
+// point and the internal/cli/* subpackages share, without depending on any of
+// them, so those subpackages can be assembled and tested in isolation.
+//
+// Subpackage layout (assembled incrementally by the CLI restructure):
+//
+//	internal/cli            — Host/Editor contracts, LiveConfig, TelemetryHolder
+//	internal/cli/ui         — color, markdown, imageref helpers
+//	internal/cli/config     — config-file loading and overrides
+//	internal/cli/run        — run assembly and tool wiring
+//	internal/cli/headless   — headless session and subagent RPC drivers
+//	internal/cli/goal       — /goal state machine
+//	internal/cli/btw        — /btw side thread
+//	internal/cli/status     — /status command
+//	internal/cli/repl       — interactive REPL and line editor
+//	internal/cli/pkgcmd     — package-manager subcommands
+//	internal/cli/testutil   — cross-subpackage test helpers
+//
+// The Host interface (see host.go) is the seam that lets the /goal, /btw,
+// /status and REPL subpackages read and mutate the session's live state
+// without importing the concrete replDeps aggregate that assembles it.
+package cli

--- a/internal/cli/host.go
+++ b/internal/cli/host.go
@@ -1,0 +1,74 @@
+// This file defines the Host and Editor contracts that let the /goal, /btw,
+// /status and REPL subpackages read and mutate a session's live state without
+// importing the concrete replDeps aggregate that assembles it (see doc.go). The
+// aggregate implements Host by exposing accessor and mutator methods over its
+// fields; the line editor implements Editor.
+package cli
+
+import (
+	"bufio"
+	"sync"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/plugin"
+	"github.com/smallnest/pigo/internal/provider"
+	"github.com/smallnest/pigo/internal/runtime"
+	"github.com/smallnest/pigo/internal/session"
+	"github.com/smallnest/pigo/internal/trust"
+)
+
+// Host is the seam through which a control command (/goal, /btw, /status) and
+// the REPL loop access the collaborators and mutable state of a session. It is
+// satisfied by the replDeps aggregate assembled once per session.
+//
+// Getters return the shared collaborators (never copies, except where noted).
+// The setters cover the fields a command may advance mid-session: the active
+// session leaf, the persisted-message count, and the last /btw side thread.
+type Host interface {
+	// Session collaborators.
+	Store() *session.Store
+	Header() session.SessionHeader
+	AgentCtx() *agentcore.AgentContext
+	Live() *LiveConfig
+	Registry() *agenttool.ToolRegistry
+	Reminders() *runtime.ReminderRegistry
+	Slash() *runtime.SlashRegistry
+	Creds() *provider.CredentialStore
+	Notifier() *plugin.EventNotifier
+	// NotifierHandle returns the plugin event-delivery callback for this
+	// session's runs, or nil when no plugin subscribed.
+	NotifierHandle() func(agentcore.AgentEvent)
+	Trust() *trust.Manager
+	Goal() *agenttool.GoalState
+	Telemetry() *TelemetryHolder
+
+	// Cwd is the directory pigo was launched in; it does not change during a
+	// session and gates side-effect tools.
+	Cwd() string
+	// Input is the shared buffered stdin reader used by both the main loop and
+	// the tool-call confirmation prompt.
+	Input() *bufio.Reader
+	// ConfirmMu serializes tool-call confirmation prompts across concurrent
+	// side-effect tool calls.
+	ConfirmMu() *sync.Mutex
+
+	// Session-tree cursor and persistence bookkeeping.
+	CurLeaf() string
+	SetCurLeaf(id string)
+	Persisted() int
+	SetPersisted(n int)
+
+	// Last /btw side thread from this process and its background base index.
+	LastBtw() *agentcore.AgentContext
+	SetLastBtw(ctx *agentcore.AgentContext)
+	LastBtwBase() int
+	SetLastBtwBase(n int)
+}
+
+// Editor is the line-input contract a control command uses to read a follow-up
+// line from the user (e.g. the /btw follow-up loop). It is satisfied by the
+// REPL's line editor.
+type Editor interface {
+	ReadLine(prompt string) (string, error)
+}

--- a/internal/cli/liveconfig.go
+++ b/internal/cli/liveconfig.go
@@ -1,0 +1,38 @@
+// This file defines LiveConfig, the mutable run configuration a control command
+// may change mid-session. It was moved verbatim from cmd/pigo (the former
+// liveRunConfig) and exported so the run, repl, btw, status and goal
+// subpackages can read and mutate it through the Host contract. The run closure
+// reads it on every prompt, so a /model switch takes effect on the next turn.
+// It carries no lock: it is read and written only on the REPL's single main
+// goroutine (slash actions and the run are both invoked synchronously from the
+// REPL loop, never concurrently).
+package cli
+
+import (
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+// LiveConfig is the mutable run configuration a control command may change
+// mid-session.
+type LiveConfig struct {
+	Model        string
+	ProviderName string
+	Provider     provider.Provider
+	BaseURL      string
+	Protocol     string
+	// ThinkingLevel is the reasoning-effort level applied to each turn. It is
+	// seeded from the resolved config chain and read on every prompt.
+	ThinkingLevel agentcore.ThinkingLevel
+	// ContextWindow is the model's total context-token budget, used to gate
+	// automatic compaction. When 0 the window is unknown and auto-compaction is
+	// disabled; the REPL seeds it with a conservative default so long sessions
+	// still compact rather than overflow.
+	ContextWindow int
+}
+
+// DefaultContextWindow is the fallback context-token budget used when a model's
+// true window is unknown. It is deliberately large so auto-compaction only fires
+// on genuinely long sessions (threshold = window - ReserveTokens), never on
+// ordinary short exchanges.
+const DefaultContextWindow = 128000

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -1,7 +1,9 @@
 // This file implements the telemetry holder that retains per-run telemetry
 // events (US-001, #291) and folds them into a cumulative accumulator for the
-// /status command to display.
-package main
+// /status command to display. It was moved verbatim from cmd/pigo
+// (telemetry_state.go, US-013) into the shared cli layer so the status and repl
+// subpackages share one holder type.
+package cli
 
 import (
 	"github.com/smallnest/pigo/internal/agentcore"

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"testing"

--- a/internal/cli/testutil/prompts.go
+++ b/internal/cli/testutil/prompts.go
@@ -1,0 +1,24 @@
+// Package testutil holds test helpers shared across the internal/cli
+// subpackages. Only helpers reused by two or more test files and free of
+// cmd/pigo-internal types belong here; helpers that build the concrete replDeps
+// aggregate stay with the package that owns it.
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// WritePrompt writes a prompt-template .md at home/<sub>/<name> with the given
+// body, creating the directory as needed. It fails the test on any I/O error.
+func WritePrompt(t *testing.T, home, sub, name, body string) {
+	t.Helper()
+	d := filepath.Join(home, sub)
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/cli` package as the shared home for the CLI subpackage layout (doc.go describes it)
- Define the `Host` interface — the seam through which /goal, /btw, /status and the REPL reach session collaborators and mutable state — plus the `Editor` line-input contract
- Implement `Host` on `replDeps` via accessor/mutator methods with a compile-time conformance assertion (`var _ cli.Host = (*replDeps)(nil)`)
- Move `LiveConfig` (former `liveRunConfig`, now exported) and the telemetry holder verbatim into `internal/cli`
- Add `internal/cli/testutil.WritePrompt` for prompt-template test helpers reused across subpackages

Closes #357

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages pass
- [x] No stale references to `liveRunConfig` / unexported live fields