### PR TITLE
Migrate config loading to internal/cli/config (#360)

### DIFF
--- a/cmd/pigo/baseurl.go
+++ b/cmd/pigo/baseurl.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/smallnest/pigo/internal/cli/config"
 	"github.com/smallnest/pigo/internal/provider"
 )
 
@@ -33,24 +34,11 @@ func resolveBaseURL(spec provider.ProviderSpec, flagBaseURL string) string {
 		}
 	}
 	// 3. Generic <PROVIDER>_BASE_URL convention.
-	if envName := genericBaseURLEnvVar(spec.Name); envName != "" {
+	if envName := config.GenericBaseURLEnvVar(spec.Name); envName != "" {
 		if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
 			return v
 		}
 	}
 	// 4. Registry default.
 	return spec.DefaultBaseURL
-}
-
-// genericBaseURLEnvVar derives the generic base-url override env var name for a
-// provider: the provider name uppercased with hyphens rewritten to underscores,
-// suffixed with _BASE_URL. For example "zai-coding-cn" → "ZAI_CODING_CN_BASE_URL"
-// and "deepseek" → "DEEPSEEK_BASE_URL". An empty provider name yields "".
-func genericBaseURLEnvVar(providerName string) string {
-	n := strings.TrimSpace(providerName)
-	if n == "" {
-		return ""
-	}
-	n = strings.ReplaceAll(n, "-", "_")
-	return strings.ToUpper(n) + "_BASE_URL"
 }

--- a/cmd/pigo/baseurl_test.go
+++ b/cmd/pigo/baseurl_test.go
@@ -6,25 +6,6 @@ import (
 	"github.com/smallnest/pigo/internal/provider"
 )
 
-// TestGenericBaseURLEnvVar verifies the <PROVIDER>_BASE_URL name derivation,
-// especially the hyphen→underscore conversion and uppercasing.
-func TestGenericBaseURLEnvVar(t *testing.T) {
-	cases := []struct {
-		name string
-		want string
-	}{
-		{"deepseek", "DEEPSEEK_BASE_URL"},
-		{"zai-coding-cn", "ZAI_CODING_CN_BASE_URL"},
-		{"vercel-ai-gateway", "VERCEL_AI_GATEWAY_BASE_URL"},
-		{"", ""},
-	}
-	for _, c := range cases {
-		if got := genericBaseURLEnvVar(c.name); got != c.want {
-			t.Errorf("genericBaseURLEnvVar(%q) = %q, want %q", c.name, got, c.want)
-		}
-	}
-}
-
 // TestResolveBaseURLPrecedence exercises all four precedence levels for a
 // hyphenated provider (zai-coding-cn → ZAI_CODING_CN_BASE_URL), asserting that
 // each higher-precedence source shadows every lower one.

--- a/cmd/pigo/config_file.go
+++ b/cmd/pigo/config_file.go
@@ -1,81 +1,22 @@
-// This file implements the optional user config file at ~/.config/pigo/config.toml
-// (honoring $XDG_CONFIG_HOME when set). Values in the file replace pigo's built-in
-// defaults, but an explicit command-line flag always wins over the file:
+// This file binds a config.FileConfig onto the parsed CLI options. The file's
+// values replace pigo's built-in defaults, but an explicit command-line flag
+// always wins over the file:
 //
 //	command-line flag > config.toml > built-in default
 //
-// A missing file is not an error (defaults apply); a malformed file is surfaced
-// to the caller so it can warn rather than silently ignore user intent.
+// The file loading/decoding itself lives in internal/cli/config; this overlay
+// stays here because it mutates cliOptions, the run-assembly options struct.
 package main
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-
-	"github.com/BurntSushi/toml"
+	"github.com/smallnest/pigo/internal/cli/config"
 )
