### PR TITLE
refactor(cli): migrate headless/subagent to internal/cli/headless

### DIFF
--- a/cmd/pigo/interactive.go
+++ b/cmd/pigo/interactive.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,6 +19,7 @@ import (
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/headless"
 	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/plugin"
@@ -29,18 +29,11 @@ import (
 	"github.com/smallnest/pigo/internal/trust"
 )
 
-// sessionStore returns the session store rooted at ~/.pigo/sessions (or under
-// PIGO_HOME when set), creating the directory on first use.
+// sessionStore returns the session store for the interactive REPL. It is a thin
+// alias for headless.SessionStore so the REPL and headless runs share one store
+// rooted at ~/.pigo/sessions (or PIGO_HOME).
 func sessionStore() (*session.Store, error) {
-	dir := os.Getenv("PIGO_HOME")
-	if dir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("resolve home dir: %w", err)
-		}
-		dir = filepath.Join(home, ".pigo")
-	}
-	return session.NewStore(filepath.Join(dir, "sessions"))
+	return headless.SessionStore()
 }
 
 // interactiveOptions carries the resolved run configuration plus optional
@@ -226,43 +219,6 @@ func runInteractive(opts interactiveOptions) error {
 		goal:      agenttool.NewGoalState(),
 		telemetry: cli.NewTelemetryHolder(),
 	})
-}
-
-// printSessions prints the stored sessions, most-recent first, to out.
-func printSessions(out io.Writer) error {
-	store, err := sessionStore()
-	if err != nil {
-		return err
-	}
-	headers, err := store.List()
-	if err != nil {
-		return err
-	}
-	if len(headers) == 0 {
-		fmt.Fprintln(out, "no sessions")
-		return nil
-	}
-	for _, h := range headers {
-		fmt.Fprintf(out, "%s\t%s\t%s\n", h.ID, h.UpdatedAt.Local().Format("2006-01-02 15:04"), h.Model)
-	}
-	return nil
-}
-
-// mostRecentSessionID returns the id of the most recently updated session, or
-// "" if there are none.
-func mostRecentSessionID() (string, error) {
-	store, err := sessionStore()
-	if err != nil {
-		return "", err
-	}
-	headers, err := store.List()
-	if err != nil {
-		return "", err
-	}
-	if len(headers) == 0 {
-		return "", nil
-	}
-	return headers[0].ID, nil
 }
 
 // promptTemplateSources carries the prompt-template discovery sources that

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -7,18 +7,13 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
-	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/cli/headless"
 	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/ui"
-	"github.com/smallnest/pigo/internal/plugin"
-	"github.com/smallnest/pigo/internal/provider"
-	"github.com/smallnest/pigo/internal/runtime"
 )
 
 // cliOptions is the parsed command line, produced by main() and consumed by
