### PR TITLE
feat(cli): migrate /btw to internal/cli/btw

### DIFF
--- a/cmd/pigo/btw_test.go
+++ b/cmd/pigo/btw_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/cli/btw"
 )
 
 // TestBtwDoesNotPolluteMainContext verifies that "/btw <q>" launches a run
@@ -30,8 +31,8 @@ func TestBtwDoesNotPolluteMainContext(t *testing.T) {
 	if len(deps.agentCtx.Messages) != 0 {
 		t.Fatalf("main context must be untouched by /btw, got %d messages", len(deps.agentCtx.Messages))
 	}
-	if !strings.Contains(out.String(), btwHeader) {
-		t.Errorf("expected side-thread header %q in output", btwHeader)
+	if !strings.Contains(out.String(), btw.BtwHeader) {
+		t.Errorf("expected side-thread header %q in output", btw.BtwHeader)
 	}
 	if !strings.Contains(out.String(), "side answer") {
 		t.Errorf("expected the side answer to be printed, got: %q", out.String())
@@ -139,10 +140,10 @@ func TestBtwFollowUpLoopAccumulates(t *testing.T) {
 	side := &agentcore.AgentContext{}
 	deps, _ := newTestDeps(t, &replProvider{reply: "a"})
 	setCancel := func(context.CancelFunc) {}
-	settings := resolveBtwSettings(&bytes.Buffer{}, &deps)
-	askSide(setCancel, &bytes.Buffer{}, &deps, side, settings, "q1")
+	settings := btw.ResolveBtwSettings(&bytes.Buffer{}, &deps)
+	btw.AskSide(setCancel, &bytes.Buffer{}, &deps, side, settings, "q1")
 	n1 := len(side.Messages)
-	askSide(setCancel, &bytes.Buffer{}, &deps, side, settings, "q2")
+	btw.AskSide(setCancel, &bytes.Buffer{}, &deps, side, settings, "q2")
 	if len(side.Messages) <= n1 {
 		t.Fatalf("side context should accumulate across follow-ups: %d then %d", n1, len(side.Messages))
 	}
@@ -156,7 +157,7 @@ func TestNewSideContextIsolated(t *testing.T) {
 			agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("hi")}},
 		},
 	}
-	side := newSideContext(main)
+	side := btw.NewSideContext(main)
 	if side.SystemPrompt != "sys" {
 		t.Errorf("side thread should inherit the system prompt")
 	}

--- a/cmd/pigo/line_editor.go
+++ b/cmd/pigo/line_editor.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,11 +11,15 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 )
 
-var errLineInterrupted = errors.New("line input interrupted")
+// errLineInterrupted aliases cli.ErrLineInterrupted so the editor's own returns
+// and tests keep the short local name while subpackages (e.g. /btw) recognize
+// the same sentinel through the exported cli.ErrLineInterrupted.
+var errLineInterrupted = cli.ErrLineInterrupted
 
 // mlBuffer models the readLine input as one or more lines with a cursor at
 // (row, col), col counted in runes within the current line. A fresh buffer
@@ -414,7 +417,7 @@ func atoiDefault(s string, def int) int {
 	return def
 }
 
