### PR TITLE
feat(cli): migrate run-assembly layer to internal/cli/run

### DIFF
--- a/cmd/pigo/btw_config.go
+++ b/cmd/pigo/btw_config.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/provider"
 )
@@ -47,7 +48,7 @@ type btwRunSettings struct {
 // btwConfigPath returns the path to the /btw override config, or "" when the
 // config directory cannot be resolved (then the config is treated as absent).
 func btwConfigPath() string {
-	dir := configDir()
+	dir := run.ConfigDir()
 	if dir == "" {
 		return ""
 	}

--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
-	"github.com/smallnest/pigo/internal/builtinskills"
 	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
@@ -94,7 +94,7 @@ type interactiveOptions struct {
 func runInteractive(opts interactiveOptions) error {
 	creds := provider.NewCredentialStore(nil)
 	creds.SetOverride(opts.providerName, opts.apiKey)
-	reg := toolRegistry(opts.tools)
+	reg := run.ToolRegistry(opts.tools)
 
 	store, err := sessionStore()
 	if err != nil {
@@ -213,7 +213,7 @@ func runInteractive(opts interactiveOptions) error {
 		agentCtx:  agentCtx,
 		live:      live,
 		reg:       reg,
-		reminders: todoReminders(opts.tools),
+		reminders: run.TodoReminders(opts.tools),
 		slash:     slash,
 		creds:     creds,
 		trust:     mgr,
@@ -394,45 +394,6 @@ func buildSlashRegistry(live *cli.LiveConfig, skills []*runtime.Skill, mgr *plug
 		fmt.Fprintf(os.Stderr, "pigo: commands shadowed by higher-priority source (rename to use): %v\n", parts)
 	}
 	return reg, nil
-}
-
-// skillsDir returns the directory skills are loaded from. It defaults to
-// ~/.agents/skills and can be overridden with PIGO_SKILLS_DIR (useful for tests
-// and non-standard layouts). An empty string is returned when the home
-// directory cannot be resolved and no override is set.
-func skillsDir() string {
-	if dir := os.Getenv("PIGO_SKILLS_DIR"); dir != "" {
-		return dir
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(home, ".agents", "skills")
-}
-
-// loadSkills discovers skills from skillsDir() once, for both prompt injection
-// (setupAgentEnv) and /skill-name registration (buildSlashRegistry), so the
-// directory is read a single time. It first bootstraps the built-in skill
-// collections into the skills dir (best-effort, first-run) so freshly installed
-// skills are picked up this launch, then loads every skill. --no-skills disables
-// discovery entirely: no bootstrap, no load, nil result. A partial parse error
-// is returned alongside the skills that DID load, so one malformed file cannot
-// hide the rest; callers treat it as a non-fatal warning.
-func loadSkills(noSkills bool) ([]*runtime.Skill, error) {
-	if noSkills {
-		return nil, nil
-	}
-	var blog io.Writer
-	if os.Getenv("PIGO_DEBUG") != "" {
-		blog = os.Stderr
-	}
-	builtinskills.Bootstrap(configDir(), skillsDir(), blog)
-	dir := skillsDir()
-	if dir == "" {
-		return nil, nil
-	}
-	return runtime.LoadSkillsDir(dir)
 }
 
 // registerPluginCommands installs each plugin-declared slash command

--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -18,11 +18,8 @@ import (
 
 	flag "github.com/spf13/pflag"
 
-	"github.com/smallnest/pigo/internal/agentcore"
-	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/cli/config"
-	"github.com/smallnest/pigo/internal/runtime"
 )
 
 // Build metadata, injected at release time via -ldflags by goreleaser
@@ -96,61 +93,4 @@ func main() {
 	}
 
 	os.Exit(dispatch(context.Background(), opts, os.Stdout, os.Stderr))
-}
-
-// builtinTools returns the default file/shell tool set rooted at cwd, or nil
-// when tools are disabled. The todo tool is stateful: a single TodoStore is
-// created here and held by the one TodoTool instance, so the task list persists
-// across calls within a run (a later write replaces the plan).
-func builtinTools(cwd string, disabled bool) []agentcore.AgentTool {
-	if disabled {
-		return nil
-	}
-	return []agentcore.AgentTool{
-		&agenttool.ReadTool{Root: cwd, ExtraRoots: readableExtraRoots()},
-		&agenttool.WriteTool{Root: cwd, ExtraRoots: readableExtraRoots()},
-		&agenttool.EditTool{Root: cwd, ExtraRoots: readableExtraRoots()},
-		&agenttool.GrepTool{Root: cwd},
-		&agenttool.FindTool{Root: cwd},
-		&agenttool.BashTool{Dir: cwd},
-		&agenttool.TodoTool{Store: agenttool.NewTodoStore()},
-		&agenttool.WebFetchTool{},
-	}
-}
-
-// readableExtraRoots returns trusted directories the file tools may reach beyond
-// the workspace root. The skills directory is included so the model can load the
-// absolute SKILL.md paths pigo advertises in the system prompt, and author or
-// update skills there (they otherwise resolve outside the workspace and are
-// rejected). An empty skills dir is dropped, so this stays a no-op when the home
-// directory cannot be resolved.
-func readableExtraRoots() []string {
-	if dir := skillsDir(); dir != "" {
-		return []string{dir}
-	}
-	return nil
-}
-
-// toolRegistry builds a registry from the given tools (skipping any that fail
-// to register, e.g. a bad schema, which should not happen for built-ins).
-func toolRegistry(tools []agentcore.AgentTool) *agenttool.ToolRegistry {
-	reg := agenttool.NewToolRegistry()
-	for _, t := range tools {
-		_ = reg.Register(t)
-	}
-	return reg
-}
-
-// todoReminders builds the per-turn system-reminder registry for a tool set
-// (US-002): it locates the stateful TodoTool and registers a TodoReminderProvider
-// over its shared store, so the model is reminded of unfinished tasks each turn.
-// Returns nil when no todo tool is present (e.g. --no-tools), leaving injection
-// disabled.
-func todoReminders(tools []agentcore.AgentTool) *runtime.ReminderRegistry {
-	for _, t := range tools {
-		if tt, ok := t.(*agenttool.TodoTool); ok && tt.Store != nil {
-			return runtime.NewReminderRegistry(&runtime.TodoReminderProvider{Store: tt.Store})
-		}
-	}
-	return nil
 }

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -1,10 +1,8 @@
-// This file holds the run-assembly seam (architecture deepening ②). main() used
-// to build the provider, tool set, system prompt, and RunConfig separately in
-// its REPL branch and its headless branch — the same assembly written twice, and
-// a RunConfig literal duplicated between here and repl.go's streamRun. That setup
-// now lives in one place: setupAgentEnv assembles the shared environment, and
-// newRunConfig builds the loop configuration both drivers run. main() is left to
-// parse flags, dispatch, and map the outcome to an exit code.
+// This file holds the run dispatch seam. main() parses flags and calls dispatch,
+// which resolves the command (list / REPL / headless / subagent-rpc) and maps
+// the outcome to an exit code. The shared run-assembly setup (provider, tools,
+// system prompt, RunConfig) moved to internal/cli/run (US-005, #362); dispatch
+// wires those pieces together for the driver each path needs.
 package main
 
 import (
@@ -13,228 +11,15 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/smallnest/pigo/internal/agentcore"
-	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 )
-
-// agentEnv is the environment every run shares: the working directory, the tool
-// set rooted at it, the resolved provider, and the system prompt. It is
-// assembled once (setupAgentEnv) and consumed by whichever driver runs.
-type agentEnv struct {
-	cwd          string
-	tools        []agentcore.AgentTool
-	provider     provider.Provider
-	providerName string
-	sysPrompt    string
-
-	// skills is the discovered skill set (loaded once here, empty under
-	// --no-skills). It is threaded into the REPL so each skill is registered as a
-	// /skill-name command, and the model-invocable subset is already injected into
-	// sysPrompt.
-	skills []*runtime.Skill
-
-	// plugins holds any loaded external plugins so the caller can Close them
-	// when the run ends. It is nil when no plugins were discovered.
-	plugins *plugin.Manager
-}
-
-// setupAgentEnv resolves the provider for model/baseURL, builds the tool set
-// rooted at the working directory, and constructs the system prompt — the setup
-// the REPL and headless drivers both need. systemPrompt, when non-empty,
-// replaces the default base instruction (对标 pi 的 --system-prompt);
-// appendSystemPrompt entries are each resolved (a path to an existing file is
-// read, otherwise the value is literal text) and layered onto the end of the
-// prompt (对标 pi 的 --append-system-prompt). It returns an error rather than
-// exiting so the caller owns exit-code mapping.
-func setupAgentEnv(model, baseURL, protocol, providerName string, noTools, noSkills bool, systemPrompt string, appendSystemPrompt []string) (agentEnv, error) {
-	cwd, _ := os.Getwd()
-	prov, resolvedName, err := provider.ResolveProvider(model, baseURL, protocol, providerName, os.Getenv)
-	if err != nil {
-		return agentEnv{}, err
-	}
-	appends, err := resolveAppendInstructions(appendSystemPrompt)
-	if err != nil {
-		return agentEnv{}, err
-	}
-	tools := builtinTools(cwd, noTools)
-	// Discover external plugins (US-016) and append their tools. Plugin loading
-	// is fault-tolerant: a plugin that fails to start is logged and skipped, and
-	// disabling tools (--no-tools) skips plugin discovery entirely.
-	var mgr *plugin.Manager
-	if !noTools {
-		if m, err := plugin.Discover(pluginsDir(), os.Stderr, os.Stderr); err == nil {
-			tools = append(tools, m.Tools()...)
-			mgr = m
-		} else {
-			fmt.Fprintf(os.Stderr, "pigo: plugin discovery failed: %v\n", err)
-		}
-	}
-	// Load skills once (shared between prompt injection and /skill-name
-	// registration). A partial parse error still yields the skills that DID load,
-	// so one malformed file is a non-fatal warning rather than a hard failure.
-	skills, err := loadSkills(noSkills)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "pigo: skills: %v\n", err)
-	}
-	// The model can only load a skill's body when the read tool is present, so
-	// advertise skills in the prompt only then (对标 pi 的 selectedTools check).
-	sysPrompt, err := runtime.BuildSystemPrompt(runtime.PromptConfig{
-		BaseInstruction:    systemPrompt,
-		WorkingDir:         cwd,
-		Root:               cwd,
-		AppendInstructions: appends,
-		Skills:             skills,
-		ReadToolAvailable:  hasReadTool(tools),
-	})
-	if err != nil {
-		return agentEnv{}, err
-	}
-	return agentEnv{
-		cwd:          cwd,
-		tools:        tools,
-		provider:     prov,
-		providerName: resolvedName,
-		sysPrompt:    sysPrompt,
-		skills:       skills,
-		plugins:      mgr,
-	}, nil
-}
-
-// hasReadTool reports whether the read tool is present in the tool set. Skills
-// are advertised in the system prompt only when it is, since the model needs
-// the read tool to load a skill's body on demand.
-func hasReadTool(tools []agentcore.AgentTool) bool {
-	for _, t := range tools {
-		if t.Name() == "read" {
-			return true
-		}
-	}
-	return false
-}
-
-// resolveAppendInstructions maps each --append-system-prompt value to the text
-// to append. Following pi, a value that names an existing regular file is read
-// and its contents are appended; any other value (a non-existent path, or a
-// directory) is treated as literal text. Only a value that stats as a regular
-// file but then fails to read (e.g. a permission error) is reported, so a
-// genuinely broken file path is not silently appended verbatim.
-func resolveAppendInstructions(values []string) ([]string, error) {
-	if len(values) == 0 {
-		return nil, nil
-	}
-	out := make([]string, 0, len(values))
-	for _, v := range values {
-		info, statErr := os.Stat(v)
-		if statErr == nil && !info.IsDir() {
-			data, err := os.ReadFile(v)
-			if err != nil {
-				return nil, fmt.Errorf("read --append-system-prompt file %q: %w", v, err)
-			}
-			out = append(out, string(data))
-			continue
-		}
-		out = append(out, v)
-	}
-	return out, nil
-}
-
-// pluginsDir returns the directory external plugins are discovered from:
-// $PIGO_HOME/plugins, or ~/.pigo/plugins by default. An empty string is returned
-// when the home directory cannot be resolved and no override is set (Discover
-// then treats it as "no plugins").
-func pluginsDir() string {
-	dir := os.Getenv("PIGO_HOME")
-	if dir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		dir = filepath.Join(home, ".pigo")
-	}
-	return filepath.Join(dir, "plugins")
-}
-
-// configDir returns the directory pigo reads its global config layer from:
-// $PIGO_HOME, or ~/.pigo by default. An empty string is returned when the home
-// directory cannot be resolved and no override is set (the caller then treats
-// the global layer as absent).
-func configDir() string {
-	dir := os.Getenv("PIGO_HOME")
-	if dir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		dir = filepath.Join(home, ".pigo")
-	}
-	return dir
-}
-
-// resolveThinkingLevel resolves the effective reasoning-effort level through the
-// layered config chain (US-023): default < global < project < env < CLI flag.
-// The global layer is $PIGO_HOME/config.json (or ~/.pigo/config.json); the
-// project layer is ./.pigo/config.json in the working directory. A malformed
-// layer file or an invalid resolved value is a hard error, surfaced to the
-// caller for exit-code mapping. cliLevel is the raw --thinking-level flag ("" =
-// unset, so lower layers show through).
-func resolveThinkingLevel(cliLevel string) (agentcore.ThinkingLevel, error) {
-	def := runtime.DefaultConfigLayer()
-	layers := []*runtime.ConfigLayer{&def}
-
-	if dir := configDir(); dir != "" {
-		global, err := runtime.LoadConfigLayer(filepath.Join(dir, "config.json"))
-		if err != nil {
-			return "", err
-		}
-		layers = append(layers, global)
-	}
-	project, err := runtime.LoadConfigLayer(filepath.Join(".pigo", "config.json"))
-	if err != nil {
-		return "", err
-	}
-	layers = append(layers, project)
-
-	env := runtime.EnvConfigLayer(os.Getenv)
-	layers = append(layers, &env)
-
-	if v := strings.TrimSpace(cliLevel); v != "" {
-		cli := runtime.ConfigLayer{ThinkingLevel: &v}
-		layers = append(layers, &cli)
-	}
-
-	cfg, err := runtime.ResolveConfig(layers...)
-	if err != nil {
-		return "", err
-	}
-	return cfg.ThinkingLevel, nil
-}
-
-// newRunConfig builds the loop configuration shared by every driver: the
-// provider stream, the dynamic API-key resolver, and the tool registry. It is
-// the single definition of "how a run is wired", so the REPL (streamRun) and the
-// headless driver cannot drift apart.
-func newRunConfig(model, providerName string, thinking agentcore.ThinkingLevel, prov provider.Provider, creds *provider.CredentialStore, reg *agenttool.ToolRegistry, reminders *runtime.ReminderRegistry) runtime.RunConfig {
-	return runtime.RunConfig{
-		LoopConfig: runtime.LoopConfig{
-			Model:         model,
-			Provider:      providerName,
-			ThinkingLevel: thinking,
-			Stream:        provider.StreamFnFromProvider(prov),
-			GetAPIKey:     creds.GetAPIKey,
-		},
-		Batch: agenttool.BatchConfig{
-			ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: reg},
-		},
-		Reminders: reminders,
-	}
-}
 
 // cliOptions is the parsed command line, produced by main() and consumed by
 // dispatch. Separating parse from dispatch makes the dispatch logic testable