@@ -89,12 +84,12 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 	// protocol over stdio and exit. It is the subprocess end of process-isolated
 	// sub-agents and shares nothing with the interactive/headless paths.
 	if opts.subagentRPC {
-		return runSubAgentRPC(ctx, os.Stdin, out, errOut)
+		return headless.RunSubAgentRPC(ctx, os.Stdin, out, errOut)
 	}
 
 	// --list-sessions is a standalone action: print and exit.
 	if opts.listSessions {
-		if err := printSessions(out); err != nil {
+		if err := headless.PrintSessions(out); err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 1
 		}
@@ -104,7 +99,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 	// --continue resolves to the most recently updated session id.
 	resumeID := opts.resumeID
 	if opts.continueLast && resumeID == "" {
-		id, err := mostRecentSessionID()
+		id, err := headless.MostRecentSessionID()
 		if err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 1
@@ -162,7 +157,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		return 0
 	}
 
-	mode, err := parseOutputMode(opts.outputFmt)
+	mode, err := headless.ParseOutputMode(opts.outputFmt)
 	if err != nil {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
 		return 2
@@ -176,134 +171,13 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 	if env.Plugins != nil {
 		defer env.Plugins.Close()
 	}
-	// Best-effort plugin slash-command support in headless mode: if the prompt is
-	// a "/cmd ..." naming a plugin command, invoke it, print its notifications to
-	// errOut, and use the returned prompt for this run (appending the raw args if
-	// the command produced no prompt). Headless has no turn injection, so
-	// appending the returned prompt is the accepted behavior. A non-plugin prompt
-	// or unknown command is left untouched.
-	headlessPrompt := resolveHeadlessPluginCommand(opts.prompt, env.Plugins, errOut)
-	promptContent, err := ui.BuildUserContent(headlessPrompt)
-	if err != nil {
-		fmt.Fprintf(errOut, "pigo: %v\n", err)
-		return 1
-	}
-
-	// Back the headless run with a session so its id appears in the first
-	// stream-json event and the run can be resumed with --resume/--continue,
-	// matching the interactive REPL and pi/Claude Code. A resumed session seeds
-	// its prior messages ahead of the new prompt.
-	priorMsgs, hs, err := openHeadlessSession(resumeID, opts.model, env.ProviderName, env.SysPrompt)
-	if err != nil {
-		fmt.Fprintf(errOut, "pigo: %v\n", err)
-		return 1
-	}
-	messages := append(priorMsgs, agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: promptContent})
-	agentCtx := &agentcore.AgentContext{
-		SystemPrompt: hs.header.SystemPrompt,
-		Messages:     messages,
-		Tools:        env.Tools,
-	}
-
-	// Resolve the effective reasoning-effort level through the layered config
-	// chain (default < global < project < env < --thinking-level flag).
-	thinking, err := run.ResolveThinkingLevel(opts.thinkingLevel)
-	if err != nil {
-		fmt.Fprintf(errOut, "pigo: %v\n", err)
-		return 2
-	}
-
-	// Resolve the API key by provider name from the environment (never logged).
-	// An explicit --api-key overrides env/config for the resolved provider.
-	creds := provider.NewCredentialStore(nil)
-	creds.SetOverride(env.ProviderName, opts.apiKey)
-	runCfg := run.NewConfig(opts.model, env.ProviderName, thinking, env.Provider, creds, run.ToolRegistry(env.Tools), run.TodoReminders(env.Tools))
-	runCfg.SessionID = hs.header.ID
-	cfg := runtime.HeadlessConfig{
-		Mode: mode,
-		Out:  out,
-		Run:  runCfg,
-	}
-	// Deliver agent lifecycle events to any subscribed plugin (US-017, #133).
-	// NewEventNotifier returns nil when no plugin subscribes, so the OnEvent hook
-	// stays unset in the common no-plugin case.
-	if n := plugin.NewEventNotifier(env.Plugins, errOut); n != nil {
-		cfg.OnEvent = n.Handle
-	}
-	runErr := runtime.RunHeadless(ctx, agentCtx, cfg)
-	// Persist the run's messages regardless of run outcome so a partial run is
-	// still resumable; a persistence failure is reported but does not mask a run
-	// error.
-	if perr := hs.persist(agentCtx); perr != nil {
-		fmt.Fprintf(errOut, "pigo: warning: could not persist session %s: %v\n", hs.header.ID, perr)
-	}
-	if runErr != nil {
-		fmt.Fprintf(errOut, "pigo: %v\n", runErr)
-		return 1
-	}
-	return 0
-}
-
-// resolveHeadlessPluginCommand gives the headless / print path best-effort
-// support for plugin slash commands. When prompt is a "/cmd ..." naming a
-// plugin command (from mgr.Commands()), it invokes the command, prints each
-// returned notification to notifyOut, and returns the command's returned Prompt
-// as the run's prompt. If the command returns no prompt, the raw argument text
-// is used instead (so a bare "/cmd" with only notifications still runs
-// something sensible rather than an empty prompt). Any other input — a
-// non-command, an unknown command, or a call error — leaves prompt unchanged so
-// the normal headless run proceeds. mgr may be nil (no plugins).
-//
-// Headless has no turn-injection loop, so "inject the returned prompt" degrades
-// to "use the returned prompt for this run", which the acceptance criteria
-// permit.
-func resolveHeadlessPluginCommand(prompt string, mgr *plugin.Manager, notifyOut io.Writer) string {
-	if mgr == nil || !strings.HasPrefix(strings.TrimLeft(prompt, " \t"), "/") {
-		return prompt
-	}
-	trimmed := strings.TrimLeft(prompt, " \t")[1:]
-	name := trimmed
-	args := ""
-	if i := strings.IndexAny(trimmed, " \t"); i >= 0 {
-		name = trimmed[:i]
-		args = strings.TrimSpace(trimmed[i+1:])
-	}
-	for _, pc := range mgr.Commands() {
-		if pc.Spec.Name != name {
-			continue
-		}
-		// Encode the raw arg text as a JSON string (never null), matching the
-		// host's CommandCallParams.Args contract.
-		raw, _ := json.Marshal(args)
-		res, err := pc.Plugin.CallCommand(context.Background(), name, json.RawMessage(raw))
-		if err != nil {
-			fmt.Fprintf(notifyOut, "pigo: plugin command %q failed: %v\n", name, err)
-			return prompt
-		}
-		for _, n := range res.Notifications {
-			if n.Type != "" {
-				fmt.Fprintf(notifyOut, "[%s] %s\n", n.Type, n.Message)
-			} else {
-				fmt.Fprintln(notifyOut, n.Message)
-			}
-		}
-		if res.Prompt != "" {
-			return res.Prompt
-		}
-		return args
-	}
-	return prompt
-}
-
-// parseOutputMode maps the --output-format flag onto a HeadlessMode, erroring on
-// an unknown value.
-func parseOutputMode(outputFmt string) (runtime.HeadlessMode, error) {
-	switch outputFmt {
-	case "text", "":
-		return runtime.PrintMode, nil
-	case "stream-json":
-		return runtime.StreamJSONMode, nil
-	default:
-		return 0, fmt.Errorf("unknown --output-format %q (want text|stream-json)", outputFmt)
-	}
+	return headless.Run(ctx, headless.RunParams{
+		Mode:          mode,
+		Env:           env,
+		Prompt:        opts.prompt,
+		Model:         opts.model,
+		APIKey:        opts.apiKey,
+		ThinkingLevel: opts.thinkingLevel,
+		ResumeID:      resumeID,
+	}, out, errOut)
 }

