### PR TITLE
TUI 骨架与默认入口接线 (US-001)

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/smallnest/pigo/internal/cli/pkgcmd"
 	"github.com/smallnest/pigo/internal/cli/repl"
 	"github.com/smallnest/pigo/internal/cli/run"
+	"github.com/smallnest/pigo/internal/cli/tui"
 	"github.com/smallnest/pigo/internal/cli/ui"
 )
 
@@ -100,6 +101,10 @@ type cliOptions struct {
 	// showVersion prints build metadata (version/commit/date, injected at release
 	// time by goreleaser) and exits, without running the agent.
 	showVersion bool
+	// noTUI forces the line-based REPL instead of the full-screen TUI (US-001).
+	// When set — or when stdout is not a TTY — the no-prompt path falls back to
+	// repl.Run rather than launching tui.Run.
+	noTUI bool
 }
 
 func main() {
@@ -130,6 +135,7 @@ func main() {
 	flag.StringArrayVar(&opts.promptTemplates, "prompt-template", nil, "load a prompt template from a file or directory (non-recursive); repeatable (对标 pi --prompt-template)")
 	flag.StringVar(&opts.thinkingLevel, "thinking-level", "", "reasoning effort: off|minimal|low|medium|high|xhigh (overrides PIGO_THINKING_LEVEL and config; default medium)")
 	flag.BoolVar(&opts.subagentRPC, "subagent-rpc", false, "internal: run as a process-isolated sub-agent JSON-RPC server over stdio (US-019)")
+	flag.BoolVar(&opts.noTUI, "no-tui", false, "使用行式 REPL 而非全屏 TUI")
 	flag.BoolVarP(&opts.showVersion, "version", "v", false, "print version information and exit")
 	// Extend the default pflag usage with a "Supported providers" block so
 	// `--help` documents the values accepted by --provider (name → env var →
@@ -247,12 +253,15 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		resumeID = id
 	}
 
-	// No prompt + an interactive terminal → start the line-based REPL (US-003). A
-	// --resume id also enters the REPL to continue an existing session. No prompt
-	// with a non-terminal stdout (pipe/CI) and no resume is an error, since there
-	// is nothing to run and nothing to interact with.
+	// No prompt + an interactive terminal → start the interactive UI. By default
+	// this is the full-screen TUI (US-001); --no-tui (or a non-terminal stdout)
+	// forces the line-based REPL (US-003). A --resume id also enters the
+	// interactive UI to continue an existing session. No prompt with a
+	// non-terminal stdout (pipe/CI) and no resume is an error, since there is
+	// nothing to run and nothing to interact with.
 	if opts.prompt == "" {
-		if resumeID == "" && !ui.StdoutIsTerminal() {
+		isTTY := ui.StdoutIsTerminal()
+		if resumeID == "" && !isTTY {
 			fmt.Fprintln(errOut, "pigo: no prompt (use -p \"...\" or positional args)")
 			return 2
 		}
@@ -268,6 +277,30 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		if err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 2
+		}
+		if shouldUseTUI(opts, isTTY) {
+			if err := tui.Run(tui.Options{
+				Model:             opts.model,
+				ProviderName:      env.ProviderName,
+				Provider:          env.Provider,
+				BaseURL:           opts.baseURL,
+				APIKey:            opts.apiKey,
+				Protocol:          opts.protocol,
+				ThinkingLevel:     thinking,
+				Tools:             env.Tools,
+				SysPrompt:         env.SysPrompt,
+				ResumeID:          resumeID,
+				Approve:           opts.approve,
+				Skills:            env.Skills,
+				Plugins:           env.Plugins,
+				ConfigPrompts:     opts.configPrompts,
+				CliPrompts:        opts.promptTemplates,
+				NoPromptTemplates: opts.noPromptTemplates,
+			}); err != nil {
+				fmt.Fprintf(errOut, "pigo: %v\n", err)
+				return 1
+			}
+			return 0
 		}
 		if err := repl.Run(repl.Options{
 			Model:             opts.model,
@@ -316,4 +349,15 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		ThinkingLevel: opts.thinkingLevel,
 		ResumeID:      resumeID,
 	}, out, errOut)
+}
+
+// shouldUseTUI is the pure entry-gating predicate for the no-prompt path
+// (US-001, SPEC 4.2/5.2): the full-screen TUI is used only when stdout is a TTY
+// and --no-tui was not set. --no-tui or a non-terminal stdout always forces the
+// line-based REPL. Keeping the decision in a side-effect-free function lets the
+// gating be unit-tested without a real terminal or spawning Bubble Tea (see
+// TestDispatchTUIGating); dispatch handles the non-TTY/no-resume usage error
+// before calling this, so it only decides TUI-vs-REPL for the interactive case.
+func shouldUseTUI(opts cliOptions, isTTY bool) bool {
+	return isTTY && !opts.noTUI
 }

--- a/cmd/pigo/main_test.go
+++ b/cmd/pigo/main_test.go
@@ -75,6 +75,32 @@ func TestDispatchBadOutputFormat(t *testing.T) {
 	}
 }
 