-func (e *replLineEditor) readLine(prompt string) (string, error) {
+func (e *replLineEditor) ReadLine(prompt string) (string, error) {
 	if e.terminal == nil {
 		fmt.Fprint(e.out, prompt)
 		return e.in.ReadString('\n')

--- a/cmd/pigo/repl.go
+++ b/cmd/pigo/repl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/btw"
 	"github.com/smallnest/pigo/internal/cli/goal"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/clipboard"
@@ -191,7 +192,7 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 
 	for {
 		fmt.Fprintln(out)
-		raw, err := editor.readLine(fmt.Sprintf("pigo(%s)> ", deps.live.Model))
+		raw, err := editor.ReadLine(fmt.Sprintf("pigo(%s)> ", deps.live.Model))
 		if errors.Is(err, errLineInterrupted) {
 			continue
 		}
@@ -305,7 +306,7 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 			// can express. The exact-or-space-prefix guard keeps "/btweak" from
 			// being mistaken for "/btw". It reuses the same SIGINT cancel plumbing
 			// as a normal turn via setCancel.
-			runBtw(setCancel, out, &deps, editor, line)
+			btw.RunBtw(setCancel, out, &deps, editor, line)
 			continue
 		}
 

--- a/docs/issue#0365.html
+++ b/docs/issue#0365.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #365</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/365">#365</a> &mdash; 迁移 /btw 到 internal/cli/btw &mdash; 2026-07-28</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> /btw decoupled from package main via cli.Host + cli.Editor</h3>
+      <p><strong>Ambiguity:</strong> /btw reaches the session's mutable state (agent context, live config, registry, trust, credentials) and reads follow-up lines from the concrete REPL line editor — all previously private to <code>replDeps</code> / <code>replLineEditor</code> in package main.</p>
+      <p><strong>Choice:</strong> <code>RunBtw</code> takes <code>host cli.Host</code> and <code>editor cli.Editor</code>; every collaborator is read through Host accessors and every follow-up line through <code>editor.ReadLine</code>, mirroring the /goal migration (#364).</p>
+      <p><strong>Rationale:</strong> keeps the dependency single-direction (repl→btw), avoids an import cycle, and reuses the seam already established for control commands.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> ErrLineInterrupted sentinel promoted to internal/cli</h3>
+      <p><strong>Ambiguity:</strong> the /btw follow-up loop must recognize an idle Ctrl+C to leave the thread, but the interrupt sentinel <code>errLineInterrupted</code> lived in the concrete line editor in package main.</p>
+      <p><strong>Choice:</strong> defined <code>cli.ErrLineInterrupted</code> beside the Editor contract; the line editor now aliases it (<code>var errLineInterrupted = cli.ErrLineInterrupted</code>) so the subpackage can match it with <code>errors.Is</code> without importing package main.</p>
+      <p><strong>Rationale:</strong> the sentinel is part of the Editor contract, so it belongs next to the interface, not in one concrete implementer.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> REPL-integration btw tests stay in package main</h3>
+      <p><strong>Spec/original:</strong> a full migration would relocate every btw test alongside the moved code.</p>
+      <p><strong>Implemented:</strong> only the config-resolution test (<code>btw_config_test.go</code>) moved to <code>package btw</code> using a fake host. The five behavioral tests (<code>btw_test.go</code>) and the isolation/help tests stay in <code>cmd/pigo</code> because they drive the whole <code>runREPL</code> loop through the <code>newTestDeps</code>/<code>replProvider</code> harness, which still lives in package main.</p>
+      <p><strong>Why acceptable:</strong> those tests exercise btw through its public entry points (<code>btw.RunBtw</code>/<code>btw.AskSide</code>/<code>btw.NewSideContext</code>/<code>btw.BtwHeader</code>); they will relocate naturally when #367 moves the REPL harness out of package main.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Fake host in config test vs. a full deps fixture</h3>
+      <p><strong>Alternatives:</strong> (a) build a full <code>replDeps</code> in the btw package test (impossible — that type is in package main); (b) embed <code>cli.Host</code> in a tiny fake and override only <code>Live()</code>.</p>
+      <p><strong>Pros/cons:</strong> (b) needs no access to package-main internals and states exactly which accessor the code under test reads; the embedded nil interface would panic if any other method were called, which the test never does.</p>
+      <p><strong>Chosen:</strong> (b) — minimal, honest about the single dependency, and matches the fake-host trick used elsewhere in the migration.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> When to relocate the REPL-integration btw tests</h3>
+      <p><strong>Assumption:</strong> the five <code>btw_test.go</code> cases and the isolation/help tests belong with the REPL harness, not the btw package, until that harness moves.</p>
+      <p><strong>Verify:</strong> during #367 (REPL migration), confirm these tests move to the new home so btw's behavioral coverage lives beside the code rather than in <code>cmd/pigo</code>.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/cli/btw/btw.go
+++ b/internal/cli/btw/btw.go
@@ -2,24 +2,26 @@
 // agent extension @narumitw/pi-btw): a throwaway "side thread" for asking the
 // model a quick side question that must NOT pollute the main conversation.
 //
-// /btw is intercepted in the REPL loop (see repl.go) rather than routed through
-// a slash Action closure because it must run an agent stream and read the live
-// main context — none of which a pure string→string Action can do, exactly like
-// /compact and /goal.
+// /btw is intercepted in the REPL loop rather than routed through a slash Action
+// closure because it must run an agent stream and read the live main context —
+// none of which a pure string→string Action can do, exactly like /compact and
+// /goal. It reaches the session's collaborators and mutable state through the
+// cli.Host contract and reads follow-up lines through cli.Editor, so it need not
+// import the concrete replDeps aggregate that assembles them.
 //
 // Isolation contract (the whole point of the feature): a side thread runs on a
 // COPY of the main conversation as background, and its question/answer are only
-// ever appended to that copy — never to deps.agentCtx.Messages. Nothing is
-// persisted: no store.Save, no change to deps.persisted / deps.curLeaf /
-// deps.header.UpdatedAt. Closing the side thread, switching sessions or
-// restarting pigo discards everything.
+// ever appended to that copy — never to host.AgentCtx().Messages. Nothing is
+// persisted: no store.Save, no change to the persisted cursor / current leaf /
+// header timestamp. Closing the side thread, switching sessions or restarting
+// pigo discards everything.
 //
 // Scope: /btw is intercepted in the REPL loop and runs a side question against a
 // copy of the main context (#279); it supports multi-turn follow-ups in the same
 // ephemeral thread (#280), bare-/btw reopen of the most recent side thread this
 // process (#281), and an optional model/thinking override config (#282, see
 // btw_config.go) that affects only the side thread.
-package main
+package btw
 
 import (
 	"context"
@@ -30,6 +32,7 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/compaction"
 	"github.com/smallnest/pigo/internal/provider"
@@ -42,11 +45,15 @@ import (
 // conversation (对标 pi-btw's "btw · side thread" header).
 const btwHeader = "btw · side thread"
 
+// BtwHeader exposes the side-thread banner text so callers (and tests) can
+// recognize it in output.
+const BtwHeader = btwHeader
+
 // btwPrompt is the input prompt shown for follow-up questions inside a side
 // thread, distinguishing it from the main "pigo(model)>" prompt.
 const btwPrompt = "btw> "
 
-// runBtw handles a /btw invocation. With an argument it starts a fresh side
+// RunBtw handles a /btw invocation. With an argument it starts a fresh side
 // thread, asks that question, then enters a follow-up loop so the user can keep
 // asking in the same ephemeral thread. Bare "/btw" reopens the most recent side
 // thread from this process — replaying its Q&A history — and drops back into the
@@ -55,45 +62,45 @@ const btwPrompt = "btw> "
 // SIGINT handler can interrupt the side run, reusing the same plumbing as a
 // normal turn.
 //
-// The main context is never mutated: runBtw builds a private side AgentContext
+// The main context is never mutated: RunBtw builds a private side AgentContext
 // seeded with a copy of the main messages, runs every turn against that copy,
-// and returns without touching deps.agentCtx or persisting anything. The side
-// thread is retained in-process (deps.lastBtw) so a later bare /btw can reopen
+// and returns without touching host.AgentCtx() or persisting anything. The side
+// thread is retained in-process (host.LastBtw()) so a later bare /btw can reopen
 // it, but it is never written to disk — restarting pigo discards it.
-func runBtw(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, editor *replLineEditor, line string) {
+func RunBtw(setCancel func(context.CancelFunc), out io.Writer, host cli.Host, editor cli.Editor, line string) {
 	question := strings.TrimSpace(strings.TrimPrefix(line, "/btw"))
 	// Resolve the side thread's model/thinking once per invocation from the
 	// session defaults overlaid with btw.json (#282). Re-read each call so an
 	// edit takes effect next time with no restart.
-	settings := resolveBtwSettings(out, deps)
+	settings := ResolveBtwSettings(out, host)
 	if question == "" {
 		// Bare /btw: reopen the most recent side thread if one exists this process,
 		// replaying its history; otherwise guide the user to supply a question.
-		if deps.lastBtw == nil {
+		if host.LastBtw() == nil {
 			fmt.Fprintln(out, "usage: /btw <question> — ask a quick side question without touching the main conversation")
 			return
 		}
 		printBtwHeader(out)
-		replaySideHistory(out, deps.lastBtw, deps.lastBtwBase)
+		replaySideHistory(out, host.LastBtw(), host.LastBtwBase())
 		if editor != nil {
-			btwFollowUpLoop(setCancel, out, deps, editor, deps.lastBtw, settings)
+			btwFollowUpLoop(setCancel, out, host, editor, host.LastBtw(), settings)
 		}
 		return
 	}
 
-	side := newSideContext(deps.agentCtx)
-	// Remember this thread so a later bare /btw can reopen it. lastBtwBase marks
+	side := NewSideContext(host.AgentCtx())
+	// Remember this thread so a later bare /btw can reopen it. LastBtwBase marks
 	// where the copied background ends and the side Q&A begins, so a reopen only
 	// replays the side turns, not the whole main transcript.
-	deps.lastBtw = side
-	deps.lastBtwBase = len(side.Messages)
+	host.SetLastBtw(side)
+	host.SetLastBtwBase(len(side.Messages))
 	printBtwHeader(out)
-	askSide(setCancel, out, deps, side, settings, question)
+	AskSide(setCancel, out, host, side, settings, question)
 	// Follow-up loop: keep answering in the same ephemeral thread until the user
 	// exits. A nil editor (direct test callers that only ask one question) skips
 	// the loop entirely, so a single /btw asks exactly one question and returns.
 	if editor != nil {
-		btwFollowUpLoop(setCancel, out, deps, editor, side, settings)
+		btwFollowUpLoop(setCancel, out, host, editor, side, settings)
 	}
 }
 
@@ -127,10 +134,10 @@ func replaySideHistory(out io.Writer, side *agentcore.AgentContext, base int) {
 // /quit, EOF, or an idle Ctrl+C (errLineInterrupted) — the same exit affordances
 // as the main REPL, but confined to the side thread (FR-5). A blank line is
 // ignored (stays in the thread). Nothing here touches the main context.
-func btwFollowUpLoop(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, editor *replLineEditor, side *agentcore.AgentContext, settings btwRunSettings) {
+func btwFollowUpLoop(setCancel func(context.CancelFunc), out io.Writer, host cli.Host, editor cli.Editor, side *agentcore.AgentContext, settings BtwRunSettings) {
 	for {
-		raw, err := editor.readLine(btwPrompt)
-		if errors.Is(err, errLineInterrupted) {
+		raw, err := editor.ReadLine(btwPrompt)
+		if errors.Is(err, cli.ErrLineInterrupted) {
 			// Idle Ctrl+C at the side prompt leaves the thread (a Ctrl+C during a
 			// run is handled inside askSide via the SIGINT cancel plumbing).
 			fmt.Fprintln(out, "left side thread")
@@ -149,16 +156,16 @@ func btwFollowUpLoop(setCancel func(context.CancelFunc), out io.Writer, deps *re
 		if q == "" {
 			continue
 		}
-		askSide(setCancel, out, deps, side, settings, q)
+		AskSide(setCancel, out, host, side, settings, q)
 	}
 }
 
-// newSideContext builds the side thread's private AgentContext. Its Messages are
+// NewSideContext builds the side thread's private AgentContext. Its Messages are
 // a fresh slice seeded with a shallow COPY of the main messages (the elements
 // are immutable value/interface messages, so a copied slice header is enough to
-// guarantee appends to the side thread never reach deps.agentCtx.Messages). The
-// system prompt and tools are shared by value; only Messages diverges.
-func newSideContext(main *agentcore.AgentContext) *agentcore.AgentContext {
+// guarantee appends to the side thread never reach the main context's Messages).
+// The system prompt and tools are shared by value; only Messages diverges.
+func NewSideContext(main *agentcore.AgentContext) *agentcore.AgentContext {
 	msgs := make(agentcore.MessageList, len(main.Messages))
 	copy(msgs, main.Messages)
 	return &agentcore.AgentContext{
@@ -173,13 +180,13 @@ func printBtwHeader(out io.Writer) {
 	fmt.Fprintln(out, ui.Colorize(ui.Enabled(), ui.Dim, btwHeader))
 }
 
-// askSide appends the question to the side context and streams one answer,
+// AskSide appends the question to the side context and streams one answer,
 // mirroring streamRun's rendering but targeting the side context so nothing is
 // written back to the main conversation or to disk. It reuses the REPL's SIGINT
 // cancel plumbing via setCancel. The model/provider/thinking come from settings
-// (session defaults overlaid with btw.json, #282), never from deps.live, so a
+// (session defaults overlaid with btw.json, #282), never from host.Live(), so a
 // /btw override cannot leak into the main session.
-func askSide(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, side *agentcore.AgentContext, settings btwRunSettings, question string) {
+func AskSide(setCancel func(context.CancelFunc), out io.Writer, host cli.Host, side *agentcore.AgentContext, settings BtwRunSettings, question string) {
 	content, err := ui.BuildUserContent(question)
 	if err != nil {
 		fmt.Fprintf(out, "pigo: %v\n", err)
@@ -203,30 +210,30 @@ func askSide(setCancel func(context.CancelFunc), out io.Writer, deps *replDeps, 
 
 	cfg := runtime.RunConfig{
 		LoopConfig: runtime.LoopConfig{
-			Model:         settings.model,
-			Provider:      settings.providerName,
-			ThinkingLevel: settings.thinkingLevel,
-			Stream:        provider.StreamFnFromProvider(settings.provider),
-			GetAPIKey:     deps.creds.GetAPIKey,
-			ContextWindow: deps.live.ContextWindow,
+			Model:         settings.Model,
+			Provider:      settings.ProviderName,
+			ThinkingLevel: settings.ThinkingLevel,
+			Stream:        provider.StreamFnFromProvider(settings.Provider),
+			GetAPIKey:     host.Creds().GetAPIKey,
+			ContextWindow: host.Live().ContextWindow,
 			Compaction:    compaction.DefaultCompactionSettings,
 		},
 		Batch: agenttool.BatchConfig{
 			ToolExecutorConfig: agenttool.ToolExecutorConfig{
-				Registry:       deps.reg,
-				BeforeToolCall: trust.BeforeToolCall(deps.trust, deps.cwd, deps.in, out, deps.confirmMu),
+				Registry:       host.Registry(),
+				BeforeToolCall: trust.BeforeToolCall(host.Trust(), host.Cwd(), host.Input(), out, host.ConfirmMu()),
 			},
 		},
-		Reminders: deps.reminders,
+		Reminders: host.Reminders(),
 	}
 	stream := runtime.StartRun(runCtx, side, cfg)
-	drainSideStream(runCtx, out, deps, stream)
+	drainSideStream(runCtx, out, host, stream)
 }
 
 // drainSideStream prints the streamed assistant text and tool activity of a side
 // run, mirroring streamRun/drainGoalStream. It blocks until the run ends. Unlike
 // the main loop it persists nothing.
-func drainSideStream(ctx context.Context, out io.Writer, deps *replDeps, stream *runtime.LoopEventStream) {
+func drainSideStream(ctx context.Context, out io.Writer, host cli.Host, stream *runtime.LoopEventStream) {
 	var reply strings.Builder
 	flushReply := func() {
 		if reply.Len() == 0 {
@@ -240,7 +247,7 @@ func drainSideStream(ctx context.Context, out io.Writer, deps *replDeps, stream 
 		reply.Reset()
 	}
 	_, err := runtime.DrainStream(ctx, stream, runtime.StreamHandler{
-		OnEvent: deps.notifierHandle(),
+		OnEvent: host.NotifierHandle(),
 		OnText: func(delta string) {
 			reply.WriteString(delta)
 		},

--- a/internal/cli/btw/btw_config.go
+++ b/internal/cli/btw/btw_config.go
@@ -8,7 +8,7 @@
 // with no restart. A missing file, an empty object, or an absent field all mean
 // "inherit the session default" silently — only a malformed file or an
 // unusable model override produces a (non-fatal) warning.
-package main
+package btw
 
 import (
 	"encoding/json"
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/provider"
@@ -34,15 +35,15 @@ type btwConfig struct {
 	ThinkingLevel string `json:"thinkingLevel,omitempty"`
 }
 
-// btwRunSettings is the resolved model/provider/thinking a side run uses. It is
+// BtwRunSettings is the resolved model/provider/thinking a side run uses. It is
 // computed once per /btw invocation from the session defaults overlaid with
-// btw.json, and passed down to askSide so every turn of that invocation uses
+// btw.json, and passed down to AskSide so every turn of that invocation uses
 // the same settings.
-type btwRunSettings struct {
-	model         string
-	providerName  string
-	provider      provider.Provider
-	thinkingLevel agentcore.ThinkingLevel
+type BtwRunSettings struct {
+	Model         string
+	ProviderName  string
+	Provider      provider.Provider
+	ThinkingLevel agentcore.ThinkingLevel
 }
 
 // btwConfigPath returns the path to the /btw override config, or "" when the
@@ -76,8 +77,8 @@ func loadBtwConfig(path string) (btwConfig, error) {
 	return cfg, nil
 }
 
-// resolveBtwSettings computes the model/provider/thinking a side run should use.
-// It starts from the session defaults (deps.live) and overlays btw.json:
+// ResolveBtwSettings computes the model/provider/thinking a side run should use.
+// It starts from the session defaults (host.Live()) and overlays btw.json:
 //
 //   - No config / empty object / absent fields → inherit the session values.
 //   - thinkingLevel set → validate and override (invalid value warns, falls back).
@@ -86,13 +87,15 @@ func loadBtwConfig(path string) (btwConfig, error) {
 //     back to the session model+provider.
 //
 // A malformed config file warns once and inherits everything. Nothing here
-// mutates deps.live, so the override is confined to the side thread (FR-8).
-func resolveBtwSettings(out io.Writer, deps *replDeps) btwRunSettings {
-	s := btwRunSettings{
-		model:         deps.live.Model,
-		providerName:  deps.live.ProviderName,
-		provider:      deps.live.Provider,
-		thinkingLevel: deps.live.ThinkingLevel,
+// mutates the session live config, so the override is confined to the side
+// thread (FR-8).
+func ResolveBtwSettings(out io.Writer, host cli.Host) BtwRunSettings {
+	live := host.Live()
+	s := BtwRunSettings{
+		Model:         live.Model,
+		ProviderName:  live.ProviderName,
+		Provider:      live.Provider,
+		ThinkingLevel: live.ThinkingLevel,
 	}
 
 	cfg, err := loadBtwConfig(btwConfigPath())
@@ -103,20 +106,20 @@ func resolveBtwSettings(out io.Writer, deps *replDeps) btwRunSettings {
 
 	if lvl := strings.TrimSpace(cfg.ThinkingLevel); lvl != "" {
 		if v, ok := validThinkingLevel(lvl); ok {
-			s.thinkingLevel = v
+			s.ThinkingLevel = v
 		} else {
-			fmt.Fprintf(out, "%s\n", ui.Colorize(ui.Enabled(), ui.Dim, fmt.Sprintf("btw: ignoring invalid thinkingLevel %q, using %q", lvl, s.thinkingLevel)))
+			fmt.Fprintf(out, "%s\n", ui.Colorize(ui.Enabled(), ui.Dim, fmt.Sprintf("btw: ignoring invalid thinkingLevel %q, using %q", lvl, s.ThinkingLevel)))
 		}
 	}
 
-	if model := strings.TrimSpace(cfg.Model); model != "" && model != s.model {
-		prov, providerName, perr := provider.ResolveProvider(model, deps.live.BaseURL, deps.live.Protocol, "", os.Getenv)
+	if model := strings.TrimSpace(cfg.Model); model != "" && model != s.Model {
+		prov, providerName, perr := provider.ResolveProvider(model, live.BaseURL, live.Protocol, "", os.Getenv)
 		if perr != nil {
-			fmt.Fprintf(out, "%s\n", ui.Colorize(ui.Enabled(), ui.Dim, fmt.Sprintf("btw: cannot use model %q (%v), falling back to %q", model, perr, s.model)))
+			fmt.Fprintf(out, "%s\n", ui.Colorize(ui.Enabled(), ui.Dim, fmt.Sprintf("btw: cannot use model %q (%v), falling back to %q", model, perr, s.Model)))
 		} else {
-			s.model = model
-			s.providerName = providerName
-			s.provider = prov
+			s.Model = model
+			s.ProviderName = providerName
+			s.Provider = prov
 		}
 	}
 

--- a/internal/cli/btw/btw_config_test.go
+++ b/internal/cli/btw/btw_config_test.go
@@ -1,4 +1,4 @@
-package main
+package btw
 
 // Tests for the /btw model/thinking override config (#282, US-005): btw.json
 // overlays the session defaults for the side thread only, is read fresh each
@@ -12,7 +12,19 @@ import (
 	"testing"
 
 	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/cli"
 )
+
+// fakeHost satisfies cli.Host by embedding the interface (so every method is
+// present) while overriding only Live(), the sole accessor ResolveBtwSettings
+// reads. The embedded nil interface would panic if any other method were
+// called, which these tests never do.
+type fakeHost struct {
+	cli.Host
+	live *cli.LiveConfig
+}
+
+func (f fakeHost) Live() *cli.LiveConfig { return f.live }
 
 // withBtwConfig points PIGO_HOME at a temp dir and writes btw.json with the
 // given contents (or removes it when contents is ""), returning nothing — the
@@ -32,16 +44,16 @@ func withBtwConfig(t *testing.T, contents string) {
 // equal the session defaults.
 func TestBtwConfigAbsentInherits(t *testing.T) {
 	withBtwConfig(t, "") // no file
-	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
-	deps.live.ThinkingLevel = agentcore.ThinkingMedium
+	live := &cli.LiveConfig{Model: "sess-model", ProviderName: "sess-prov", ThinkingLevel: agentcore.ThinkingMedium}
+	host := fakeHost{live: live}
 
 	var warn bytes.Buffer
-	s := resolveBtwSettings(&warn, &deps)
-	if s.model != deps.live.Model || s.providerName != deps.live.ProviderName {
-		t.Errorf("absent config must inherit model/provider, got %q/%q", s.model, s.providerName)
+	s := ResolveBtwSettings(&warn, host)
+	if s.Model != live.Model || s.ProviderName != live.ProviderName {
+		t.Errorf("absent config must inherit model/provider, got %q/%q", s.Model, s.ProviderName)
 	}
-	if s.thinkingLevel != agentcore.ThinkingMedium {
-		t.Errorf("absent config must inherit thinkingLevel, got %q", s.thinkingLevel)
+	if s.ThinkingLevel != agentcore.ThinkingMedium {
+		t.Errorf("absent config must inherit thinkingLevel, got %q", s.ThinkingLevel)
 	}
 	if warn.Len() != 0 {
 		t.Errorf("absent config must not warn, got %q", warn.String())
@@ -52,13 +64,13 @@ func TestBtwConfigAbsentInherits(t *testing.T) {
 // everything without warning.
 func TestBtwConfigEmptyObjectInherits(t *testing.T) {
 	withBtwConfig(t, "{}")
-	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
-	deps.live.ThinkingLevel = agentcore.ThinkingLow
+	live := &cli.LiveConfig{Model: "sess-model", ThinkingLevel: agentcore.ThinkingLow}
+	host := fakeHost{live: live}
 
 	var warn bytes.Buffer
-	s := resolveBtwSettings(&warn, &deps)
-	if s.model != deps.live.Model || s.thinkingLevel != agentcore.ThinkingLow {
-		t.Errorf("empty object must inherit, got model=%q thinking=%q", s.model, s.thinkingLevel)
+	s := ResolveBtwSettings(&warn, host)
+	if s.Model != live.Model || s.ThinkingLevel != agentcore.ThinkingLow {
+		t.Errorf("empty object must inherit, got model=%q thinking=%q", s.Model, s.ThinkingLevel)
 	}
 	if warn.Len() != 0 {
 		t.Errorf("empty object must not warn, got %q", warn.String())
@@ -69,16 +81,16 @@ func TestBtwConfigEmptyObjectInherits(t *testing.T) {
 // the model still inherits (partial config falls back per-field).
 func TestBtwConfigThinkingOverride(t *testing.T) {
 	withBtwConfig(t, `{"thinkingLevel":"high"}`)
-	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
-	deps.live.ThinkingLevel = agentcore.ThinkingLow
+	live := &cli.LiveConfig{Model: "sess-model", ThinkingLevel: agentcore.ThinkingLow}
+	host := fakeHost{live: live}
 
 	var warn bytes.Buffer
-	s := resolveBtwSettings(&warn, &deps)
-	if s.thinkingLevel != agentcore.ThinkingHigh {
-		t.Errorf("expected thinkingLevel override 'high', got %q", s.thinkingLevel)
+	s := ResolveBtwSettings(&warn, host)
+	if s.ThinkingLevel != agentcore.ThinkingHigh {
+		t.Errorf("expected thinkingLevel override 'high', got %q", s.ThinkingLevel)
 	}
-	if s.model != deps.live.Model {
-		t.Errorf("model must still inherit when only thinkingLevel is set, got %q", s.model)
+	if s.Model != live.Model {
+		t.Errorf("model must still inherit when only thinkingLevel is set, got %q", s.Model)
 	}
 	if warn.Len() != 0 {
 		t.Errorf("valid override must not warn, got %q", warn.String())
@@ -89,13 +101,13 @@ func TestBtwConfigThinkingOverride(t *testing.T) {
 // warns on one line and keeps the session value.
 func TestBtwConfigInvalidThinkingWarnsAndFallsBack(t *testing.T) {
 	withBtwConfig(t, `{"thinkingLevel":"bogus"}`)
-	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
-	deps.live.ThinkingLevel = agentcore.ThinkingMedium
+	live := &cli.LiveConfig{Model: "sess-model", ThinkingLevel: agentcore.ThinkingMedium}
+	host := fakeHost{live: live}
 
 	var warn bytes.Buffer
-	s := resolveBtwSettings(&warn, &deps)
-	if s.thinkingLevel != agentcore.ThinkingMedium {
-		t.Errorf("invalid thinkingLevel must fall back to session value, got %q", s.thinkingLevel)
+	s := ResolveBtwSettings(&warn, host)
+	if s.ThinkingLevel != agentcore.ThinkingMedium {
+		t.Errorf("invalid thinkingLevel must fall back to session value, got %q", s.ThinkingLevel)
 	}
 	if !strings.Contains(warn.String(), "thinkingLevel") {
 		t.Errorf("expected a warning about the invalid thinkingLevel, got %q", warn.String())
@@ -106,28 +118,29 @@ func TestBtwConfigInvalidThinkingWarnsAndFallsBack(t *testing.T) {
 // once and inherits every field (never crashes /btw).
 func TestBtwConfigMalformedWarnsAndInherits(t *testing.T) {
 	withBtwConfig(t, `{not json`)
-	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
-	deps.live.ThinkingLevel = agentcore.ThinkingLow
+	live := &cli.LiveConfig{Model: "sess-model", ThinkingLevel: agentcore.ThinkingLow}
+	host := fakeHost{live: live}
 
 	var warn bytes.Buffer
-	s := resolveBtwSettings(&warn, &deps)
-	if s.model != deps.live.Model || s.thinkingLevel != agentcore.ThinkingLow {
-		t.Errorf("malformed config must inherit, got model=%q thinking=%q", s.model, s.thinkingLevel)
+	s := ResolveBtwSettings(&warn, host)
+	if s.Model != live.Model || s.ThinkingLevel != agentcore.ThinkingLow {
+		t.Errorf("malformed config must inherit, got model=%q thinking=%q", s.Model, s.ThinkingLevel)
 	}
 	if !strings.Contains(warn.String(), "invalid btw.json") {
 		t.Errorf("expected a malformed-config warning, got %q", warn.String())
 	}
 }
 
-// TestBtwConfigDoesNotMutateSession verifies resolveBtwSettings never mutates
-// deps.live, so a /btw override cannot leak into the main session (FR-8).
+// TestBtwConfigDoesNotMutateSession verifies ResolveBtwSettings never mutates
+// the session live config, so a /btw override cannot leak into the main session
+// (FR-8).
 func TestBtwConfigDoesNotMutateSession(t *testing.T) {
 	withBtwConfig(t, `{"thinkingLevel":"xhigh"}`)
-	deps, _ := newTestDeps(t, &replProvider{reply: "x"})
-	deps.live.ThinkingLevel = agentcore.ThinkingLow
+	live := &cli.LiveConfig{Model: "sess-model", ThinkingLevel: agentcore.ThinkingLow}
+	host := fakeHost{live: live}
 
-	_ = resolveBtwSettings(&bytes.Buffer{}, &deps)
-	if deps.live.ThinkingLevel != agentcore.ThinkingLow {
-		t.Errorf("session thinkingLevel must be unchanged by /btw config, got %q", deps.live.ThinkingLevel)
+	_ = ResolveBtwSettings(&bytes.Buffer{}, host)
+	if live.ThinkingLevel != agentcore.ThinkingLow {
+		t.Errorf("session thinkingLevel must be unchanged by /btw config, got %q", live.ThinkingLevel)
 	}
 }

--- a/internal/cli/host.go
+++ b/internal/cli/host.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"bufio"
+	"errors"
 	"sync"
 
 	"github.com/smallnest/pigo/internal/agentcore"
@@ -17,6 +18,13 @@ import (
 	"github.com/smallnest/pigo/internal/session"
 	"github.com/smallnest/pigo/internal/trust"
 )
+
+// ErrLineInterrupted is returned by an Editor.ReadLine when the user hits an
+// idle Ctrl+C at the prompt (rather than during a run). Control commands that
+// run their own follow-up loop (e.g. /btw) check for it with errors.Is to leave
+// the loop cleanly. It lives here, beside the Editor contract, so a subpackage
+// can recognize the interrupt without importing the concrete line editor.
+var ErrLineInterrupted = errors.New("line input interrupted")
 
 // Host is the seam through which a control command (/goal, /btw, /status) and
 // the REPL loop access the collaborators and mutable state of a session. It is


### PR DESCRIPTION
## Summary
- Move the `/btw` side-thread command from package main into `internal/cli/btw`, decoupled from `replDeps` via the `cli.Host` and `cli.Editor` contracts (mirrors the /goal migration in #364).
- Promote the line-interrupt sentinel to `cli.ErrLineInterrupted` so the follow-up loop recognizes an idle Ctrl+C without importing package main; the line editor now aliases it and its `readLine` method was renamed to `ReadLine` to satisfy `cli.Editor`.
- Export `RunBtw`/`AskSide`/`NewSideContext`/`BtwHeader`/`ResolveBtwSettings`/`BtwRunSettings`; config-resolution test moves to package btw with a fake host.
- REPL-integration btw tests stay in `cmd/pigo` until #367 relocates the REPL harness (see docs/issue#0365.html).

Closes #365

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all green; btw + cmd/pigo suites pass)