--- a/cmd/pigo/run_test.go
+++ b/cmd/pigo/run_test.go
@@ -10,8 +10,6 @@ import (
 	"context"
 	"strings"
 	"testing"
-
-	"github.com/smallnest/pigo/internal/runtime"
 )
 
 // TestDispatchListSessionsEmpty verifies --list-sessions is a standalone action
@@ -43,36 +41,6 @@ func TestDispatchContinueNoSessions(t *testing.T) {
 	}
 	if !strings.Contains(errOut.String(), "no sessions to continue") {
 		t.Errorf("errOut = %q, want the no-sessions-to-continue message", errOut.String())
-	}
-}
-
-// TestParseOutputMode covers the three accepted spellings and one rejection,
-// pinning the flag contract the headless driver depends on.
-func TestParseOutputMode(t *testing.T) {
-	cases := []struct {
-		in      string
-		want    runtime.HeadlessMode
-		wantErr bool
-	}{
-		{"text", runtime.PrintMode, false},
-		{"", runtime.PrintMode, false},
-		{"stream-json", runtime.StreamJSONMode, false},
-		{"yaml", 0, true},
-	}
-	for _, c := range cases {
-		got, err := parseOutputMode(c.in)
-		if c.wantErr {
-			if err == nil {
-				t.Errorf("parseOutputMode(%q): want error, got nil", c.in)
-			}
-			continue
-		}
-		if err != nil {
-			t.Errorf("parseOutputMode(%q): unexpected error %v", c.in, err)
-		}
-		if got != c.want {
-			t.Errorf("parseOutputMode(%q) = %v, want %v", c.in, got, c.want)
-		}
 	}
 }
 

