### PR TITLE
feat(tui): rich tool-call cards (#389)

### DIFF
--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -60,6 +60,16 @@ type Model struct {
 	// cwd is the launch directory, captured once at construction and reused for
 	// the git probe and the status bar's path display.
 	cwd string
+
+	// toolCards indexes the rich tool-call cards (#389, US-006) by tool-call id so
+	// a toolEndMsg can locate the card started earlier and flip its state / attach
+	// the parsed response. Each card is also appended to the transcript as an
+	// ordered block (by pointer), so mutating one here re-renders it inline on the
+	// next reflow.
+	toolCards map[string]*toolCard
+	// lastToolCard points at the most recently started card; Ctrl+O toggles its
+	// expanded state and re-flows the transcript.
+	lastToolCard *toolCard
 }
 
 // NewModel builds the root model from the assembled Options. It performs no I/O
@@ -78,6 +88,7 @@ func NewModel(opts Options) Model {
 		transcript: newTranscript(theme),
 		cwd:        cwd,
 		statusBar:  newStatusBar(theme, opts, cwd),
+		toolCards:  make(map[string]*toolCard),
 	}
 }
 
@@ -116,14 +127,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.pumpNext()
 
 	case toolStartMsg:
-		// Tool cards land in #389; for now a system line records the activity.
-		m.transcript.addSystem("· " + msg.name)
+		// Create a rich tool-call card, index it by id for the later end event, and
+		// append it as an ordered transcript block so it renders inline (#389).
+		card := &toolCard{id: msg.id, name: msg.name, input: msg.input, state: cardRunning}
+		m.toolCards[msg.id] = card
+		m.lastToolCard = card
+		m.transcript.addToolCard(card)
 		return m, m.pumpNext()
 
 	case toolUpdateMsg:
 		return m, m.pumpNext()
 
 	case toolEndMsg:
+		// Flip the card's state and attach the parsed response tree. The card is
+		// held by pointer in the transcript, so a reflow re-renders it in place.
+		if card, ok := m.toolCards[msg.id]; ok {
+			if msg.ok {
+				card.state = cardSuccess
+			} else {
+				card.state = cardWarn
+			}
+			card.response = parseToolResult(msg.result)
+			m.transcript.reflow()
+		}
 		return m, m.pumpNext()
 
 	case telemetryMsg:
@@ -158,6 +184,14 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+c", "ctrl+d":
 		m.quitting = true
 		return m, tea.Quit