+// TestDispatchTUIGating verifies the pure entry-gating predicate shouldUseTUI
+// (US-001, SPEC 4.2/5.2) that dispatch uses to choose the full-screen TUI vs the
+// line-based REPL on the no-prompt path. The decision is tested directly so it
+// needs no real TTY and never spawns Bubble Tea: TUI only when stdout is a TTY
+// and --no-tui is unset; --no-tui or a non-terminal stdout always forces REPL.
+func TestDispatchTUIGating(t *testing.T) {
+	tests := []struct {
+		name  string
+		opts  cliOptions
+		isTTY bool
+		want  bool
+	}{
+		{name: "TTY and no flag uses TUI", opts: cliOptions{}, isTTY: true, want: true},
+		{name: "--no-tui forces REPL on a TTY", opts: cliOptions{noTUI: true}, isTTY: true, want: false},
+		{name: "non-TTY never uses TUI", opts: cliOptions{}, isTTY: false, want: false},
+		{name: "non-TTY with --no-tui stays REPL", opts: cliOptions{noTUI: true}, isTTY: false, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldUseTUI(tt.opts, tt.isTTY); got != tt.want {
+				t.Errorf("shouldUseTUI(%+v, %v) = %v, want %v", tt.opts, tt.isTTY, got, tt.want)
+			}
+		})
+	}
+}
+
 // --- config.toml overlay ---
 
 // changedSet turns a set of flag names into a lookup func for applyFileConfig.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/smallnest/pigo
 go 1.27rc1
 
 require (
+	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/BurntSushi/toml v1.6.0
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2
@@ -21,7 +22,7 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318 // indirect
+	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
+charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/lipgloss/v2 v2.0.5 h1:kbNxgeeUOYv5J0YdpxFjfvf3dFvqH8Aci4zB6xqFtrY=
 charm.land/lipgloss/v2 v2.0.5/go.mod h1:9oqhxt4yxIMe6q5A4kHr44DremZk7J9UNh74GlWa5nc=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
@@ -24,8 +26,8 @@ github.com/charmbracelet/glamour v1.0.0 h1:AWMLOVFHTsysl4WV8T8QgkQ0s/ZNZo7CiE4WK
 github.com/charmbracelet/glamour v1.0.0/go.mod h1:DSdohgOBkMr2ZQNhw4LZxSGpx3SvpeujNoXrQyH2hxo=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
-github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318 h1:OqDqxQZliC7C8adA7KjelW3OjtAxREfeHkNcd66wpeI=
-github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318/go.mod h1:Y6kE2GzHfkyQQVCSL9r2hwokSrIlHGzZG+71+wDYSZI=
+github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 h1:3FmWoGNWK4STvqg0O0Aeav2T7rodWJAPeF0QpH+8gFw=
+github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7/go.mod h1:f/jRa757WUmaOZrbPspXymbg/GnbF+rwe4OLsG7aXYo=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=

--- a/internal/cli/tui/doc.go
+++ b/internal/cli/tui/doc.go
@@ -1,0 +1,14 @@
+// Package tui hosts the full-screen terminal UI for pigo's interactive mode
+// (US-001). It is the alt-screen counterpart to the line-based REPL in
+// internal/cli/repl: cmd/pigo's dispatch launches it via Run when there is no
+// prompt, stdout is a TTY, and --no-tui is not set; otherwise the REPL path is
+// used. See tasks/spec-tui-agent.md (Sections 2.1, 4.2, 5.2) for the design.
+//
+// This node is the skeleton: a root Model (Init/Update/View) built on Bubble
+// Tea v2 (charm.land/bubbletea/v2) that renders an empty shell — a placeholder
+// status bar, an empty transcript area, and an empty input line — starts on the
+// alt-screen, and quits cleanly on Ctrl+C / Ctrl+D, restoring the terminal.
+// Session assembly, the run bridge, tool cards, and slash-command completion
+// land in downstream nodes; Options already mirrors repl.Options so those nodes
+// can wire real behavior without changing the entry seam.
+package tui

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -1,0 +1,110 @@
+package tui
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// Model is the root Bubble Tea model for the full-screen TUI. In this skeleton
+// node it holds only the terminal dimensions and renders a static three-region
+// shell: a placeholder status bar, an empty transcript area, and an empty input
+// line. Downstream nodes grow it into the real transcript/tool-card/status-bar
+// composition (see tasks/spec-tui-agent.md Section 2.2); the Init/Update/View
+// contract and the alt-screen + quit-key handling established here stay stable.
+type Model struct {
+	opts Options
+
+	// width and height track the terminal size reported by tea.WindowSizeMsg.
+	// They are zero until the first size message arrives; View degrades to a
+	// minimal render in that window.
+	width  int
+	height int
+
+	// quitting is set when a quit key (Ctrl+C / Ctrl+D) is seen, so View can be a
+	// no-op on the final frame while the program tears down and restores the
+	// terminal.
+	quitting bool
+}
+
+// NewModel builds the root model from the assembled Options. It performs no I/O;
+// session/live/slash/trust assembly is deferred to downstream nodes.
+func NewModel(opts Options) Model {
+	return Model{opts: opts}
+}
+
+// Init implements tea.Model. The skeleton has no startup command; the alt-screen
+// is requested declaratively via the AltScreen field on the View returned by
+// View, so there is nothing to kick off here.
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+// Update implements tea.Model. It tracks the terminal size and quits on the
+// standard exit keys (Ctrl+C / Ctrl+D). Returning tea.Quit lets Bubble Tea tear
+// down the program and restore the terminal (leaving the alt-screen) cleanly.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "ctrl+c", "ctrl+d":
+			m.quitting = true
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+// View implements tea.Model. It renders the empty shell on the alt-screen: a
+// placeholder status bar at the top, an empty transcript area that grows to fill
+// the available height, and an empty input line at the bottom. Setting
+// AltScreen on the returned View is how Bubble Tea v2 enters/leaves the
+// alternate screen buffer, so the user's scrollback is restored on quit.
+func (m Model) View() tea.View {
+	if m.quitting {
+		return tea.View{AltScreen: true}
+	}
+
+	width := m.width
+	if width <= 0 {
+		width = 80
+	}
+	height := m.height
+	if height <= 0 {
+		height = 24
+	}
+
+	status := lipgloss.NewStyle().
+		Width(width).
+		Foreground(lipgloss.Color("15")).
+		Background(lipgloss.Color("62")).
+		Render("pigo — TUI (骨架) · Ctrl+C/Ctrl+D 退出")
+
+	input := lipgloss.NewStyle().
+		Width(width).
+		Foreground(lipgloss.Color("241")).
+		Render("> ")
+
+	// Reserve one row for the status bar and one for the input line; the rest is
+	// the (currently empty) transcript area. Guard against tiny terminals so the
+	// filler count never goes negative.
+	transcriptRows := height - 2
+	if transcriptRows < 0 {
+		transcriptRows = 0
+	}
+
+	var b strings.Builder
+	b.WriteString(status)
+	b.WriteByte('\n')
+	for i := 0; i < transcriptRows; i++ {
+		b.WriteByte('\n')
+	}
+	b.WriteString(input)
+
+	return tea.View{Content: b.String(), AltScreen: true}
+}

--- a/internal/cli/tui/model_test.go
+++ b/internal/cli/tui/model_test.go
@@ -1,0 +1,58 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestModelQuitKeys verifies the root model returns tea.Quit on the standard
+// exit keys (Ctrl+C / Ctrl+D), which is how Bubble Tea tears down the program
+// and restores the terminal from the alt-screen.
+func TestModelQuitKeys(t *testing.T) {
+	for _, key := range []string{"ctrl+c", "ctrl+d"} {
+		m := NewModel(Options{})
+		got, cmd := m.Update(keyPress(key))
+		if cmd == nil {
+			t.Fatalf("%s: expected a quit command, got nil", key)
+		}
+		if msg := cmd(); msg != (tea.QuitMsg{}) {
+			t.Errorf("%s: cmd produced %T, want tea.QuitMsg", key, msg)
+		}
+		if !got.(Model).quitting {
+			t.Errorf("%s: model should be marked quitting", key)
+		}
+	}
+}
+
+// TestModelViewShell verifies the empty shell renders on the alt-screen and,
+// once a size is known, occupies the full terminal height (status bar + empty
+// transcript rows + input line).
+func TestModelViewShell(t *testing.T) {
+	m := NewModel(Options{})
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
+	view := next.View()
+	if !view.AltScreen {
+		t.Error("View should request the alt-screen")
+	}
+	if got := strings.Count(view.Content, "\n"); got != 9 {
+		t.Errorf("newline count = %d, want 9 (10 rows)", got)
+	}
+	if !strings.Contains(view.Content, "TUI") {
+		t.Errorf("status bar placeholder missing from view: %q", view.Content)
+	}
+}
+
+// keyPress builds a KeyPressMsg matching String()==s for the simple keys used
+// in these tests (ctrl+<letter>).
+func keyPress(s string) tea.KeyPressMsg {
+	switch s {
+	case "ctrl+c":
+		return tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
+	case "ctrl+d":
+		return tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl}
+	default:
+		return tea.KeyPressMsg{}
+	}
+}