--- a/docs/issue#0363.html
+++ b/docs/issue#0363.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #363</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+    code { background:#F2EFEA; padding:0.05rem 0.3rem; border-radius:3px; font-size:0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/363">#363</a> &mdash; 迁移 headless/subagent 到 internal/cli/headless &mdash; 2026-07-28</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>SessionStore</code> exported and homed in the headless package</h3>
+      <p><strong>Ambiguity:</strong> The session-store constructor was a private <code>sessionStore()</code> in <code>cmd/pigo</code>, used by both the REPL and the headless path. The spec did not say where it should live after the split.</p>
+      <p><strong>Choice:</strong> Moved it to <code>internal/cli/headless</code> as the exported <code>SessionStore()</code>, alongside <code>PrintSessions</code> and <code>MostRecentSessionID</code>, which all depend on it.</p>
+      <p><strong>Rationale:</strong> <code>printSessions</code>/<code>mostRecentSessionID</code>/<code>openHeadlessSession</code> all move here and use the store; headless cannot import <code>cmd/pigo</code> (package main), so the store must sit at or below headless.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Extract dispatch's headless block into <code>headless.Run(RunParams)</code></h3>
+      <p><strong>Ambiguity:</strong> The run-lifecycle wiring (plugin command resolve → session open → thinking level → credentials → RunHeadless → persist) lived inline in <code>dispatch</code>.</p>
+      <p><strong>Choice:</strong> Moved it behind a <code>RunParams</code> struct and a single <code>headless.Run</code> entry point; <code>dispatch</code> now only resolves <code>Mode</code> and <code>Env</code> then delegates.</p>
+      <p><strong>Rationale:</strong> Keeps the headless run owned by the headless package and makes <code>dispatch</code> a thin seam, matching the #362 run-assembly split.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Export only symbols crossed by the package boundary</h3>
+      <p><strong>Ambiguity:</strong> Which of the moved identifiers to export.</p>
+      <p><strong>Choice:</strong> Exported <code>RunSubAgentRPC</code>, <code>ParseOutputMode</code>, <code>Run</code>, <code>RunParams</code>, <code>SessionStore</code>, <code>PrintSessions</code>, <code>MostRecentSessionID</code>; kept <code>openHeadlessSession</code>, <code>headlessSession</code>, <code>persist</code>, <code>filterBuiltinTools</code>, <code>handleSubAgentRequest</code>, <code>resolveHeadlessPluginCommand</code> unexported.</p>
+      <p><strong>Rationale:</strong> Same export policy as #362 — export a symbol only when a caller outside the package needs it.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Removed the duplicate session helpers from <code>cmd/pigo</code></h3>
+      <p><strong>Spec:</strong> A pure move would leave the callers referencing the new package.</p>
+      <p><strong>Implemented:</strong> Deleted <code>printSessions</code>/<code>mostRecentSessionID</code> from <code>interactive.go</code> outright (they became dead once <code>dispatch</code> called the headless versions), and reduced <code>sessionStore()</code> to a one-line wrapper over <code>headless.SessionStore()</code>.</p>
+      <p><strong>Why:</strong> Leaving two copies would be a maintenance trap; the wrapper is kept only so the REPL call site reads naturally.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> <code>ParseOutputMode</code> kept as a separate call in dispatch</h3>
+      <p><strong>Alternatives:</strong> (a) fold output-mode parsing into <code>headless.Run</code>; (b) keep it a distinct exported call in <code>dispatch</code> before <code>SetupEnv</code>.</p>
+      <p><strong>Chosen:</strong> (b).</p>
+      <p><strong>Why:</strong> A bad <code>--output-format</code> must return exit code 2 <em>before</em> provider/env setup; keeping the parse ahead of <code>SetupEnv</code> preserves the original exit-code ordering, verified by <code>TestDispatchBadOutputFormat</code>.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> REPL → headless <code>SessionStore</code> dependency direction</h3>
+      <p><strong>Assumption:</strong> It is acceptable for the interactive REPL (staying in <code>cmd/pigo</code>, later <code>internal/cli/repl</code>) to depend on <code>internal/cli/headless</code> purely for the shared session store.</p>
+      <p><strong>Verify:</strong> When #367 moves the REPL into <code>internal/cli/repl</code>, decide whether <code>SessionStore</code> should instead live in a neutral package (e.g. <code>internal/session</code> or <code>internal/cli/run</code>) so neither of REPL/headless depends on the other.</p>
+      <p><strong>Follow-up:</strong> Revisit during #367.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>
+

