### PR TITLE
refactor(cli): migrate /goal to internal/cli/goal (#364)

### DIFF
--- a/cmd/pigo/btw.go
+++ b/cmd/pigo/btw.go
@@ -247,10 +247,10 @@ func drainSideStream(ctx context.Context, out io.Writer, deps *replDeps, stream 
 		OnTurnEnd: func(msg agentcore.AssistantMessage, results []agentcore.ToolResultMessage) {
 			flushReply()
 			for _, c := range msg.ToolCalls() {
-				fmt.Fprintf(out, "  %s %s\n", ui.Colorize(ui.Enabled(), ui.Green, "→ tool:"), toolCallLabel(c))
+				fmt.Fprintf(out, "  %s %s\n", ui.Colorize(ui.Enabled(), ui.Green, "→ tool:"), ui.ToolCallLabel(c))
 			}
 			for _, tr := range results {
-				renderToolResult(out, tr)
+				ui.RenderToolResult(out, tr)
 			}
 		},
 	})

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/goal"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/clipboard"
 	"github.com/smallnest/pigo/internal/compaction"
@@ -294,7 +295,7 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 			// which a slash Action closure (string→string) can do. It drives the
 			// autonomous goal loop, reusing the same SIGINT cancel plumbing as a
 			// normal turn via setCancel.
-			runGoal(setCancel, out, &deps, line)
+			goal.RunGoal(setCancel, out, &deps, line)
 			continue
 		}
 		if line == "/btw" || strings.HasPrefix(line, "/btw ") {
@@ -352,34 +353,8 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 		// than a truncated linear rewrite.
 		deps.header.Model = deps.live.Model
 		deps.header.Provider = deps.live.ProviderName
-		persistTurn(out, &deps)
+		cli.PersistTurn(out, &deps)
 	}
-}
-
-// persistTurn writes the messages produced since the last persist as a new
-// branch descending from deps.curLeaf, advancing curLeaf to the new leaf and
-// persisted to the current message count (US-007, #123). Growing the tree with
-// AppendBranch (rather than rewriting the whole file linearly with Save) is what
-// lets a /tree leaf-switch fork the on-disk history instead of clobbering it. If
-// nothing new was produced it is a no-op: the on-disk tree is already current, so
-// the file is left untouched (rewriting it would regenerate ids and flatten the
-// tree).
-func persistTurn(out io.Writer, deps *replDeps) {
-	tail := deps.agentCtx.Messages[deps.persisted:]
-	if len(tail) == 0 {
-		// Nothing new to persist. Do NOT rewrite the file: Save regenerates entry
-		// ids and flattens the tree, which would invalidate curLeaf and drop any
-		// sibling branches. The on-disk tree is already current.
-		return
-	}
-	deps.header.UpdatedAt = time.Now().UTC()
-	leaf, err := deps.store.AppendBranch(deps.header, deps.curLeaf, tail)
-	if err != nil {
-		fmt.Fprintf(out, "pigo: session save failed: %v\n", err)
-		return
-	}
-	deps.curLeaf = leaf
-	deps.persisted = len(deps.agentCtx.Messages)
 }
 
 // streamRun appends the prompt to the shared context, starts an agent run, and
@@ -450,10 +425,10 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 		OnTurnEnd: func(msg agentcore.AssistantMessage, results []agentcore.ToolResultMessage) {
 			flushReply()
 			for _, c := range msg.ToolCalls() {
-				fmt.Fprintf(out, "  %s %s\n", ui.Colorize(ui.Enabled(), ui.Green, "→ tool:"), toolCallLabel(c))
+				fmt.Fprintf(out, "  %s %s\n", ui.Colorize(ui.Enabled(), ui.Green, "→ tool:"), ui.ToolCallLabel(c))
 			}
 			for _, tr := range results {
-				renderToolResult(out, tr)
+				ui.RenderToolResult(out, tr)
 			}
 		},
 	})
