### PR TITLE
feat(tui): bind real run seam + session resume/persistence (#392)

### DIFF
--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -6,6 +6,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+
+	"github.com/smallnest/pigo/internal/agentcore"
 )
 
 // Model is the root Bubble Tea model for the full-screen TUI. It composes a
@@ -41,11 +43,17 @@ type Model struct {
 	runCh chan tea.Msg
 
 	// startRunFn launches an agent run for the submitted prompt, returning the
-	// bridge channel and the first waitForEvent Cmd (see bridge.startRun). It is a
-	// seam: the real binding — constructing an AgentContext + RunConfig from opts
-	// and the live session — lands with session wiring (#392). Until then it may
-	// be nil, in which case a submit records the prompt but starts no run.
+	// bridge channel and the first waitForEvent Cmd (see bridge.startRun). It is
+	// bound to runSession.startRun by withSession (#392): the real binding
+	// constructs an AgentContext + RunConfig from opts and the live session. It is
+	// nil for a session-less model (the pure constructor / tests), in which case a
+	// submit records the prompt but starts no run.
 	startRunFn func(prompt string) (chan tea.Msg, tea.Cmd)
+
+	// session is the assembled run/persistence state (store, header, growing
+	// context, live config). It is nil for a session-less model; when set, the
+	// model persists the conversation to ~/.pigo/sessions after each turn ends.
+	session *runSession
 
 	// quitting is set when a quit key (Ctrl+C / Ctrl+D) is seen, so View can be a
 	// no-op on the final frame while the program tears down and restores the
@@ -90,6 +98,18 @@ func NewModel(opts Options) Model {
 		statusBar:  newStatusBar(theme, opts, cwd),
 		toolCards:  make(map[string]*toolCard),
 	}
+}
+
+// withSession binds the assembled run session to the model: it wires the real
+// run seam (startRunFn) and, for a resumed session, replays the prior history
+// into the transcript so the user sees the conversation so far before entering
+// interactive mode. Run calls it right after NewModel; the session-less
+// constructor path (tests, pure construction) leaves startRunFn nil.
+func (m Model) withSession(s *runSession, history []agentcore.Message) Model {
+	m.session = s
+	m.startRunFn = s.startRun
+	seedTranscript(&m.transcript, history)
+	return m
 }
 
 // Init implements tea.Model. It kicks off the async git probe so the status bar
@@ -169,6 +189,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.runCh = nil
 		if msg.err != nil {
 			m.transcript.addSystem("运行结束：" + msg.err.Error())
+		}
+		// Persist the turn's new messages as a branch so the conversation survives
+		// exit and can be resumed (FR-16). This is race-free: the pump goroutine
+		// owns agentCtx.Messages during the run and only sends runEndMsg after
+		// DrainStream returns (loop done), so no goroutine is still writing the
+		// context when persist reads it here on the tea goroutine. A save failure
+		// is surfaced but non-fatal.
+		if m.session != nil {
+			if err := m.session.persist(); err != nil {
+				m.transcript.addSystem("会话保存失败：" + err.Error())
+			}
 		}
 		// A run may have changed the working tree (edits, new files); re-probe git
 		// so the status bar reflects the post-run dirty/ahead state.