-
-// fileConfig is the on-disk shape of config.toml. Every field is optional; an
-// absent (zero-value) field leaves the corresponding default/flag untouched.
-// Keys are snake_case to read naturally in TOML.
-type fileConfig struct {
-	Model         string `toml:"model"`
-	BaseURL       string `toml:"base_url"`
-	APIKey        string `toml:"api_key"`
-	Protocol      string `toml:"protocol"`
-	Provider      string `toml:"provider"`
-	ThinkingLevel string `toml:"thinking_level"`
-	OutputFormat  string `toml:"output_format"`
-	NoTools       bool   `toml:"no_tools"`
-	NoSkills      bool   `toml:"no_skills"`
-	Approve       bool   `toml:"approve"`
-	SystemPrompt  string `toml:"system_prompt"`
-	// Prompts is the config.toml `prompts` array: paths (files or dirs) to load
-	// prompt templates from at the settings tier (对标 pi's settings prompts).
-	Prompts []string `toml:"prompts"`
-}
-
-// fileConfigPath returns the path to the user config file:
-// $XDG_CONFIG_HOME/pigo/config.toml, or ~/.config/pigo/config.toml by default.
-// It returns "" when neither can be resolved, so the caller treats the file as
-// absent.
-func fileConfigPath() string {
-	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
-		return filepath.Join(dir, "pigo", "config.toml")
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(home, ".config", "pigo", "config.toml")
-}
-
-// loadFileConfig reads and decodes config.toml. A missing file (or an empty
-// path) returns a zero config with no error; a malformed file is an error.
-func loadFileConfig(path string) (fileConfig, error) {
-	if path == "" {
-		return fileConfig{}, nil
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return fileConfig{}, nil
-		}
-		return fileConfig{}, fmt.Errorf("read config %s: %w", path, err)
-	}
-	var cfg fileConfig
-	if err := toml.Unmarshal(data, &cfg); err != nil {
-		return fileConfig{}, fmt.Errorf("parse config %s: %w", path, err)
-	}
-	return cfg, nil
-}
 
 // applyFileConfig overlays config.toml values onto opts, but only for flags the
 // user did not set on the command line (changed reports whether a flag name was
 // explicitly passed). This yields the precedence: CLI flag > config file >
 // default. Zero-valued config fields never override.
