### PR TITLE
feat(tui): streaming transcript with viewport scrolling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/smallnest/pigo
 go 1.27rc1
 
 require (
+	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/BurntSushi/toml v1.6.0
@@ -35,7 +36,7 @@ require (
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
-	github.com/mattn/go-runewidth v0.0.23 // indirect
+	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+charm.land/bubbles/v2 v2.1.1 h1:7r55WzBxpo/R3z98hGmY7KKPd3ET6vsf0Fb9sDHOV60=
+charm.land/bubbles/v2 v2.1.1/go.mod h1:GE6M31gaWZVXzGw73OeuTTgy4lX+OtkH0E5ymnNsHxo=
 charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
 charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/lipgloss/v2 v2.0.5 h1:kbNxgeeUOYv5J0YdpxFjfvf3dFvqH8Aci4zB6xqFtrY=
@@ -59,8 +61,8 @@ github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
-github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
-github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
+github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -8,20 +8,44 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// Model is the root Bubble Tea model for the full-screen TUI. In this skeleton
-// node it holds only the terminal dimensions and renders a static three-region
-// shell: a placeholder status bar, an empty transcript area, and an empty input
-// line. Downstream nodes grow it into the real transcript/tool-card/status-bar
-// composition (see tasks/spec-tui-agent.md Section 2.2); the Init/Update/View
-// contract and the alt-screen + quit-key handling established here stay stable.
+// Model is the root Bubble Tea model for the full-screen TUI. It composes a
+// scrolling transcript (US-005) with the persistent status bar (#386) and a
+// minimal input line, and owns the run lifecycle: on prompt submit it starts an
+// agent run through the event bridge (bridge.go) and pumps the resulting tea.Msg
+// stream into the transcript one message at a time. Downstream nodes grow the
+// input into a full textarea (#390), render tool cards (#389), and wire the real
+// session/run assembly (#392); the Init/Update/View contract and the alt-screen
+// + quit-key handling stay stable.
 type Model struct {
-	opts Options
+	opts  Options
+	theme Theme
 
 	// width and height track the terminal size reported by tea.WindowSizeMsg.
 	// They are zero until the first size message arrives; View degrades to a
 	// minimal render in that window.
 	width  int
 	height int
+
+	// transcript is the scrolling message log (user / assistant / system turns).
+	transcript transcript
+
+	// input is the minimal prompt buffer. The full textarea (with CJK-aware
+	// editing) lands in #390; this holds just enough to submit a line.
+	input string
+
+	// running is true while an agent run is draining through runCh. Input submit
+	// is gated on it so a new run cannot start mid-run.
+	running bool
+	// runCh is the bridge channel for the in-flight run, or nil when idle. Update
+	// re-issues waitForEvent(runCh) after every bridged msg except runEndMsg.
+	runCh chan tea.Msg
+
+	// startRunFn launches an agent run for the submitted prompt, returning the
+	// bridge channel and the first waitForEvent Cmd (see bridge.startRun). It is a
+	// seam: the real binding — constructing an AgentContext + RunConfig from opts
+	// and the live session — lands with session wiring (#392). Until then it may
+	// be nil, in which case a submit records the prompt but starts no run.
+	startRunFn func(prompt string) (chan tea.Msg, tea.Cmd)
 
 	// quitting is set when a quit key (Ctrl+C / Ctrl+D) is seen, so View can be a
 	// no-op on the final frame while the program tears down and restores the
@@ -47,10 +71,13 @@ func NewModel(opts Options) Model {
 	if err != nil {
 		cwd = ""
 	}
+	theme := DefaultTheme()
 	return Model{
-		opts:      opts,
-		cwd:       cwd,
-		statusBar: newStatusBar(DefaultTheme(), opts, cwd),
+		opts:       opts,
+		theme:      theme,
+		transcript: newTranscript(theme),
+		cwd:        cwd,
+		statusBar:  newStatusBar(theme, opts, cwd),
 	}
 }
 
@@ -61,43 +88,140 @@ func (m Model) Init() tea.Cmd {
 	return fetchGitCmd(m.cwd)
 }
 
-// Update implements tea.Model. It tracks the terminal size and quits on the
-// standard exit keys (Ctrl+C / Ctrl+D). Returning tea.Quit lets Bubble Tea tear
-// down the program and restore the terminal (leaving the alt-screen) cleanly.
+// Update implements tea.Model. It tracks the terminal size, drives the minimal
+// input line, starts runs on submit, and pumps bridged run events into the
+// transcript and status bar. It quits on the standard exit keys (Ctrl+C /
+// Ctrl+D).
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		m.transcript.setSize(msg.Width, transcriptHeight(msg.Height))
 		return m, nil
+
 	case gitInfoMsg:
 		m.statusBar.SetGit(msg)
 		return m, nil
+
+	case tea.KeyPressMsg:
+		return m.handleKey(msg)
+
+	case textDeltaMsg:
+		m.transcript.appendDelta(msg.delta)
+		return m, m.pumpNext()
+
+	case turnEndMsg:
+		m.transcript.finalizeTurn(msg.msg)
+		return m, m.pumpNext()
+
+	case toolStartMsg:
+		// Tool cards land in #389; for now a system line records the activity.
+		m.transcript.addSystem("· " + msg.name)
+		return m, m.pumpNext()
+
+	case toolUpdateMsg:
+		return m, m.pumpNext()
+
+	case toolEndMsg:
+		return m, m.pumpNext()
+
 	case telemetryMsg:
+		// Feed the status bar's context-usage readout, then keep the pump running.
 		m.statusBar.SetTelemetry(telemetryEventView{
 			util:   msg.ev.ContextUtilization,
 			window: msg.ev.ContextWindow,
 		})
-		return m, nil
+		return m, m.pumpNext()
+
+	case compactionMsg:
+		m.transcript.addSystem("（上下文已压缩）")
+		return m, m.pumpNext()
+
 	case runEndMsg:
+		m.running = false
+		m.runCh = nil
+		if msg.err != nil {
+			m.transcript.addSystem("运行结束：" + msg.err.Error())
+		}
 		// A run may have changed the working tree (edits, new files); re-probe git
 		// so the status bar reflects the post-run dirty/ahead state.
 		return m, fetchGitCmd(m.cwd)
-	case tea.KeyPressMsg:
-		switch msg.String() {
-		case "ctrl+c", "ctrl+d":
-			m.quitting = true
-			return m, tea.Quit
-		}
 	}
 	return m, nil
 }
 
-// View implements tea.Model. It renders the shell on the alt-screen: an empty
-// transcript area that grows to fill the available height, the persistent status
-// bar (#386) on the second-to-last row, and the input line at the bottom.
-// Setting AltScreen on the returned View is how Bubble Tea v2 enters/leaves the
-// alternate screen buffer, so the user's scrollback is restored on quit.
+// handleKey processes a key press: quit keys, prompt submit, minimal line
+// editing, and viewport scrolling.
+func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c", "ctrl+d":
+		m.quitting = true
+		return m, tea.Quit
+	case "enter":
+		if !m.running {
+			return m.submit()
+		}
+		return m, nil
+	case "backspace":
+		if !m.running && m.input != "" {
+			r := []rune(m.input)
+			m.input = string(r[:len(r)-1])
+		}
+		return m, nil
+	case "up", "down", "pgup", "pgdown", "home", "end":
+		// Scrolling reaches the transcript viewport whether idle or running, so
+		// history stays readable while a run streams.
+		cmd := m.transcript.update(msg)
+		return m, cmd
+	}
+
+	// Printable input extends the buffer (minimal; full textarea is #390). Gated
+	// on idle so keystrokes don't corrupt a prompt while a run streams.
+	if !m.running && msg.Text != "" {
+		m.input += msg.Text
+	}
+	return m, nil
+}
+
+// submit starts a run for the current input line: it appends the user block,
+// clears the buffer, and — when a run starter is wired — flips to running and
+// returns the first pump Cmd. With no starter (pre-#392) it records the prompt
+// and a system note without launching anything.
+func (m Model) submit() (tea.Model, tea.Cmd) {
+	prompt := strings.TrimSpace(m.input)
+	if prompt == "" {
+		return m, nil
+	}
+	m.transcript.addUser(prompt)
+	m.input = ""
+
+	if m.startRunFn == nil {
+		m.transcript.addSystem("（运行未接入：会话装配见 #392）")
+		return m, nil
+	}
+
+	ch, cmd := m.startRunFn(prompt)
+	m.runCh = ch
+	m.running = true
+	return m, cmd
+}
+
+// pumpNext re-issues waitForEvent for the in-flight run so the next bridged msg
+// is pulled. It returns nil once the run has ended (runCh cleared), stopping the
+// pump.
+func (m Model) pumpNext() tea.Cmd {
+	if m.running && m.runCh != nil {
+		return waitForEvent(m.runCh)
+	}
+	return nil
+}
+
+// View implements tea.Model. It renders the shell on the alt-screen: the
+// scrolling transcript filling the top rows, the persistent status bar (#386) on
+// the second-to-last row, and the minimal input line at the bottom. Setting
+// AltScreen on the returned View is how Bubble Tea v2 enters/leaves the alternate
+// screen buffer, so the user's scrollback is restored on quit.
 func (m Model) View() tea.View {
 	if m.quitting {
 		return tea.View{AltScreen: true}
@@ -117,23 +241,38 @@ func (m Model) View() tea.View {
 	input := lipgloss.NewStyle().
 		Width(width).
 		Foreground(lipgloss.Color("241")).
-		Render("> ")
+		Render("> " + m.input)
 
 	// Reserve one row for the status bar and one for the input line; the rest is
-	// the (currently empty) transcript area. Guard against tiny terminals so the
-	// filler count never goes negative.
-	transcriptRows := height - 2
-	if transcriptRows < 0 {
-		transcriptRows = 0
-	}
+	// the transcript area. Guard against tiny terminals so the region never goes
+	// negative.
+	rows := transcriptHeight(height)
+	sized := m.width > 0 && m.height > 0
 
 	var b strings.Builder
-	for i := 0; i < transcriptRows; i++ {
+	if sized {
+		// The viewport pads its content to exactly `rows` lines.
+		b.WriteString(m.transcript.view())
 		b.WriteByte('\n')
+	} else {
+		for i := 0; i < rows; i++ {
+			b.WriteByte('\n')
+		}
 	}
 	b.WriteString(status)
 	b.WriteByte('\n')
 	b.WriteString(input)
 
 	return tea.View{Content: b.String(), AltScreen: true}
+}
+
+// transcriptHeight returns the number of rows available to the transcript for a
+// given total terminal height: the total minus the status bar and input rows,
+// floored at zero so tiny terminals never produce a negative extent.
+func transcriptHeight(total int) int {
+	h := total - 2
+	if h < 0 {
+		h = 0
+	}
+	return h
 }

--- a/internal/cli/tui/transcript.go
+++ b/internal/cli/tui/transcript.go
@@ -1,0 +1,178 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// This file implements the scrolling transcript region of the full-screen TUI
+// (US-005, SPEC 5.1 transcript, FR-5/FR-10). The transcript owns a
+// viewport.Model and an ordered list of rendered blocks (user / assistant /
+// system turns). Streaming assistant text arrives as textDeltaMsg values that
+// append to the current assistant block; turnEndMsg finalizes it. Content is
+// re-flowed through the viewport with theme.WrapToWidth at the live width so CJK
+// and emoji never split mid-rune. Tool cards are a later node (#389); this file
+// leaves a clean seam (system lines) without building cards.
+
+// blockRole distinguishes the three transcript block kinds so each renders with
+// its own theme style.
+type blockRole int
+
+const (
+	roleUser blockRole = iota
+	roleAssistant
+	roleSystem
+)
+
+// transcriptBlock is one rendered turn in the transcript. text is the raw
+// (unstyled, unwrapped) message body; the role selects the theme style and any
+// prefix applied at render time.
+type transcriptBlock struct {
+	role blockRole
+	text string
+}
+
+// transcript is the scrolling message log. It wraps a viewport.Model and keeps
+// the source blocks so it can re-flow on width changes. activeAssistant indexes
+// the assistant block currently receiving streaming deltas, or -1 when no turn
+// is streaming.
+type transcript struct {
+	vp    viewport.Model
+	theme Theme
+
+	// width is the content width (terminal columns) the blocks wrap to. It is
+	// separate from the viewport's own width so reflow measurements stay stable
+	// even before the first size message.
+	width int
+
+	blocks          []transcriptBlock
+	activeAssistant int
+}
+
+// newTranscript builds an empty transcript with the given theme. The viewport
+// starts zero-sized; the model drives setSize from the first tea.WindowSizeMsg.
+func newTranscript(theme Theme) transcript {
+	vp := viewport.New()
+	return transcript{
+		vp:              vp,
+		theme:           theme,
+		activeAssistant: -1,
+	}
+}
+
+// setSize resizes the transcript's viewport and re-flows the blocks to the new
+// width. A non-positive dimension is clamped to zero so the viewport never sees
+// a negative extent.
+func (t *transcript) setSize(width, height int) {
+	if width < 0 {
+		width = 0
+	}
+	if height < 0 {
+		height = 0
+	}
+	t.width = width
+	t.vp.SetWidth(width)
+	t.vp.SetHeight(height)
+	t.reflow()
+}
+
+// addUser appends a user turn and closes any streaming assistant block, then
+// re-flows (sticking to the bottom when already there).
+func (t *transcript) addUser(text string) {
+	t.blocks = append(t.blocks, transcriptBlock{role: roleUser, text: text})
+	t.activeAssistant = -1
+	t.reflow()
+}
+
+// addSystem appends a system / meta notice (used for tool activity and run
+// lifecycle until tool cards land in #389).
+func (t *transcript) addSystem(text string) {
+	t.blocks = append(t.blocks, transcriptBlock{role: roleSystem, text: text})
+	t.reflow()
+}
+
+// appendDelta grows the current assistant block by delta, creating the block on
+// the first delta of a turn. The re-flow auto-sticks to the bottom when the user
+// has not scrolled up.
+func (t *transcript) appendDelta(delta string) {
+	if t.activeAssistant < 0 {
+		t.blocks = append(t.blocks, transcriptBlock{role: roleAssistant})
+		t.activeAssistant = len(t.blocks) - 1
+	}
+	t.blocks[t.activeAssistant].text += delta
+	t.reflow()
+}
+
+// finalizeTurn closes the streaming assistant block. When the final message
+// carries text it becomes the block's authoritative body (covering turns that
+// arrive without incremental deltas); otherwise the accumulated deltas stand.
+func (t *transcript) finalizeTurn(msg agentcore.AssistantMessage) {
+	text := agentcore.ContentToText(msg.Content)
+	if t.activeAssistant >= 0 {
+		if text != "" {
+			t.blocks[t.activeAssistant].text = text
+		}
+	} else if text != "" {
+		t.blocks = append(t.blocks, transcriptBlock{role: roleAssistant, text: text})
+	}
+	t.activeAssistant = -1
+	t.reflow()
+}
+
+// update forwards a message (typically a key press or scroll) to the viewport so
+// PgUp/PgDn/arrow scrolling works. Auto-stick is decided per content change in
+// reflow, so a user scroll-up here naturally pauses it until they return to the
+// bottom.
+func (t *transcript) update(msg tea.Msg) tea.Cmd {
+	var cmd tea.Cmd
+	t.vp, cmd = t.vp.Update(msg)
+	return cmd
+}
+
+// view renders the current visible slice of the transcript.
+func (t transcript) view() string {
+	return t.vp.View()
+}
+
+// reflow re-renders every block to the current width and pushes the joined
+// content into the viewport. It captures the bottom-stick state before mutating
+// content: if the viewport was at the bottom, new content auto-scrolls
+// (GotoBottom); if the user had scrolled up, the offset is preserved so reading
+// history is not interrupted.
+func (t *transcript) reflow() {
+	stick := t.vp.AtBottom()
+
+	var b strings.Builder
+	for i, blk := range t.blocks {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(t.renderBlock(blk))
+	}
+
+	t.vp.SetContent(b.String())
+
+	if stick {
+		t.vp.GotoBottom()
+	}
+}
+
+// renderBlock wraps a block's text to the content width and applies the role's
+// theme style. Wrapping happens on the raw text (measured in display columns via
+// WrapToWidth) before styling so ANSI escapes never confuse the width math and
+// no double-width rune is split.
+func (t transcript) renderBlock(blk transcriptBlock) string {
+	wrapped := WrapToWidth(blk.text, t.width)
+	switch blk.role {
+	case roleUser:
+		return t.theme.User.Render(wrapped)
+	case roleSystem:
+		return t.theme.System.Render(wrapped)
+	default:
+		return t.theme.Assistant.Render(wrapped)
+	}
+}

--- a/internal/cli/tui/transcript_test.go
+++ b/internal/cli/tui/transcript_test.go
@@ -1,0 +1,117 @@
+package tui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/cli/ui"
+)
+
+// ansiRE strips SGR escape sequences so tests can inspect the raw text the
+// transcript stored, independent of the theme's coloring.
+var ansiRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+func stripANSI(s string) string { return ansiRE.ReplaceAllString(s, "") }
+
+// apply runs one Update tick and returns the concrete Model, failing on an
+// unexpected model type. It keeps the streaming tests terse.
+func apply(t *testing.T, m tea.Model, msg tea.Msg) Model {
+	t.Helper()
+	next, _ := m.Update(msg)
+	got, ok := next.(Model)
+	if !ok {
+		t.Fatalf("Update returned %T, want tui.Model", next)
+	}
+	return got
+}
+
+// TestTranscriptStreamingConcat feeds a run of text deltas then a turn end and
+// asserts the assistant block accumulates the deltas in order and the joined
+// text is rendered in the View.
+func TestTranscriptStreamingConcat(t *testing.T) {
+	m := apply(t, NewModel(Options{}), tea.WindowSizeMsg{Width: 40, Height: 12})
+
+	m = apply(t, m, textDeltaMsg{delta: "Hello "})
+	m = apply(t, m, textDeltaMsg{delta: "world"})
+	m = apply(t, m, turnEndMsg{msg: agentcore.AssistantMessage{
+		Content: agentcore.ContentList{agentcore.NewTextContent("Hello world")},
+	}})
+
+	if n := len(m.transcript.blocks); n != 1 {
+		t.Fatalf("block count = %d, want 1 assistant block", n)
+	}
+	if got := m.transcript.blocks[0]; got.role != roleAssistant || got.text != "Hello world" {
+		t.Errorf("assistant block = %+v, want role assistant text %q", got, "Hello world")
+	}
+	if content := stripANSI(m.View().Content); !strings.Contains(content, "Hello world") {
+		t.Errorf("rendered View missing streamed text; got:\n%s", content)
+	}
+	// The turn was finalized, so a fresh delta starts a NEW assistant block.
+	if m.transcript.activeAssistant != -1 {
+		t.Errorf("activeAssistant = %d after turn end, want -1", m.transcript.activeAssistant)
+	}
+}
+
+// TestTranscriptAutoStick verifies the stick-to-bottom rule: while the viewport
+// is at the bottom, new content keeps it pinned there; once the user scrolls up,
+// new content no longer forces a jump to the bottom.
+func TestTranscriptAutoStick(t *testing.T) {
+	tr := newTranscript(DefaultTheme())
+	tr.setSize(20, 3) // 3 visible rows
+
+	for i := 0; i < 6; i++ {
+		tr.addUser("line")
+	}
+	if !tr.vp.AtBottom() {
+		t.Fatal("transcript should stick to the bottom while at the bottom")
+	}
+
+	// More content while pinned keeps it pinned.
+	tr.addUser("more")
+	if !tr.vp.AtBottom() {
+		t.Fatal("new content should keep a bottom-pinned transcript at the bottom")
+	}
+
+	// Simulate a user scroll-up through the viewport's key handling.
+	tr.update(tea.KeyPressMsg{Code: tea.KeyUp})
+	if tr.vp.AtBottom() {
+		t.Fatal("scrolling up should move the viewport off the bottom")
+	}
+
+	// Content arriving while scrolled up must NOT yank the view back to bottom.
+	tr.addUser("streamed while reading history")
+	if tr.vp.AtBottom() {
+		t.Error("auto-stick should stay paused after the user scrolls up")
+	}
+}
+
+// TestTranscriptCJKWrap feeds a long CJK line into a narrow transcript and
+// asserts every wrapped line fits the width in display columns (not bytes) and
+// that no rune was dropped or split.
+func TestTranscriptCJKWrap(t *testing.T) {
+	const width = 10
+	tr := newTranscript(DefaultTheme())
+	tr.setSize(width, 20)
+
+	line := strings.Repeat("你好世界", 5) // 20 CJK runes = 40 display columns
+	tr.addUser(line)
+
+	content := tr.vp.GetContent()
+	lines := strings.Split(content, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected the CJK line to wrap onto multiple rows, got %d line(s)", len(lines))
+	}
+	for i, ln := range lines {
+		if w := ui.Width(ln); w > width {
+			t.Errorf("wrapped line %d width = %d columns, want <= %d: %q", i, w, width, stripANSI(ln))
+		}
+	}
+	// No rune was cut or dropped: every source rune survives the wrap.
+	if got := strings.Count(stripANSI(content), "你"); got != 5 {
+		t.Errorf("counted %d 你 runes after wrap, want 5", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a `transcript` component wrapping `charm.land/bubbles/v2/viewport` that renders ordered user/assistant/system blocks with per-role theme styling.
- Streaming: `textDeltaMsg` appends to the current assistant block (created on first delta); `turnEndMsg` finalizes it. Content re-flows via `WrapToWidth` so CJK/emoji never split mid-rune.
- Auto-stick-to-bottom: new content stays pinned while at bottom; pauses once the user scrolls up (PgUp/PgDn/arrows routed through the viewport).
- Wire the transcript + bridge run pump into `Model.Update/View`: a minimal Enter-driven submit starts a run via a `startRunFn` seam (real AgentContext assembly is #392); bridged msgs route to the transcript and re-schedule `waitForEvent` until `runEndMsg`.
- Add `charm.land/bubbles/v2` as a direct dependency.

Closes #388

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/cli/tui/...`
- [x] `go test ./internal/cli/tui/...` (streaming concat, auto-stick pause, CJK width-aware wrap; existing model tests still pass)