+	case "ctrl+o":
+		// Toggle the most-recent tool card between its capped preview and the full
+		// response tree, then re-flow so the change shows inline (#389).
+		if m.lastToolCard != nil {
+			m.lastToolCard.expanded = !m.lastToolCard.expanded
+			m.transcript.reflow()
+		}
+		return m, nil
 	case "enter":
 		if !m.running {
 			return m.submit()

--- a/internal/cli/tui/toolcard.go
+++ b/internal/cli/tui/toolcard.go
@@ -1,0 +1,164 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/smallnest/pigo/internal/cli/ui"
+)
+
+// This file implements the rich tool-call card component (US-006, SPEC 3.2,
+// FR-6/7/8). A toolCard is a bordered inline block in the transcript that shows
+// a single tool invocation: a header with the tool name and a status icon
+// (running / success / warn), the decoded call arguments, and the tool's
+// response rendered as an indented tree. Cards are created on toolStartMsg,
+// completed on toolEndMsg, and toggled between a capped and a full response view
+// with Ctrl+O (see model.go). All width math goes through ui.Width /
+// WrapToWidth / TruncateToWidth so CJK and emoji (two columns) never split.
+
+// cardState is the lifecycle of a tool card: running while the tool executes,
+// then success or warn once it finishes (warn covers a reported tool error).
+type cardState int
+
+const (
+	cardRunning cardState = iota
+	cardSuccess
+	cardWarn
+)
+
+// respNode is one line of a tool's response, with depth giving the tree indent
+// level (each level is rendered as two leading spaces).
+type respNode struct {
+	text  string
+	depth int
+}
+
+// toolCard is a single tool invocation rendered as a bordered card. input holds
+// the decoded call arguments (nil when the args were not a JSON object);
+// response is the parsed result tree, populated on completion. expanded flips
+// the response between a capped preview and the full tree.
+type toolCard struct {
+	id       string
+	name     string
+	input    map[string]any
+	response []respNode
+	state    cardState
+	expanded bool
+}
+
+// collapsedResponseLines is how many response lines a card shows before it is
+// expanded; past this the preview is truncated and a Ctrl+O hint is appended.
+const collapsedResponseLines = 5
+
+// statusIcon returns the header status glyph for the card's state. Running is a
+// spinner-like ellipsis, success a check, warn a bang.
+func (c toolCard) statusIcon() string {
+	switch c.state {
+	case cardSuccess:
+		return "✓"
+	case cardWarn:
+		return "!"
+	default:
+		return "…"
+	}
+}
+
+// styledIcon renders the status glyph with the state's theme color: gray while
+// running, green on success, yellow/red on warn.
+func (c toolCard) styledIcon(theme Theme) string {
+	icon := c.statusIcon()
+	switch c.state {
+	case cardSuccess:
+		return theme.Success.Render(icon)
+	case cardWarn:
+		return theme.Warn.Render(icon)
+	default:
+		return theme.System.Render(icon)
+	}
+}
+
+// render draws the card at the given content width: a rounded border wrapping a
+// header (status icon + tool name), a "调用输入参数" section listing the input map,
+// and a "Response" section with the tree lines. When not expanded the response
+// is capped to collapsedResponseLines with a "(Ctrl+O for more)" hint; when
+// expanded every line is shown.
+func (c toolCard) render(theme Theme, width int) string {
+	if width < 4 {
+		width = 4
+	}
+	// The rounded border consumes one column on each side; wrap everything to the
+	// inner width so nothing overflows the frame.
+	inner := width - 2
+
+	var lines []string
+
+	icon := c.styledIcon(theme)
+	nameBudget := inner - ui.Width(icon) - 1
+	if nameBudget < 1 {
+		nameBudget = 1
+	}
+	name := TruncateToWidth(c.name, nameBudget)
+	lines = append(lines, icon+" "+theme.ToolHeader.Render(name))
+
+	if len(c.input) > 0 {
+		lines = append(lines, theme.ToolBody.Render("调用输入参数"))
+		for _, k := range sortedKeys(c.input) {
+			kv := "  " + k + ": " + fmt.Sprintf("%v", c.input[k])
+			lines = append(lines, theme.ToolBody.Render(WrapToWidth(kv, inner)))
+		}
+	}
+
+	if len(c.response) > 0 {
+		lines = append(lines, theme.ToolBody.Render("Response"))
+		resp := c.response
+		truncated := false
+		if !c.expanded && len(resp) > collapsedResponseLines {
+			resp = resp[:collapsedResponseLines]
+			truncated = true
+		}
+		for _, n := range resp {
+			indent := strings.Repeat("  ", n.depth)
+			lines = append(lines, theme.ToolBody.Render(WrapToWidth(indent+n.text, inner)))
+		}
+		if truncated {
+			lines = append(lines, theme.System.Render("(Ctrl+O for more)"))
+		}
+	}
+
+	border := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(colorGray)).
+		Width(inner)
+	return border.Render(strings.Join(lines, "\n"))
+}
+
+// sortedKeys returns the map keys in a stable (sorted) order so the input
+// section renders deterministically instead of in Go's random map order.
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// parseToolResult splits a tool's textual result into response tree nodes,
+// inferring depth from leading whitespace (every two leading spaces is one
+// level). Trailing empty lines are trimmed so the card does not render blank
+// tail rows.
+func parseToolResult(result string) []respNode {
+	lines := strings.Split(result, "\n")
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	nodes := make([]respNode, 0, len(lines))
+	for _, ln := range lines {
+		leading := len(ln) - len(strings.TrimLeft(ln, " "))
+		nodes = append(nodes, respNode{text: ln[leading:], depth: leading / 2})
+	}
+	return nodes
+}

