### PR TITLE
feat(tui): bridge AgentEvent stream to tea.Msg

### DIFF
--- a/internal/cli/tui/bridge.go
+++ b/internal/cli/tui/bridge.go
@@ -1,0 +1,108 @@
+package tui
+
+import (
+	"context"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// This file bridges the agent run seam (runtime.StartRun + runtime.DrainStream)
+// to Bubble Tea (US-004, SPEC 5.1 bridge / 3.2). The agent loop runs on its own
+// goroutine and emits AgentEvents; a Bubble Tea program consumes tea.Msg values
+// one at a time from its Update loop. The bridge is a pump: a goroutine drains
+// the run and converts every event into the matching tea.Msg (see msgs.go),
+// sending it into a buffered channel; a tea.Cmd (waitForEvent) receives one msg
+// per Update tick. The channel is the only synchronization point, so the
+// producer never touches the model and the model never touches the run — all
+// state transitions happen on the tea goroutine.
+//
+// Back-pressure is intentional: the channel blocks the draining goroutine when
+// the buffer is full, so no event is ever dropped (the tea loop always catches
+// up). Node #388 wires startRun into Model.Init/Update; this file only provides
+// the reusable, unit-testable primitives.
+
+// eventChanCap is the buffer size of the bridge channel. A modest buffer lets a
+// burst of tool events queue without blocking the run's goroutine on every send,
+// while still bounding memory (blocking, never dropping, past the cap).
+const eventChanCap = 64
+
+// newEventChan allocates the buffered channel the bridge pumps run events
+// through.
+func newEventChan() chan tea.Msg {
+	return make(chan tea.Msg, eventChanCap)
+}
+
+// newStreamHandler builds the runtime.StreamHandler that converts each run event
+// into a tea.Msg and sends it into ch. Sends block when ch is full, applying
+// back-pressure to the draining goroutine so no event is lost. It is factored
+// out of pump so the callback→msg conversion can be unit-tested without a real
+// provider run (see bridge_test.go).
+func newStreamHandler(ch chan tea.Msg) runtime.StreamHandler {
+	return runtime.StreamHandler{
+		OnText: func(delta string) {
+			ch <- textDeltaMsg{delta: delta}
+		},
+		OnTurnEnd: func(msg agentcore.AssistantMessage, results []agentcore.ToolResultMessage) {
+			ch <- turnEndMsg{msg: msg, results: results}
+		},
+		OnEvent: func(ev agentcore.AgentEvent) {
+			switch e := ev.(type) {
+			case agentcore.ToolExecutionStartEvent:
+				ch <- toolStartMsg{id: e.ToolCallID, name: e.ToolName, input: argsToMap(e.Args)}
+			case agentcore.ToolExecutionUpdateEvent:
+				ch <- toolUpdateMsg{id: e.ToolCallID, partial: agentcore.ContentToText(e.PartialResult.Content)}
+			case agentcore.ToolExecutionEndEvent:
+				ch <- toolEndMsg{id: e.ToolCallID, ok: !e.IsError, result: agentcore.ContentToText(e.Result.Content)}
+			case agentcore.TelemetryEvent:
+				ch <- telemetryMsg{ev: e}
+			case agentcore.CompactionEvent:
+				ch <- compactionMsg{}
+			}
+		},
+	}
+}
+
+// argsToMap coerces a tool call's untyped Args into a map[string]any when it is a
+// JSON object, returning nil otherwise. The event layer carries Args as an
+// untyped any (the decoded JSON arguments), so a consumer that wants structured
+// input gets the object form when available and nil for non-object args.
+func argsToMap(args any) map[string]any {
+	if m, ok := args.(map[string]any); ok {
+		return m
+	}
+	return nil
+}
+
+// pump runs the agent loop to completion on the calling goroutine, converting
+// every event to a tea.Msg on ch, and finally sends a runEndMsg carrying the
+// run's result error. It is meant to be launched as a goroutine by startRun.
+func pump(ctx context.Context, ch chan tea.Msg, agentCtx *agentcore.AgentContext, cfg runtime.RunConfig) {
+	stream := runtime.StartRun(ctx, agentCtx, cfg)
+	_, err := runtime.DrainStream(ctx, stream, newStreamHandler(ch))
+	ch <- runEndMsg{err: err}
+}
+
+// waitForEvent returns a tea.Cmd that blocks until the next bridge msg arrives.
+// The Update loop re-issues it after handling each msg (except runEndMsg) to
+// keep pulling events one at a time, so ordering is preserved and the tea
+// goroutine never spins.
+func waitForEvent(ch chan tea.Msg) tea.Cmd {
+	return func() tea.Msg {
+		return <-ch
+	}
+}
+
+// startRun launches the run pump on a new goroutine and returns the channel it
+// feeds together with the first waitForEvent Cmd. The caller (node #388's model)
+// stores the channel and, on every subsequent event, issues waitForEvent(ch)
+// again to pull the next msg. Returning the channel keeps the bridge
+// self-contained: the model owns the handle and decides when to stop pulling
+// (after runEndMsg).
+func startRun(ctx context.Context, agentCtx *agentcore.AgentContext, cfg runtime.RunConfig) (chan tea.Msg, tea.Cmd) {
+	ch := newEventChan()
+	go pump(ctx, ch, agentCtx, cfg)
+	return ch, waitForEvent(ch)
+}

--- a/internal/cli/tui/bridge_test.go
+++ b/internal/cli/tui/bridge_test.go
@@ -1,0 +1,145 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// drain collects every msg queued on ch without blocking, stopping at the first
+// would-block. The bridge sends are synchronous into a buffered channel, so once
+// the fake sequence has been driven the msgs are all present and this returns
+// them in order.
+func drain(ch chan tea.Msg) []tea.Msg {
+	var out []tea.Msg
+	for {
+		select {
+		case m := <-ch:
+			out = append(out, m)
+		default:
+			return out
+		}
+	}
+}
+
+// TestStreamHandlerConversion drives a synthetic event sequence directly through
+// the StreamHandler the bridge builds and asserts each callback produces the
+// matching tea.Msg, in order. It fakes the run entirely (no provider), exercising
+// the callback→msg conversion + channel ordering in isolation.
+func TestStreamHandlerConversion(t *testing.T) {
+	ch := newEventChan()
+	h := newStreamHandler(ch)
+
+	// A representative sequence: two text deltas, a tool start/update/end, a
+	// telemetry summary, a compaction, and a turn end.
+	h.OnText("Hello ")
+	h.OnText("world")
+	h.OnEvent(agentcore.ToolExecutionStartEvent{
+		ToolCallID: "call-1",
+		ToolName:   "read_file",
+		Args:       map[string]any{"path": "/tmp/x"},
+	})
+	h.OnEvent(agentcore.ToolExecutionUpdateEvent{
+		ToolCallID:    "call-1",
+		ToolName:      "read_file",
+		PartialResult: agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent("partial")}},
+	})
+	h.OnEvent(agentcore.ToolExecutionEndEvent{
+		ToolCallID: "call-1",
+		ToolName:   "read_file",
+		Result:     agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent("done")}},
+		IsError:    false,
+	})
+	h.OnEvent(agentcore.TelemetryEvent{Turns: 3})
+	h.OnEvent(agentcore.CompactionEvent{Reason: "threshold"})
+	h.OnTurnEnd(
+		agentcore.AssistantMessage{Content: agentcore.ContentList{agentcore.NewTextContent("Hello world")}},
+		[]agentcore.ToolResultMessage{{ToolCallID: "call-1"}},
+	)
+	// Simulate drain-done: the pump appends runEndMsg after DrainStream returns.
+	ch <- runEndMsg{err: nil}
+
+	got := drain(ch)
+
+	if len(got) != 9 {
+		t.Fatalf("expected 9 msgs, got %d: %#v", len(got), got)
+	}
+
+	if m, ok := got[0].(textDeltaMsg); !ok || m.delta != "Hello " {
+		t.Errorf("msg[0] = %#v, want textDeltaMsg{delta:%q}", got[0], "Hello ")
+	}
+	if m, ok := got[1].(textDeltaMsg); !ok || m.delta != "world" {
+		t.Errorf("msg[1] = %#v, want textDeltaMsg{delta:%q}", got[1], "world")
+	}
+	if m, ok := got[2].(toolStartMsg); !ok || m.id != "call-1" || m.name != "read_file" || m.input["path"] != "/tmp/x" {
+		t.Errorf("msg[2] = %#v, want toolStartMsg for call-1", got[2])
+	}
+	if m, ok := got[3].(toolUpdateMsg); !ok || m.id != "call-1" || m.partial != "partial" {
+		t.Errorf("msg[3] = %#v, want toolUpdateMsg{partial:%q}", got[3], "partial")
+	}
+	if m, ok := got[4].(toolEndMsg); !ok || m.id != "call-1" || !m.ok || m.result != "done" {
+		t.Errorf("msg[4] = %#v, want toolEndMsg{ok:true, result:%q}", got[4], "done")
+	}
+	if m, ok := got[5].(telemetryMsg); !ok || m.ev.Turns != 3 {
+		t.Errorf("msg[5] = %#v, want telemetryMsg{Turns:3}", got[5])
+	}
+	if _, ok := got[6].(compactionMsg); !ok {
+		t.Errorf("msg[6] = %#v, want compactionMsg", got[6])
+	}
+	if m, ok := got[7].(turnEndMsg); !ok || len(m.results) != 1 || m.results[0].ToolCallID != "call-1" {
+		t.Errorf("msg[7] = %#v, want turnEndMsg with one result", got[7])
+	}
+	if m, ok := got[8].(runEndMsg); !ok || m.err != nil {
+		t.Errorf("msg[8] = %#v, want runEndMsg{err:nil}", got[8])
+	}
+}
+
+// TestToolEndError verifies the ok flag inverts IsError.
+func TestToolEndError(t *testing.T) {
+	ch := newEventChan()
+	h := newStreamHandler(ch)
+	h.OnEvent(agentcore.ToolExecutionEndEvent{
+		ToolCallID: "c",
+		Result:     agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent("boom")}},
+		IsError:    true,
+	})
+	got := drain(ch)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 msg, got %d", len(got))
+	}
+	m, ok := got[0].(toolEndMsg)
+	if !ok || m.ok || m.result != "boom" {
+		t.Errorf("got %#v, want toolEndMsg{ok:false, result:%q}", got[0], "boom")
+	}
+}
+
+// TestArgsToMap covers the object / non-object coercion of tool call args.
+func TestArgsToMap(t *testing.T) {
+	if m := argsToMap(map[string]any{"k": "v"}); m == nil || m["k"] != "v" {
+		t.Errorf("object args: got %#v, want map with k=v", m)
+	}
+	if m := argsToMap("not-an-object"); m != nil {
+		t.Errorf("non-object args: got %#v, want nil", m)
+	}
+	if m := argsToMap(nil); m != nil {
+		t.Errorf("nil args: got %#v, want nil", m)
+	}
+}
+
+// TestWaitForEvent verifies the pump Cmd returns the next queued msg.
+func TestWaitForEvent(t *testing.T) {
+	ch := newEventChan()
+	want := runEndMsg{err: errors.New("stop")}
+	ch <- want
+	cmd := waitForEvent(ch)
+	if cmd == nil {
+		t.Fatal("waitForEvent returned nil Cmd")
+	}
+	got, ok := cmd().(runEndMsg)
+	if !ok || got.err == nil || got.err.Error() != "stop" {
+		t.Errorf("cmd() = %#v, want runEndMsg{err:stop}", got)
+	}
+}