@@ -489,7 +464,7 @@ func runForkClone(out io.Writer, deps *replDeps, line string) {
 	// Persist the current turn as a branch so Fork copies an up-to-date tree
 	// without flattening any existing branches (a plain Save would rewrite the
 	// file linearly and drop siblings).
-	persistTurn(out, deps)
+	cli.PersistTurn(out, deps)
 	_, entries, err := deps.store.LoadEntries(deps.header.ID)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		fmt.Fprintf(out, "pigo: cannot read session tree: %v\n", err)
@@ -530,7 +505,7 @@ func runForkClone(out io.Writer, deps *replDeps, line string) {
 			// List the user messages for selection.
 			fmt.Fprintln(out, "fork from which message? run /fork <n>:")
 			for n, u := range users {
-				fmt.Fprintf(out, "  %d. %s\n", n+1, oneLine(u.text))
+				fmt.Fprintf(out, "  %d. %s\n", n+1, ui.OneLine(u.text))
 			}
 			return
 		}
@@ -596,7 +571,7 @@ func runForkClone(out io.Writer, deps *replDeps, line string) {
 //     real sibling branch on disk rather than truncating history.
 func runTree(out io.Writer, deps *replDeps, line string) {
 	// Persist any un-saved turn first so the tree reflects the live conversation.
-	persistTurn(out, deps)
+	cli.PersistTurn(out, deps)
 	_, entries, err := deps.store.LoadEntries(deps.header.ID)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		fmt.Fprintf(out, "pigo: cannot read session tree: %v\n", err)
@@ -661,7 +636,7 @@ func pathCommandArg(line, cmd string) string {
 // (or .htm) writes a self-contained HTML transcript; any other extension writes
 // JSONL. The JSONL form round-trips losslessly through /import.
 func runExport(out io.Writer, deps *replDeps, line string) {
-	persistTurn(out, deps)
+	cli.PersistTurn(out, deps)
 	path := pathCommandArg(line, "/export")
 	if path == "" {
 		path = deps.header.ID + ".jsonl"
@@ -833,63 +808,17 @@ func replayTranscript(out io.Writer, messages []agentcore.AgentMessage) {
 				fmt.Fprintln(out, t)
 			}
 			for _, c := range msg.ToolCalls() {
-				fmt.Fprintf(out, "  %s %s\n", ui.Colorize(color, ui.Green, "→ tool:"), toolCallLabel(c))
+				fmt.Fprintf(out, "  %s %s\n", ui.Colorize(color, ui.Green, "→ tool:"), ui.ToolCallLabel(c))
 			}
 		case agentcore.ToolResultMessage:
 			if msg.IsError {
-				fmt.Fprintf(out, "  %s %s\n", ui.Colorize(color, ui.Red, "← error:"), oneLine(agentcore.ContentToText(msg.Content)))
+				fmt.Fprintf(out, "  %s %s\n", ui.Colorize(color, ui.Red, "← error:"), ui.OneLine(agentcore.ContentToText(msg.Content)))
 			} else {
-				fmt.Fprintf(out, "  %s %s\n", ui.Colorize(color, ui.Green, "← result:"), oneLine(agentcore.ContentToText(msg.Content)))
+				fmt.Fprintf(out, "  %s %s\n", ui.Colorize(color, ui.Green, "← result:"), ui.OneLine(agentcore.ContentToText(msg.Content)))
 			}
 		}
 	}
 }
 
-// renderToolResult prints a single tool result under the compact status. Most
-// results collapse to a one-line "← result:" summary, but the todo tool's
-// progress block is rendered in full (indented, multi-line) so the user sees the
-// live task checklist after each update — that visible progress is the point of
-// the tool (US-011).
-func renderToolResult(out io.Writer, tr agentcore.ToolResultMessage) {
-	text := agentcore.ContentToText(tr.Content)
-	color := ui.Enabled()
-	if tr.ToolName == "todo" && !tr.IsError {
-		fmt.Fprintln(out, "  "+ui.Colorize(color, ui.Green, "← todo:"))
-		for _, line := range strings.Split(text, "\n") {
-			fmt.Fprintf(out, "    %s\n", line)
-		}
-		return
-	}
-	// Success results show a green "← result:" label; failures show a red
-	// "← error:" label so the outcome is scannable at a glance.
-	if tr.IsError {
-		fmt.Fprintf(out, "  %s %s\n", ui.Colorize(color, ui.Red, "← error:"), oneLine(text))
-		return
-	}
-	fmt.Fprintf(out, "  %s %s\n", ui.Colorize(color, ui.Green, "← result:"), oneLine(text))
-}
-
-// toolCallLabel renders a tool call as "name args" for the compact "→ tool:"
-// status, so the user can see what a tool was actually invoked with (e.g. the
-// shell command bash ran). Empty or "{}" arguments collapse to just the name.
-func toolCallLabel(c agentcore.ToolCallContent) string {
-	args := strings.TrimSpace(string(c.Arguments))
-	if args == "" || args == "{}" {
-		return c.Name
-	}
-	return c.Name + " " + oneLine(args)
-}
-
-// oneLine collapses a possibly multi-line tool result into a single trimmed
-// line for the compact "← result:" status, truncating very long results.
-func oneLine(s string) string {
-	s = strings.TrimSpace(s)
-	if i := strings.IndexByte(s, '\n'); i >= 0 {
-		s = s[:i] + " …"
-	}
-	const max = 120
-	if len(s) > max {
-		s = s[:max] + " …"
-	}
-	return s
-}
+// (Compact tool-activity renderers moved to internal/cli/ui: ui.RenderToolResult,
+// ui.ToolCallLabel, ui.OneLine — shared by the REPL, /btw and /goal.)

--- a/cmd/pigo/repl_test.go
+++ b/cmd/pigo/repl_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 	"github.com/smallnest/pigo/internal/session"
@@ -271,7 +272,7 @@ func TestREPLPersistsModelIntoHeader(t *testing.T) {
 // progress on update), while a non-todo result stays a one-line summary.
 func TestRenderToolResultTodoFull(t *testing.T) {
 	var out bytes.Buffer
-	renderToolResult(&out, agentcore.ToolResultMessage{
+	ui.RenderToolResult(&out, agentcore.ToolResultMessage{
 		RoleField: agentcore.RoleToolResult, ToolName: "todo",
 		Content: agentcore.ContentList{agentcore.NewTextContent("Todos:\n  [x] a\n  [ ] b\n(1/2 completed)")},
 	})
@@ -283,7 +284,7 @@ func TestRenderToolResultTodoFull(t *testing.T) {
 	}
 
 	out.Reset()
-	renderToolResult(&out, agentcore.ToolResultMessage{
+	ui.RenderToolResult(&out, agentcore.ToolResultMessage{
 		RoleField: agentcore.RoleToolResult, ToolName: "bash",
 		Content: agentcore.ContentList{agentcore.NewTextContent("line1\nline2")},
 	})

--- a/docs/issue#0364.html
+++ b/docs/issue#0364.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #364</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/364">#364</a> &mdash; 迁移 /goal 到 internal/cli/goal (US-008) &mdash; 2026-07-28</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> /goal decoupled from package main via the cli.Host contract</h3>
+      <p><strong>Ambiguity:</strong> The spec asked to move /goal into <code>internal/cli/goal</code>, but /goal reaches deep into the session's mutable state (agent context, live config, goal state, session store) that lived on the concrete <code>replDeps</code> struct in package main.</p>
+      <p><strong>Choice:</strong> <code>RunGoal</code> takes <code>host cli.Host</code> and reads every collaborator through Host accessors (<code>host.AgentCtx()</code>, <code>host.Live()</code>, <code>host.Goal()</code>, …) instead of importing <code>replDeps</code>.</p>
+      <p><strong>Rationale:</strong> goal must not import package main (cmd/pigo); the Host seam keeps the dependency single-direction (repl→goal) and avoids an import cycle, matching the pattern already used by /compact and /fork.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Shared REPL helpers relocated to neutral packages before the goal move</h3>
+      <p><strong>Ambiguity:</strong> /goal reused three renderers (<code>renderToolResult</code>/<code>toolCallLabel</code>/<code>oneLine</code>) and <code>persistTurn</code> that were private to package main.</p>
+      <p><strong>Choice:</strong> Moved the renderers to <code>internal/cli/ui</code> (<code>RenderToolResult</code>/<code>ToolCallLabel</code>/<code>OneLine</code>) and <code>persistTurn</code> to <code>internal/cli</code> (<code>PersistTurn(out, Host)</code>), then rewired repl.go, btw.go and goal.go to the shared versions.</p>
+      <p><strong>Rationale:</strong> Both repl(main) and goal now depend downward on neutral packages with no duplication and no cycle, rather than goal reaching sideways into main.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> PersistTurn no longer mutates the in-memory header timestamp</h3>
+      <p><strong>Spec/original:</strong> The old <code>persistTurn</code> set <code>deps.header.UpdatedAt</code> in place, so the live struct carried the fresh timestamp after a persist.</p>
+      <p><strong>Implemented:</strong> <code>Host.Header()</code> returns a value copy, so <code>PersistTurn</code> stamps <code>UpdatedAt</code> on that copy and passes it to <code>AppendBranch</code>; the disk record is correct but the in-memory <code>deps.header.UpdatedAt</code> is not advanced by PersistTurn.</p>
+      <p><strong>Why acceptable:</strong> No in-process reader depends on the freshness of <code>deps.header.UpdatedAt</code> after a persist — the /compact path stamps it independently before its own <code>Save</code>, and header timestamps are read from disk-loaded headers when listing sessions. Persistence is behavior-equivalent.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Host accessor pattern vs. exporting replDeps</h3>
+      <p><strong>Alternatives:</strong> (a) export <code>replDeps</code> and its fields so goal could import it; (b) pass a narrow <code>cli.Host</code> interface.</p>
+      <p><strong>Pros/cons:</strong> (a) is fewer lines but forces goal to import package main (impossible — cycle) or forces replDeps into internal/cli (a large, main-specific aggregate). (b) adds one accessor call per field but keeps packages loosely coupled.</p>
+      <p><strong>Chosen:</strong> (b) — the Host contract already existed from #357 and is the established seam for control commands; reusing it keeps the migration consistent with #362/#363.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Duplicate renderer test left in package main</h3>
+      <p><strong>Assumption:</strong> <code>TestRenderToolResultTodoFull</code> in <code>cmd/pigo/repl_test.go</code> now exercises <code>ui.RenderToolResult</code> from the main package rather than being relocated to <code>internal/cli/ui</code>.</p>
+      <p><strong>Verify:</strong> Whether the renderer test should move to the <code>ui</code> package alongside the code it now tests, or stay as an integration-style check that main wires the shared renderer. Left in place to keep this PR mechanical; can be relocated when #367 migrates the REPL.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/cli/goal/goal.go
+++ b/internal/cli/goal/goal.go
@@ -5,15 +5,17 @@
 // (goal_blocked), or a safety guard (max turns / no-progress) or the token
 // budget stops it.
 //
-// /goal is intercepted in the REPL loop (see repl.go) rather than routed through
-// a slash Action closure because it must run agent streams and mutate the shared
+// /goal is intercepted in the REPL loop rather than routed through a slash
+// Action closure because it must run agent streams and mutate the shared
 // context and goal state — none of which a pure string→string Action can do,
-// exactly like /compact and /fork.
+// exactly like /compact and /fork. It reaches the session's collaborators and
+// mutable state through the cli.Host contract, so it need not import the
+// concrete replDeps aggregate that assembles them.
 //
 // Scope: core autonomous continuation plus an optional token budget. Goal state
-// lives only in the session's in-memory GoalState (deps.goal); it is not
+// lives only in the session's in-memory GoalState (host.Goal()); it is not
 // persisted across process restarts.
-package main
+package goal
 
 import (
 	"context"
@@ -25,6 +27,7 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/compaction"
 	"github.com/smallnest/pigo/internal/provider"
@@ -44,35 +47,35 @@ const goalMaxNoProgress = 3
 // runGoal parses and dispatches a /goal invocation. setCancel publishes the
 // active run's cancel func so the REPL's SIGINT handler can interrupt an
 // autonomous run (same plumbing as a normal turn).
-func runGoal(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, line string) {
+func RunGoal(setCancel func(context.CancelFunc), out io.Writer, host cli.Host, line string) {
 	args := strings.TrimSpace(strings.TrimPrefix(line, "/goal"))
 
 	switch {
 	case args == "":
-		printGoalStatus(out, deps.goal)
+		printGoalStatus(out, host.Goal())
 		return
 	case args == "clear":
-		deps.goal.Clear()
+		host.Goal().Clear()
 		fmt.Fprintln(out, "goal cleared")
 		return
 	case args == "pause":
-		snap := deps.goal.Snapshot()
+		snap := host.Goal().Snapshot()
 		if snap.Status != agenttool.GoalActive && snap.Status != agenttool.GoalPaused {
 			fmt.Fprintln(out, "no active goal to pause")
 			return
 		}
-		deps.goal.SetStatus(agenttool.GoalPaused)
+		host.Goal().SetStatus(agenttool.GoalPaused)
 		fmt.Fprintln(out, "goal paused — run /goal resume to continue")
 		return
 	case args == "resume":
-		snap := deps.goal.Snapshot()
+		snap := host.Goal().Snapshot()
 		if snap.Status != agenttool.GoalPaused && snap.Status != agenttool.GoalBudgetLimited {
 			fmt.Fprintln(out, "no paused goal to resume")
 			return
 		}
-		deps.goal.Resume()
-		fmt.Fprintf(out, "resuming goal: %s\n", oneLine(snap.Objective))
-		runGoalLoop(setCancel, out, deps)
+		host.Goal().Resume()
+		fmt.Fprintf(out, "resuming goal: %s\n", ui.OneLine(snap.Objective))
+		runGoalLoop(setCancel, out, host)
 		return
 	}
 
@@ -86,13 +89,13 @@ func runGoal(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, 
 		fmt.Fprintln(out, "usage: /goal [--tokens N] <objective>")
 		return
 	}
-	deps.goal.Start(newGoalID(), objective, budget)
+	host.Goal().Start(newGoalID(), objective, budget)
 	if budget > 0 {
-		fmt.Fprintf(out, "goal set (token budget %d): %s\n", budget, oneLine(objective))
+		fmt.Fprintf(out, "goal set (token budget %d): %s\n", budget, ui.OneLine(objective))
 	} else {
-		fmt.Fprintf(out, "goal set: %s\n", oneLine(objective))
+		fmt.Fprintf(out, "goal set: %s\n", ui.OneLine(objective))
 	}
-	runGoalLoop(setCancel, out, deps)
+	runGoalLoop(setCancel, out, host)
 }
 
 // newGoalID returns a short unique id for a goal (used to key goal_complete's
@@ -186,9 +189,9 @@ func goalFollowUpDecision(snap agenttool.GoalSnapshot) (cont bool, terminal agen
 // the run or goalFollowUpDecision trips a guard. On return it prints the outcome
 // and persists the turn. The run reuses the REPL's SIGINT cancel plumbing via
 // setCancel.
-func runGoalLoop(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps) {
-	goalReg := goalToolRegistry(deps.reg, deps.goal)
-	reminders := goalReminders(deps.reg, deps.goal)
+func runGoalLoop(setCancel func(context.CancelFunc), out io.Writer, host cli.Host) {
+	goalReg := goalToolRegistry(host.Registry(), host.Goal())
+	reminders := goalReminders(host.Registry(), host.Goal())
 
 	runCtx, cancel := context.WithCancel(context.Background())
 	setCancel(cancel)
@@ -200,22 +203,22 @@ func runGoalLoop(setCancel func(context.CancelFunc), out io.Writer, deps *replDe
 	// lastSeen tracks how many messages we have already accounted for, so each
 	// settle folds in only the assistant turns produced since the previous one:
 	// their output tokens (budget) and whether any tool ran (no-progress guard).
-	lastSeen := len(deps.agentCtx.Messages)
+	lastSeen := len(host.AgentCtx().Messages)
 
 	cfg := runtime.RunConfig{
 		LoopConfig: runtime.LoopConfig{
-			Model:         deps.live.Model,
-			Provider:      deps.live.ProviderName,
-			ThinkingLevel: deps.live.ThinkingLevel,
-			Stream:        provider.StreamFnFromProvider(deps.live.Provider),
-			GetAPIKey:     deps.creds.GetAPIKey,
-			ContextWindow: deps.live.ContextWindow,
+			Model:         host.Live().Model,
+			Provider:      host.Live().ProviderName,
+			ThinkingLevel: host.Live().ThinkingLevel,
+			Stream:        provider.StreamFnFromProvider(host.Live().Provider),
+			GetAPIKey:     host.Creds().GetAPIKey,
+			ContextWindow: host.Live().ContextWindow,
 			Compaction:    compaction.DefaultCompactionSettings,
 		},
 		Batch: agenttool.BatchConfig{
 			ToolExecutorConfig: agenttool.ToolExecutorConfig{
 				Registry:       goalReg,
-				BeforeToolCall: trust.BeforeToolCall(deps.trust, deps.cwd, deps.in, out, deps.confirmMu),
+				BeforeToolCall: trust.BeforeToolCall(host.Trust(), host.Cwd(), host.Input(), out, host.ConfirmMu()),
 			},
 		},
 		Reminders: reminders,
@@ -230,12 +233,12 @@ func runGoalLoop(setCancel func(context.CancelFunc), out io.Writer, deps *replDe
 			}
 			outputTokens, hadTool := goalTurnActivity(agentCtx.Messages[lastSeen:])
 			lastSeen = len(agentCtx.Messages)
-			deps.goal.RecordIteration(outputTokens, hadTool)
+			host.Goal().RecordIteration(outputTokens, hadTool)
 
-			cont, terminal := goalFollowUpDecision(deps.goal.Snapshot())
+			cont, terminal := goalFollowUpDecision(host.Goal().Snapshot())
 			if !cont {
 				if terminal != agenttool.GoalIdle {
-					deps.goal.SetStatus(terminal)
+					host.Goal().SetStatus(terminal)
 				}
 				return nil
 			}
@@ -249,11 +252,11 @@ func runGoalLoop(setCancel func(context.CancelFunc), out io.Writer, deps *replDe
 	// The first turn is driven by the goal reminder alone (the objective is
 	// injected as background context); no explicit user prompt is appended so the
 	// objective is not duplicated in the durable history.
-	stream := runtime.StartRun(runCtx, deps.agentCtx, cfg)
-	drainGoalStream(runCtx, out, deps, stream)
+	stream := runtime.StartRun(runCtx, host.AgentCtx(), cfg)
+	drainGoalStream(runCtx, out, host, stream)
 
-	printGoalOutcome(out, deps.goal.Snapshot())
-	persistTurn(out, deps)
+	printGoalOutcome(out, host.Goal().Snapshot())
+	cli.PersistTurn(out, host)
 }
 
 // goalToolRegistry returns a registry holding every tool from base plus the two
@@ -310,7 +313,7 @@ func goalTurnActivity(tail []agentcore.AgentMessage) (outputTokens int, hadTool 
 
 // drainGoalStream prints the streamed assistant text and tool activity of a goal
 // run to out, mirroring streamRun's rendering. It blocks until the run ends.
-func drainGoalStream(ctx context.Context, out io.Writer, deps *replDeps, stream *runtime.LoopEventStream) {
+func drainGoalStream(ctx context.Context, out io.Writer, host cli.Host, stream *runtime.LoopEventStream) {
 	var reply strings.Builder
 	flushReply := func() {
 		if reply.Len() == 0 {
@@ -324,17 +327,17 @@ func drainGoalStream(ctx context.Context, out io.Writer, deps *replDeps, stream 
 		reply.Reset()
 	}
 	_, err := runtime.DrainStream(ctx, stream, runtime.StreamHandler{
-		OnEvent: deps.notifierHandle(),
+		OnEvent: host.NotifierHandle(),
 		OnText: func(delta string) {
 			reply.WriteString(delta)
 		},
 		OnTurnEnd: func(msg agentcore.AssistantMessage, results []agentcore.ToolResultMessage) {
 			flushReply()
 			for _, c := range msg.ToolCalls() {
-				fmt.Fprintf(out, "  %s %s\n", ui.Colorize(ui.Enabled(), ui.Green, "→ tool:"), toolCallLabel(c))
+				fmt.Fprintf(out, "  %s %s\n", ui.Colorize(ui.Enabled(), ui.Green, "→ tool:"), ui.ToolCallLabel(c))
 			}
 			for _, tr := range results {
-				renderToolResult(out, tr)
+				ui.RenderToolResult(out, tr)
 			}
 		},
 	})
@@ -342,7 +345,7 @@ func drainGoalStream(ctx context.Context, out io.Writer, deps *replDeps, stream 
 	if err != nil {
 		if ctx.Err() != nil {
 			fmt.Fprintln(out, "^C interrupted — goal paused (run /goal resume to continue)")
-			deps.goal.SetStatus(agenttool.GoalPaused)
+			host.Goal().SetStatus(agenttool.GoalPaused)
 		} else {
 			fmt.Fprintf(out, "error: %v\n", err)
 		}

--- a/internal/cli/goal/goal_test.go
+++ b/internal/cli/goal/goal_test.go
@@ -2,7 +2,7 @@
 // logic (terminal states, token budget, turn cap, no-progress guard),
 // parseGoalObjective / parseTokenBudget flag parsing, and goalTurnActivity's
 // token/tool accounting.
-package main
+package goal
 
 import (
 	"testing"

--- a/internal/cli/persist.go
+++ b/internal/cli/persist.go
@@ -1,0 +1,34 @@
+// This file holds PersistTurn, the session-tree persistence step shared by the
+// REPL loop and the /goal autonomous loop. It reads and advances a session's
+// mutable cursor state through the Host contract, so a command need not import
+// the concrete replDeps aggregate to persist the tail of a turn.
+package cli
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+// PersistTurn appends the messages produced since the last persist as a new
+// branch descending from the host's current leaf, advancing the leaf and the
+// persisted-message cursor. Growing the tree with AppendBranch (rather than a
+// full linear Save) is what lets a later /tree leaf-switch fork the on-disk
+// history instead of clobbering it. If nothing new was produced it is a no-op:
+// rewriting the file would regenerate entry ids and flatten the tree.
+func PersistTurn(out io.Writer, h Host) {
+	agentCtx := h.AgentCtx()
+	tail := agentCtx.Messages[h.Persisted():]
+	if len(tail) == 0 {
+		return
+	}
+	header := h.Header()
+	header.UpdatedAt = time.Now().UTC()
+	leaf, err := h.Store().AppendBranch(header, h.CurLeaf(), tail)
+	if err != nil {
+		fmt.Fprintf(out, "pigo: session save failed: %v\n", err)
+		return
+	}
+	h.SetCurLeaf(leaf)
+	h.SetPersisted(len(agentCtx.Messages))
+}

--- a/internal/cli/ui/toolrender.go
+++ b/internal/cli/ui/toolrender.go
@@ -1,0 +1,58 @@
+// This file holds the compact tool-activity renderers shared by the REPL, the
+// /goal autonomous loop, and /btw side threads: a tool call is shown as a green
+// "→ tool:" line and a tool result as a green "← result:" (or red "← error:")
+// line, with multi-line output collapsed to one line. The todo tool is the one
+// exception — its result is printed in full so the live checklist stays visible.
+package ui
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// RenderToolResult prints a tool result to out: the todo tool's result is shown
+// in full (indented) so the live checklist stays visible; every other result is
+// collapsed to a single "← result:"/"← error:" line.
+func RenderToolResult(out io.Writer, tr agentcore.ToolResultMessage) {
+	text := agentcore.ContentToText(tr.Content)
+	color := Enabled()
+	if tr.ToolName == "todo" && !tr.IsError {
+		fmt.Fprintln(out, "  "+Colorize(color, Green, "← todo:"))
+		for _, line := range strings.Split(text, "\n") {
+			fmt.Fprintf(out, "    %s\n", line)
+		}
+		return
+	}
+	if tr.IsError {
+		fmt.Fprintf(out, "  %s %s\n", Colorize(color, Red, "← error:"), OneLine(text))
+		return
+	}
+	fmt.Fprintf(out, "  %s %s\n", Colorize(color, Green, "← result:"), OneLine(text))
+}
+
+// ToolCallLabel renders a tool call as "name args" for the compact "→ tool:"
+// status. Empty or "{}" arguments collapse to just the name.
+func ToolCallLabel(c agentcore.ToolCallContent) string {
+	args := strings.TrimSpace(string(c.Arguments))
+	if args == "" || args == "{}" {
+		return c.Name
+	}
+	return c.Name + " " + OneLine(args)
+}
+
+// OneLine collapses a possibly multi-line string into a single trimmed line,
+// truncating very long values, for the compact tool-activity statuses.
+func OneLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i] + " …"
+	}
+	const max = 120
+	if len(s) > max {
+		s = s[:max] + " …"
+	}
+	return s
+}


### PR DESCRIPTION
## Summary
- Move the `/goal` autonomous loop from `cmd/pigo` (package main) into `internal/cli/goal`, driving it through the `cli.Host` contract instead of the concrete `replDeps`.
- Relocate shared REPL helpers to neutral packages first so both repl(main) and goal depend downward with no import cycle: compact tool-activity renderers → `internal/cli/ui` (`RenderToolResult`/`ToolCallLabel`/`OneLine`); `persistTurn` → `internal/cli` (`PersistTurn(out, Host)`).
- Rewire repl.go / btw.go / repl_test.go to the shared `ui.*` renderers and `cli.PersistTurn`.

Closes #364

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`