--- a/internal/cli/headless/headless.go
+++ b/internal/cli/headless/headless.go
@@ -1,0 +1,175 @@
+// This file is the headless run driver: the print / stream-json run path
+// (US-020) extracted from the CLI dispatch seam (#363). dispatch resolves the
+// output mode and the run environment, then hands off to Run, which wires the
+// session, prompt, thinking level, and provider credentials into a
+// runtime.HeadlessConfig and executes one run. Plugin slash commands and output
+// mode parsing live here because they are specific to the headless path.
+package headless
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/cli/run"
+	"github.com/smallnest/pigo/internal/cli/ui"
+	"github.com/smallnest/pigo/internal/plugin"
+	"github.com/smallnest/pigo/internal/provider"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// RunParams carries the resolved inputs for one headless run. Mode and Env are
+// resolved by the caller (dispatch) — Mode via ParseOutputMode, Env via
+// run.SetupEnv — so their distinct exit codes stay at the call site; Run owns
+// the rest of the run lifecycle.
+type RunParams struct {
+	Mode          runtime.HeadlessMode
+	Env           run.Env
+	Prompt        string
+	Model         string
+	APIKey        string
+	ThinkingLevel string
+	ResumeID      string
+}
+
+// Run executes one headless run over p.Prompt, writing agent output to out and
+// diagnostics to errOut, and returns a process exit code (0 = success). The run
+// is backed by a session so its id appears in the first stream-json event and it
+// can be resumed with --resume/--continue; a resumed session seeds its prior
+// messages ahead of the new prompt.
+func Run(ctx context.Context, p RunParams, out, errOut io.Writer) int {
+	env := p.Env
+	// Best-effort plugin slash-command support in headless mode: if the prompt is
+	// a "/cmd ..." naming a plugin command, invoke it, print its notifications to
+	// errOut, and use the returned prompt for this run (appending the raw args if
+	// the command produced no prompt). Headless has no turn injection, so
+	// appending the returned prompt is the accepted behavior. A non-plugin prompt
+	// or unknown command is left untouched.
+	headlessPrompt := resolveHeadlessPluginCommand(p.Prompt, env.Plugins, errOut)
+	promptContent, err := ui.BuildUserContent(headlessPrompt)
+	if err != nil {
+		fmt.Fprintf(errOut, "pigo: %v\n", err)
+		return 1
+	}
+
+	// Back the headless run with a session so its id appears in the first
+	// stream-json event and the run can be resumed with --resume/--continue,
+	// matching the interactive REPL and pi/Claude Code. A resumed session seeds
+	// its prior messages ahead of the new prompt.
+	priorMsgs, hs, err := openHeadlessSession(p.ResumeID, p.Model, env.ProviderName, env.SysPrompt)
+	if err != nil {
+		fmt.Fprintf(errOut, "pigo: %v\n", err)
+		return 1
+	}
+	messages := append(priorMsgs, agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: promptContent})
+	agentCtx := &agentcore.AgentContext{
+		SystemPrompt: hs.header.SystemPrompt,
+		Messages:     messages,
+		Tools:        env.Tools,
+	}
+
+	// Resolve the effective reasoning-effort level through the layered config
+	// chain (default < global < project < env < --thinking-level flag).
+	thinking, err := run.ResolveThinkingLevel(p.ThinkingLevel)
+	if err != nil {
+		fmt.Fprintf(errOut, "pigo: %v\n", err)
+		return 2
+	}
+
+	// Resolve the API key by provider name from the environment (never logged).
+	// An explicit --api-key overrides env/config for the resolved provider.
+	creds := provider.NewCredentialStore(nil)
+	creds.SetOverride(env.ProviderName, p.APIKey)
+	runCfg := run.NewConfig(p.Model, env.ProviderName, thinking, env.Provider, creds, run.ToolRegistry(env.Tools), run.TodoReminders(env.Tools))
+	runCfg.SessionID = hs.header.ID
+	cfg := runtime.HeadlessConfig{
+		Mode: p.Mode,
+		Out:  out,
+		Run:  runCfg,
+	}
+	// Deliver agent lifecycle events to any subscribed plugin (US-017, #133).
+	// NewEventNotifier returns nil when no plugin subscribes, so the OnEvent hook
+	// stays unset in the common no-plugin case.
+	if n := plugin.NewEventNotifier(env.Plugins, errOut); n != nil {
+		cfg.OnEvent = n.Handle
+	}
+	runErr := runtime.RunHeadless(ctx, agentCtx, cfg)
+	// Persist the run's messages regardless of run outcome so a partial run is
+	// still resumable; a persistence failure is reported but does not mask a run
+	// error.
+	if perr := hs.persist(agentCtx); perr != nil {
+		fmt.Fprintf(errOut, "pigo: warning: could not persist session %s: %v\n", hs.header.ID, perr)
+	}
+	if runErr != nil {
+		fmt.Fprintf(errOut, "pigo: %v\n", runErr)
+		return 1
+	}
+	return 0
+}
+
+// resolveHeadlessPluginCommand gives the headless / print path best-effort
+// support for plugin slash commands. When prompt is a "/cmd ..." naming a
+// plugin command (from mgr.Commands()), it invokes the command, prints each
+// returned notification to notifyOut, and returns the command's returned Prompt
+// as the run's prompt. If the command returns no prompt, the raw argument text
+// is used instead (so a bare "/cmd" with only notifications still runs
+// something sensible rather than an empty prompt). Any other input — a
+// non-command, an unknown command, or a call error — leaves prompt unchanged so
+// the normal headless run proceeds. mgr may be nil (no plugins).
+//
+// Headless has no turn-injection loop, so "inject the returned prompt" degrades
+// to "use the returned prompt for this run", which the acceptance criteria
+// permit.
+func resolveHeadlessPluginCommand(prompt string, mgr *plugin.Manager, notifyOut io.Writer) string {
+	if mgr == nil || !strings.HasPrefix(strings.TrimLeft(prompt, " \t"), "/") {
+		return prompt
+	}
+	trimmed := strings.TrimLeft(prompt, " \t")[1:]
+	name := trimmed
+	args := ""
+	if i := strings.IndexAny(trimmed, " \t"); i >= 0 {
+		name = trimmed[:i]
+		args = strings.TrimSpace(trimmed[i+1:])
+	}
+	for _, pc := range mgr.Commands() {
+		if pc.Spec.Name != name {
+			continue
+		}
+		// Encode the raw arg text as a JSON string (never null), matching the
+		// host's CommandCallParams.Args contract.
+		raw, _ := json.Marshal(args)
+		res, err := pc.Plugin.CallCommand(context.Background(), name, json.RawMessage(raw))
+		if err != nil {
+			fmt.Fprintf(notifyOut, "pigo: plugin command %q failed: %v\n", name, err)
+			return prompt
+		}
+		for _, n := range res.Notifications {
+			if n.Type != "" {
+				fmt.Fprintf(notifyOut, "[%s] %s\n", n.Type, n.Message)
+			} else {
+				fmt.Fprintln(notifyOut, n.Message)
+			}
+		}
+		if res.Prompt != "" {
+			return res.Prompt
+		}
+		return args
+	}
+	return prompt
+}
+
+// ParseOutputMode maps the --output-format flag onto a HeadlessMode, erroring on
+// an unknown value.
+func ParseOutputMode(outputFmt string) (runtime.HeadlessMode, error) {
+	switch outputFmt {
+	case "text", "":
+		return runtime.PrintMode, nil
+	case "stream-json":
+		return runtime.StreamJSONMode, nil
+	default:
+		return 0, fmt.Errorf("unknown --output-format %q (want text|stream-json)", outputFmt)
+	}
+}