--- a/internal/cli/tui/run.go
+++ b/internal/cli/tui/run.go
@@ -11,7 +11,14 @@ import (
 // the View returned by the root Model, so a clean return here restores the
 // terminal to the user's prior scrollback.
 func Run(opts Options) error {
-	p := tea.NewProgram(NewModel(opts))
-	_, err := p.Run()
+	// Assemble the session (store, resume-or-fresh context, live config) before
+	// entering the alt-screen, mirroring repl.Run: a store/resume failure is a
+	// clean pre-launch error rather than a broken interactive session.
+	s, history, err := newRunSession(opts)
+	if err != nil {
+		return err
+	}
+	p := tea.NewProgram(NewModel(opts).withSession(s, history))
+	_, err = p.Run()
 	return err
 }

--- a/internal/cli/tui/session.go
+++ b/internal/cli/tui/session.go
@@ -1,0 +1,230 @@
+// This file binds the full-screen TUI to the real agent run seam and the local
+// session store (US-009, FR-16/17). It is the TUI counterpart to the REPL's
+// replDeps + streamRun + cli.PersistTurn plumbing (internal/cli/repl): it
+// assembles an AgentContext + RunConfig from the model's Options, feeds them to
+// the event bridge (bridge.go's startRun → runtime.StartRun/DrainStream), and
+// persists the growing conversation to ~/.pigo/sessions after each turn.
+//
+// It deliberately imports the SHARED lower-level packages the REPL also uses
+// (session, runtime, provider, cli, cli/run, cli/headless, cli/ui) rather than
+// the repl package itself, so the two entry paths share one store and one
+// run-config shape without an import cycle (repl and tui are siblings; prompts
+// imports tui, so tui must not reach back into repl/prompts).
+package tui
+
+import (
+	"context"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/headless"
+	"github.com/smallnest/pigo/internal/cli/run"
+	"github.com/smallnest/pigo/internal/cli/ui"
+	"github.com/smallnest/pigo/internal/compaction"
+	"github.com/smallnest/pigo/internal/provider"
+	"github.com/smallnest/pigo/internal/runtime"
+	"github.com/smallnest/pigo/internal/session"
+)
+
+// runSession holds the assembled per-session state for a TUI run: the persisted
+// store + header, the growing conversation context, the live (mutable) run
+// config, and the tool/credential collaborators. It mirrors the subset of
+// repl.replDeps the TUI needs, and owns the same session-tree cursor bookkeeping
+// (curLeaf / persisted) so each turn is persisted as a branch rather than a
+// flattening rewrite.
+type runSession struct {
+	store     *session.Store
+	header    session.SessionHeader
+	agentCtx  *agentcore.AgentContext
+	live      *cli.LiveConfig
+	reg       *agenttool.ToolRegistry
+	reminders *runtime.ReminderRegistry
+	creds     *provider.CredentialStore
+
+	// curLeaf is the id of the on-disk entry the next turn descends from; persisted
+	// is the number of agentCtx.Messages already written. persist() appends only
+	// Messages[persisted:] as a branch from curLeaf (see cli.PersistTurn).
+	curLeaf   string
+	persisted int
+}
+
+// newRunSession assembles the run session from the resolved Options, opening the
+// shared ~/.pigo/sessions store. When Options carries a ResumeID it loads that
+// session's entries and rebuilds the context (the returned history seeds the
+// replayed transcript); otherwise it starts a fresh session with a new header.
+// It is the production entry; newRunSessionWithStore holds the store-agnostic
+// core so tests can drive it against a temp-dir store.
+func newRunSession(opts Options) (*runSession, []agentcore.Message, error) {
+	store, err := headless.SessionStore()
+	if err != nil {
+		return nil, nil, err
+	}
+	return newRunSessionWithStore(store, opts)
+}
+
+// newRunSessionWithStore is the store-agnostic core of newRunSession: given an
+// already-opened store it resolves resume-vs-fresh, builds the live config and
+// collaborators, and returns the session plus the resumed history (nil for a
+// fresh session).
+func newRunSessionWithStore(store *session.Store, opts Options) (*runSession, []agentcore.Message, error) {
+	creds := provider.NewCredentialStore(nil)
+	creds.SetOverride(opts.ProviderName, opts.APIKey)
+
+	now := time.Now().UTC()
+	var (
+		agentCtx *agentcore.AgentContext
+		header   session.SessionHeader
+		history  []agentcore.Message
+		curLeaf  string
+	)
+	if opts.ResumeID != "" {
+		h, entries, err := store.LoadEntries(opts.ResumeID)
+		if err != nil {
+			return nil, nil, err
+		}
+		msgs := make(agentcore.MessageList, len(entries))
+		for i, e := range entries {
+			msgs[i] = e.Message
+		}
+		if len(entries) > 0 {
+			curLeaf = entries[len(entries)-1].ID
+		}
+		header = h
+		sysPrompt := h.SystemPrompt
+		if sysPrompt == "" {
+			sysPrompt = opts.SysPrompt
+		}
+		agentCtx = &agentcore.AgentContext{SystemPrompt: sysPrompt, Messages: msgs, Tools: opts.Tools}
+		history = msgs
+	} else {
+		agentCtx = &agentcore.AgentContext{SystemPrompt: opts.SysPrompt, Tools: opts.Tools}
+		header = session.SessionHeader{
+			ID:           session.NewID(now),
+			CreatedAt:    now,
+			UpdatedAt:    now,
+			Model:        opts.Model,
+			Provider:     opts.ProviderName,
+			SystemPrompt: opts.SysPrompt,
+		}
+	}
+
+	live := &cli.LiveConfig{
+		Model:         opts.Model,
+		ProviderName:  opts.ProviderName,
+		Provider:      opts.Provider,
+		BaseURL:       opts.BaseURL,
+		Protocol:      opts.Protocol,
+		ThinkingLevel: opts.ThinkingLevel,
+		ContextWindow: cli.DefaultContextWindow,
+	}
+
+	s := &runSession{
+		store:     store,
+		header:    header,
+		agentCtx:  agentCtx,
+		live:      live,
+		reg:       run.ToolRegistry(opts.Tools),
+		reminders: run.TodoReminders(opts.Tools),
+		creds:     creds,
+		curLeaf:   curLeaf,
+		persisted: len(history),
+	}
+	return s, history, nil
+}
+
+// buildConfig assembles the RunConfig for one turn from the live config and
+// collaborators. It replicates repl.streamRun's assembly (same LoopConfig fields,
+// tool registry and reminders) minus the interactive trust confirmation hook: the
+// TUI has no stdin prompt to confirm side-effect tool calls on, so tools run
+// under the trust granted up front by --approve (Options.Approve) rather than a
+// per-call BeforeToolCall prompt. The stream fn is derived from the live provider
+// and the API key resolved through the credential store, exactly as the REPL does.
+func (s *runSession) buildConfig() runtime.RunConfig {
+	return runtime.RunConfig{
+		LoopConfig: runtime.LoopConfig{
+			Model:         s.live.Model,
+			Provider:      s.live.ProviderName,
+			ThinkingLevel: s.live.ThinkingLevel,
+			Stream:        provider.StreamFnFromProvider(s.live.Provider),
+			GetAPIKey:     s.creds.GetAPIKey,
+			ContextWindow: s.live.ContextWindow,
+			Compaction:    compaction.DefaultCompactionSettings,
+		},
+		Batch: agenttool.BatchConfig{
+			ToolExecutorConfig: agenttool.ToolExecutorConfig{
+				Registry: s.reg,
+			},
+		},
+		Reminders: s.reminders,
+	}
+}
+
+// startRun is the real binding for Model.startRunFn: it appends the submitted
+// prompt to the growing context as a user message, then hands the context and a
+// freshly-built config to the event bridge (bridge.startRun → runtime.StartRun +
+// DrainStream on a goroutine), returning the bridge channel and the first
+// waitForEvent Cmd so Update can pump the run's events. The context grows in
+// place (agentCtx is a pointer), so the next turn continues the conversation.
+func (s *runSession) startRun(prompt string) (chan tea.Msg, tea.Cmd) {
+	content, err := ui.BuildUserContent(prompt)
+	if err != nil {
+		// A malformed image reference must not swallow the turn: fall back to the
+		// raw prompt as plain text so the run still starts.
+		content = agentcore.ContentList{agentcore.NewTextContent(prompt)}
+	}
+	s.agentCtx.Messages = append(s.agentCtx.Messages, agentcore.UserMessage{
+		RoleField: agentcore.RoleUser,
+		Content:   content,
+	})
+	return startRun(context.Background(), s.agentCtx, s.buildConfig())
+}
+
+// persist writes the messages produced since the last persist as a new branch
+// descending from the active leaf, advancing the leaf and the persisted cursor.
+// It mirrors cli.PersistTurn: growing the on-disk tree with AppendBranch (rather
+// than a linear rewrite) keeps history intact. A no-op when nothing new was
+// produced, so an idle turn-end never regenerates entry ids.
+func (s *runSession) persist() error {
+	tail := s.agentCtx.Messages[s.persisted:]
+	if len(tail) == 0 {
+		return nil
+	}
+	s.header.UpdatedAt = time.Now().UTC()
+	s.header.Model = s.live.Model
+	s.header.Provider = s.live.ProviderName
+	leaf, err := s.store.AppendBranch(s.header, s.curLeaf, tail)
+	if err != nil {
+		return err
+	}
+	s.curLeaf = leaf
+	s.persisted = len(s.agentCtx.Messages)
+	return nil
+}
+
+// seedTranscript replays a resumed session's prior messages into the transcript
+// so the user sees the conversation so far before re-prompting (the TUI analogue
+// of repl.replayTranscript). User and assistant text become their respective
+// blocks; assistant tool calls render as system lines (tool cards land in #389).
+// Tool-result messages are omitted here — their content is echoed live during a
+// run, and replaying raw results would clutter the resumed view.
+func seedTranscript(t *transcript, history []agentcore.Message) {
+	for _, m := range history {
+		switch msg := m.(type) {
+		case agentcore.UserMessage:
+			if text := agentcore.ContentToText(msg.Content); text != "" {
+				t.addUser(text)
+			}
+		case agentcore.AssistantMessage:
+			if text := agentcore.ContentToText(msg.Content); text != "" {
+				t.finalizeTurn(msg)
+			}
+			for _, c := range msg.ToolCalls() {
+				t.addSystem("· " + c.Name)
+			}
+		}
+	}
+}

--- a/internal/cli/tui/session_test.go
+++ b/internal/cli/tui/session_test.go
@@ -1,0 +1,157 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/session"
+)
+
+// newTestStore opens a session store rooted at a temp dir so persistence/resume
+// can be exercised without touching ~/.pigo.
+func newTestStore(t *testing.T) *session.Store {
+	t.Helper()
+	store, err := session.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return store
+}
+
+// saveSession writes a linear session with the given messages and returns its id.
+func saveSession(t *testing.T, store *session.Store, msgs agentcore.MessageList) string {
+	t.Helper()
+	now := time.Now().UTC()
+	header := session.SessionHeader{
+		ID:        session.NewID(now),
+		CreatedAt: now,
+		UpdatedAt: now,
+		Model:     "test-model",
+		Provider:  "test-provider",
+	}
+	if err := store.Save(header, msgs); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	return header.ID
+}
+
+// TestResumeSeedsTranscript constructs a session with a few messages, resumes it
+// through newRunSessionWithStore, seeds a transcript with the returned history,
+// and asserts the initial transcript blocks carry those messages (FR-16 resume).
+func TestResumeSeedsTranscript(t *testing.T) {
+	store := newTestStore(t)
+	id := saveSession(t, store, agentcore.MessageList{
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("你好，世界")}},
+		agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant, Content: agentcore.ContentList{agentcore.NewTextContent("hello back")}},
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("second question")}},
+	})
+
+	s, history, err := newRunSessionWithStore(store, Options{ResumeID: id})
+	if err != nil {
+		t.Fatalf("newRunSessionWithStore: %v", err)
+	}
+	if len(history) != 3 {
+		t.Fatalf("history len = %d, want 3", len(history))
+	}
+	// The persisted cursor must cover the full resumed history so the first new
+	// turn appends only fresh messages, not a re-save of history.
+	if s.persisted != 3 {
+		t.Errorf("persisted = %d, want 3", s.persisted)
+	}
+	if s.curLeaf == "" {
+		t.Error("curLeaf should be the resumed leaf, got empty")
+	}
+
+	tr := newTranscript(DefaultTheme())
+	seedTranscript(&tr, history)
+
+	wantTexts := []string{"你好，世界", "hello back", "second question"}
+	if len(tr.blocks) != len(wantTexts) {
+		t.Fatalf("transcript blocks = %d, want %d", len(tr.blocks), len(wantTexts))
+	}
+	for i, want := range wantTexts {
+		if tr.blocks[i].text != want {
+			t.Errorf("block[%d] = %q, want %q", i, tr.blocks[i].text, want)
+		}
+	}
+}
+
+// TestBuildConfigAssembly asserts the run-config assembly maps the live config
+// onto RunConfig without a live provider: the model/provider/thinking/window
+// fields flow through, compaction is enabled, and the tool registry is wired.
+func TestBuildConfigAssembly(t *testing.T) {
+	store := newTestStore(t)
+	s, _, err := newRunSessionWithStore(store, Options{
+		Model:         "opus-test",
+		ProviderName:  "anthropic",
+		ThinkingLevel: agentcore.ThinkingLevel("high"),
+	})
+	if err != nil {
+		t.Fatalf("newRunSessionWithStore: %v", err)
+	}
+
+	cfg := s.buildConfig()
+	if cfg.Model != "opus-test" {
+		t.Errorf("cfg.Model = %q, want opus-test", cfg.Model)
+	}
+	if cfg.Provider != "anthropic" {
+		t.Errorf("cfg.Provider = %q, want anthropic", cfg.Provider)
+	}
+	if cfg.ThinkingLevel != agentcore.ThinkingLevel("high") {
+		t.Errorf("cfg.ThinkingLevel = %q, want high", cfg.ThinkingLevel)
+	}
+	if cfg.ContextWindow <= 0 {
+		t.Errorf("cfg.ContextWindow = %d, want a positive default", cfg.ContextWindow)
+	}
+	if !cfg.Compaction.Enabled {
+		t.Error("cfg.Compaction.Enabled = false, want true (DefaultCompactionSettings)")
+	}
+	if cfg.Batch.Registry == nil {
+		t.Error("cfg.Batch.Registry is nil, want the assembled tool registry")
+	}
+	if cfg.Stream == nil {
+		t.Error("cfg.Stream is nil, want a stream fn derived from the provider")
+	}
+}
+
+// TestFreshSessionPersists starts a fresh session, appends a turn to the context,
+// persists it, and confirms it round-trips back through the store (FR-16 persist).
+func TestFreshSessionPersists(t *testing.T) {
+	store := newTestStore(t)
+	s, history, err := newRunSessionWithStore(store, Options{Model: "m", ProviderName: "p"})
+	if err != nil {
+		t.Fatalf("newRunSessionWithStore: %v", err)
+	}
+	if history != nil {
+		t.Fatalf("fresh session history = %v, want nil", history)
+	}
+
+	s.agentCtx.Messages = append(s.agentCtx.Messages,
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("hi")}},
+		agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant, Content: agentcore.ContentList{agentcore.NewTextContent("yo")}},
+	)
+	if err := s.persist(); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+	if s.persisted != 2 {
+		t.Errorf("persisted = %d, want 2", s.persisted)
+	}
+
+	_, msgs, err := store.Load(s.header.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("persisted messages = %d, want 2", len(msgs))
+	}
+
+	// A second persist with no new messages is a no-op.
+	before := s.curLeaf
+	if err := s.persist(); err != nil {
+		t.Fatalf("persist (no-op): %v", err)
+	}
+	if s.curLeaf != before {
+		t.Errorf("curLeaf changed on no-op persist: %q -> %q", before, s.curLeaf)
+	}
+}


### PR DESCRIPTION
## Summary
- Bind the TUI model's `startRunFn` seam to the real agent run: `internal/cli/tui/session.go` assembles an `AgentContext` + `RunConfig` from the model `Options` (mirroring `repl.streamRun`) and hands off to the merged event bridge (`runtime.StartRun`/`DrainStream`).
- Resume: when `Options.ResumeID` is set, load history via `session.Store.LoadEntries` and replay prior user/assistant messages into the transcript before interactive mode.
- Persist: on `runEndMsg` the turn is written to `~/.pigo/sessions` as a tree branch (mirroring `cli.PersistTurn`), so conversations survive exit and are resumable.
- Shares the lower-level `session`/`runtime`/`provider`/`cli`/`cli/run`/`cli/headless`/`cli/ui` packages rather than importing `repl`, avoiding an import cycle (`prompts` imports `tui`).
- `--list-sessions` dispatch is unchanged: it still prints and exits before the TUI/REPL path (FR-17).

Closes #392

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/cli/tui/... ./cmd/pigo/...` green
- [x] `go test -race ./internal/cli/tui/...` green (persist-after-runEnd ordering)
- [x] New `session_test.go`: resume seeds transcript, run-config assembly, fresh-session persist round-trip + no-op