### PR TITLE
feat(tui): persistent bottom status bar (#386)

### DIFF
--- a/internal/cli/tui/gitinfo.go
+++ b/internal/cli/tui/gitinfo.go
@@ -1,0 +1,136 @@
+package tui
+
+import (
+	"os/exec"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// gitInfoMsg is the result of an async git probe (fetchGitCmd). It is defined
+// here rather than in msgs.go to avoid conflicting with the event-bridge message
+// set (#387). The status bar consumes it to render the branch + working-tree
+// state segment.
+//
+//   - branch: the current branch name (empty when detached / unknown).
+//   - ahead:  commits the branch is ahead of its upstream (0 when unknown or no
+//     upstream). Derived cheaply from `git status --porcelain -b`.
+//   - dirty:  number of changed/untracked entries reported by `git status
+//     --porcelain` (staged, unstaged, and untracked all count).
+//   - ok:     false when the cwd is not a git repository or any git command
+//     failed; the status bar hides the git segment in that case.
+type gitInfoMsg struct {
+	branch string
+	ahead  int
+	dirty  int
+	ok     bool
+}
+
+// fetchGitCmd returns a tea.Cmd that probes the git working tree rooted at cwd
+// and reports a gitInfoMsg. It runs read-only git plumbing with fixed arguments
+// (no user interpolation, so no command-injection surface) off the tea
+// goroutine. Any error — not a repo, git missing, detached parse failure —
+// collapses to gitInfoMsg{ok:false}, which the status bar renders as "no git".
+func fetchGitCmd(cwd string) tea.Cmd {
+	return func() tea.Msg {
+		// One porcelain call with the branch header gives us branch name, ahead
+		// count, and every dirty/untracked entry in a single stable, parseable
+		// format (-z would drop the header line, so we keep the newline form).
+		out, err := runGit(cwd, "status", "--porcelain", "-b")
+		if err != nil {
+			return gitInfoMsg{ok: false}
+		}
+		return parseGitStatus(out)
+	}
+}
+
+// runGit executes a read-only git subcommand in dir and returns its stdout. The
+// argument list is always caller-controlled constants (see fetchGitCmd), never
+// user input.
+func runGit(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// parseGitStatus parses the output of `git status --porcelain -b` into a
+// gitInfoMsg. The first line is the branch header ("## branch...upstream [ahead N,
+// behind M]"); every subsequent non-empty line is one changed or untracked entry.
+// A parsed result always has ok=true, since reaching this point means git ran.
+func parseGitStatus(out string) gitInfoMsg {
+	info := gitInfoMsg{ok: true}
+	lines := strings.Split(out, "\n")
+	for i, line := range lines {
+		if i == 0 {
+			info.branch, info.ahead = parseBranchHeader(line)
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		info.dirty++
+	}
+	return info
+}
+
+// parseBranchHeader extracts the branch name and ahead count from a porcelain
+// branch header line, e.g.:
+//
+//	## master...origin/master [ahead 4, behind 1]
+//	## feature-x
+//	## HEAD (no branch)
+//
+// It returns the branch name and ahead count (0 when absent). A line that is not
+// a branch header yields ("", 0).
+func parseBranchHeader(line string) (string, int) {
+	const prefix = "## "
+	if !strings.HasPrefix(line, prefix) {
+		return "", 0
+	}
+	rest := strings.TrimPrefix(line, prefix)
+
+	// Split off the optional " [ahead N, behind M]" tracking suffix.
+	branchPart := rest
+	ahead := 0
+	if idx := strings.Index(rest, " ["); idx >= 0 {
+		branchPart = rest[:idx]
+		ahead = parseAhead(rest[idx:])
+	}
+
+	// "## HEAD (no branch)" — detached; keep the raw token as the branch label.
+	branchPart = strings.TrimSpace(branchPart)
+
+	// Trim the "...upstream" tracking-branch tail if present.
+	if idx := strings.Index(branchPart, "..."); idx >= 0 {
+		branchPart = branchPart[:idx]
+	}
+	return branchPart, ahead
+}
+
+// parseAhead pulls the integer following "ahead " out of a tracking suffix such
+// as "[ahead 4, behind 1]". It returns 0 when no ahead count is present.
+func parseAhead(suffix string) int {
+	const marker = "ahead "
+	idx := strings.Index(suffix, marker)
+	if idx < 0 {
+		return 0
+	}
+	digits := suffix[idx+len(marker):]
+	n := 0
+	found := false
+	for _, r := range digits {
+		if r < '0' || r > '9' {
+			break
+		}
+		n = n*10 + int(r-'0')
+		found = true
+	}
+	if !found {
+		return 0
+	}
+	return n
+}

--- a/internal/cli/tui/gitinfo_test.go
+++ b/internal/cli/tui/gitinfo_test.go
@@ -1,0 +1,99 @@
+package tui
+
+import "testing"
+
+func TestParseGitStatusDirtyCount(t *testing.T) {
+	// Sample `git status --porcelain -b` output: header + 4 entries (staged,
+	// modified, deleted, untracked).
+	out := "## master...origin/master [ahead 4, behind 1]\n" +
+		"M  cmd/pigo/main.go\n" +
+		" M internal/foo.go\n" +
+		"D  cmd/pigo/run.go\n" +
+		"?? new_file.go\n"
+
+	info := parseGitStatus(out)
+	if !info.ok {
+		t.Fatal("parseGitStatus should report ok=true")
+	}
+	if info.branch != "master" {
+		t.Errorf("branch = %q, want master", info.branch)
+	}
+	if info.dirty != 4 {
+		t.Errorf("dirty = %d, want 4", info.dirty)
+	}
+	if info.ahead != 4 {
+		t.Errorf("ahead = %d, want 4", info.ahead)
+	}
+}
+
+func TestParseGitStatusCleanTree(t *testing.T) {
+	out := "## main...origin/main\n"
+	info := parseGitStatus(out)
+	if !info.ok {
+		t.Fatal("ok should be true")
+	}
+	if info.branch != "main" {
+		t.Errorf("branch = %q, want main", info.branch)
+	}
+	if info.dirty != 0 {
+		t.Errorf("dirty = %d, want 0", info.dirty)
+	}
+	if info.ahead != 0 {
+		t.Errorf("ahead = %d, want 0", info.ahead)
+	}
+}
+
+func TestParseGitStatusNoUpstream(t *testing.T) {
+	out := "## feature-x\n M a.go\n"
+	info := parseGitStatus(out)
+	if info.branch != "feature-x" {
+		t.Errorf("branch = %q, want feature-x", info.branch)
+	}
+	if info.ahead != 0 {
+		t.Errorf("ahead = %d, want 0", info.ahead)
+	}
+	if info.dirty != 1 {
+		t.Errorf("dirty = %d, want 1", info.dirty)
+	}
+}
+
+func TestParseGitStatusDetached(t *testing.T) {
+	out := "## HEAD (no branch)\n"
+	info := parseGitStatus(out)
+	if info.branch != "HEAD (no branch)" {
+		t.Errorf("branch = %q, want %q", info.branch, "HEAD (no branch)")
+	}
+}
+
+func TestParseBranchHeaderAhead(t *testing.T) {
+	branch, ahead := parseBranchHeader("## dev...origin/dev [ahead 12]")
+	if branch != "dev" {
+		t.Errorf("branch = %q, want dev", branch)
+	}
+	if ahead != 12 {
+		t.Errorf("ahead = %d, want 12", ahead)
+	}
+}
+
+func TestParseBranchHeaderBehindOnly(t *testing.T) {
+	branch, ahead := parseBranchHeader("## dev...origin/dev [behind 3]")
+	if branch != "dev" {
+		t.Errorf("branch = %q, want dev", branch)
+	}
+	if ahead != 0 {
+		t.Errorf("ahead = %d, want 0 (behind only)", ahead)
+	}
+}
+
+func TestFetchGitCmdNonRepo(t *testing.T) {
+	// A path that is not a git repository should collapse to ok=false. /tmp is
+	// (almost) never a repo; if it somehow is on this host, skip.
+	msg := fetchGitCmd("/")()
+	git, ok := msg.(gitInfoMsg)
+	if !ok {
+		t.Fatalf("expected gitInfoMsg, got %T", msg)
+	}
+	if git.ok {
+		t.Skip("host root unexpectedly reports a git repo; skipping")
+	}
+}

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"os"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -26,19 +27,38 @@ type Model struct {
 	// no-op on the final frame while the program tears down and restores the
 	// terminal.
 	quitting bool
+
+	// statusBar renders the persistent bottom line (#386, US-003). It is fed the
+	// terminal width, telemetry-derived context usage, and the async git probe
+	// result; View renders it just above the input line.
+	statusBar statusBar
+
+	// cwd is the launch directory, captured once at construction and reused for
+	// the git probe and the status bar's path display.
+	cwd string
 }
 
-// NewModel builds the root model from the assembled Options. It performs no I/O;
-// session/live/slash/trust assembly is deferred to downstream nodes.
+// NewModel builds the root model from the assembled Options. It performs no I/O
+// beyond reading the current working directory (for the status bar's path
+// display and git probe); session/live/slash/trust assembly is deferred to
+// downstream nodes.
 func NewModel(opts Options) Model {
-	return Model{opts: opts}
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = ""
+	}
+	return Model{
+		opts:      opts,
+		cwd:       cwd,
+		statusBar: newStatusBar(DefaultTheme(), opts, cwd),
+	}
 }
 
-// Init implements tea.Model. The skeleton has no startup command; the alt-screen
-// is requested declaratively via the AltScreen field on the View returned by
-// View, so there is nothing to kick off here.
+// Init implements tea.Model. It kicks off the async git probe so the status bar
+// can show the branch/dirty state as soon as it resolves; the alt-screen is
+// requested declaratively via the AltScreen field on the View returned by View.
 func (m Model) Init() tea.Cmd {
-	return nil
+	return fetchGitCmd(m.cwd)
 }
 
 // Update implements tea.Model. It tracks the terminal size and quits on the
@@ -50,6 +70,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		return m, nil
+	case gitInfoMsg:
+		m.statusBar.SetGit(msg)
+		return m, nil
+	case telemetryMsg:
+		m.statusBar.SetTelemetry(telemetryEventView{
+			util:   msg.ev.ContextUtilization,
+			window: msg.ev.ContextWindow,
+		})
+		return m, nil
+	case runEndMsg:
+		// A run may have changed the working tree (edits, new files); re-probe git
+		// so the status bar reflects the post-run dirty/ahead state.
+		return m, fetchGitCmd(m.cwd)
 	case tea.KeyPressMsg:
 		switch msg.String() {
 		case "ctrl+c", "ctrl+d":
@@ -60,10 +93,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// View implements tea.Model. It renders the empty shell on the alt-screen: a
-// placeholder status bar at the top, an empty transcript area that grows to fill
-// the available height, and an empty input line at the bottom. Setting
-// AltScreen on the returned View is how Bubble Tea v2 enters/leaves the
+// View implements tea.Model. It renders the shell on the alt-screen: an empty
+// transcript area that grows to fill the available height, the persistent status
+// bar (#386) on the second-to-last row, and the input line at the bottom.
+// Setting AltScreen on the returned View is how Bubble Tea v2 enters/leaves the
 // alternate screen buffer, so the user's scrollback is restored on quit.
 func (m Model) View() tea.View {
 	if m.quitting {
@@ -79,11 +112,7 @@ func (m Model) View() tea.View {
 		height = 24
 	}
 
-	status := lipgloss.NewStyle().
-		Width(width).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("62")).
-		Render("pigo — TUI (骨架) · Ctrl+C/Ctrl+D 退出")
+	status := m.statusBar.Render(width)
 
 	input := lipgloss.NewStyle().
 		Width(width).
@@ -99,11 +128,11 @@ func (m Model) View() tea.View {
 	}
 
 	var b strings.Builder
-	b.WriteString(status)
-	b.WriteByte('\n')
 	for i := 0; i < transcriptRows; i++ {
 		b.WriteByte('\n')
 	}
+	b.WriteString(status)
+	b.WriteByte('\n')
 	b.WriteString(input)
 
 	return tea.View{Content: b.String(), AltScreen: true}

--- a/internal/cli/tui/model_test.go
+++ b/internal/cli/tui/model_test.go
@@ -27,11 +27,12 @@ func TestModelQuitKeys(t *testing.T) {
 }
 
 // TestModelViewShell verifies the empty shell renders on the alt-screen and,
-// once a size is known, occupies the full terminal height (status bar + empty
-// transcript rows + input line).
+// once a size is known, occupies the full terminal height (empty transcript rows
+// + status bar + input line), with the real status bar (#386) painting its
+// fields.
 func TestModelViewShell(t *testing.T) {
-	m := NewModel(Options{})
-	next, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
+	m := NewModel(Options{Model: "test-model"})
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 60, Height: 10})
 	view := next.View()
 	if !view.AltScreen {
 		t.Error("View should request the alt-screen")
@@ -39,8 +40,8 @@ func TestModelViewShell(t *testing.T) {
 	if got := strings.Count(view.Content, "\n"); got != 9 {
 		t.Errorf("newline count = %d, want 9 (10 rows)", got)
 	}
-	if !strings.Contains(view.Content, "TUI") {
-		t.Errorf("status bar placeholder missing from view: %q", view.Content)
+	if !strings.Contains(view.Content, "test-model") {
+		t.Errorf("status bar model field missing from view: %q", view.Content)
 	}
 }
 

--- a/internal/cli/tui/statusbar.go
+++ b/internal/cli/tui/statusbar.go
@@ -1,0 +1,240 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/cli/ui"
+)
+
+// statusBar renders the persistent bottom line described in the SPEC (US-003,
+// Section 5.1): model name, thinking level, cwd (with $HOME abbreviated to ~),
+// git branch + dirty/ahead markers, context-usage %, and the current task text.
+// It holds no styling of its own beyond the Theme's StatusBar style; all width
+// fitting is done against ui.Width so CJK/emoji count as two columns.
+//
+// The component is a plain value: Update-side code copies it into the Model,
+// mutates the exported-to-package snapshot fields via the setters, and calls
+// Render(width) from View. It never performs I/O — the git probe lives in
+// gitinfo.go and feeds it via SetGit.
+type statusBar struct {
+	theme Theme
+
+	// Static-ish config sourced from Options.
+	model    string
+	thinking string
+
+	// cwd is the launch directory with $HOME already abbreviated to "~".
+	cwd string
+
+	// git is the latest probe result; rendered only when git.ok is true.
+	git gitInfoMsg
+
+	// contextPct is the latest context-window utilization in percent [0,100],
+	// derived from telemetryMsg (ContextUtilization * 100). -1 means unknown, so
+	// the segment is hidden until the first telemetry arrives.
+	contextPct int
+
+	// task is the current activity text (e.g. the running tool or turn state).
+	task string
+}
+
+// newStatusBar builds a status bar from the theme, resolved Options, and the
+// launch directory. contextPct starts at -1 (unknown) so the token segment stays
+// hidden until telemetry arrives.
+func newStatusBar(theme Theme, opts Options, cwd string) statusBar {
+	return statusBar{
+		theme:      theme,
+		model:      opts.Model,
+		thinking:   string(opts.ThinkingLevel),
+		cwd:        abbreviateHome(cwd),
+		contextPct: -1,
+	}
+}
+
+// SetGit stores the latest git probe result.
+func (s *statusBar) SetGit(g gitInfoMsg) { s.git = g }
+
+// SetTelemetry updates the context-usage percentage from a telemetry event.
+// A zero/unknown window (ContextWindow == 0) leaves the segment hidden.
+func (s *statusBar) SetTelemetry(ev telemetryEventView) {
+	if ev.window <= 0 {
+		s.contextPct = -1
+		return
+	}
+	pct := int(ev.util*100 + 0.5)
+	if pct < 0 {
+		pct = 0
+	}
+	if pct > 100 {
+		pct = 100
+	}
+	s.contextPct = pct
+}
+
+// SetTask records the current activity text shown at the far right / high
+// priority slot of the bar.
+func (s *statusBar) SetTask(task string) { s.task = task }
+
+// telemetryEventView is the minimal projection of agentcore.TelemetryEvent the
+// status bar needs, so the caller (model.go) adapts the event rather than this
+// file depending on agentcore directly for a two-field read.
+type telemetryEventView struct {
+	util   float64
+	window int
+}
+
+// segment is one labelled field of the bar together with its truncation
+// priority. Higher priority survives longer when the terminal is too narrow.
+type segment struct {
+	text     string
+	priority int // larger = kept longer under truncation
+}
+
+// Priority order (SPEC: task > model > token > git > cwd). Higher is more
+// important and dropped/truncated last.
+const (
+	prioCwd   = 0
+	prioGit   = 1
+	prioToken = 2
+	prioModel = 3
+	prioTask  = 4
+)
+
+// Render lays the bar out to exactly the configured width. It joins the visible
+// segments with " · " separators and, when the result would exceed the width,
+// drops whole segments from lowest to highest priority, then truncates the
+// remaining joined string with TruncateToWidth as a final guard. The returned
+// string's display width (ui.Width) is always <= width. A non-positive width
+// yields the empty string.
+func (s statusBar) Render(width int) string {
+	if width <= 0 {
+		return ""
+	}
+
+	segs := s.segments()
+
+	// Drop lowest-priority segments until the joined content fits, so that under
+	// pressure we keep task > model > token > git > cwd.
+	for len(segs) > 0 {
+		joined := joinSegments(segs)
+		if ui.Width(joined) <= width {
+			return s.theme.StatusBar.Render(joined)
+		}
+		segs = dropLowest(segs)
+	}
+
+	// Even a single highest-priority segment overflows: hard-truncate it.
+	return s.theme.StatusBar.Render(TruncateToWidth(s.highestText(), width))
+}
+
+// segments builds the ordered list of visible segments. Order in the slice is
+// the left-to-right display order; priority governs truncation, not position.
+func (s statusBar) segments() []segment {
+	var segs []segment
+
+	if s.model != "" {
+		segs = append(segs, segment{text: s.model, priority: prioModel})
+	}
+	if s.thinking != "" {
+		// Thinking rides with the model priority — it is cheap and contextual.
+		segs = append(segs, segment{text: "think:" + s.thinking, priority: prioModel})
+	}
+	if s.cwd != "" {
+		segs = append(segs, segment{text: s.cwd, priority: prioCwd})
+	}
+	if s.git.ok {
+		segs = append(segs, segment{text: s.gitText(), priority: prioGit})
+	}
+	if s.contextPct >= 0 {
+		segs = append(segs, segment{text: fmt.Sprintf("ctx:%d%%", s.contextPct), priority: prioToken})
+	}
+	if s.task != "" {
+		segs = append(segs, segment{text: s.task, priority: prioTask})
+	}
+	return segs
+}
+
+// gitText formats the git segment, e.g. "master *3 +4": branch, then "*N" for N
+// dirty entries and "+N" for N commits ahead, each shown only when non-zero.
+func (s statusBar) gitText() string {
+	var b strings.Builder
+	b.WriteString(s.git.branch)
+	if s.git.dirty > 0 {
+		fmt.Fprintf(&b, " *%d", s.git.dirty)
+	}
+	if s.git.ahead > 0 {
+		fmt.Fprintf(&b, " +%d", s.git.ahead)
+	}
+	return b.String()
+}
+
+// highestText returns the text of the highest-priority segment, used as the last
+// thing standing when the terminal cannot even fit one full segment.
+func (s statusBar) highestText() string {
+	segs := s.segments()
+	if len(segs) == 0 {
+		return ""
+	}
+	best := segs[0]
+	for _, seg := range segs[1:] {
+		if seg.priority > best.priority {
+			best = seg
+		}
+	}
+	return best.text
+}
+
+// joinSegments renders the segments left-to-right joined by " · ".
+func joinSegments(segs []segment) string {
+	parts := make([]string, len(segs))
+	for i, seg := range segs {
+		parts[i] = seg.text
+	}
+	return strings.Join(parts, " · ")
+}
+
+// dropLowest removes one occurrence of the lowest-priority segment, preserving
+// display order among the rest. It returns the shortened slice.
+func dropLowest(segs []segment) []segment {
+	if len(segs) == 0 {
+		return segs
+	}
+	lowIdx := 0
+	for i, seg := range segs {
+		if seg.priority < segs[lowIdx].priority {
+			lowIdx = i
+		}
+	}
+	out := make([]segment, 0, len(segs)-1)
+	out = append(out, segs[:lowIdx]...)
+	out = append(out, segs[lowIdx+1:]...)
+	return out
+}
+
+// abbreviateHome replaces a leading $HOME in path with "~" so the status bar
+// stays compact. It leaves paths outside $HOME untouched and never fails.
+func abbreviateHome(path string) string {
+	home := homeDir()
+	if home == "" || path == "" {
+		return path
+	}
+	if path == home {
+		return "~"
+	}
+	if strings.HasPrefix(path, home+"/") {
+		return "~" + strings.TrimPrefix(path, home)
+	}
+	return path
+}
+
+// homeDir returns the user's home directory, or "" when it cannot be
+// determined. Kept as a tiny wrapper so abbreviateHome stays testable.
+func homeDir() string {
+	h, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return h
+}

--- a/internal/cli/tui/statusbar_test.go
+++ b/internal/cli/tui/statusbar_test.go
@@ -1,0 +1,140 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/cli/ui"
+)
+
+// newTestStatusBar builds a status bar with a known cwd (already ~-abbreviated
+// by the caller's intent) so tests do not depend on the real $HOME.
+func newTestStatusBar() statusBar {
+	opts := Options{Model: "claude-opus", ThinkingLevel: agentcore.ThinkingHigh}
+	s := newStatusBar(DefaultTheme(), opts, "/tmp/project")
+	s.cwd = "~/project"
+	return s
+}
+
+func TestStatusBarRendersAllFields(t *testing.T) {
+	s := newTestStatusBar()
+	s.SetGit(gitInfoMsg{branch: "master", dirty: 3, ahead: 4, ok: true})
+	s.SetTelemetry(telemetryEventView{util: 0.42, window: 200000})
+	s.SetTask("running: Read")
+
+	const width = 200
+	out := s.Render(width)
+
+	for _, want := range []string{
+		"claude-opus",   // model
+		"think:high",    // thinking level
+		"~/project",     // cwd
+		"master",        // git branch
+		"*3",            // dirty marker
+		"+4",            // ahead marker
+		"ctx:42%",       // context usage
+		"running: Read", // task
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("render missing %q; got %q", want, out)
+		}
+	}
+
+	if w := ui.Width(out); w > width {
+		t.Errorf("render width %d exceeds terminal width %d", w, width)
+	}
+}
+
+func TestStatusBarHidesGitWhenNotRepo(t *testing.T) {
+	s := newTestStatusBar()
+	s.SetGit(gitInfoMsg{ok: false})
+
+	out := s.Render(120)
+	if strings.Contains(out, "master") || strings.Contains(out, "*") || strings.Contains(out, "+") {
+		t.Errorf("git segment should be hidden when ok=false; got %q", out)
+	}
+}
+
+func TestStatusBarHidesContextWhenUnknown(t *testing.T) {
+	s := newTestStatusBar()
+	// No telemetry set (window 0) → context segment hidden.
+	s.SetTelemetry(telemetryEventView{util: 0.5, window: 0})
+
+	out := s.Render(120)
+	if strings.Contains(out, "ctx:") {
+		t.Errorf("context segment should be hidden when window unknown; got %q", out)
+	}
+}
+
+func TestStatusBarTruncationKeepsPriorityFields(t *testing.T) {
+	s := newTestStatusBar()
+	s.SetGit(gitInfoMsg{branch: "master", dirty: 3, ahead: 4, ok: true})
+	s.SetTelemetry(telemetryEventView{util: 0.42, window: 200000})
+	s.SetTask("TASK")
+
+	// Narrow width: only the highest-priority fields (task > model > token)
+	// should survive; cwd and git should drop first.
+	const width = 24
+	out := s.Render(width)
+
+	if w := ui.Width(out); w > width {
+		t.Fatalf("truncated render width %d exceeds %d: %q", w, width, out)
+	}
+	if !strings.Contains(out, "TASK") {
+		t.Errorf("highest-priority task field dropped under truncation: %q", out)
+	}
+	// cwd (lowest priority) must be gone before task.
+	if strings.Contains(out, "~/project") {
+		t.Errorf("lowest-priority cwd should drop first under truncation: %q", out)
+	}
+}
+
+func TestStatusBarVeryNarrowNeverOverflows(t *testing.T) {
+	s := newTestStatusBar()
+	s.SetTask("a-fairly-long-task-description-that-cannot-fit")
+
+	for _, width := range []int{1, 2, 3, 5, 8} {
+		out := s.Render(width)
+		if w := ui.Width(out); w > width {
+			t.Errorf("width %d: render width %d overflows: %q", width, w, out)
+		}
+	}
+}
+
+func TestStatusBarZeroWidthEmpty(t *testing.T) {
+	s := newTestStatusBar()
+	if out := s.Render(0); out != "" {
+		t.Errorf("zero width should render empty, got %q", out)
+	}
+}
+
+func TestAbbreviateHome(t *testing.T) {
+	home := homeDir()
+	if home == "" {
+		t.Skip("no home dir available")
+	}
+	if got := abbreviateHome(home); got != "~" {
+		t.Errorf("abbreviateHome(home) = %q, want ~", got)
+	}
+	if got := abbreviateHome(home + "/foo/bar"); got != "~/foo/bar" {
+		t.Errorf("abbreviateHome(home/foo/bar) = %q, want ~/foo/bar", got)
+	}
+	if got := abbreviateHome("/etc/passwd"); got != "/etc/passwd" {
+		t.Errorf("abbreviateHome(/etc/passwd) = %q, want unchanged", got)
+	}
+}
+
+// TestStatusBarGitTextFormatting checks the "*N +N" markers appear only when
+// non-zero.
+func TestStatusBarGitTextFormatting(t *testing.T) {
+	s := newTestStatusBar()
+	s.SetGit(gitInfoMsg{branch: "main", ok: true})
+	out := s.Render(120)
+	if strings.Contains(out, "*") || strings.Contains(out, "+") {
+		t.Errorf("clean tree should show no *N/+N markers: %q", out)
+	}
+	if !strings.Contains(out, "main") {
+		t.Errorf("branch name missing: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a width-aware bottom status bar (`internal/cli/tui/statusbar.go`) rendering model name, thinking level, cwd (with `$HOME`→`~`), git branch + dirty/ahead markers (`master *3 +4`), context-usage %, and current-task text.
- Truncate by priority (task > model > token > git > cwd) via `theme.TruncateToWidth`/`ui.Width` so total display width never exceeds the terminal.
- Add async read-only git probe (`internal/cli/tui/gitinfo.go`, `git status --porcelain -b`, fixed args) surfaced as `gitInfoMsg`; parses branch, dirty count, ahead count; `ok=false` hides the segment when not a repo.
- Wire into `model.go`: probe on `Init`, re-probe after `runEndMsg`, update usage on `telemetryMsg`, render the bar just above the input line.

Closes #386

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/cli/tui/...`
- [x] `go test ./internal/cli/tui/...`