### PR TITLE
Move trust interactive glue into internal/trust (#359)

### DIFF
--- a/cmd/pigo/btw.go
+++ b/cmd/pigo/btw.go
@@ -34,6 +34,7 @@ import (
 	"github.com/smallnest/pigo/internal/compaction"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
+	"github.com/smallnest/pigo/internal/trust"
 )
 
 // btwHeader is the fixed banner shown when entering a side thread, so the user
@@ -213,7 +214,7 @@ func askSide(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, 
 		Batch: agenttool.BatchConfig{
 			ToolExecutorConfig: agenttool.ToolExecutorConfig{
 				Registry:       deps.reg,
-				BeforeToolCall: trustBeforeToolCall(deps.trust, deps.cwd, deps.in, out, deps.confirmMu),
+				BeforeToolCall: trust.BeforeToolCall(deps.trust, deps.cwd, deps.in, out, deps.confirmMu),
 			},
 		},
 		Reminders: deps.reminders,

--- a/cmd/pigo/goal.go
+++ b/cmd/pigo/goal.go
@@ -29,6 +29,7 @@ import (
 	"github.com/smallnest/pigo/internal/compaction"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
+	"github.com/smallnest/pigo/internal/trust"
 )
 
 // goalMaxAutomaticTurns caps how many autonomous continuations a single /goal
@@ -214,7 +215,7 @@ func runGoalLoop(setCancel func(context.CancelFunc), out io.Writer, deps *replDe
 		Batch: agenttool.BatchConfig{
 			ToolExecutorConfig: agenttool.ToolExecutorConfig{
 				Registry:       goalReg,
-				BeforeToolCall: trustBeforeToolCall(deps.trust, deps.cwd, deps.in, out, deps.confirmMu),
+				BeforeToolCall: trust.BeforeToolCall(deps.trust, deps.cwd, deps.in, out, deps.confirmMu),
 			},
 		},
 		Reminders: reminders,

--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -192,7 +192,7 @@ func runInteractive(opts interactiveOptions) error {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "pigo: slash-commands: %v\n", err)
 	}
-	registerTrustCommand(slash, mgr, cwd)
+	trust.RegisterCommand(slash, mgr, cwd)
 
 	// --approve grants the launch directory session trust up front (对标 pi 的
 	// --approve/-a), so the first-launch prompt is skipped and side-effect tools
@@ -200,7 +200,7 @@ func runInteractive(opts interactiveOptions) error {
 	// undecided directory, ask the user how much to trust it before any tool
 	// runs. This happens before replay so the trust question is the first thing
 	// the user sees, not their prior history.
-	establishTrust(os.Stdout, reader, mgr, cwd, opts.approve)
+	trust.EstablishTrust(os.Stdout, reader, mgr, cwd, opts.approve)
 
 	// Replay the resumed conversation so the user sees history before re-prompting.
 	if len(history) > 0 {

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -409,7 +409,7 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 		Batch: agenttool.BatchConfig{
 			ToolExecutorConfig: agenttool.ToolExecutorConfig{
 				Registry:       deps.reg,
-				BeforeToolCall: trustBeforeToolCall(deps.trust, deps.cwd, deps.in, out, deps.confirmMu),
+				BeforeToolCall: trust.BeforeToolCall(deps.trust, deps.cwd, deps.in, out, deps.confirmMu),
 			},
 		},
 		Reminders: deps.reminders,

--- a/docs/issue#0359.html
+++ b/docs/issue#0359.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0359</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/359">#359</a> &mdash; trust.go 并入 internal/trust &mdash; 2026-07-28</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> New file <code>interactive.go</code> instead of appending to <code>manager.go</code></h3>
+      <p><strong>Ambiguity:</strong> The spec said "全部符号迁入 internal/trust" without specifying file layout within the package.</p>
+      <p><strong>Choice:</strong> Put the REPL-facing pieces in a new <code>internal/trust/interactive.go</code> (and <code>interactive_test.go</code>), leaving the persistence store in <code>manager.go</code>.</p>
+      <p><strong>Rationale:</strong> Preserves the original separation the package doc already described (store vs. interactive glue), keeps each file focused, and avoids a 600-line manager.go. Same package, so exported names are shared regardless.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Exported only the six named symbols; kept helpers unexported</h3>
+      <p><strong>Ambiguity:</strong> The spec named <code>EstablishTrust/EnsureTrustPrompt/RegisterCommand/BeforeToolCall/ConfirmToolCall/SideEffectTools</code> but was silent on the internal helpers (<code>chooseScope</code>, <code>readMenuChoice</code>, <code>toolCallSummary</code>, <code>truncateForPrompt</code>).</p>
+      <p><strong>Choice:</strong> Exported exactly the six listed symbols; left the four helpers lowercase.</p>
+      <p><strong>Rationale:</strong> The helpers have no cross-package callers — exporting them would widen the API surface for no benefit. Tests for helpers live in-package so they access them directly.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None — implementation followed the spec as written. All six symbols exported with the exact names given, tests moved to <code>package trust</code>, old <code>cmd/pigo/trust.go</code> deleted, behavior byte-for-byte preserved.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> <code>SideEffectTools</code> exported as a mutable package var</h3>
+      <p><strong>Alternatives:</strong> (a) export the map as-is; (b) hide it behind an <code>IsSideEffect(name string) bool</code> accessor to prevent external mutation.</p>
+      <p><strong>Pros/cons:</strong> The accessor is safer against accidental mutation but adds indirection and diverges from the spec's explicit <code>SideEffectTools</code> name.</p>
+      <p><strong>Why chosen:</strong> The spec names <code>SideEffectTools</code> directly, and the only consumers are in-package (<code>BeforeToolCall</code>). A mutable-map risk is theoretical here; matched the spec verbatim.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> <code>internal/trust</code> now imports <code>internal/runtime</code> and <code>internal/agentcore</code></h3>
+      <p><strong>Alternatives:</strong> keep the interactive glue in <code>cmd/pigo</code> (status quo) vs. move it into <code>internal/trust</code> and accept the new deps.</p>
+      <p><strong>Pros/cons:</strong> The move consolidates all trust logic in one package (spec goal) but couples the previously dependency-free store package to runtime/agentcore.</p>
+      <p><strong>Why chosen:</strong> Verified no import cycle — <code>internal/runtime</code> and <code>internal/agentcore</code> do not import <code>internal/trust</code>, so the dependency is one-directional and <code>go build ./...</code> confirms it.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should the store stay dependency-free?</h3>
+      <p><strong>Assumption:</strong> It is acceptable for <code>internal/trust</code> to depend on <code>internal/runtime</code> and <code>internal/agentcore</code> now that the interactive glue lives here.</p>
+      <p><strong>Verify:</strong> If a future goal is to keep the persistence store importable from low-level packages without pulling in runtime, the interactive glue may need to move to a sub-package (e.g. <code>internal/trust/prompt</code>). Not needed today.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/trust/interactive.go
+++ b/internal/trust/interactive.go
@@ -1,18 +1,19 @@
 // This file holds the interactive pieces of project trust (US-018, #134). The
-// trust store itself lives in internal/trust; here we have the REPL-only parts:
+// trust store itself lives alongside in manager.go; here are the REPL-facing
+// parts:
 //
-//   - the first-run trust dialog (ensureTrustPrompt), shown when the cwd has no
+//   - the first-run trust dialog (EnsureTrustPrompt), shown when the cwd has no
 //     saved decision;
-//   - the /trust command (registerTrustCommand), which saves or reports the
+//   - the /trust command (RegisterCommand), which saves or reports the
 //     current project's decision;
-//   - the BeforeToolCall hook (trustBeforeToolCall) that asks before side-effect
+//   - the BeforeToolCall hook (BeforeToolCall) that asks before side-effect
 //     tools (bash/write/edit) run in an untrusted directory.
 //
 // All prompts share the REPL's single *bufio.Reader so input typed ahead is
 // never split between the main loop and a confirmation. Headless mode is
 // unaffected: trust is a REPL safety feature and headless is an explicit,
 // non-interactive invocation.
-package main
+package trust
 
 import (
 	"bufio"
@@ -27,39 +28,38 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/runtime"
-	"github.com/smallnest/pigo/internal/trust"
 )
 
-// sideEffectTools are the built-in tools with filesystem or process side
+// SideEffectTools are the built-in tools with filesystem or process side
 // effects that trust gates. Read-only tools (read/grep/find), in-memory tools
 // (todo), and network-read tools (webfetch) are never gated.
-var sideEffectTools = map[string]bool{
+var SideEffectTools = map[string]bool{
 	"bash":  true,
 	"write": true,
 	"edit":  true,
 }
 
-// establishTrust decides how the launch directory's trust is established before
+// EstablishTrust decides how the launch directory's trust is established before
 // the REPL runs. When approve is true (对标 pi 的 --approve/-a), it grants
 // session trust up front so the first-launch prompt is skipped and side-effect
 // tools run without per-call confirmation. Otherwise it defers to
-// ensureTrustPrompt, which asks only on the first launch in an undecided
+// EnsureTrustPrompt, which asks only on the first launch in an undecided
 // directory. mgr==nil disables trust entirely, so approve is a no-op.
-func establishTrust(out io.Writer, in *bufio.Reader, mgr *trust.Manager, cwd string, approve bool) {
+func EstablishTrust(out io.Writer, in *bufio.Reader, mgr *Manager, cwd string, approve bool) {
 	if approve {
 		if mgr != nil {
 			mgr.SetSessionTrust(cwd)
 		}
 		return
 	}
-	ensureTrustPrompt(out, in, mgr, cwd)
+	EnsureTrustPrompt(out, in, mgr, cwd)
 }
 
-// ensureTrustPrompt runs the first-run trust dialog when cwd has no saved
+// EnsureTrustPrompt runs the first-run trust dialog when cwd has no saved
 // decision (NearestTrustDecision reports Found=false). When a decision already
 // exists (trusted/untrusted/null) it is a no-op: the user already answered, so
 // pigo does not re-ask on every launch. mgr==nil disables trust entirely.
-func ensureTrustPrompt(out io.Writer, in *bufio.Reader, mgr *trust.Manager, cwd string) {
+func EnsureTrustPrompt(out io.Writer, in *bufio.Reader, mgr *Manager, cwd string) {
 	if mgr == nil {
 		return
 	}
@@ -78,14 +78,14 @@ func ensureTrustPrompt(out io.Writer, in *bufio.Reader, mgr *trust.Manager, cwd 
 	switch choice {
 	case 1:
 		target := chooseScope(out, in, cwd)
-		if err := mgr.SetDecision(target, trust.Trusted); err != nil {
+		if err := mgr.SetDecision(target, Trusted); err != nil {
 			fmt.Fprintf(out, "pigo: could not save trust decision: %v\n", err)
 			return
 		}
 		fmt.Fprintf(out, "Trusted %s (saved to %s).\n", cwd, target)
 	case 3:
 		target := chooseScope(out, in, cwd)
-		if err := mgr.SetDecision(target, trust.Untrusted); err != nil {
+		if err := mgr.SetDecision(target, Untrusted); err != nil {
 			fmt.Fprintf(out, "pigo: could not save trust decision: %v\n", err)
 			return
 		}
@@ -138,12 +138,12 @@ func readMenuChoice(out io.Writer, in *bufio.Reader, prompt string, max, def int
 	}
 }
 
-// registerTrustCommand installs the /trust action command, which saves or
+// RegisterCommand installs the /trust action command, which saves or
 // reports the current project's trust decision. It is an instance built-in
 // (AddBuiltin) because its closure captures the trust manager and cwd - state
 // out of reach of an init()-time global registration. mgr==nil is a no-op: the
 // command is not installed, so /trust reports unknown when trust is disabled.
-func registerTrustCommand(reg *runtime.SlashRegistry, mgr *trust.Manager, cwd string) {
+func RegisterCommand(reg *runtime.SlashRegistry, mgr *Manager, cwd string) {
 	if mgr == nil {
 		return
 	}
@@ -153,7 +153,7 @@ func registerTrustCommand(reg *runtime.SlashRegistry, mgr *trust.Manager, cwd st
 		Action: func(args string) string {
 			switch strings.TrimSpace(strings.ToLower(args)) {
 			case "", "on":
-				if err := mgr.SetDecision(cwd, trust.Trusted); err != nil {
+				if err := mgr.SetDecision(cwd, Trusted); err != nil {
 					return fmt.Sprintf("pigo: could not save trust: %v", err)
 				}
 				return fmt.Sprintf("trusted %s (saved)", cwd)
@@ -163,7 +163,7 @@ func registerTrustCommand(reg *runtime.SlashRegistry, mgr *trust.Manager, cwd st
 				// "always" granted earlier in the session would keep the dir
 				// trusted until restart and the message below would be a lie.
 				mgr.ClearSessionTrust(cwd)
-				if err := mgr.SetDecision(cwd, trust.Untrusted); err != nil {
+				if err := mgr.SetDecision(cwd, Untrusted); err != nil {
 					return fmt.Sprintf("pigo: could not save trust: %v", err)
 				}
 				return fmt.Sprintf("marked %s untrusted (saved); side-effect tools will ask", cwd)
@@ -183,7 +183,7 @@ func registerTrustCommand(reg *runtime.SlashRegistry, mgr *trust.Manager, cwd st
 	})
 }
 
-// trustBeforeToolCall builds the permission hook that gates side-effect tools
+// BeforeToolCall builds the permission hook that gates side-effect tools
 // (bash/write/edit) on the cwd's trust decision. In a trusted directory the
 // call is allowed (nil). Otherwise the user is prompted; "always" grants
 // session trust so subsequent side-effect calls skip the prompt. mgr==nil
@@ -207,12 +207,12 @@ func registerTrustCommand(reg *runtime.SlashRegistry, mgr *trust.Manager, cwd st
 // ToolExecutionStartEvent returns ctx.Err() and the tool never runs. A fix that
 // unblocks the read on signal would require injecting input on SIGINT, which is
 // out of scope for this change.
-func trustBeforeToolCall(mgr *trust.Manager, cwd string, in *bufio.Reader, out io.Writer, mu *sync.Mutex) agentcore.BeforeToolCallFunc {
+func BeforeToolCall(mgr *Manager, cwd string, in *bufio.Reader, out io.Writer, mu *sync.Mutex) agentcore.BeforeToolCallFunc {
 	if mgr == nil {
 		return nil
 	}
 	return func(ctx context.Context, call agentcore.AgentToolCall) *agentcore.BeforeToolCallDecision {
-		if !sideEffectTools[call.Name] {
+		if !SideEffectTools[call.Name] {
 			return nil
 		}
 		if mu != nil {
@@ -226,7 +226,7 @@ func trustBeforeToolCall(mgr *trust.Manager, cwd string, in *bufio.Reader, out i
 		if mgr.IsTrusted(cwd) {
 			return nil
 		}
-		allow, always := confirmToolCall(out, in, call)
+		allow, always := ConfirmToolCall(out, in, call)
 		if always {
 			mgr.SetSessionTrust(cwd)
 		}
@@ -241,11 +241,11 @@ func trustBeforeToolCall(mgr *trust.Manager, cwd string, in *bufio.Reader, out i
 	}
 }
 
-// confirmToolCall asks whether a side-effect tool call may run in an untrusted
+// ConfirmToolCall asks whether a side-effect tool call may run in an untrusted
 // directory. It returns (allow, always): allow runs the call this once; always
 // runs it AND grants session trust so subsequent side-effect calls skip the
 // prompt. Denial (no/empty/EOF) returns (false, false).
-func confirmToolCall(out io.Writer, in *bufio.Reader, call agentcore.AgentToolCall) (allow bool, always bool) {
+func ConfirmToolCall(out io.Writer, in *bufio.Reader, call agentcore.AgentToolCall) (allow bool, always bool) {
 	fmt.Fprintf(out, "\npigo wants to run %q in an untrusted directory.\n", call.Name)
 	if summary := toolCallSummary(call); summary != "" {
 		fmt.Fprintf(out, "  %s\n", summary)

--- a/internal/trust/interactive_test.go
+++ b/internal/trust/interactive_test.go
@@ -1,9 +1,9 @@
-package main
+package trust
 
-// Tests for the project-trust REPL integration (US-018, #134): the first-run
+// Tests for the project-trust interactive glue (US-018, #134): the first-run
 // prompt, the tool-call confirmation, the summary preview, and the
 // BeforeToolCall gating hook. The trust store itself is covered in
-// internal/trust; here we exercise the interactive glue.
+// manager_test.go; here we exercise the interactive pieces.
 
 import (
 	"bufio"
@@ -16,13 +16,12 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/runtime"
-	"github.com/smallnest/pigo/internal/trust"
 )
 
 // newTrustManagerAt builds a Manager backed by path.
-func newTrustManagerAt(t *testing.T, path string) *trust.Manager {
+func newTrustManagerAt(t *testing.T, path string) *Manager {
 	t.Helper()
-	m, err := trust.NewManager(path)
+	m, err := NewManager(path)
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
@@ -31,7 +30,7 @@ func newTrustManagerAt(t *testing.T, path string) *trust.Manager {
 
 // newTrustManager builds a Manager backed by a fresh temp file and returns the
 // manager plus its path (so a test can reload to verify persistence).
-func newTrustManager(t *testing.T) (*trust.Manager, string) {
+func newTrustManager(t *testing.T) (*Manager, string) {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "trust.json")
 	return newTrustManagerAt(t, path), path
@@ -46,9 +45,9 @@ func TestEnsureTrustPromptTrustedThisDir(t *testing.T) {
 	mgr, _ := newTrustManager(t)
 	cwd := t.TempDir()
 	var out bytes.Buffer
-	ensureTrustPrompt(&out, readerOf("1\n1\n"), mgr, cwd)
+	EnsureTrustPrompt(&out, readerOf("1\n1\n"), mgr, cwd)
 
-	if got := mgr.NearestTrustDecision(cwd); !got.Found || got.Decision != trust.Trusted || got.Path != cwd {
+	if got := mgr.NearestTrustDecision(cwd); !got.Found || got.Decision != Trusted || got.Path != cwd {
 		t.Errorf("after prompt, NearestTrustDecision(%q) = %+v, want Trusted/@cwd", cwd, got)
 	}
 	if !strings.Contains(out.String(), "First time in this directory") {
@@ -62,9 +61,9 @@ func TestEnsureTrustPromptRejectParent(t *testing.T) {
 	mgr, _ := newTrustManager(t)
 	cwd := t.TempDir()
 	parent := filepath.Dir(cwd)
-	ensureTrustPrompt(&bytes.Buffer{}, readerOf("3\n2\n"), mgr, cwd)
+	EnsureTrustPrompt(&bytes.Buffer{}, readerOf("3\n2\n"), mgr, cwd)
 
-	if got := mgr.NearestTrustDecision(cwd); !got.Found || got.Decision != trust.Untrusted || got.Path != parent {
+	if got := mgr.NearestTrustDecision(cwd); !got.Found || got.Decision != Untrusted || got.Path != parent {
 		t.Errorf("after reject-parent, NearestTrustDecision(%q) = %+v, want Untrusted/@parent", cwd, got)
 	}
 }
@@ -74,7 +73,7 @@ func TestEnsureTrustPromptRejectParent(t *testing.T) {
 func TestEnsureTrustPromptJustOnce(t *testing.T) {
 	mgr, path := newTrustManager(t)
 	cwd := t.TempDir()
-	ensureTrustPrompt(&bytes.Buffer{}, readerOf("2\n"), mgr, cwd)
+	EnsureTrustPrompt(&bytes.Buffer{}, readerOf("2\n"), mgr, cwd)
 
 	if !mgr.IsTrusted(cwd) {
 		t.Error("IsTrusted(cwd) = false after just-once, want true")
@@ -87,18 +86,18 @@ func TestEnsureTrustPromptJustOnce(t *testing.T) {
 }
 
 // TestEnsureTrustPromptSkipsWhenDecided verifies that when a decision already
-// exists, ensureTrustPrompt is a no-op: it writes nothing and reads nothing.
+// exists, EnsureTrustPrompt is a no-op: it writes nothing and reads nothing.
 func TestEnsureTrustPromptSkipsWhenDecided(t *testing.T) {
 	mgr, _ := newTrustManager(t)
 	cwd := t.TempDir()
-	if err := mgr.SetDecision(cwd, trust.Trusted); err != nil {
+	if err := mgr.SetDecision(cwd, Trusted); err != nil {
 		t.Fatalf("SetDecision: %v", err)
 	}
 	var out bytes.Buffer
 	// Empty reader: if the prompt tried to read it would block/EOF; it must not.
-	ensureTrustPrompt(&out, readerOf(""), mgr, cwd)
+	EnsureTrustPrompt(&out, readerOf(""), mgr, cwd)
 	if out.Len() != 0 {
-		t.Errorf("ensureTrustPrompt wrote %q when a decision existed, want no output", out.String())
+		t.Errorf("EnsureTrustPrompt wrote %q when a decision existed, want no output", out.String())
 	}
 }
 
@@ -110,13 +109,13 @@ func TestEstablishTrustApprove(t *testing.T) {
 	mgr, path := newTrustManager(t)
 	cwd := t.TempDir()
 	var out bytes.Buffer
-	establishTrust(&out, readerOf(""), mgr, cwd, true)
+	EstablishTrust(&out, readerOf(""), mgr, cwd, true)
 
 	if !mgr.IsTrusted(cwd) {
 		t.Error("IsTrusted(cwd) = false after --approve, want true")
 	}
 	if out.Len() != 0 {
-		t.Errorf("establishTrust wrote %q with --approve, want no prompt", out.String())
+		t.Errorf("EstablishTrust wrote %q with --approve, want no prompt", out.String())
 	}
 	m2 := newTrustManagerAt(t, path)
 	if m2.IsTrusted(cwd) {
@@ -124,7 +123,7 @@ func TestEstablishTrustApprove(t *testing.T) {
 	}
 }
 
-// TestEstablishTrustWithoutApprove verifies that without --approve, establishTrust
+// TestEstablishTrustWithoutApprove verifies that without --approve, EstablishTrust
 // defers to the first-launch prompt (which runs for an undecided directory).
 func TestEstablishTrustWithoutApprove(t *testing.T) {
 	mgr, _ := newTrustManager(t)
@@ -132,13 +131,13 @@ func TestEstablishTrustWithoutApprove(t *testing.T) {
 	var out bytes.Buffer
 	// "2\n" answers the just-once prompt; if the prompt did not run, this input
 	// would be left unread and IsTrusted would stay false.
-	establishTrust(&out, readerOf("2\n"), mgr, cwd, false)
+	EstablishTrust(&out, readerOf("2\n"), mgr, cwd, false)
 
 	if !strings.Contains(out.String(), "First time in this directory") {
 		t.Errorf("without --approve, expected the trust prompt; got %q", out.String())
 	}
 	if !mgr.IsTrusted(cwd) {
-		t.Error("IsTrusted(cwd) = false after just-once via establishTrust, want true")
+		t.Error("IsTrusted(cwd) = false after just-once via EstablishTrust, want true")
 	}
 }
 
@@ -160,9 +159,9 @@ func TestConfirmToolCall(t *testing.T) {
 	}
 	for _, c := range cases {
 		var out bytes.Buffer
-		allow, always := confirmToolCall(&out, readerOf(c.in), call)
+		allow, always := ConfirmToolCall(&out, readerOf(c.in), call)
 		if allow != c.allow || always != c.always {
-			t.Errorf("confirmToolCall(%q) = (%v,%v), want (%v,%v)", c.in, allow, always, c.allow, c.always)
+			t.Errorf("ConfirmToolCall(%q) = (%v,%v), want (%v,%v)", c.in, allow, always, c.allow, c.always)
 		}
 	}
 }
@@ -210,16 +209,16 @@ func TestTrustBeforeToolCallGating(t *testing.T) {
 	call := agentcore.AgentToolCall{Name: "write", Arguments: []byte(`{"path":"/tmp/x"}`)}
 
 	// nil manager -> no hook.
-	if h := trustBeforeToolCall(nil, cwd, nil, nil, mu); h != nil {
+	if h := BeforeToolCall(nil, cwd, nil, nil, mu); h != nil {
 		t.Error("nil manager should yield nil hook")
 	}
 
 	// Trusted dir: hook returns nil (allow) without prompting.
 	mgr, _ := newTrustManager(t)
-	if err := mgr.SetDecision(cwd, trust.Trusted); err != nil {
+	if err := mgr.SetDecision(cwd, Trusted); err != nil {
 		t.Fatalf("SetDecision: %v", err)
 	}
-	hook := trustBeforeToolCall(mgr, cwd, readerOf(""), &bytes.Buffer{}, mu)
+	hook := BeforeToolCall(mgr, cwd, readerOf(""), &bytes.Buffer{}, mu)
 	if dec := hook(context.Background(), call); dec != nil {
 		t.Errorf("trusted dir: hook returned %+v, want nil", dec)
 	}
@@ -227,7 +226,7 @@ func TestTrustBeforeToolCallGating(t *testing.T) {
 	// Untrusted dir, user denies: hook blocks with an error result.
 	mgr2, _ := newTrustManager(t)
 	var out bytes.Buffer
-	hook2 := trustBeforeToolCall(mgr2, cwd, readerOf("n\n"), &out, mu)
+	hook2 := BeforeToolCall(mgr2, cwd, readerOf("n\n"), &out, mu)
 	dec := hook2(context.Background(), call)
 	if dec == nil || !dec.Block {
 		t.Errorf("untrusted + deny: hook returned %+v, want a Block decision", dec)
@@ -238,7 +237,7 @@ func TestTrustBeforeToolCallGating(t *testing.T) {
 	mgr3, _ := newTrustManager(t)
 	var out3 bytes.Buffer
 	// Only one line of input ("a\n"); a second prompt would block on EOF.
-	hook3 := trustBeforeToolCall(mgr3, cwd, readerOf("a\n"), &out3, mu)
+	hook3 := BeforeToolCall(mgr3, cwd, readerOf("a\n"), &out3, mu)
 	if dec := hook3(context.Background(), call); dec != nil {
 		t.Errorf("untrusted + always: hook returned %+v, want nil (allow)", dec)
 	}
@@ -257,7 +256,7 @@ func TestTrustBeforeToolCallSkipsNonSideEffect(t *testing.T) {
 	cwd := t.TempDir()
 	mgr, _ := newTrustManager(t)
 	mu := &sync.Mutex{}
-	hook := trustBeforeToolCall(mgr, cwd, readerOf(""), &bytes.Buffer{}, mu)
+	hook := BeforeToolCall(mgr, cwd, readerOf(""), &bytes.Buffer{}, mu)
 	for _, name := range []string{"read", "grep", "find", "todo", "webfetch"} {
 		if dec := hook(context.Background(), agentcore.AgentToolCall{Name: name}); dec != nil {
 			t.Errorf("non-side-effect tool %q was gated (%+v), want nil", name, dec)
@@ -274,7 +273,7 @@ func TestRegisterTrustCommand(t *testing.T) {
 	cwd := t.TempDir()
 	mgr, _ := newTrustManager(t)
 	reg := runtime.NewSlashRegistry()
-	registerTrustCommand(reg, mgr, cwd)
+	RegisterCommand(reg, mgr, cwd)
 	cmd, ok := reg.Lookup("trust")
 	if !ok {
 		t.Fatal("/trust command not registered")
@@ -288,7 +287,7 @@ func TestRegisterTrustCommand(t *testing.T) {
 	if got := cmd.Action(""); !strings.Contains(got, "trusted") {
 		t.Errorf("on = %q, want 'trusted'", got)
 	}
-	if res := mgr.NearestTrustDecision(cwd); !res.Found || res.Decision != trust.Trusted {
+	if res := mgr.NearestTrustDecision(cwd); !res.Found || res.Decision != Trusted {
 		t.Errorf("after on, nearest = %+v, want Trusted/@cwd", res)
 	}
 
@@ -297,7 +296,7 @@ func TestRegisterTrustCommand(t *testing.T) {
 	cwd2 := t.TempDir()
 	mgr2, _ := newTrustManager(t)
 	reg2 := runtime.NewSlashRegistry()
-	registerTrustCommand(reg2, mgr2, cwd2)
+	RegisterCommand(reg2, mgr2, cwd2)
 	cmd2, _ := reg2.Lookup("trust")
 	cmd2.Action("once")
 	if !mgr2.IsTrusted(cwd2) {
@@ -309,7 +308,7 @@ func TestRegisterTrustCommand(t *testing.T) {
 	if mgr2.IsTrusted(cwd2) {
 		t.Error("after off, IsTrusted = true, want false (session grant must be revoked)")
 	}
-	if res := mgr2.NearestTrustDecision(cwd2); !res.Found || res.Decision != trust.Untrusted {
+	if res := mgr2.NearestTrustDecision(cwd2); !res.Found || res.Decision != Untrusted {
 		t.Errorf("after off, nearest = %+v, want Untrusted/@cwd", res)
 	}
 


### PR DESCRIPTION
## Summary
- Migrate all `cmd/pigo/trust.go` symbols into `internal/trust`, exported as `EstablishTrust`/`EnsureTrustPrompt`/`RegisterCommand`/`BeforeToolCall`/`ConfirmToolCall`/`SideEffectTools` (new file `internal/trust/interactive.go`)
- Relocate the tests to `package trust` (`internal/trust/interactive_test.go`)
- Update the four call sites in `btw.go`/`goal.go`/`interactive.go`/`repl.go`
- Delete the original `cmd/pigo/trust.go`; no behavior change; `internal/runtime` does not import `internal/trust` (no cycle)

Closes #359

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` pass