@@ -340,33 +125,33 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			fmt.Fprintln(errOut, "pigo: no prompt (use -p \"...\" or positional args)")
 			return 2
 		}
-		env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt)
+		env, err := run.SetupEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt)
 		if err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 1
 		}
-		if env.plugins != nil {
-			defer env.plugins.Close()
+		if env.Plugins != nil {
+			defer env.Plugins.Close()
 		}
-		thinking, err := resolveThinkingLevel(opts.thinkingLevel)
+		thinking, err := run.ResolveThinkingLevel(opts.thinkingLevel)
 		if err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 2
 		}
 		if err := runInteractive(interactiveOptions{
 			model:             opts.model,
-			providerName:      env.providerName,
-			provider:          env.provider,
+			providerName:      env.ProviderName,
+			provider:          env.Provider,
 			baseURL:           opts.baseURL,
 			apiKey:            opts.apiKey,
 			protocol:          opts.protocol,
 			thinkingLevel:     thinking,
-			tools:             env.tools,
-			sysPrompt:         env.sysPrompt,
+			tools:             env.Tools,
+			sysPrompt:         env.SysPrompt,
 			resumeID:          resumeID,
 			approve:           opts.approve,
-			skills:            env.skills,
-			plugins:           env.plugins,
+			skills:            env.Skills,
+			plugins:           env.Plugins,
 			configPrompts:     opts.configPrompts,
 			cliPrompts:        opts.promptTemplates,
 			noPromptTemplates: opts.noPromptTemplates,
@@ -383,13 +168,13 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		return 2
 	}
 
-	env, err := setupAgentEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt)
+	env, err := run.SetupEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt)
 	if err != nil {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
 		return 1
 	}