--- a/internal/cli/headless/headless_test.go
+++ b/internal/cli/headless/headless_test.go
@@ -1,0 +1,41 @@
+package headless
+
+// Tests for the headless run driver's flag parsing. The run lifecycle (Run) is
+// exercised via session/subagent tests here and provider-backed tests in
+// internal/runtime; ParseOutputMode is pure and pinned directly.
+
+import (
+	"testing"
+
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// TestParseOutputMode covers the three accepted spellings and one rejection,
+// pinning the flag contract the headless driver depends on.
+func TestParseOutputMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    runtime.HeadlessMode
+		wantErr bool
+	}{
+		{"text", runtime.PrintMode, false},
+		{"", runtime.PrintMode, false},
+		{"stream-json", runtime.StreamJSONMode, false},
+		{"yaml", 0, true},
+	}
+	for _, c := range cases {
+		got, err := ParseOutputMode(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("ParseOutputMode(%q): want error, got nil", c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseOutputMode(%q): unexpected error %v", c.in, err)
+		}
+		if got != c.want {
+			t.Errorf("ParseOutputMode(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/cli/headless/session.go
+++ b/internal/cli/headless/session.go
@@ -1,3 +1,7 @@
+// Package headless drives pigo's non-interactive run paths: the print /
+// stream-json headless run, the session listing/resume helpers, and the
+// process-isolated sub-agent JSON-RPC server (--subagent-rpc).
+//
 // This file gives headless / stream-json runs the same session persistence and
 // resume the interactive REPL has (cmd/pigo/interactive.go). Before this, a
 // headless run built an in-memory AgentContext and threw it away on exit, so
@@ -10,14 +14,70 @@
 // after it completes. The session id is threaded into the run so it appears in
 // the first stream-json event (对标 pi/Claude Code) and can be passed back via
 // --resume to continue the run.
-package main
+package headless
 
 import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/session"
 )
+
+// SessionStore returns the session store rooted at ~/.pigo/sessions (or under
+// PIGO_HOME when set), creating the directory on first use. It is shared by the
+// headless run path and the interactive REPL.
+func SessionStore() (*session.Store, error) {
+	dir := os.Getenv("PIGO_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve home dir: %w", err)
+		}
+		dir = filepath.Join(home, ".pigo")
+	}
+	return session.NewStore(filepath.Join(dir, "sessions"))
+}
+
+// PrintSessions prints the stored sessions, most-recent first, to out.
+func PrintSessions(out io.Writer) error {
+	store, err := SessionStore()
+	if err != nil {
+		return err
+	}
+	headers, err := store.List()
+	if err != nil {
+		return err
+	}
+	if len(headers) == 0 {
+		fmt.Fprintln(out, "no sessions")
+		return nil
+	}
+	for _, h := range headers {
+		fmt.Fprintf(out, "%s\t%s\t%s\n", h.ID, h.UpdatedAt.Local().Format("2006-01-02 15:04"), h.Model)
+	}
+	return nil
+}
+
+// MostRecentSessionID returns the id of the most recently updated session, or
+// "" if there are none.
+func MostRecentSessionID() (string, error) {
+	store, err := SessionStore()
+	if err != nil {
+		return "", err
+	}
+	headers, err := store.List()
+	if err != nil {
+		return "", err
+	}
+	if len(headers) == 0 {
+		return "", nil
+	}
+	return headers[0].ID, nil
+}
 
 // headlessSession is the session state backing one headless run: the store, the
 // header (whose ID is the session id emitted and used for resume), and the
@@ -43,7 +103,7 @@ type headlessSession struct {
 // messages to seed into the context ahead of the new prompt, plus the session
 // state used to persist the run afterward.
 func openHeadlessSession(resumeID, model, providerName, sysPrompt string) (agentcore.MessageList, headlessSession, error) {
-	store, err := sessionStore()
+	store, err := SessionStore()
 	if err != nil {
 		return nil, headlessSession{}, err
 	}

--- a/internal/cli/headless/session_test.go
+++ b/internal/cli/headless/session_test.go
@@ -1,4 +1,4 @@
-package main
+package headless
 
 // Tests for headless session persistence and resume (session id in stream-json
 // + --resume for headless runs). openHeadlessSession/persist are exercised

--- a/internal/cli/headless/subagent_rpc.go
+++ b/internal/cli/headless/subagent_rpc.go
@@ -8,7 +8,7 @@
 // It reuses internal/jsonrpc's message types (Request/Response/ID/Version) for
 // (de)serialization so the wire format matches the client exactly; the agent
 // execution itself is runtime.RunSubAgentOnce.
-package main
+package headless
 
 import (
 	"bufio"
@@ -27,14 +27,14 @@ import (
 	"github.com/smallnest/pigo/internal/runtime"
 )
 
-// runSubAgentRPC is the `pigo --subagent-rpc` entry point. It reads
+// RunSubAgentRPC is the `pigo --subagent-rpc` entry point. It reads
 // newline-delimited JSON-RPC requests from in, runs each sub-agent request, and
 // writes one response per request to out. It returns 0 (success) when stdin
 // closes; a per-request failure is an RPC error response, not a non-zero exit,
 // so the parent can distinguish "the child answered with an error" from "the
 // child crashed" (the latter is detected by the parent's transport when stdout
 // closes without a response).
-func runSubAgentRPC(ctx context.Context, in io.Reader, out, errOut io.Writer) int {
+func RunSubAgentRPC(ctx context.Context, in io.Reader, out, errOut io.Writer) int {
 	scanner := bufio.NewScanner(in)
 	// A sub-agent prompt can be large; match the jsonrpc client's line cap.
 	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)

--- a/internal/cli/headless/subagent_rpc_test.go
+++ b/internal/cli/headless/subagent_rpc_test.go
@@ -1,7 +1,7 @@
-package main
+package headless
 
 // Tests for the sub-agent RPC subprocess mode (US-019, #135): the pure
-// filterBuiltinTools helper and the runSubAgentRPC validation branches
+// filterBuiltinTools helper and the RunSubAgentRPC validation branches
 // (method-not-found, invalid params, parse error) that return RPC errors before
 // any provider is resolved. The happy-path transport is covered in
 // internal/runtime via a compiled helper binary; RunSubAgentOnce (the agent
@@ -78,7 +78,7 @@ func TestRunSubAgentRPCValidation(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			var out, errOut bytes.Buffer
-			code := runSubAgentRPC(context.Background(), strings.NewReader(c.line+"\n"), &out, &errOut)
+			code := RunSubAgentRPC(context.Background(), strings.NewReader(c.line+"\n"), &out, &errOut)
 			if code != 0 {
 				t.Errorf("exit code = %d, want 0 (validation errors are RPC responses, not non-zero exits)", code)
 			}
@@ -110,7 +110,7 @@ func TestRunSubAgentRPCScannerError(t *testing.T) {
 	// A line longer than the 16 MiB scanner cap triggers a scanner error.
 	huge := strings.Repeat("a", 17*1024*1024)
 	var out, errOut bytes.Buffer
-	code := runSubAgentRPC(context.Background(), strings.NewReader(huge), &out, &errOut)
+	code := RunSubAgentRPC(context.Background(), strings.NewReader(huge), &out, &errOut)
 	if code == 0 {
 		t.Error("exit code = 0 on scanner error, want non-zero")
 	}


### PR DESCRIPTION
## Summary
- Move `headless_session.go`, `subagent_rpc.go` and their tests into `internal/cli/headless`
- Extract dispatch's headless run block into `headless.Run(RunParams)`; export `SessionStore`/`PrintSessions`/`MostRecentSessionID`/`RunSubAgentRPC`/`ParseOutputMode`, keep the run-lifecycle helpers unexported
- `cmd/pigo/dispatch` now resolves `Mode`+`Env` and delegates; `interactive.go`'s `sessionStore()` is a thin wrapper over `headless.SessionStore()`

Closes #363

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`