--- a/internal/cli/tui/msgs.go
+++ b/internal/cli/tui/msgs.go
@@ -1,0 +1,57 @@
+package tui
+
+import "github.com/smallnest/pigo/internal/agentcore"
+
+// This file defines the tea.Msg types the event bridge (bridge.go) produces from
+// a run's AgentEvents (US-004, SPEC 5.1). Each raw runtime signal is converted to
+// exactly one of these value types so the Bubble Tea Update loop can dispatch on
+// them with a plain type switch, keeping all run-time state changes on the tea
+// goroutine (node #388 wires them into Model.Update). Every type is a value (not
+// a pointer) so it flows through the tea.Msg (any) channel without aliasing the
+// producer goroutine's state.
+
+// textDeltaMsg carries the newest suffix of streaming assistant text — the bytes
+// produced since the previous delta for the current turn (see DrainStream's
+// OnText contract).
+type textDeltaMsg struct{ delta string }
+
+// turnEndMsg fires once per completed turn with the final assistant message and
+// the tool results produced during it.
+type turnEndMsg struct {
+	msg     agentcore.AssistantMessage
+	results []agentcore.ToolResultMessage
+}
+
+// toolStartMsg is emitted before a tool runs. input holds the decoded call
+// arguments when they are a JSON object; it is nil otherwise (the raw Args are
+// an untyped any at the event layer).
+type toolStartMsg struct {
+	id    string
+	name  string
+	input map[string]any
+}
+
+// toolUpdateMsg carries a partial result streamed during a tool's execution.
+type toolUpdateMsg struct {
+	id      string
+	partial string
+}
+
+// toolEndMsg is emitted when a tool finishes. ok is false when the tool reported
+// an error; result is the tool's textual output.
+type toolEndMsg struct {
+	id     string
+	ok     bool
+	result string
+}
+
+// telemetryMsg carries the run's end-of-run telemetry summary.
+type telemetryMsg struct{ ev agentcore.TelemetryEvent }
+
+// compactionMsg signals that the loop compacted the context window. The event's
+// details are not needed by the transcript, so it is a bare signal.
+type compactionMsg struct{}
+
+// runEndMsg is the final message: the run has fully drained. err is non-nil when
+// the run ended in error (or was interrupted).
+type runEndMsg struct{ err error }


### PR DESCRIPTION
## Summary
- Add `msgs.go` defining the tea.Msg value types the TUI dispatches on (textDelta / turnEnd / toolStart / toolUpdate / toolEnd / telemetry / compaction / runEnd).
- Add `bridge.go`: `newStreamHandler` converts each runtime AgentEvent to the matching msg, a buffered channel (cap 64) applies blocking back-pressure so no event is dropped, the `pump` goroutine drives StartRun + DrainStream and appends runEndMsg, and `startRun`/`waitForEvent` expose the pump as tea.Cmds.
- Reuses the existing `runtime.StartRun`/`DrainStream` seam; does NOT wire into model.go (node #388's job). Self-contained and unit-testable.

Closes #387

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/cli/tui/...`
- [x] `go test ./internal/cli/tui/...` (conversion order, error flag, argsToMap, waitForEvent)