--- a/internal/cli/tui/toolcard_test.go
+++ b/internal/cli/tui/toolcard_test.go
@@ -1,0 +1,164 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// ctrlKey builds a Ctrl+<letter> key press matching String()=="ctrl+<letter>".
+func ctrlKey(r rune) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: r, Mod: tea.ModCtrl}
+}
+
+// TestParseToolResult verifies depth inference from leading spaces and trailing
+// blank-line trimming.
+func TestParseToolResult(t *testing.T) {
+	nodes := parseToolResult("root\n  child\n    grandchild\n\n")
+	if len(nodes) != 3 {
+		t.Fatalf("node count = %d, want 3 (trailing blank trimmed)", len(nodes))
+	}
+	want := []respNode{
+		{text: "root", depth: 0},
+		{text: "child", depth: 1},
+		{text: "grandchild", depth: 2},
+	}
+	for i, w := range want {
+		if nodes[i] != w {
+			t.Errorf("node[%d] = %+v, want %+v", i, nodes[i], w)
+		}
+	}
+}
+
+// TestToolCardRender checks the header (name + status icon), the input section,
+// and the response tree lines appear in the rendered card, and that the status
+// icon reflects the state.
+func TestToolCardRender(t *testing.T) {
+	theme := DefaultTheme()
+	cases := []struct {
+		name  string
+		state cardState
+		icon  string
+	}{
+		{"running", cardRunning, "…"},
+		{"success", cardSuccess, "✓"},
+		{"warn", cardWarn, "!"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			card := toolCard{
+				id:       "1",
+				name:     "read_file",
+				input:    map[string]any{"path": "/tmp/x"},
+				response: parseToolResult("line one\n  nested"),
+				state:    tc.state,
+			}
+			out := card.render(theme, 60)
+			for _, want := range []string{"read_file", tc.icon, "调用输入参数", "path: /tmp/x", "Response", "line one", "nested"} {
+				if !strings.Contains(out, want) {
+					t.Errorf("render missing %q\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+// TestToolCardExpandTruncation verifies the collapsed card caps the response and
+// shows the Ctrl+O hint, while the expanded card reveals every line.
+func TestToolCardExpandTruncation(t *testing.T) {
+	theme := DefaultTheme()
+	var b strings.Builder
+	for i := 0; i < collapsedResponseLines+3; i++ {
+		b.WriteString("resp-line-")
+		b.WriteByte(byte('a' + i))
+		b.WriteByte('\n')
+	}
+	card := toolCard{name: "grep", response: parseToolResult(b.String()), state: cardSuccess}
+
+	collapsed := card.render(theme, 60)
+	if !strings.Contains(collapsed, "(Ctrl+O for more)") {
+		t.Errorf("collapsed card should show Ctrl+O hint\n%s", collapsed)
+	}
+	lastLine := "resp-line-" + string(byte('a'+collapsedResponseLines+2))
+	if strings.Contains(collapsed, lastLine) {
+		t.Errorf("collapsed card should not show %q\n%s", lastLine, collapsed)
+	}
+
+	card.expanded = true
+	expanded := card.render(theme, 60)
+	if strings.Contains(expanded, "(Ctrl+O for more)") {
+		t.Errorf("expanded card should not show Ctrl+O hint\n%s", expanded)
+	}
+	if !strings.Contains(expanded, lastLine) {
+		t.Errorf("expanded card should show %q\n%s", lastLine, expanded)
+	}
+}
+
+// TestModelToolCardFlow drives the model through a tool start/end and asserts the
+// card is created, transitions running→success, and that a failed tool yields
+// warn.
+func TestModelToolCardFlow(t *testing.T) {
+	m := NewModel(Options{})
+	next, _ := m.Update(toolStartMsg{id: "t1", name: "read_file", input: map[string]any{"path": "a.go"}})
+	mm := next.(Model)
+	card, ok := mm.toolCards["t1"]
+	if !ok {
+		t.Fatalf("toolStartMsg should create a card")
+	}
+	if card.state != cardRunning {
+		t.Errorf("new card state = %v, want cardRunning", card.state)
+	}
+
+	next, _ = mm.Update(toolEndMsg{id: "t1", ok: true, result: "done\n  detail"})
+	mm = next.(Model)
+	if mm.toolCards["t1"].state != cardSuccess {
+		t.Errorf("state after ok end = %v, want cardSuccess", mm.toolCards["t1"].state)
+	}
+	if len(mm.toolCards["t1"].response) != 2 {
+		t.Errorf("response nodes = %d, want 2", len(mm.toolCards["t1"].response))
+	}
+
+	// A failed tool flips the same card to warn.
+	next, _ = m.Update(toolStartMsg{id: "t2", name: "bash"})
+	mm = next.(Model)
+	next, _ = mm.Update(toolEndMsg{id: "t2", ok: false, result: "boom"})
+	mm = next.(Model)
+	if mm.toolCards["t2"].state != cardWarn {
+		t.Errorf("state after failed end = %v, want cardWarn", mm.toolCards["t2"].state)
+	}
+}
+
+// TestModelCtrlOTogglesExpanded verifies Ctrl+O flips the most-recent card's
+// expanded flag so more response lines become visible.
+func TestModelCtrlOTogglesExpanded(t *testing.T) {
+	m := NewModel(Options{})
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 60, Height: 24})
+	mm := next.(Model)
+
+	var b strings.Builder
+	for i := 0; i < collapsedResponseLines+3; i++ {
+		b.WriteString("row")
+		b.WriteByte(byte('0' + i))
+		b.WriteByte('\n')
+	}
+	next, _ = mm.Update(toolStartMsg{id: "t1", name: "grep"})
+	mm = next.(Model)
+	next, _ = mm.Update(toolEndMsg{id: "t1", ok: true, result: b.String()})
+	mm = next.(Model)
+
+	if mm.lastToolCard.expanded {
+		t.Fatalf("card should start collapsed")
+	}
+	next, _ = mm.Update(ctrlKey('o'))
+	mm = next.(Model)
+	if !mm.lastToolCard.expanded {
+		t.Errorf("Ctrl+O should expand the most-recent card")
+	}
+	// Toggling again collapses it.
+	next, _ = mm.Update(ctrlKey('o'))
+	mm = next.(Model)
+	if mm.lastToolCard.expanded {
+		t.Errorf("second Ctrl+O should collapse the card")
+	}
+}

--- a/internal/cli/tui/transcript.go
+++ b/internal/cli/tui/transcript.go
@@ -26,14 +26,18 @@ const (
 	roleUser blockRole = iota
 	roleAssistant
 	roleSystem
+	roleTool
 )
 
 // transcriptBlock is one rendered turn in the transcript. text is the raw
 // (unstyled, unwrapped) message body; the role selects the theme style and any
-// prefix applied at render time.
+// prefix applied at render time. For roleTool blocks text is unused and card
+// points at the live tool card (#389); the pointer lets a later toolEndMsg /
+// Ctrl+O mutate the card in place and have it re-render on the next reflow.
 type transcriptBlock struct {
 	role blockRole
 	text string
+	card *toolCard
 }
 
 // transcript is the scrolling message log. It wraps a viewport.Model and keeps
@@ -88,10 +92,19 @@ func (t *transcript) addUser(text string) {
 	t.reflow()
 }
 
-// addSystem appends a system / meta notice (used for tool activity and run
-// lifecycle until tool cards land in #389).
+// addSystem appends a system / meta notice (used for run lifecycle and other
+// inline notes).
 func (t *transcript) addSystem(text string) {
 	t.blocks = append(t.blocks, transcriptBlock{role: roleSystem, text: text})
+	t.reflow()
+}
+
+// addToolCard appends a rich tool-call card (#389) as an ordered block so it
+// renders inline in the transcript. The card is held by pointer, so a later
+// state change (toolEndMsg) or expand toggle (Ctrl+O) followed by reflow
+// re-renders it in place.
+func (t *transcript) addToolCard(c *toolCard) {
+	t.blocks = append(t.blocks, transcriptBlock{role: roleTool, card: c})
 	t.reflow()
 }
 
@@ -166,6 +179,9 @@ func (t *transcript) reflow() {
 // WrapToWidth) before styling so ANSI escapes never confuse the width math and
 // no double-width rune is split.
 func (t transcript) renderBlock(blk transcriptBlock) string {
+	if blk.role == roleTool && blk.card != nil {
+		return blk.card.render(t.theme, t.width)
+	}
 	wrapped := WrapToWidth(blk.text, t.width)
 	switch blk.role {
 	case roleUser:


### PR DESCRIPTION
## Summary
- Add bordered `toolCard` component (`internal/cli/tui/toolcard.go`, SPEC 3.2 / US-006 / FR-6/7/8): header with tool name + status icon (running `…` / success `✓` / warn `!`), "调用输入参数" section, and "Response" rendered as an indented tree.
- Collapsed cards cap the response to a few lines with a "(Ctrl+O for more)" hint; Ctrl+O toggles the most-recent card's expanded view.
- Wire `toolStartMsg`/`toolEndMsg` into `model.go` (card map indexed by tool-call id, appended as an ordered transcript block by pointer so state changes re-render inline); add `parseToolResult` depth inference.
- All width math flows through `ui.Width` / `WrapToWidth` / `TruncateToWidth` (CJK-aware).

Closes #389

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cli/tui/...`