-func applyFileConfig(opts *cliOptions, cfg fileConfig, changed func(string) bool) {
+func applyFileConfig(opts *cliOptions, cfg config.FileConfig, changed func(string) bool) {
 	if cfg.Model != "" && !changed("model") {
 		opts.model = cfg.Model
 	}

--- a/cmd/pigo/config_file_test.go
+++ b/cmd/pigo/config_file_test.go
@@ -1,103 +1,10 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
-	"reflect"
 	"testing"
+
+	"github.com/smallnest/pigo/internal/cli/config"
 )
-
-func TestFileConfigPath_XDGOverride(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdgroot")
-	got := fileConfigPath()
-	want := filepath.Join("/tmp/xdgroot", "pigo", "config.toml")
-	if got != want {
-		t.Fatalf("fileConfigPath() = %q, want %q", got, want)
-	}
-}
-
-func TestFileConfigPath_DefaultHome(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", "")
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skip("no home dir")
-	}
-	got := fileConfigPath()
-	want := filepath.Join(home, ".config", "pigo", "config.toml")
-	if got != want {
-		t.Fatalf("fileConfigPath() = %q, want %q", got, want)
-	}
-}
-
-func TestLoadFileConfig_Missing(t *testing.T) {
-	cfg, err := loadFileConfig(filepath.Join(t.TempDir(), "does-not-exist.toml"))
-	if err != nil {
-		t.Fatalf("missing file should not error, got %v", err)
-	}
-	if !reflect.DeepEqual(cfg, fileConfig{}) {
-		t.Fatalf("missing file should yield zero config, got %+v", cfg)
-	}
-}
-
-func TestLoadFileConfig_EmptyPath(t *testing.T) {
-	cfg, err := loadFileConfig("")
-	if err != nil {
-		t.Fatalf("empty path should not error, got %v", err)
-	}
-	if !reflect.DeepEqual(cfg, fileConfig{}) {
-		t.Fatalf("empty path should yield zero config, got %+v", cfg)
-	}
-}
-
-func TestLoadFileConfig_Valid(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "config.toml")
-	content := `
-model = "claude-opus-4-8"
-base_url = "https://example.com"
-api_key = "sk-test"
-protocol = "anthropic"
-provider = "deepseek"
-thinking_level = "high"
-output_format = "stream-json"
-no_tools = true
-no_skills = true
-approve = true
-system_prompt = "be terse"
-`
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	cfg, err := loadFileConfig(path)
-	if err != nil {
-		t.Fatalf("valid file should parse, got %v", err)
-	}
-	want := fileConfig{
-		Model:         "claude-opus-4-8",
-		BaseURL:       "https://example.com",
-		APIKey:        "sk-test",
-		Protocol:      "anthropic",
-		Provider:      "deepseek",
-		ThinkingLevel: "high",
-		OutputFormat:  "stream-json",
-		NoTools:       true,
-		NoSkills:      true,
-		Approve:       true,
-		SystemPrompt:  "be terse",
-	}
-	if !reflect.DeepEqual(cfg, want) {
-		t.Fatalf("parsed config = %+v, want %+v", cfg, want)
-	}
-}
-
-func TestLoadFileConfig_Malformed(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "bad.toml")
-	if err := os.WriteFile(path, []byte("model = = ="), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := loadFileConfig(path); err == nil {
-		t.Fatal("malformed file should error")
-	}
-}
 
 // changedSet turns a set of flag names into a lookup func for applyFileConfig.
 func changedSet(names ...string) func(string) bool {
@@ -110,7 +17,7 @@ func changedSet(names ...string) func(string) bool {
 
 func TestApplyFileConfig_FillsUnsetFlags(t *testing.T) {
 	opts := cliOptions{model: "openrouter/free", outputFmt: "text"}
-	cfg := fileConfig{
+	cfg := config.FileConfig{
 		Model:         "claude-opus-4-8",
 		BaseURL:       "https://example.com",
 		APIKey:        "sk-test",
@@ -156,7 +63,7 @@ func TestApplyFileConfig_FillsUnsetFlags(t *testing.T) {
 
 func TestApplyFileConfig_CLIWins(t *testing.T) {
 	opts := cliOptions{model: "cli-model", outputFmt: "text"}
-	cfg := fileConfig{Model: "config-model", OutputFormat: "stream-json"}
+	cfg := config.FileConfig{Model: "config-model", OutputFormat: "stream-json"}
 	// --model was set on the command line; --output-format was not.
 	applyFileConfig(&opts, cfg, changedSet("model"))
 
@@ -170,7 +77,7 @@ func TestApplyFileConfig_CLIWins(t *testing.T) {
 
 func TestApplyFileConfig_EmptyConfigNoChange(t *testing.T) {
 	opts := cliOptions{model: "openrouter/free", outputFmt: "text"}
-	applyFileConfig(&opts, fileConfig{}, changedSet())
+	applyFileConfig(&opts, config.FileConfig{}, changedSet())
 	if opts.model != "openrouter/free" || opts.outputFmt != "text" {
 		t.Fatalf("empty config should not change opts, got %+v", opts)
 	}

--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/cli/config"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 )
@@ -78,7 +79,7 @@ func main() {
 	// Overlay ~/.config/pigo/config.toml: file values replace built-in defaults,
 	// but any flag the user set on the command line still wins (CLI > file >
 	// default). A malformed file warns but does not abort — defaults apply.
-	if cfg, err := loadFileConfig(fileConfigPath()); err != nil {
+	if cfg, err := config.LoadFileConfig(config.FileConfigPath()); err != nil {
 		fmt.Fprintf(os.Stderr, "pigo: %v\n", err)
 	} else {
 		applyFileConfig(&opts, cfg, flag.CommandLine.Changed)

--- a/cmd/pigo/prompts_config_test.go
+++ b/cmd/pigo/prompts_config_test.go
@@ -12,28 +12,14 @@ import (
 	"testing"
 
 	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/config"
 	"github.com/smallnest/pigo/internal/cli/testutil"
 	"github.com/smallnest/pigo/internal/runtime"
 )
 
-func TestLoadFileConfigPromptsArray(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "config.toml")
-	content := "prompts = [\"./my-prompts\", \"/abs/x.md\"]\n"
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	cfg, err := loadFileConfig(path)
-	if err != nil {
-		t.Fatalf("loadFileConfig: %v", err)
-	}
-	if len(cfg.Prompts) != 2 || cfg.Prompts[0] != "./my-prompts" || cfg.Prompts[1] != "/abs/x.md" {
-		t.Errorf("Prompts = %v, want [./my-prompts /abs/x.md]", cfg.Prompts)
-	}
-}
-
 func TestApplyFileConfigPrompts(t *testing.T) {
 	var opts cliOptions
-	cfg := fileConfig{Prompts: []string{"./my-prompts", "/abs/x.md"}}
+	cfg := config.FileConfig{Prompts: []string{"./my-prompts", "/abs/x.md"}}
 	applyFileConfig(&opts, cfg, func(string) bool { return false })
 	if len(opts.configPrompts) != 2 || opts.configPrompts[0] != "./my-prompts" || opts.configPrompts[1] != "/abs/x.md" {
 		t.Errorf("opts.configPrompts = %v, want [./my-prompts /abs/x.md]", opts.configPrompts)

--- a/docs/issue#0360.html
+++ b/docs/issue#0360.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0360</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/360">#360</a> &mdash; internal/cli/config：配置文件加载/覆盖与 baseurl 非 provider 部分 &mdash; 2026-07-28</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span>"baseurl 非 provider 部分" 界定为纯名称派生函数</h3>
+      <p><strong>Ambiguity:</strong> 验收要求迁出 baseurl 的"非 provider 部分"，但 <code>resolveBaseURL</code> 与 provider 注册表耦合，边界不明确。</p>
+      <p><strong>Choice:</strong> 仅将私有辅助 <code>genericBaseURLEnvVar</code> 提升为 <code>config.GenericBaseURLEnvVar</code>（hyphen→underscore、大写、加 <code>_BASE_URL</code> 后缀），<code>resolveBaseURL</code> 留在 cmd/pigo 调用它。</p>
+      <p><strong>Rationale:</strong> 该函数是纯字符串派生，不依赖 provider 注册表，正是"非 provider 部分"；<code>resolveBaseURL</code> 依赖 <code>ProviderSpec</code>，按验收明确留待 #361。config 包不 import provider，无环风险。</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span>config 包保持零 cliOptions 依赖</h3>
+      <p><strong>Ambiguity:</strong> 验收列出 <code>loadFileConfig/applyFileConfig/fileConfigPath</code> 一并"导出化"，未说明是否都进 config 包。</p>
+      <p><strong>Choice:</strong> config 包只承载与 cliOptions 无关的加载/派生逻辑（<code>FileConfig</code>、<code>FileConfigPath</code>、<code>LoadFileConfig</code>、<code>GenericBaseURLEnvVar</code>）；overlay 绑定 <code>applyFileConfig</code> 留在 cmd/pigo。</p>
+      <p><strong>Rationale:</strong> config 包保持"只加载与解码、不涉及运行装配"的单一职责，与包 doc 注释一致，也避免过早牵动 cliOptions。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span><code>applyFileConfig</code> 未迁入 config 包</h3>
+      <p><strong>Spec:</strong> "<code>loadFileConfig/applyFileConfig/fileConfigPath</code> 等导出化，cmd/pigo 改引用新包"，字面读法暗示三者都进 config 包。</p>
+      <p><strong>Implemented:</strong> <code>applyFileConfig</code> 保留在 cmd/pigo，签名改为消费 <code>config.FileConfig</code>；其余三个迁入 config 包并导出。</p>
+      <p><strong>Why:</strong> <code>applyFileConfig</code> 直接读写 <code>cliOptions</code>（package main 的未导出结构体，属 #362 运行装配层）。若强行迁入会迫使 cliOptions 提前迁移或引入额外抽象，破坏 PR 聚焦度。行为（CLI > file > default 优先级）完全不变。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span>拆分加载逻辑 vs 一次性搬运整个配置层</h3>
+      <p><strong>Alternatives:</strong> (A) 只搬纯加载/派生部分，overlay 留在原地；(B) 连同 cliOptions 一起迁入 config 包一步到位。</p>
+      <p><strong>Pros/Cons:</strong> B 让配置层"完整"但会吞掉 #362 的范围、引入 config→run 的耦合，且本 issue 依赖链只到 #357；A 保持每个 issue 边界清晰、可独立 review 与回滚。</p>
+      <p><strong>Winner:</strong> A —— 与 issue 拆分粒度一致，overlay 待 cliOptions 在 #362 落位后再自然归位。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span><code>applyFileConfig</code> 的最终归属</h3>
+      <p><strong>Assumption:</strong> overlay 绑定会随 #362（cliOptions 迁入 internal/cli/run）一起搬走，而非留在 cmd/pigo。</p>
+      <p><strong>Verify:</strong> 处理 #362 时确认 <code>applyFileConfig</code> 迁入 run 包并消费 <code>config.FileConfig</code>，届时 cmd/pigo 不再持有任何配置 overlay 逻辑。</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span>无独立 SPEC/PRD 文件</h3>
+      <p><strong>Assumption:</strong> 需求以 GitHub Issue #360 正文的验收条件为准，无 <code>tasks/prd-*.md</code>。接口契约由现有代码用法推导，正确性由 build/vet/test + 既有测试断言把关。</p>
+      <p><strong>Verify:</strong> 若后续存在正式 PRD，复核 config 包公开 API 命名与其一致。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -1,0 +1,97 @@
+// Package config implements pigo's optional user config file at
+// ~/.config/pigo/config.toml (honoring $XDG_CONFIG_HOME when set) plus the
+// provider-agnostic base-url env-var name derivation. Values in the file
+// replace pigo's built-in defaults, but an explicit command-line flag always
+// wins over the file:
+//
+//	command-line flag > config.toml > built-in default
+//
+// A missing file is not an error (defaults apply); a malformed file is surfaced
+// to the caller so it can warn rather than silently ignore user intent.
+//
+// The package is intentionally free of any cliOptions/run-assembly concern: it
+// only loads and decodes the file and derives env-var names. Overlaying a
+// FileConfig onto the parsed CLI options lives in cmd/pigo, alongside the
+// options struct it mutates.
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// FileConfig is the on-disk shape of config.toml. Every field is optional; an
+// absent (zero-value) field leaves the corresponding default/flag untouched.
+// Keys are snake_case to read naturally in TOML.
+type FileConfig struct {
+	Model         string `toml:"model"`
+	BaseURL       string `toml:"base_url"`
+	APIKey        string `toml:"api_key"`
+	Protocol      string `toml:"protocol"`
+	Provider      string `toml:"provider"`
+	ThinkingLevel string `toml:"thinking_level"`
+	OutputFormat  string `toml:"output_format"`
+	NoTools       bool   `toml:"no_tools"`
+	NoSkills      bool   `toml:"no_skills"`
+	Approve       bool   `toml:"approve"`
+	SystemPrompt  string `toml:"system_prompt"`
+	// Prompts is the config.toml `prompts` array: paths (files or dirs) to load
+	// prompt templates from at the settings tier (对标 pi's settings prompts).
+	Prompts []string `toml:"prompts"`
+}
+
+// FileConfigPath returns the path to the user config file:
+// $XDG_CONFIG_HOME/pigo/config.toml, or ~/.config/pigo/config.toml by default.
+// It returns "" when neither can be resolved, so the caller treats the file as
+// absent.
+func FileConfigPath() string {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return filepath.Join(dir, "pigo", "config.toml")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "pigo", "config.toml")
+}
+
+// LoadFileConfig reads and decodes config.toml. A missing file (or an empty
+// path) returns a zero config with no error; a malformed file is an error.
+func LoadFileConfig(path string) (FileConfig, error) {
+	if path == "" {
+		return FileConfig{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return FileConfig{}, nil
+		}
+		return FileConfig{}, fmt.Errorf("read config %s: %w", path, err)
+	}
+	var cfg FileConfig
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return FileConfig{}, fmt.Errorf("parse config %s: %w", path, err)
+	}
+	return cfg, nil
+}
+
+// GenericBaseURLEnvVar derives the generic base-url override env var name for a
+// provider: the provider name uppercased with hyphens rewritten to underscores,
+// suffixed with _BASE_URL. For example "zai-coding-cn" → "ZAI_CODING_CN_BASE_URL"
+// and "deepseek" → "DEEPSEEK_BASE_URL". An empty provider name yields "".
+//
+// It lives here (not with resolveBaseURL) because it is a pure name derivation
+// with no dependency on the provider registry — the provider-agnostic part of
+// base-url resolution. resolveBaseURL itself stays in cmd/pigo pending #361.
+func GenericBaseURLEnvVar(providerName string) string {
+	n := strings.TrimSpace(providerName)
+	if n == "" {
+		return ""
+	}
+	n = strings.ReplaceAll(n, "-", "_")
+	return strings.ToUpper(n) + "_BASE_URL"
+}

--- a/internal/cli/config/config_test.go
+++ b/internal/cli/config/config_test.go
@@ -1,0 +1,134 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestFileConfigPath_XDGOverride(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdgroot")
+	got := FileConfigPath()
+	want := filepath.Join("/tmp/xdgroot", "pigo", "config.toml")
+	if got != want {
+		t.Fatalf("FileConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestFileConfigPath_DefaultHome(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	got := FileConfigPath()
+	want := filepath.Join(home, ".config", "pigo", "config.toml")
+	if got != want {
+		t.Fatalf("FileConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestLoadFileConfig_Missing(t *testing.T) {
+	cfg, err := LoadFileConfig(filepath.Join(t.TempDir(), "does-not-exist.toml"))
+	if err != nil {
+		t.Fatalf("missing file should not error, got %v", err)
+	}
+	if !reflect.DeepEqual(cfg, FileConfig{}) {
+		t.Fatalf("missing file should yield zero config, got %+v", cfg)
+	}
+}
+
+func TestLoadFileConfig_EmptyPath(t *testing.T) {
+	cfg, err := LoadFileConfig("")
+	if err != nil {
+		t.Fatalf("empty path should not error, got %v", err)
+	}
+	if !reflect.DeepEqual(cfg, FileConfig{}) {
+		t.Fatalf("empty path should yield zero config, got %+v", cfg)
+	}
+}
+
+func TestLoadFileConfig_Valid(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := `
+model = "claude-opus-4-8"
+base_url = "https://example.com"
+api_key = "sk-test"
+protocol = "anthropic"
+provider = "deepseek"
+thinking_level = "high"
+output_format = "stream-json"
+no_tools = true
+no_skills = true
+approve = true
+system_prompt = "be terse"
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("valid file should parse, got %v", err)
+	}
+	want := FileConfig{
+		Model:         "claude-opus-4-8",
+		BaseURL:       "https://example.com",
+		APIKey:        "sk-test",
+		Protocol:      "anthropic",
+		Provider:      "deepseek",
+		ThinkingLevel: "high",
+		OutputFormat:  "stream-json",
+		NoTools:       true,
+		NoSkills:      true,
+		Approve:       true,
+		SystemPrompt:  "be terse",
+	}
+	if !reflect.DeepEqual(cfg, want) {
+		t.Fatalf("parsed config = %+v, want %+v", cfg, want)
+	}
+}
+
+func TestLoadFileConfig_Malformed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.toml")
+	if err := os.WriteFile(path, []byte("model = = ="), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadFileConfig(path); err == nil {
+		t.Fatal("malformed file should error")
+	}
+}
+
+func TestLoadFileConfigPromptsArray(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := "prompts = [\"./my-prompts\", \"/abs/x.md\"]\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+	if len(cfg.Prompts) != 2 || cfg.Prompts[0] != "./my-prompts" || cfg.Prompts[1] != "/abs/x.md" {
+		t.Errorf("Prompts = %v, want [./my-prompts /abs/x.md]", cfg.Prompts)
+	}
+}
+
+// TestGenericBaseURLEnvVar verifies the <PROVIDER>_BASE_URL name derivation,
+// especially the hyphen→underscore conversion and uppercasing.
+func TestGenericBaseURLEnvVar(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"deepseek", "DEEPSEEK_BASE_URL"},
+		{"zai-coding-cn", "ZAI_CODING_CN_BASE_URL"},
+		{"vercel-ai-gateway", "VERCEL_AI_GATEWAY_BASE_URL"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := GenericBaseURLEnvVar(c.name); got != c.want {
+			t.Errorf("GenericBaseURLEnvVar(%q) = %q, want %q", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Move `FileConfig`, `FileConfigPath`, `LoadFileConfig` and the provider-agnostic `GenericBaseURLEnvVar` name derivation into `internal/cli/config` (exported); tests migrated to `package config`.
- `cmd/pigo` now calls `config.LoadFileConfig(config.FileConfigPath())`; `baseurl.go` calls `config.GenericBaseURLEnvVar`.
- `applyFileConfig` stays in `cmd/pigo` (now consumes `config.FileConfig`) because it mutates `cliOptions` — deferred to #362. `resolveBaseURL` stays pending #361.
- CLI > file > default override precedence unchanged.

Closes #360

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/pigo/ ./internal/cli/config/`