### PR TITLE
refactor(cli): migrate REPL to internal/cli/repl

### DIFF
--- a/cmd/pigo/prompts_config_test.go
+++ b/cmd/pigo/prompts_config_test.go
@@ -1,20 +1,14 @@
 package main
 
-// Tests for config.toml `prompts` array -> settings-tier prompt templates
-// (US-007, #338): fileConfig parses the array, applyFileConfig passes it to
-// cliOptions, loadSettingsPrompts loads file/dir entries (warning on missing),
-// and buildSlashRegistry registers them at the settings tier (overridden by
-// global same-name templates).
+// Test for config.toml `prompts` array -> settings-tier prompt templates
+// (US-007, #338): applyFileConfig passes the parsed array into cliOptions.
+// The loadPromptPaths/buildSlashRegistry tests moved to package repl
+// (internal/cli/repl/prompts_config_test.go) alongside those functions.
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/cli/config"
-	"github.com/smallnest/pigo/internal/cli/testutil"
-	"github.com/smallnest/pigo/internal/runtime"
 )
 
 func TestApplyFileConfigPrompts(t *testing.T) {
@@ -23,103 +17,5 @@ func TestApplyFileConfigPrompts(t *testing.T) {
 	applyFileConfig(&opts, cfg, func(string) bool { return false })
 	if len(opts.configPrompts) != 2 || opts.configPrompts[0] != "./my-prompts" || opts.configPrompts[1] != "/abs/x.md" {
 		t.Errorf("opts.configPrompts = %v, want [./my-prompts /abs/x.md]", opts.configPrompts)
-	}
-}
-
-func TestLoadSettingsPromptsFileDirMissing(t *testing.T) {
-	home := t.TempDir()
-	// file entry -> 1 cmd.
-	filePath := filepath.Join(home, "single.md")
-	if err := os.WriteFile(filePath, []byte("Single: $ARGUMENTS"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	// dir entry -> 2 cmds.
-	dirPath := filepath.Join(home, "promptsdir")
-	if err := os.MkdirAll(dirPath, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dirPath, "a.md"), []byte("A: $1"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dirPath, "b.md"), []byte("B: $1"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	// missing entry -> 0 cmds (warned, not fatal).
-	missing := filepath.Join(home, "nope")
-
-	cmds := loadPromptPaths([]string{filePath, dirPath, missing})
-	if len(cmds) != 3 {
-		t.Fatalf("got %d cmds, want 3 (file=1 + dir=2 + missing=0)", len(cmds))
-	}
-	names := map[string]bool{}
-	for _, c := range cmds {
-		names[c.Name] = true
-	}
-	for _, want := range []string{"single", "a", "b"} {
-		if !names[want] {
-			t.Errorf("missing cmd %q; got %v", want, names)
-		}
-	}
-}
-
-func TestBuildSlashRegistryLoadsSettingsPrompts(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("PIGO_HOME", home)
-	// A settings-tier prompt dir (loaded via configPrompts).
-	settingsDir := filepath.Join(home, "settings-prompts")
-	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(settingsDir, "review.md"), []byte("FROM SETTINGS"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
-		promptTemplateSources{settings: []string{settingsDir}})
-	if err != nil {
-		t.Fatalf("buildSlashRegistry: %v", err)
-	}
-	cmd, ok := reg.Lookup("review")
-	if !ok {
-		t.Fatal("/review not found")
-	}
-	if got := cmd.Expand(""); got != "FROM SETTINGS" {
-		t.Errorf("settings prompt: got %q, want \"FROM SETTINGS\"", got)
-	}
-}
-
-func TestBuildSlashRegistryGlobalOverridesSettings(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("PIGO_HOME", home)
-	// global prompt (TierGlobal) under ~/.pigo/prompts.
-	testutil.WritePrompt(t, home, "prompts", "dup.md", "FROM GLOBAL")
-	// settings-tier prompt (file) of the same name, placed at the home root
-	// (not under prompts/, so the global loop does not also load it).
-	settingsFile := filepath.Join(home, "dup.md")
-	if err := os.WriteFile(settingsFile, []byte("FROM SETTINGS"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
-		promptTemplateSources{settings: []string{settingsFile}})
-	if err != nil {
-		t.Fatalf("buildSlashRegistry: %v", err)
-	}
-	cmd, ok := reg.Lookup("dup")
-	if !ok {
-		t.Fatal("/dup not found")
-	}
-	if got := cmd.Expand(""); got != "FROM GLOBAL" {
-		t.Errorf("global should override settings, got %q", got)
-	}
-	// The settings loser is shadowed with TierSettings.
-	found := false
-	for _, e := range reg.Shadowed() {
-		if e.Name == "dup" && e.Tier == runtime.TierSettings {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("settings dup should be shadowed with TierSettings, got %v", reg.Shadowed())
 	}
 }

--- a/cmd/pigo/run.go
+++ b/cmd/pigo/run.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/smallnest/pigo/internal/cli/headless"
+	"github.com/smallnest/pigo/internal/cli/repl"
 	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/ui"
 )
@@ -133,23 +134,23 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 2
 		}
-		if err := runInteractive(interactiveOptions{
-			model:             opts.model,
-			providerName:      env.ProviderName,
-			provider:          env.Provider,
-			baseURL:           opts.baseURL,
-			apiKey:            opts.apiKey,
-			protocol:          opts.protocol,
-			thinkingLevel:     thinking,
-			tools:             env.Tools,
-			sysPrompt:         env.SysPrompt,
-			resumeID:          resumeID,
-			approve:           opts.approve,
-			skills:            env.Skills,
-			plugins:           env.Plugins,
-			configPrompts:     opts.configPrompts,
-			cliPrompts:        opts.promptTemplates,
-			noPromptTemplates: opts.noPromptTemplates,
+		if err := repl.Run(repl.Options{
+			Model:             opts.model,
+			ProviderName:      env.ProviderName,
+			Provider:          env.Provider,
+			BaseURL:           opts.baseURL,
+			APIKey:            opts.apiKey,
+			Protocol:          opts.protocol,
+			ThinkingLevel:     thinking,
+			Tools:             env.Tools,
+			SysPrompt:         env.SysPrompt,
+			ResumeID:          resumeID,
+			Approve:           opts.approve,
+			Skills:            env.Skills,
+			Plugins:           env.Plugins,
+			ConfigPrompts:     opts.configPrompts,
+			CliPrompts:        opts.promptTemplates,
+			NoPromptTemplates: opts.noPromptTemplates,
 		}); err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 1

--- a/docs/issue#0367.html
+++ b/docs/issue#0367.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0367</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer {
+      text-align: center; margin-top: 2.5rem; color: #B0AAA4;
+      font-size: 0.6875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/367">#367</a> &mdash; 迁移 REPL 到 internal/cli/repl &mdash; 2026-07-28</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Export exactly one entry point: repl.Run(repl.Options{})</h3>
+      <p><strong>Ambiguity:</strong> The issue names <code>runInteractive</code>-&gt;<code>Run</code> and <code>interactiveOptions</code>-&gt;<code>Options</code> but does not say what else must cross the package boundary.</p>
+      <p><strong>Choice:</strong> Exported only <code>Run</code> and the <code>Options</code> struct with all 16 fields (Model, ProviderName, Provider, BaseURL, APIKey, Protocol, ThinkingLevel, Tools, SysPrompt, ResumeID, Approve, Skills, Plugins, ConfigPrompts, CliPrompts, NoPromptTemplates). Everything else — replDeps, runREPL, replLineEditor, buildSlashRegistry, loadPromptPaths, promptTemplateSources — stays package-private.</p>
+      <p><strong>Rationale:</strong> run.go is the sole cross-package caller; a single exported constructor keeps the seam minimal and lets the REPL internals evolve freely. Mirrors the established pattern from #364/#365/#366.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> prompts_config_test.go split across two packages</h3>
+      <p><strong>Spec:</strong> "对应 *_test.go 迁入并转为 package repl" reads as moving whole test files.</p>
+      <p><strong>Implemented:</strong> Split the file — <code>TestApplyFileConfigPrompts</code> (drives <code>cliOptions</code>/<code>applyFileConfig</code>, both in package main) stays in cmd/pigo; the three tests exercising <code>loadPromptPaths</code>/<code>buildSlashRegistry</code>/<code>promptTemplateSources</code> moved to internal/cli/repl since those symbols moved with the REPL.</p>
+      <p><strong>Why:</strong> A test must live in the package that owns the unexported symbols it calls. <code>cliOptions</code>/<code>applyFileConfig</code> are CLI-parse concerns that stay in main (per #369's thin-entry goal), so a clean split is the only compiling option.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> git mv + perl package-rename over hand-editing 19 files</h3>
+      <p><strong>Alternatives:</strong> (a) manually move and re-clause each file; (b) <code>git mv</code> in bulk then perl-rewrite the package clause.</p>
+      <p><strong>Pros/cons:</strong> (b) preserves rename history in the diff and is fast, but files with leading comment blocks before <code>package main</code> needed a second targeted perl pass (first-match <code>^package main</code>) since <code>\Apackage</code> did not match.</p>
+      <p><strong>Winner:</strong> (b) — history-preserving and verifiable via "no package main remaining" grep; build/vet/test gate correctness.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Do cliOptions/applyFileConfig eventually move too?</h3>
+      <p><strong>Assumption:</strong> They stay in package main as flag-parsing glue; #369 (thin main entry) will decide whether any of that logic relocates into internal/cli.</p>
+      <p><strong>Verify:</strong> During #369, confirm the main package retains only flag parse + dispatch and that TestApplyFileConfigPrompts still belongs there.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/cli/repl/autocomplete_label_test.go
+++ b/internal/cli/repl/autocomplete_label_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 // Tests for formatSlashAutocompleteLabel (US-010, #340): the Tab-completion
 // label renders as "name <argument-hint> - description", omitting the hint
@@ -50,10 +50,10 @@ func TestSlashAutocompleteSuggestionStillCompletesName(t *testing.T) {
 	reg := runtime.NewSlashRegistry()
 	reg.AddBuiltin(runtime.SlashCommand{Name: "model", Action: func(string) string { return "" }})
 	reg.AddUser(runtime.SlashCommand{
-		Name:          "review",
-		ArgumentHint:  "<PR-URL>",
-		Description:   "Review PRs",
-		Expand:        func(string) string { return "" },
+		Name:         "review",
+		ArgumentHint: "<PR-URL>",
+		Description:  "Review PRs",
+		Expand:       func(string) string { return "" },
 	})
 	e := newREPLLineEditor(strings.NewReader(""), bufio.NewReader(strings.NewReader("")), io.Discard, reg, nil)
 	if got := e.suggestion("/rev"); got != "/review" {

--- a/internal/cli/repl/btw_help_test.go
+++ b/internal/cli/repl/btw_help_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 // Tests for /btw discoverability (#283, US-006/FR-10): /btw must appear in the
 // /help listing and be completable at the REPL slash prompt. Both flow from

--- a/internal/cli/repl/btw_isolation_test.go
+++ b/internal/cli/repl/btw_isolation_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 // Isolation / zero-pollution tests for /btw (#284, PRD Success Metrics). These
 // lock the feature's most important correctness guarantee: a side thread's

--- a/internal/cli/repl/btw_test.go
+++ b/internal/cli/repl/btw_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 // Tests for the /btw side-thread command (#279): a side question must run an
 // agent stream but MUST NOT mutate or persist the main conversation. These

--- a/internal/cli/repl/color_test.go
+++ b/internal/cli/repl/color_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 import (
 	"strings"

--- a/internal/cli/repl/help_line_test.go
+++ b/internal/cli/repl/help_line_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 // Tests for /help's template listing (US-011, #341): formatHelpLine renders
 // "/name <argument-hint> - description (source: <tier>)" (hint omitted when

--- a/internal/cli/repl/host.go
+++ b/internal/cli/repl/host.go
@@ -3,7 +3,7 @@
 // and mutable state through the cli.Host contract rather than the concrete
 // aggregate. The compile-time assertion below fails the build if replDeps drifts
 // out of conformance.
-package main
+package repl
 
 import (
 	"bufio"

--- a/internal/cli/repl/interactive.go
+++ b/internal/cli/repl/interactive.go
@@ -3,7 +3,7 @@
 // terminal, pigo starts the REPL loop (see repl.go); each run's messages are
 // persisted to a local JSONL session so the conversation can be listed, resumed
 // and replayed later.
-package main
+package repl
 
 import (
 	"bufio"
@@ -36,58 +36,58 @@ func sessionStore() (*session.Store, error) {
 	return headless.SessionStore()
 }
 
-// interactiveOptions carries the resolved run configuration plus optional
-// resume state into runInteractive.
-type interactiveOptions struct {
-	model        string
-	providerName string
-	provider     provider.Provider
-	baseURL      string
-	apiKey       string
-	protocol     string
-	// thinkingLevel is the resolved reasoning-effort level (US-023): it seeds the
+// Options carries the resolved run configuration plus optional
+// resume state into Run.
+type Options struct {
+	Model        string
+	ProviderName string
+	Provider     provider.Provider
+	BaseURL      string
+	APIKey       string
+	Protocol     string
+	// ThinkingLevel is the resolved reasoning-effort level (US-023): it seeds the
 	// live run config so every REPL turn requests it, until a control command
 	// changes it.
-	thinkingLevel agentcore.ThinkingLevel
-	tools         []agentcore.AgentTool
-	sysPrompt     string
+	ThinkingLevel agentcore.ThinkingLevel
+	Tools         []agentcore.AgentTool
+	SysPrompt     string
 
-	// resumeID, when non-empty, resumes an existing session: its messages seed
+	// ResumeID, when non-empty, resumes an existing session: its messages seed
 	// the context and replayed transcript. Otherwise a fresh session is created.
-	resumeID string
+	ResumeID string
 
-	// approve, when true, grants the launch directory session trust before the
+	// Approve, when true, grants the launch directory session trust before the
 	// run so the first-launch trust prompt is skipped and side-effect tools run
 	// without per-call confirmation (对标 pi 的 --approve/-a).
-	approve bool
-	// skills is the pre-loaded skill set (loaded once by setupAgentEnv, shared
+	Approve bool
+	// Skills is the pre-loaded skill set (loaded once by setupAgentEnv, shared
 	// with prompt injection). Each is registered as a /skill-name command. Empty
 	// under --no-skills, so nothing is registered.
-	skills []*runtime.Skill
+	Skills []*runtime.Skill
 
-	// plugins holds the loaded plugin manager so the REPL can deliver lifecycle
+	// Plugins holds the loaded plugin manager so the REPL can deliver lifecycle
 	// events to subscribed plugins (US-017, #133). It may be nil (no plugins).
-	plugins *plugin.Manager
+	Plugins *plugin.Manager
 
-	// configPrompts holds prompt-template paths from the config.toml `prompts`
+	// ConfigPrompts holds prompt-template paths from the config.toml `prompts`
 	// array (settings tier); each is a file or dir loaded non-recursively.
-	configPrompts []string
-	// cliPrompts holds --prompt-template paths (CLI tier, repeatable).
-	cliPrompts []string
-	// noPromptTemplates disables all prompt-template discovery (global, project,
+	ConfigPrompts []string
+	// CliPrompts holds --prompt-template paths (CLI tier, repeatable).
+	CliPrompts []string
+	// NoPromptTemplates disables all prompt-template discovery (global, project,
 	// settings, CLI); built-in slash commands are unaffected. Independent of
 	// --no-skills.
-	noPromptTemplates bool
+	NoPromptTemplates bool
 }
 
-// runInteractive starts the line-based REPL over a persisted session. It keeps
+// Run starts the line-based REPL over a persisted session. It keeps
 // a single growing AgentContext across prompts (so turns share history) and
 // saves the session's messages after each run completes (see runREPL/streamRun
 // in repl.go).
-func runInteractive(opts interactiveOptions) error {
+func Run(opts Options) error {
 	creds := provider.NewCredentialStore(nil)
-	creds.SetOverride(opts.providerName, opts.apiKey)
-	reg := run.ToolRegistry(opts.tools)
+	creds.SetOverride(opts.ProviderName, opts.APIKey)
+	reg := run.ToolRegistry(opts.Tools)
 
 	store, err := sessionStore()
 	if err != nil {
@@ -102,11 +102,11 @@ func runInteractive(opts interactiveOptions) error {
 		history  []agentcore.AgentMessage
 		curLeaf  string // active leaf id on resume; "" for a fresh session
 	)
-	if opts.resumeID != "" {
+	if opts.ResumeID != "" {
 		// Interactive resume always appends a fresh user message before running,
 		// so a session that ended normally (trailing assistant reply) is resumable
 		// here. Load the raw session and rebuild the context directly.
-		h, entries, err := store.LoadEntries(opts.resumeID)
+		h, entries, err := store.LoadEntries(opts.ResumeID)
 		if err != nil {
 			return err
 		}
@@ -118,20 +118,20 @@ func runInteractive(opts interactiveOptions) error {
 			curLeaf = entries[len(entries)-1].ID
 		}
 		header = h
-		agentCtx = &agentcore.AgentContext{SystemPrompt: h.SystemPrompt, Messages: msgs, Tools: opts.tools}
+		agentCtx = &agentcore.AgentContext{SystemPrompt: h.SystemPrompt, Messages: msgs, Tools: opts.Tools}
 		history = msgs
 		if agentCtx.SystemPrompt == "" {
-			agentCtx.SystemPrompt = opts.sysPrompt
+			agentCtx.SystemPrompt = opts.SysPrompt
 		}
 	} else {
-		agentCtx = &agentcore.AgentContext{SystemPrompt: opts.sysPrompt, Tools: opts.tools}
+		agentCtx = &agentcore.AgentContext{SystemPrompt: opts.SysPrompt, Tools: opts.Tools}
 		header = session.SessionHeader{
 			ID:           session.NewID(now),
 			CreatedAt:    now,
 			UpdatedAt:    now,
-			Model:        opts.model,
-			Provider:     opts.providerName,
-			SystemPrompt: opts.sysPrompt,
+			Model:        opts.Model,
+			Provider:     opts.ProviderName,
+			SystemPrompt: opts.SysPrompt,
 		}
 	}
 
@@ -140,12 +140,12 @@ func runInteractive(opts interactiveOptions) error {
 	// takes effect on the next turn; header is updated so the switch is persisted
 	// with the session.
 	live := &cli.LiveConfig{
-		Model:         opts.model,
-		ProviderName:  opts.providerName,
-		Provider:      opts.provider,
-		BaseURL:       opts.baseURL,
-		Protocol:      opts.protocol,
-		ThinkingLevel: opts.thinkingLevel,
+		Model:         opts.Model,
+		ProviderName:  opts.ProviderName,
+		Provider:      opts.Provider,
+		BaseURL:       opts.BaseURL,
+		Protocol:      opts.Protocol,
+		ThinkingLevel: opts.ThinkingLevel,
 		ContextWindow: cli.DefaultContextWindow,
 	}
 
@@ -175,10 +175,10 @@ func runInteractive(opts interactiveOptions) error {
 	// ~/.agents/skills. A load error is non-fatal — the REPL still runs with the
 	// built-ins. Instance built-ins that need live state (/model, /help) are
 	// registered against `live`.
-	slash, err := buildSlashRegistry(live, opts.skills, opts.plugins, promptTemplateSources{
-		settings:       opts.configPrompts,
-		cli:            opts.cliPrompts,
-		disable:        opts.noPromptTemplates,
+	slash, err := buildSlashRegistry(live, opts.Skills, opts.Plugins, promptTemplateSources{
+		settings:       opts.ConfigPrompts,
+		cli:            opts.CliPrompts,
+		disable:        opts.NoPromptTemplates,
 		projectDir:     filepath.Join(cwd, ".pigo", "prompts"),
 		projectTrusted: mgr != nil && mgr.IsTrusted(cwd),
 	})
@@ -193,7 +193,7 @@ func runInteractive(opts interactiveOptions) error {
 	// undecided directory, ask the user how much to trust it before any tool
 	// runs. This happens before replay so the trust question is the first thing
 	// the user sees, not their prior history.
-	trust.EstablishTrust(os.Stdout, reader, mgr, cwd, opts.approve)
+	trust.EstablishTrust(os.Stdout, reader, mgr, cwd, opts.Approve)
 
 	// Replay the resumed conversation so the user sees history before re-prompting.
 	if len(history) > 0 {
@@ -206,7 +206,7 @@ func runInteractive(opts interactiveOptions) error {
 		agentCtx:  agentCtx,
 		live:      live,
 		reg:       reg,
-		reminders: run.TodoReminders(opts.tools),
+		reminders: run.TodoReminders(opts.Tools),
 		slash:     slash,
 		creds:     creds,
 		trust:     mgr,
@@ -215,7 +215,7 @@ func runInteractive(opts interactiveOptions) error {
 		confirmMu: &sync.Mutex{},
 		curLeaf:   curLeaf,
 		persisted: len(history),
-		notifier:  plugin.NewEventNotifier(opts.plugins, os.Stderr),
+		notifier:  plugin.NewEventNotifier(opts.Plugins, os.Stderr),
 		goal:      agenttool.NewGoalState(),
 		telemetry: cli.NewTelemetryHolder(),
 	})

--- a/internal/cli/repl/line_editor.go
+++ b/internal/cli/repl/line_editor.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 import (
 	"bufio"

--- a/internal/cli/repl/line_editor_test.go
+++ b/internal/cli/repl/line_editor_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 import (
 	"bufio"
@@ -368,7 +368,7 @@ func TestMLBufferLeftRightCrossLines(t *testing.T) {
 func TestMLBufferUpDownClampColumn(t *testing.T) {
 	b := newMLBuffer()
 	b.setString("long line\nhi") // cursor at end of "hi" → (1,2)
-	b.up()                        // move to "long line", col stays 2
+	b.up()                       // move to "long line", col stays 2
 	if b.row != 0 || b.col != 2 {
 		t.Fatalf("up = (%d,%d), want (0,2)", b.row, b.col)
 	}

--- a/internal/cli/repl/plugin_commands_test.go
+++ b/internal/cli/repl/plugin_commands_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 // Tests for plugin slash-command wiring (#265): a plugin-declared command
 // (Manager.Commands()) is registered into the REPL slash registry as a hybrid

--- a/internal/cli/repl/presets_test.go
+++ b/internal/cli/repl/presets_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 // Tests for the /models preset listing. presetListing renders the curated
 // catalog for the REPL /models command. Provider-resolution tests moved to

--- a/internal/cli/repl/prompts_cli_test.go
+++ b/internal/cli/repl/prompts_cli_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 // Tests for --prompt-template (CLI tier) and --no-prompt-templates (US-008,
 // #339): CLI paths load at the CLI tier, --no-prompt-templates suppresses all

--- a/internal/cli/repl/prompts_config_test.go
+++ b/internal/cli/repl/prompts_config_test.go
@@ -1,0 +1,115 @@
+package repl
+
+// Tests for settings-tier prompt templates (US-007, #338): loadPromptPaths
+// loads file/dir entries (warning on missing), and buildSlashRegistry
+// registers them at the settings tier (overridden by global same-name
+// templates). The applyFileConfig parse test stays in package main
+// (cmd/pigo/prompts_config_test.go) since it drives cliOptions.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/testutil"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+func TestLoadSettingsPromptsFileDirMissing(t *testing.T) {
+	home := t.TempDir()
+	// file entry -> 1 cmd.
+	filePath := filepath.Join(home, "single.md")
+	if err := os.WriteFile(filePath, []byte("Single: $ARGUMENTS"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// dir entry -> 2 cmds.
+	dirPath := filepath.Join(home, "promptsdir")
+	if err := os.MkdirAll(dirPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirPath, "a.md"), []byte("A: $1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dirPath, "b.md"), []byte("B: $1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// missing entry -> 0 cmds (warned, not fatal).
+	missing := filepath.Join(home, "nope")
+
+	cmds := loadPromptPaths([]string{filePath, dirPath, missing})
+	if len(cmds) != 3 {
+		t.Fatalf("got %d cmds, want 3 (file=1 + dir=2 + missing=0)", len(cmds))
+	}
+	names := map[string]bool{}
+	for _, c := range cmds {
+		names[c.Name] = true
+	}
+	for _, want := range []string{"single", "a", "b"} {
+		if !names[want] {
+			t.Errorf("missing cmd %q; got %v", want, names)
+		}
+	}
+}
+
+func TestBuildSlashRegistryLoadsSettingsPrompts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+	// A settings-tier prompt dir (loaded via configPrompts).
+	settingsDir := filepath.Join(home, "settings-prompts")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(settingsDir, "review.md"), []byte("FROM SETTINGS"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
+		promptTemplateSources{settings: []string{settingsDir}})
+	if err != nil {
+		t.Fatalf("buildSlashRegistry: %v", err)
+	}
+	cmd, ok := reg.Lookup("review")
+	if !ok {
+		t.Fatal("/review not found")
+	}
+	if got := cmd.Expand(""); got != "FROM SETTINGS" {
+		t.Errorf("settings prompt: got %q, want \"FROM SETTINGS\"", got)
+	}
+}
+
+func TestBuildSlashRegistryGlobalOverridesSettings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PIGO_HOME", home)
+	// global prompt (TierGlobal) under ~/.pigo/prompts.
+	testutil.WritePrompt(t, home, "prompts", "dup.md", "FROM GLOBAL")
+	// settings-tier prompt (file) of the same name, placed at the home root
+	// (not under prompts/, so the global loop does not also load it).
+	settingsFile := filepath.Join(home, "dup.md")
+	if err := os.WriteFile(settingsFile, []byte("FROM SETTINGS"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, err := buildSlashRegistry(&cli.LiveConfig{Model: "test", ProviderName: "test"}, nil, nil,
+		promptTemplateSources{settings: []string{settingsFile}})
+	if err != nil {
+		t.Fatalf("buildSlashRegistry: %v", err)
+	}
+	cmd, ok := reg.Lookup("dup")
+	if !ok {
+		t.Fatal("/dup not found")
+	}
+	if got := cmd.Expand(""); got != "FROM GLOBAL" {
+		t.Errorf("global should override settings, got %q", got)
+	}
+	// The settings loser is shadowed with TierSettings.
+	found := false
+	for _, e := range reg.Shadowed() {
+		if e.Name == "dup" && e.Tier == runtime.TierSettings {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("settings dup should be shadowed with TierSettings, got %v", reg.Shadowed())
+	}
+}

--- a/internal/cli/repl/prompts_dir_test.go
+++ b/internal/cli/repl/prompts_dir_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 // Tests for global prompt-template discovery (US-005, #336): buildSlashRegistry
 // loads both the legacy ~/.pigo/commands and the pi-aligned ~/.pigo/prompts

--- a/internal/cli/repl/prompts_project_test.go
+++ b/internal/cli/repl/prompts_project_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 // Tests for project-level .pigo/prompts (US-006, #337): loaded at the project
 // tier only when the project is trusted, overrides global same-name templates,

--- a/internal/cli/repl/repl.go
+++ b/internal/cli/repl/repl.go
@@ -9,7 +9,7 @@
 // to stdout as it streams, persists the session, and returns to the prompt. A
 // SIGINT during a run cancels that run's context and returns to the prompt; when
 // idle, the reader sees EOF/interrupt and exits cleanly.
-package main
+package repl
 
 import (
 	"bufio"
@@ -41,7 +41,7 @@ import (
 )
 
 // replDeps bundles the collaborators a REPL run needs. They are assembled once
-// by runInteractive and reused across every prompt in the session.
+// by Run and reused across every prompt in the session.
 type replDeps struct {
 	store    *session.Store
 	header   session.SessionHeader
@@ -70,7 +70,7 @@ type replDeps struct {
 	cwd string
 	// in is the shared buffered input reader. The main loop and the tool-call
 	// confirmation prompt both read from it so input typed ahead is never split
-	// between them. It is created by runInteractive (wrapping os.Stdin) or, for
+	// between them. It is created by Run (wrapping os.Stdin) or, for
 	// direct test callers, lazily from the in argument at the top of runREPL.
 	in *bufio.Reader
 	// confirmMu serializes tool-call confirmation prompts so concurrent
@@ -92,7 +92,7 @@ type replDeps struct {
 	persisted int
 
 	// goal holds the session's autonomous-goal state (对标 pi-goal), driven by
-	// the /goal command. It is always non-nil (runInteractive seeds an idle
+	// the /goal command. It is always non-nil (Run seeds an idle
 	// state); the GoalReminderProvider and the goal tools share this handle so
 	// the objective is injected each turn and goal_complete/goal_blocked can end
 	// the run.
@@ -149,7 +149,7 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 	// between them the way it would be if the loop used a bufio.Scanner with
 	// its own private buffer (a Scanner can read past the current line into its
 	// internal buffer, trapping bytes the confirmation prompt would then never
-	// see). deps.in is set by runInteractive (wrapping os.Stdin); the in
+	// see). deps.in is set by Run (wrapping os.Stdin); the in
 	// parameter is only a fallback for direct callers (tests) that do not set
 	// deps.in, and is ignored once deps.in is populated.
 	if deps.in == nil {

--- a/internal/cli/repl/repl_test.go
+++ b/internal/cli/repl/repl_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 // Tests for the line-based REPL (#106): slash-command dispatch (action prints
 // message and does NOT run; prompt runs; unknown command errors and does NOT

--- a/internal/cli/repl/skills_test.go
+++ b/internal/cli/repl/skills_test.go
@@ -1,4 +1,4 @@
-package main
+package repl
 
 // Tests for default skill loading from ~/.agents/skills and its exposure as
 // /skill-name slash commands. skillsDir honors the PIGO_SKILLS_DIR override so

--- a/internal/cli/repl/status_repl_test.go
+++ b/internal/cli/repl/status_repl_test.go
@@ -2,7 +2,7 @@
 // (US-005, #295) that drive the package-main REPL harness (runREPL/newTestDeps)
 // or inspect CLI flags. The direct-call rendering tests live in
 // internal/cli/status alongside RunStatus.
-package main
+package repl
 
 import (
 	"bytes"


### PR DESCRIPTION
## Summary
- Move `repl.go`/`interactive.go`/`line_editor.go`/`host.go` and their tests from `cmd/pigo` (package main) into `internal/cli/repl` (package repl), preserving rename history.
- Export the single entry point `repl.Run(repl.Options{})` (was unexported `runInteractive`/`interactiveOptions`); all 16 option fields exported. Rewire `cmd/pigo/run.go` to call `repl.Run`.
- Keep REPL internals (`replDeps`, `runREPL`, `replLineEditor`, `buildSlashRegistry`, `loadPromptPaths`, `promptTemplateSources`) package-private.
- Split `prompts_config_test.go`: `TestApplyFileConfigPrompts` (drives `cliOptions`/`applyFileConfig`) stays in package main; the `loadPromptPaths`/`buildSlashRegistry` tests move into package repl alongside their symbols.

Closes #367

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (repl + cmd/pigo packages green)