-	if env.plugins != nil {
-		defer env.plugins.Close()
+	if env.Plugins != nil {
+		defer env.Plugins.Close()
 	}
 	// Best-effort plugin slash-command support in headless mode: if the prompt is
 	// a "/cmd ..." naming a plugin command, invoke it, print its notifications to
@@ -397,7 +182,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 	// the command produced no prompt). Headless has no turn injection, so
 	// appending the returned prompt is the accepted behavior. A non-plugin prompt
 	// or unknown command is left untouched.
-	headlessPrompt := resolveHeadlessPluginCommand(opts.prompt, env.plugins, errOut)
+	headlessPrompt := resolveHeadlessPluginCommand(opts.prompt, env.Plugins, errOut)
 	promptContent, err := ui.BuildUserContent(headlessPrompt)
 	if err != nil {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
@@ -408,7 +193,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 	// stream-json event and the run can be resumed with --resume/--continue,
 	// matching the interactive REPL and pi/Claude Code. A resumed session seeds
 	// its prior messages ahead of the new prompt.
-	priorMsgs, hs, err := openHeadlessSession(resumeID, opts.model, env.providerName, env.sysPrompt)
+	priorMsgs, hs, err := openHeadlessSession(resumeID, opts.model, env.ProviderName, env.SysPrompt)
 	if err != nil {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
 		return 1
@@ -417,12 +202,12 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 	agentCtx := &agentcore.AgentContext{
 		SystemPrompt: hs.header.SystemPrompt,
 		Messages:     messages,
-		Tools:        env.tools,
+		Tools:        env.Tools,
 	}
 
 	// Resolve the effective reasoning-effort level through the layered config
 	// chain (default < global < project < env < --thinking-level flag).
-	thinking, err := resolveThinkingLevel(opts.thinkingLevel)
+	thinking, err := run.ResolveThinkingLevel(opts.thinkingLevel)
 	if err != nil {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
 		return 2
@@ -431,8 +216,8 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 	// Resolve the API key by provider name from the environment (never logged).
 	// An explicit --api-key overrides env/config for the resolved provider.
 	creds := provider.NewCredentialStore(nil)
-	creds.SetOverride(env.providerName, opts.apiKey)
-	runCfg := newRunConfig(opts.model, env.providerName, thinking, env.provider, creds, toolRegistry(env.tools), todoReminders(env.tools))
+	creds.SetOverride(env.ProviderName, opts.apiKey)
+	runCfg := run.NewConfig(opts.model, env.ProviderName, thinking, env.Provider, creds, run.ToolRegistry(env.Tools), run.TodoReminders(env.Tools))
 	runCfg.SessionID = hs.header.ID
 	cfg := runtime.HeadlessConfig{
 		Mode: mode,
@@ -442,7 +227,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 	// Deliver agent lifecycle events to any subscribed plugin (US-017, #133).
 	// NewEventNotifier returns nil when no plugin subscribes, so the OnEvent hook
 	// stays unset in the common no-plugin case.
-	if n := plugin.NewEventNotifier(env.plugins, errOut); n != nil {
+	if n := plugin.NewEventNotifier(env.Plugins, errOut); n != nil {
 		cfg.OnEvent = n.Handle
 	}
 	runErr := runtime.RunHeadless(ctx, agentCtx, cfg)

--- a/cmd/pigo/skills_test.go
+++ b/cmd/pigo/skills_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/runtime"
 )
 
@@ -39,9 +40,9 @@ func TestLoadSkillsFromDir(t *testing.T) {
 	t.Setenv("PIGO_HOME", t.TempDir())
 	writeSkill(t, dir, "greet.md", "---\nname: greet\ndescription: say hello\n---\nYou are a friendly greeter.")
 
-	skills, err := loadSkills(false)
+	skills, err := run.LoadSkills(false)
 	if err != nil {
-		t.Fatalf("loadSkills: %v", err)
+		t.Fatalf("run.LoadSkills: %v", err)
 	}
 	s := findSkill(skills, "greet")
 	if s == nil {
@@ -69,9 +70,9 @@ func TestLoadSkillsNoSkills(t *testing.T) {
 	t.Setenv("PIGO_SKILLS_DIR", dir)
 	t.Setenv("PIGO_HOME", t.TempDir())
 
-	skills, err := loadSkills(true)
+	skills, err := run.LoadSkills(true)
 	if err != nil {
-		t.Fatalf("loadSkills(true): %v", err)
+		t.Fatalf("run.LoadSkills(true): %v", err)
 	}
 	if len(skills) != 0 {
 		t.Errorf("got %d skills, want 0 under --no-skills", len(skills))
@@ -94,9 +95,9 @@ func TestBuildSlashRegistryIncludesSkills(t *testing.T) {
 	t.Setenv("PIGO_HOME", t.TempDir())
 	writeSkill(t, dir, "summarize.md", "---\nname: summarize\ndescription: summarize input\n---\nSummarize the following: $ARGUMENTS")
 
-	skills, err := loadSkills(false)
+	skills, err := run.LoadSkills(false)
 	if err != nil {
-		t.Fatalf("loadSkills: %v", err)
+		t.Fatalf("run.LoadSkills: %v", err)
 	}
 	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, skills, nil, promptTemplateSources{})
 	if err != nil {
@@ -142,9 +143,9 @@ func TestLoadSkillsBootstrapsBuiltinSkills(t *testing.T) {
 	t.Setenv("PIGO_SKILLS_DIR", dir)
 	t.Setenv("PIGO_HOME", t.TempDir())
 
-	skills, err := loadSkills(false)
+	skills, err := run.LoadSkills(false)
 	if err != nil {
-		t.Fatalf("loadSkills: %v", err)
+		t.Fatalf("run.LoadSkills: %v", err)
 	}
 	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, skills, nil, promptTemplateSources{})
 	if err != nil {

--- a/cmd/pigo/subagent_rpc.go
+++ b/cmd/pigo/subagent_rpc.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/jsonrpc"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
@@ -93,8 +94,8 @@ func handleSubAgentRequest(ctx context.Context, enc *json.Encoder, req *jsonrpc.
 		return
 	}
 	cwd, _ := os.Getwd()
-	tools := filterBuiltinTools(builtinTools(cwd, false), params.Tools)
-	reg := toolRegistry(tools)
+	tools := filterBuiltinTools(run.BuiltinTools(cwd, false), params.Tools)
+	reg := run.ToolRegistry(tools)
 	creds := provider.NewCredentialStore(nil) // env-resolved
 	runCfg := runtime.RunConfig{
 		LoopConfig: runtime.LoopConfig{

--- a/cmd/pigo/subagent_rpc_test.go
+++ b/cmd/pigo/subagent_rpc_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/jsonrpc"
 	"github.com/smallnest/pigo/internal/runtime"
 )
@@ -23,9 +24,9 @@ import (
 // list keeps all builtins, a subset keeps only the named tools, and unknown
 // names are silently ignored.
 func TestFilterBuiltinTools(t *testing.T) {
-	all := builtinTools(t.TempDir(), false)
+	all := run.BuiltinTools(t.TempDir(), false)
 	if len(all) == 0 {
-		t.Fatal("builtinTools returned no tools")
+		t.Fatal("BuiltinTools returned no tools")
 	}
 	namesOf := func(ts []agentcore.AgentTool) []string {
 		out := make([]string, len(ts))

--- a/docs/issue#0362.html
+++ b/docs/issue#0362.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0362</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/362">#362</a> &mdash; 迁移运行装配层到 internal/cli/run &mdash; 2026-07-28</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 助手函数一并迁入 run 包（超出显式列表）</h3>
+      <p><strong>Ambiguity:</strong> Issue 明确要求迁移 <code>setupAgentEnv/newRunConfig/agentEnv</code> 与 6 个工具助手，但 <code>hasReadTool</code>、<code>resolveAppendInstructions</code>、<code>pluginsDir</code>、<code>configDir</code>、<code>loadSkills</code> 是它们的私有依赖，未逐一点名。</p>
+      <p><strong>Choice:</strong> 将这些依赖一并迁入 <code>internal/cli/run/run.go</code>，其中纯内部的 <code>hasReadTool</code>/<code>resolveAppendInstructions</code> 保持非导出，被外部调用的 <code>ConfigDir</code>/<code>LoadSkills</code>/<code>PluginsDir</code> 导出。</p>
+      <p><strong>Rationale:</strong> <code>SetupEnv</code> 依赖它们，留在 cmd/pigo 会造成反向依赖或重复实现。按"是否被包外调用"决定导出与否，最小化 run 包的公开面。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> env 注入沿用 os.Getenv 直传</h3>
+      <p><strong>Ambiguity:</strong> <code>SetupEnv</code> 内部调用 <code>provider.ResolveProvider(..., env)</code> 需要一个 env 函数。</p>
+      <p><strong>Choice:</strong> 在 <code>SetupEnv</code> 内直接传 <code>os.Getenv</code>，不把 env 提升为 <code>SetupEnv</code> 的参数。</p>
+      <p><strong>Rationale:</strong> 与 <a href="https://github.com/smallnest/pigo/issues/361">#361</a> 一致——生产装配读真实进程环境是正确行为；env 注入只在 provider 解析的单元测试中需要，装配层无需为此扩签名。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> cmd/pigo/run.go 保留 dispatch 及 print/stream 驱动</h3>
+      <p><strong>Spec:</strong> "原 cmd/pigo/run.go 中装配相关代码删除（print/stream 驱动留待 #369/#7）"。</p>
+      <p><strong>Implemented:</strong> 删除了 <code>agentEnv</code>/<code>setupAgentEnv</code>/<code>newRunConfig</code> 等装配代码，但 <code>dispatch</code>、<code>resolveHeadlessPluginCommand</code>、<code>parseOutputMode</code> 及 headless 运行逻辑仍留在 run.go。</p>
+      <p><strong>Why:</strong> 与 Spec 一致——本 Issue 只搬装配层；驱动/dispatch 的进一步收敛属于 #363（headless）与 #369（薄 main）范围，提前搬动会与后续 Issue 冲突。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 测试拆分：按被测符号归属分流</h3>
+      <p><strong>Alternatives:</strong> (a) 全部相关测试整体迁入 run 包；(b) 按被测函数是否随源码迁移分流。</p>
+      <p><strong>Chosen:</strong> (b)——<code>thinking_test.go</code>、<code>prompt_flags_test.go</code>（测被迁走的 <code>ResolveThinkingLevel</code>/<code>resolveAppendInstructions</code>）随源码迁入 <code>package run</code>；<code>skills_test.go</code>/<code>subagent_rpc_test.go</code> 因仍测留在 main 的 <code>buildSlashRegistry</code>/<code>filterBuiltinTools</code>，留在 main 仅把调用改为 <code>run.LoadSkills</code>/<code>run.BuiltinTools</code>。</p>
+      <p><strong>Why:</strong> <code>resolveAppendInstructions</code> 非导出，其测试只能同包；混合测试文件按主被测对象归属，避免跨包私有访问。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 回退两个无关测试文件的 gofmt 重排</h3>
+      <p><strong>Alternatives:</strong> (a) 接受 goimports 顺带产生的 <code>autocomplete_label_test.go</code>/<code>line_editor_test.go</code> 对齐改动；(b) 回退以保持 PR 聚焦。</p>
+      <p><strong>Chosen:</strong> (b)，仅提交 #362 相关文件。</p>
+      <p><strong>Why:</strong> 这两处是既有的对齐偏差，与本 Issue 无关；混入会污染 diff、模糊 review 焦点。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> ConfigDir/PluginsDir/SkillsDir 的最终归属</h3>
+      <p><strong>Assumption:</strong> 这三个路径解析器现居 <code>internal/cli/run</code>，被 btw_config.go 等跨文件复用。</p>
+      <p><strong>Verify:</strong> 随 #365(btw)/#366(status)/#369(薄 main) 推进，是否应进一步下沉到更中性的位置（如 internal/cli 或专门的 paths 包），避免其他子包为拿路径而依赖 run 包？本 Issue 暂按最小改动放在 run。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/cli/run/prompt_flags_test.go
+++ b/internal/cli/run/prompt_flags_test.go
@@ -1,4 +1,4 @@
-package main
+package run
 
 // Tests for --append-system-prompt value resolution (对标 pi): each value is
 // either a path to an existing file whose contents are appended, or literal

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -1,0 +1,324 @@
+// Package run holds the run-assembly layer (US-005, #362): the shared setup that
+// both the interactive REPL and the headless driver need — resolving the
+// provider, building the tool set rooted at the working directory, discovering
+// skills and plugins, and constructing the loop RunConfig. Pulling it out of
+// cmd/pigo lets the subpackages assemble a run through one exported API instead
+// of duplicating the wiring.
+package run
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/builtinskills"
+	"github.com/smallnest/pigo/internal/plugin"
+	"github.com/smallnest/pigo/internal/provider"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// Env is the environment every run shares: the working directory, the tool set
+// rooted at it, the resolved provider, and the system prompt. It is assembled
+// once (SetupEnv) and consumed by whichever driver runs.
+type Env struct {
+	Cwd          string
+	Tools        []agentcore.AgentTool
+	Provider     provider.Provider
+	ProviderName string
+	SysPrompt    string
+
+	// Skills is the discovered skill set (loaded once here, empty under
+	// --no-skills). It is threaded into the REPL so each skill is registered as a
+	// /skill-name command, and the model-invocable subset is already injected into
+	// SysPrompt.
+	Skills []*runtime.Skill
+
+	// Plugins holds any loaded external plugins so the caller can Close them when
+	// the run ends. It is nil when no plugins were discovered.
+	Plugins *plugin.Manager
+}
+
+// SetupEnv resolves the provider for model/baseURL, builds the tool set rooted
+// at the working directory, and constructs the system prompt — the setup the
+// REPL and headless drivers both need. systemPrompt, when non-empty, replaces
+// the default base instruction (对标 pi 的 --system-prompt); appendSystemPrompt
+// entries are each resolved (a path to an existing file is read, otherwise the
+// value is literal text) and layered onto the end of the prompt (对标 pi 的
+// --append-system-prompt). It returns an error rather than exiting so the caller
+// owns exit-code mapping.
+func SetupEnv(model, baseURL, protocol, providerName string, noTools, noSkills bool, systemPrompt string, appendSystemPrompt []string) (Env, error) {
+	cwd, _ := os.Getwd()
+	prov, resolvedName, err := provider.ResolveProvider(model, baseURL, protocol, providerName, os.Getenv)
+	if err != nil {
+		return Env{}, err
+	}
+	appends, err := resolveAppendInstructions(appendSystemPrompt)
+	if err != nil {
+		return Env{}, err
+	}
+	tools := BuiltinTools(cwd, noTools)
+	// Discover external plugins (US-016) and append their tools. Plugin loading
+	// is fault-tolerant: a plugin that fails to start is logged and skipped, and
+	// disabling tools (--no-tools) skips plugin discovery entirely.
+	var mgr *plugin.Manager
+	if !noTools {
+		if m, err := plugin.Discover(PluginsDir(), os.Stderr, os.Stderr); err == nil {
+			tools = append(tools, m.Tools()...)
+			mgr = m
+		} else {
+			fmt.Fprintf(os.Stderr, "pigo: plugin discovery failed: %v\n", err)
+		}
+	}
+	// Load skills once (shared between prompt injection and /skill-name
+	// registration). A partial parse error still yields the skills that DID load,
+	// so one malformed file is a non-fatal warning rather than a hard failure.
+	skills, err := LoadSkills(noSkills)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pigo: skills: %v\n", err)
+	}
+	// The model can only load a skill's body when the read tool is present, so
+	// advertise skills in the prompt only then (对标 pi 的 selectedTools check).
+	sysPrompt, err := runtime.BuildSystemPrompt(runtime.PromptConfig{
+		BaseInstruction:    systemPrompt,
+		WorkingDir:         cwd,
+		Root:               cwd,
+		AppendInstructions: appends,
+		Skills:             skills,
+		ReadToolAvailable:  hasReadTool(tools),
+	})
+	if err != nil {
+		return Env{}, err
+	}
+	return Env{
+		Cwd:          cwd,
+		Tools:        tools,
+		Provider:     prov,
+		ProviderName: resolvedName,
+		SysPrompt:    sysPrompt,
+		Skills:       skills,
+		Plugins:      mgr,
+	}, nil
+}
+
+// hasReadTool reports whether the read tool is present in the tool set. Skills
+// are advertised in the system prompt only when it is, since the model needs the
+// read tool to load a skill's body on demand.
+func hasReadTool(tools []agentcore.AgentTool) bool {
+	for _, t := range tools {
+		if t.Name() == "read" {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveAppendInstructions maps each --append-system-prompt value to the text
+// to append. Following pi, a value that names an existing regular file is read
+// and its contents are appended; any other value (a non-existent path, or a
+// directory) is treated as literal text. Only a value that stats as a regular
+// file but then fails to read (e.g. a permission error) is reported, so a
+// genuinely broken file path is not silently appended verbatim.
+func resolveAppendInstructions(values []string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		info, statErr := os.Stat(v)
+		if statErr == nil && !info.IsDir() {
+			data, err := os.ReadFile(v)
+			if err != nil {
+				return nil, fmt.Errorf("read --append-system-prompt file %q: %w", v, err)
+			}
+			out = append(out, string(data))
+			continue
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// BuiltinTools returns the default file/shell tool set rooted at cwd, or nil
+// when tools are disabled. The todo tool is stateful: a single TodoStore is
+// created here and held by the one TodoTool instance, so the task list persists
+// across calls within a run (a later write replaces the plan).
+func BuiltinTools(cwd string, disabled bool) []agentcore.AgentTool {
+	if disabled {
+		return nil
+	}
+	return []agentcore.AgentTool{
+		&agenttool.ReadTool{Root: cwd, ExtraRoots: ReadableExtraRoots()},
+		&agenttool.WriteTool{Root: cwd, ExtraRoots: ReadableExtraRoots()},
+		&agenttool.EditTool{Root: cwd, ExtraRoots: ReadableExtraRoots()},
+		&agenttool.GrepTool{Root: cwd},
+		&agenttool.FindTool{Root: cwd},
+		&agenttool.BashTool{Dir: cwd},
+		&agenttool.TodoTool{Store: agenttool.NewTodoStore()},
+		&agenttool.WebFetchTool{},
+	}
+}
+
+// ReadableExtraRoots returns trusted directories the file tools may reach beyond
+// the workspace root. The skills directory is included so the model can load the
+// absolute SKILL.md paths pigo advertises in the system prompt, and author or
+// update skills there (they otherwise resolve outside the workspace and are
+// rejected). An empty skills dir is dropped, so this stays a no-op when the home
+// directory cannot be resolved.
+func ReadableExtraRoots() []string {
+	if dir := SkillsDir(); dir != "" {
+		return []string{dir}
+	}
+	return nil
+}
+
+// ToolRegistry builds a registry from the given tools (skipping any that fail to
+// register, e.g. a bad schema, which should not happen for built-ins).
+func ToolRegistry(tools []agentcore.AgentTool) *agenttool.ToolRegistry {
+	reg := agenttool.NewToolRegistry()
+	for _, t := range tools {
+		_ = reg.Register(t)
+	}
+	return reg
+}
+
+// TodoReminders builds the per-turn system-reminder registry for a tool set
+// (US-002): it locates the stateful TodoTool and registers a TodoReminderProvider
+// over its shared store, so the model is reminded of unfinished tasks each turn.
+// Returns nil when no todo tool is present (e.g. --no-tools), leaving injection
+// disabled.
+func TodoReminders(tools []agentcore.AgentTool) *runtime.ReminderRegistry {
+	for _, t := range tools {
+		if tt, ok := t.(*agenttool.TodoTool); ok && tt.Store != nil {
+			return runtime.NewReminderRegistry(&runtime.TodoReminderProvider{Store: tt.Store})
+		}
+	}
+	return nil
+}
+
+// SkillsDir returns the directory skills are loaded from. It defaults to
+// ~/.agents/skills, overridable via PIGO_SKILLS_DIR. An empty string is returned
+// when the home directory cannot be resolved and no override is set.
+func SkillsDir() string {
+	if dir := os.Getenv("PIGO_SKILLS_DIR"); dir != "" {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".agents", "skills")
+}
+
+// LoadSkills discovers skills from SkillsDir() once, for both prompt injection
+// and /skill-name registration. Under --no-skills it is a no-op. Built-in skills
+// are bootstrapped into the skills dir first, then the directory is loaded.
+func LoadSkills(noSkills bool) ([]*runtime.Skill, error) {
+	if noSkills {
+		return nil, nil
+	}
+	var blog io.Writer
+	if os.Getenv("PIGO_DEBUG") != "" {
+		blog = os.Stderr
+	}
+	builtinskills.Bootstrap(ConfigDir(), SkillsDir(), blog)
+	dir := SkillsDir()
+	if dir == "" {
+		return nil, nil
+	}
+	return runtime.LoadSkillsDir(dir)
+}
+
+// PluginsDir returns the directory external plugins are discovered from:
+// $PIGO_HOME/plugins, or ~/.pigo/plugins by default. An empty string is returned
+// when the home directory cannot be resolved and no override is set (Discover
+// then treats it as "no plugins").
+func PluginsDir() string {
+	dir := os.Getenv("PIGO_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		dir = filepath.Join(home, ".pigo")
+	}
+	return filepath.Join(dir, "plugins")
+}
+
+// ConfigDir returns the directory pigo reads its global config layer from:
+// $PIGO_HOME, or ~/.pigo by default. An empty string is returned when the home
+// directory cannot be resolved and no override is set (the caller then treats
+// the global layer as absent).
+func ConfigDir() string {
+	dir := os.Getenv("PIGO_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		dir = filepath.Join(home, ".pigo")
+	}
+	return dir
+}
+
+// ResolveThinkingLevel resolves the effective reasoning-effort level through the
+// layered config chain (US-023): default < global < project < env < CLI flag.
+// The global layer is $PIGO_HOME/config.json (or ~/.pigo/config.json); the
+// project layer is ./.pigo/config.json in the working directory. A malformed
+// layer file or an invalid resolved value is a hard error, surfaced to the
+// caller for exit-code mapping. cliLevel is the raw --thinking-level flag ("" =
+// unset, so lower layers show through).
+func ResolveThinkingLevel(cliLevel string) (agentcore.ThinkingLevel, error) {
+	def := runtime.DefaultConfigLayer()
+	layers := []*runtime.ConfigLayer{&def}
+
+	if dir := ConfigDir(); dir != "" {
+		global, err := runtime.LoadConfigLayer(filepath.Join(dir, "config.json"))
+		if err != nil {
+			return "", err
+		}
+		layers = append(layers, global)
+	}
+	project, err := runtime.LoadConfigLayer(filepath.Join(".pigo", "config.json"))
+	if err != nil {
+		return "", err
+	}
+	layers = append(layers, project)
+
+	env := runtime.EnvConfigLayer(os.Getenv)
+	layers = append(layers, &env)
+
+	if v := strings.TrimSpace(cliLevel); v != "" {
+		cli := runtime.ConfigLayer{ThinkingLevel: &v}
+		layers = append(layers, &cli)
+	}
+
+	cfg, err := runtime.ResolveConfig(layers...)
+	if err != nil {
+		return "", err
+	}
+	return cfg.ThinkingLevel, nil
+}
+
+// NewConfig builds the loop configuration shared by every driver: the provider
+// stream, the dynamic API-key resolver, and the tool registry. It is the single
+// definition of "how a run is wired", so the REPL (streamRun) and the headless
+// driver cannot drift apart.
+func NewConfig(model, providerName string, thinking agentcore.ThinkingLevel, prov provider.Provider, creds *provider.CredentialStore, reg *agenttool.ToolRegistry, reminders *runtime.ReminderRegistry) runtime.RunConfig {
+	return runtime.RunConfig{
+		LoopConfig: runtime.LoopConfig{
+			Model:         model,
+			Provider:      providerName,
+			ThinkingLevel: thinking,
+			Stream:        provider.StreamFnFromProvider(prov),
+			GetAPIKey:     creds.GetAPIKey,
+		},
+		Batch: agenttool.BatchConfig{
+			ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: reg},
+		},
+		Reminders: reminders,
+	}
+}

--- a/internal/cli/run/thinking_test.go
+++ b/internal/cli/run/thinking_test.go
@@ -1,4 +1,4 @@
-package main
+package run
 
 // Tests for resolveThinkingLevel: the CLI end of the layered config chain
 // (US-023). It resolves the effective reasoning-effort level through
@@ -51,7 +51,7 @@ func writeConfig(t *testing.T, path, level string) {
 // when no layer sets a level.
 func TestResolveThinkingLevelDefault(t *testing.T) {
 	isolateConfig(t)
-	got, err := resolveThinkingLevel("")
+	got, err := ResolveThinkingLevel("")
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestResolveThinkingLevelFlagWins(t *testing.T) {
 	writeConfig(t, filepath.Join(".pigo", "config.json"), "high")
 	t.Setenv("PIGO_THINKING_LEVEL", "minimal")
 
-	got, err := resolveThinkingLevel("xhigh")
+	got, err := ResolveThinkingLevel("xhigh")
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestResolveThinkingLevelEnvOverProject(t *testing.T) {
 	writeConfig(t, filepath.Join(".pigo", "config.json"), "high")
 	t.Setenv("PIGO_THINKING_LEVEL", "off")
 
-	got, err := resolveThinkingLevel("")
+	got, err := ResolveThinkingLevel("")
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestResolveThinkingLevelProjectOverGlobal(t *testing.T) {
 	writeConfig(t, filepath.Join(home, "config.json"), "low")
 	writeConfig(t, filepath.Join(".pigo", "config.json"), "high")
 
-	got, err := resolveThinkingLevel("")
+	got, err := ResolveThinkingLevel("")
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
@@ -114,7 +114,7 @@ func TestResolveThinkingLevelProjectOverGlobal(t *testing.T) {
 // (surfaced for exit-code mapping), not silently coerced.
 func TestResolveThinkingLevelInvalid(t *testing.T) {
 	isolateConfig(t)
-	if _, err := resolveThinkingLevel("turbo"); err == nil {
+	if _, err := ResolveThinkingLevel("turbo"); err == nil {
 		t.Error("expected error for invalid thinking level, got nil")
 	}
 }


### PR DESCRIPTION
## Summary
- Move the shared run-assembly setup out of `cmd/pigo` into a new `internal/cli/run` package: `Env`/`SetupEnv`/`NewConfig` plus `BuiltinTools`/`ToolRegistry`/`TodoReminders`/`ReadableExtraRoots`/`SkillsDir`/`LoadSkills`/`PluginsDir`/`ConfigDir`/`ResolveThinkingLevel` (and internal `hasReadTool`/`resolveAppendInstructions`).
- `dispatch` now wires runs through `run.SetupEnv`/`run.NewConfig`/`run.ResolveThinkingLevel`; call sites in `interactive.go`, `subagent_rpc.go`, `btw_config.go` updated to the exported API. `dispatch` and the print/stream drivers stay in `cmd/pigo` pending #363/#369.
- Tests for the moved functions (`ResolveThinkingLevel`, `resolveAppendInstructions`) migrate to `package run`; `skills_test.go`/`subagent_rpc_test.go` stay in `main` (they exercise `buildSlashRegistry`/`filterBuiltinTools`) and now call `run.LoadSkills`/`run.BuiltinTools`.

Closes #362

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`