--- a/internal/cli/tui/options.go
+++ b/internal/cli/tui/options.go
@@ -1,0 +1,56 @@
+package tui
+
+import (
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/plugin"
+	"github.com/smallnest/pigo/internal/provider"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// Options carries the resolved run configuration into Run. It deliberately
+// mirrors repl.Options (see internal/cli/repl/interactive.go) field-for-field so
+// cmd/pigo's dispatch can map the same assembled environment to either path, and
+// so downstream nodes can port the REPL's session/live/slash/trust wiring into
+// the TUI without reshaping the entry seam. This skeleton node does not yet
+// consume most fields — they are here to lock the contract.
+type Options struct {
+	Model        string
+	ProviderName string
+	Provider     provider.Provider
+	BaseURL      string
+	APIKey       string
+	Protocol     string
+	// ThinkingLevel is the resolved reasoning-effort level (US-023): it seeds the
+	// live run config so every turn requests it, until a control command changes
+	// it.
+	ThinkingLevel agentcore.ThinkingLevel
+	Tools         []agentcore.AgentTool
+	SysPrompt     string
+
+	// ResumeID, when non-empty, resumes an existing session: its messages seed
+	// the context and replayed transcript. Otherwise a fresh session is created.
+	ResumeID string
+
+	// Approve, when true, grants the launch directory session trust before the
+	// run so the first-launch trust prompt is skipped and side-effect tools run
+	// without per-call confirmation (对标 pi 的 --approve/-a).
+	Approve bool
+	// Skills is the pre-loaded skill set (loaded once by run.SetupEnv, shared with
+	// prompt injection). Each is registered as a /skill-name command. Empty under
+	// --no-skills, so nothing is registered.
+	Skills []*runtime.Skill
+
+	// Plugins holds the loaded plugin manager so the TUI can deliver lifecycle
+	// events to subscribed plugins (US-017, #133). It may be nil (no plugins).
+	Plugins *plugin.Manager
+
+	// ConfigPrompts holds prompt-template paths from the config.toml `prompts`
+	// array (settings tier); each is a file or dir loaded non-recursively.
+	ConfigPrompts []string
+	// CliPrompts holds --prompt-template paths (CLI tier, repeatable).
+	CliPrompts []string
+	// NoPromptTemplates disables all prompt-template discovery (global, project,
+	// settings, CLI); built-in slash commands are unaffected. Independent of
+	// --no-skills.
+	NoPromptTemplates bool
+}

--- a/internal/cli/tui/run.go
+++ b/internal/cli/tui/run.go
@@ -1,0 +1,17 @@
+package tui
+
+import (
+	tea "charm.land/bubbletea/v2"
+)
+
+// Run starts the full-screen TUI and blocks until the user quits (Ctrl+C /
+// Ctrl+D) or the program errors. It is the alt-screen counterpart to repl.Run:
+// cmd/pigo's dispatch calls it on the (no prompt + TTY + no --no-tui) path and
+// maps its error to the process exit code. The alt-screen is entered/left via
+// the View returned by the root Model, so a clean return here restores the
+// terminal to the user's prior scrollback.
+func Run(opts Options) error {
+	p := tea.NewProgram(NewModel(opts))
+	_, err := p.Run()
+	return err
+}


### PR DESCRIPTION
## Summary
- 新增 `internal/cli/tui` 包:根 Bubble Tea v2 (`charm.land/bubbletea/v2`) Model(Init/Update/View)与 `Run(Options)`,渲染空壳(占位状态栏 + 空 transcript + 空输入框),alt-screen 启停,Ctrl+C/Ctrl+D 干净退出并恢复终端。
- `Options` 字段镜像 `repl.Options`,便于下游节点接线真实会话/事件桥逻辑而不改动入口 seam。
- `cmd/pigo` dispatch 在「无 prompt + TTY + 未 --no-tui」时启动 TUI,否则回落行式 REPL;判定抽为纯函数 `shouldUseTUI`,可脱离真实 TTY 单测。
- 新增 `--no-tui` flag(置位强制 REPL)。非 TTY 无 prompt 行为与退出码保持不变。

Closes #384

## Test plan
- [x] `go build ./...` / `go vet ./...` / `go test ./...` 全绿
- [x] `TestDispatchTUIGating` 覆盖 TTY+无 flag→TUI、--no-tui→REPL、非 TTY→REPL
- [x] `TestDispatchNoPromptNonTerminal` 仍返回退出码 2
- [x] tui Model 单测:Ctrl+C/Ctrl+D 退出、alt-screen 空壳渲染

## NEW_WORK (供下游节点复用)
bubbletea v2 模块路径为 `charm.land/bubbletea/v2 v2.0.8`(非 github.com/charmbracelet);bubbles v2 为 `charm.land/bubbles/v2 v2.1.1`;lipgloss v2 已在 repo `charm.land/lipgloss/v2 v2.0.5`。alt-screen 在 v2 通过 `tea.View{AltScreen: true}` 声明式开启(非 WithAltScreen program option)。