### PR TITLE
多行输入框 + CJK + 两段式中断 (#390)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 require (
 	github.com/JohannesKaufmann/dom v0.3.1 // indirect
 	github.com/alecthomas/chroma/v2 v2.20.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,12 +10,16 @@ github.com/JohannesKaufmann/dom v0.3.1 h1:J16l9JAHWgkFPR3VIPbQ1gvS0cWab6laK1q7PF
 github.com/JohannesKaufmann/dom v0.3.1/go.mod h1:BZPkf8ZeYrBgABjwJn9iiKt8aiCtkxpHkevms+Yp2DE=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2 h1:XFJZFWESIWlUEHHjzBuv8RvrtCWnSGlimEX17ysSDb8=
 github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2/go.mod h1:BHWO8lJzttJLqwuV8Rb1B3OG2OSzLbssZDI1FRg2eAA=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.20.0 h1:sfIHpxPyR07/Oylvmcai3X/exDlE8+FA820NTz+9sGw=
 github.com/alecthomas/chroma/v2 v2.20.0/go.mod h1:e7tViK0xh/Nf4BYHl00ycY6rV7b8iXBksI9E359yNmA=
 github.com/alecthomas/repr v0.5.1 h1:E3G4t2QbHTSNpPKBgMTln5KLkZHLOcU7r37J4pXBuIg=
 github.com/alecthomas/repr v0.5.1/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=

--- a/internal/cli/tui/input.go
+++ b/internal/cli/tui/input.go
@@ -1,0 +1,93 @@
+package tui
+
+import (
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+)
+
+// This file implements the prompt input field of the full-screen TUI (US-007,
+// FR-11/13/14). It wraps charm.land/bubbles/v2/textarea into a small `input`
+// component so the model can embed a real multi-line editor instead of the
+// throwaway string buffer the skeleton shipped with.
+//
+// Why textarea rather than a hand-rolled buffer: textarea edits by grapheme /
+// rune, so CJK and emoji are inserted and deleted whole. This is exactly the
+// class of bug the old REPL input had — it keyed on byte length (len==1) and
+// silently dropped the trailing bytes of every multi-byte rune. We deliberately
+// delegate all character handling to textarea and never touch bytes ourselves.
+
+// newlineKey is the key chord that inserts a literal newline into the buffer.
+// Enter is reserved by the model for submitting the prompt, so a hard line break
+// is entered with Alt+Enter (ctrl+j is kept as a fallback for terminals that
+// cannot emit alt+enter).
+const newlineKey = "alt+enter"
+
+// input is the prompt editor. It embeds a textarea.Model and exposes just the
+// surface the root model needs: value/clear, focus/blur (input is blurred while
+// a run is in flight so keystrokes never corrupt an in-flight prompt), a width
+// setter driven by tea.WindowSizeMsg, and a render string for View.
+type input struct {
+	ta textarea.Model
+}
+
+// newInput builds a focused single-visible-row editor. The visible height stays
+// at one row so the model's View row accounting (transcript + status + input)
+// is unchanged; the buffer itself is unbounded and grows across newlines, and
+// textarea scrolls its own viewport when the content exceeds the visible row.
+func newInput() input {
+	ta := textarea.New()
+	ta.Prompt = "> "
+	ta.ShowLineNumbers = false
+	ta.CharLimit = 0
+	ta.SetHeight(1)
+	// Enter must NOT insert a newline: the model intercepts it as submit. Rebind
+	// the newline action to Alt+Enter (see newlineKey) so multi-line input still
+	// works while Enter stays free for submission.
+	ta.KeyMap.InsertNewline = key.NewBinding(
+		key.WithKeys(newlineKey, "ctrl+j"),
+		key.WithHelp(newlineKey, "insert newline"),
+	)
+	// Draw the cursor into the rendered string: the model composes View as a
+	// plain string rather than driving textarea's real cursor reporting.
+	ta.SetVirtualCursor(true)
+	ta.Focus()
+	return input{ta: ta}
+}
+
+// Update forwards a message (typically a key press) to the underlying textarea
+// and returns the updated component. The model calls this only for keys it does
+// not intercept itself (submit / newline / interrupt / quit), so textarea sees
+// ordinary editing keys — including CJK and emoji runes, which it inserts whole.
+func (in input) Update(msg tea.Msg) (input, tea.Cmd) {
+	var cmd tea.Cmd
+	in.ta, cmd = in.ta.Update(msg)
+	return in, cmd
+}
+
+// Value returns the current buffer contents, including any embedded newlines.
+func (in input) Value() string { return in.ta.Value() }
+
+// Clear empties the buffer and resets the cursor to the start.
+func (in *input) Clear() { in.ta.Reset() }
+
+// Focus enables editing and returns the cursor-blink Cmd.
+func (in *input) Focus() tea.Cmd { return in.ta.Focus() }
+
+// Blur disables editing (used while a run is in flight).
+func (in *input) Blur() { in.ta.Blur() }
+
+// Focused reports whether the editor currently accepts input.
+func (in input) Focused() bool { return in.ta.Focused() }
+
+// SetWidth resizes the editor to the terminal width so wrapping and the prompt
+// column line up with the rest of the shell.
+func (in *input) SetWidth(w int) {
+	if w < 0 {
+		w = 0
+	}
+	in.ta.SetWidth(w)
+}
+
+// View renders the editor to a string for embedding in the model's View.
+func (in input) View() string { return in.ta.View() }

--- a/internal/cli/tui/input_test.go
+++ b/internal/cli/tui/input_test.go
@@ -1,0 +1,174 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// runeKey builds a printable-character key press carrying r, mirroring what a
+// terminal sends for a typed rune: Code is the rune and Text is its UTF-8
+// encoding (textarea inserts from Text). This is how CJK / emoji reach the
+// component.
+func runeKey(r rune) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: r, Text: string(r)}
+}
+
+// TestInputCJKByRune drives the input with the runes of "你好" and asserts the
+// buffer holds the full multi-byte string with the cursor left on a rune
+// boundary. This guards against the old REPL bug that keyed on byte length
+// (len==1) and dropped the trailing bytes of every multi-byte rune.
+func TestInputCJKByRune(t *testing.T) {
+	in := newInput()
+	for _, r := range "你好" {
+		var cmd tea.Cmd
+		in, cmd = in.Update(runeKey(r))
+		_ = cmd
+	}
+
+	got := in.Value()
+	if got != "你好" {
+		t.Fatalf("Value() = %q, want %q", got, "你好")
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("Value() is not valid UTF-8: %q", got)
+	}
+	if n := utf8.RuneCountInString(got); n != 2 {
+		t.Fatalf("rune count = %d, want 2 (no dropped chars)", n)
+	}
+	// The cursor column is a rune index into the line; after two runes it must be
+	// 2, proving textarea advanced by whole runes rather than bytes.
+	if col := in.ta.Column(); col != 2 {
+		t.Errorf("cursor column = %d, want 2 (rune boundary)", col)
+	}
+}
+
+// TestInputEmojiByRune confirms a multi-byte emoji is inserted whole.
+func TestInputEmojiByRune(t *testing.T) {
+	in := newInput()
+	in, _ = in.Update(runeKey('🚀'))
+	if got := in.Value(); got != "🚀" {
+		t.Fatalf("Value() = %q, want %q", got, "🚀")
+	}
+}
+
+// TestInputAltEnterNewline verifies Alt+Enter inserts a newline into the buffer
+// (the documented multi-line key) while plain runes fill each line.
+func TestInputAltEnterNewline(t *testing.T) {
+	in := newInput()
+	in, _ = in.Update(runeKey('你'))
+	in, _ = in.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModAlt})
+	in, _ = in.Update(runeKey('好'))
+
+	if got := in.Value(); got != "你\n好" {
+		t.Fatalf("Value() = %q, want %q", got, "你\n好")
+	}
+}
+
+// TestInputEnterIsNotNewline confirms plain Enter does NOT insert a newline in
+// the editor: the model intercepts it as submit, so the editor must leave it
+// alone (only Alt+Enter breaks a line).
+func TestInputEnterIsNotNewline(t *testing.T) {
+	in := newInput()
+	in, _ = in.Update(runeKey('a'))
+	in, _ = in.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if got := in.Value(); got != "a" {
+		t.Fatalf("Value() = %q, want %q (Enter must not add a newline)", got, "a")
+	}
+}
+
+// TestInputClearBlurFocus exercises the lifecycle methods the model relies on
+// while gating input during a run.
+func TestInputClearBlurFocus(t *testing.T) {
+	in := newInput()
+	in, _ = in.Update(runeKey('x'))
+	in.Clear()
+	if got := in.Value(); got != "" {
+		t.Errorf("after Clear, Value() = %q, want empty", got)
+	}
+	if !in.Focused() {
+		t.Error("newInput should start focused")
+	}
+	in.Blur()
+	if in.Focused() {
+		t.Error("after Blur, Focused() should be false")
+	}
+	in.Focus()
+	if !in.Focused() {
+		t.Error("after Focus, Focused() should be true")
+	}
+}
+
+// TestModelEnterSubmits feeds a typed line and Enter to the model and asserts the
+// prompt is submitted: the user turn lands in the transcript and the editor is
+// cleared (Enter yields a submit, not a newline). With no startRunFn wired the
+// model stays idle and records the pre-#392 system note.
+func TestModelEnterSubmits(t *testing.T) {
+	m := NewModel(Options{})
+	var model tea.Model = m
+	for _, r := range "你好世界" {
+		model, _ = model.Update(runeKey(r))
+	}
+	model, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	got := model.(Model)
+	if got.input.Value() != "" {
+		t.Errorf("after submit, input = %q, want cleared", got.input.Value())
+	}
+	joined := strings.Join(blockTexts(got.transcript), "\n")
+	if !strings.Contains(joined, "你好世界") {
+		t.Errorf("submitted prompt missing from transcript: %q", joined)
+	}
+}
+
+// TestModelTwoStageInterrupt verifies FR-14: while running, Esc / Ctrl+C
+// interrupts the in-flight run (calls interruptFn) and does NOT quit; while
+// idle, the same keys quit the program.
+func TestModelTwoStageInterrupt(t *testing.T) {
+	for _, key := range []tea.KeyPressMsg{
+		{Code: tea.KeyEscape},
+		{Code: 'c', Mod: tea.ModCtrl},
+	} {
+		// Running: first press interrupts, no quit.
+		interrupted := false
+		running := NewModel(Options{})
+		running.running = true
+		running.interruptFn = func() { interrupted = true }
+		next, cmd := running.Update(key)
+		if !interrupted {
+			t.Errorf("%s while running: interruptFn was not called", key.String())
+		}
+		if next.(Model).quitting {
+			t.Errorf("%s while running: model should not be quitting", key.String())
+		}
+		if cmd != nil {
+			if _, isQuit := cmd().(tea.QuitMsg); isQuit {
+				t.Errorf("%s while running: should not quit", key.String())
+			}
+		}
+
+		// Idle: the same key quits.
+		idle := NewModel(Options{})
+		got, cmd := idle.Update(key)
+		if cmd == nil {
+			t.Fatalf("%s while idle: expected a quit command", key.String())
+		}
+		if _, isQuit := cmd().(tea.QuitMsg); !isQuit {
+			t.Errorf("%s while idle: cmd should be tea.Quit", key.String())
+		}
+		if !got.(Model).quitting {
+			t.Errorf("%s while idle: model should be marked quitting", key.String())
+		}
+	}
+}
+
+// blockTexts extracts the raw text of every transcript block for assertions.
+func blockTexts(t transcript) []string {
+	out := make([]string, len(t.blocks))
+	for i, b := range t.blocks {
+		out[i] = b.text
+	}
+	return out
+}

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 )
@@ -31,9 +30,10 @@ type Model struct {
 	// transcript is the scrolling message log (user / assistant / system turns).
 	transcript transcript
 
-	// input is the minimal prompt buffer. The full textarea (with CJK-aware
-	// editing) lands in #390; this holds just enough to submit a line.
-	input string
+	// input is the multi-line prompt editor (#390). It wraps a bubbles textarea
+	// so CJK / emoji are edited by rune (no dropped-byte bug), Enter submits and
+	// Alt+Enter inserts a newline. It is blurred while a run is in flight.
+	input input
 
 	// running is true while an agent run is draining through runCh. Input submit
 	// is gated on it so a new run cannot start mid-run.
@@ -54,6 +54,14 @@ type Model struct {
 	// context, live config). It is nil for a session-less model; when set, the
 	// model persists the conversation to ~/.pigo/sessions after each turn ends.
 	session *runSession
+
+	// interruptFn cancels the in-flight run (the first stage of the two-stage
+	// interrupt, FR-14): pressing Esc / Ctrl+C while running signals the run to
+	// stop rather than quitting the program. It is a seam wired alongside
+	// startRunFn by session assembly (#392) — typically the run ctx's cancel
+	// func. Until then it may be nil, in which case an interrupt while running is
+	// a safe no-op (the pump keeps draining until it ends on its own).
+	interruptFn func()
 
 	// quitting is set when a quit key (Ctrl+C / Ctrl+D) is seen, so View can be a
 	// no-op on the final frame while the program tears down and restores the
@@ -94,6 +102,7 @@ func NewModel(opts Options) Model {
 		opts:       opts,
 		theme:      theme,
 		transcript: newTranscript(theme),
+		input:      newInput(),
 		cwd:        cwd,
 		statusBar:  newStatusBar(theme, opts, cwd),
 		toolCards:  make(map[string]*toolCard),
@@ -108,6 +117,7 @@ func NewModel(opts Options) Model {
 func (m Model) withSession(s *runSession, history []agentcore.Message) Model {
 	m.session = s
 	m.startRunFn = s.startRun
+	m.interruptFn = s.interrupt
 	seedTranscript(&m.transcript, history)
 	return m
 }
@@ -116,7 +126,7 @@ func (m Model) withSession(s *runSession, history []agentcore.Message) Model {
 // can show the branch/dirty state as soon as it resolves; the alt-screen is
 // requested declaratively via the AltScreen field on the View returned by View.
 func (m Model) Init() tea.Cmd {
-	return fetchGitCmd(m.cwd)
+	return tea.Batch(fetchGitCmd(m.cwd), m.input.Focus())
 }
 
 // Update implements tea.Model. It tracks the terminal size, drives the minimal
@@ -129,6 +139,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.transcript.setSize(msg.Width, transcriptHeight(msg.Height))
+		m.input.SetWidth(msg.Width)
 		return m, nil
 
 	case gitInfoMsg:
@@ -201,18 +212,32 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.transcript.addSystem("会话保存失败：" + err.Error())
 			}
 		}
-		// A run may have changed the working tree (edits, new files); re-probe git
-		// so the status bar reflects the post-run dirty/ahead state.
-		return m, fetchGitCmd(m.cwd)
+		// The editor was blurred at submit; re-enable it so the next prompt can be
+		// typed, and re-probe git since a run may have changed the working tree.
+		focus := m.input.Focus()
+		return m, tea.Batch(focus, fetchGitCmd(m.cwd))
 	}
 	return m, nil
 }
 
-// handleKey processes a key press: quit keys, prompt submit, minimal line
-// editing, and viewport scrolling.
+// handleKey processes a key press. It resolves the keys the shell owns —
+// two-stage interrupt/quit, prompt submit, transcript scrolling — and delegates
+// everything else (character entry, in-buffer cursor movement, Alt+Enter
+// newline) to the input editor while idle. Keys are matched via KeyPressMsg
+// .String() so the mapping is terminal-independent.
 func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "ctrl+c", "ctrl+d":
+	case "esc", "ctrl+c":
+		// Two-stage interrupt (FR-14): while a run is in flight the first press
+		// interrupts that run (cancel the run ctx / signal the pump) and stays in
+		// the program; when idle it quits.
+		if m.running {
+			if m.interruptFn != nil {
+				m.interruptFn()
+			}
+			m.transcript.addSystem("（正在中断当前运行…）")
+			return m, nil
+		}
 		m.quitting = true
 		return m, tea.Quit
 	case "ctrl+o":
@@ -223,49 +248,58 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.transcript.reflow()
 		}
 		return m, nil
+	case "ctrl+d":
+		// Ctrl+D quits only when idle; mid-run it is ignored so a run is never
+		// dropped by a stray EOF key.
+		if !m.running {
+			m.quitting = true
+			return m, tea.Quit
+		}
+		return m, nil
 	case "enter":
 		if !m.running {
 			return m.submit()
 		}
 		return m, nil
-	case "backspace":
-		if !m.running && m.input != "" {
-			r := []rune(m.input)
-			m.input = string(r[:len(r)-1])
-		}
-		return m, nil
-	case "up", "down", "pgup", "pgdown", "home", "end":
-		// Scrolling reaches the transcript viewport whether idle or running, so
-		// history stays readable while a run streams.
+	case "pgup", "pgdown":
+		// Page scrolling reaches the transcript viewport whether idle or running,
+		// so history stays readable while a run streams. Line-oriented keys (up /
+		// down / home / end) belong to the multi-line editor and are delegated
+		// below.
 		cmd := m.transcript.update(msg)
 		return m, cmd
 	}
 
-	// Printable input extends the buffer (minimal; full textarea is #390). Gated
-	// on idle so keystrokes don't corrupt a prompt while a run streams.
-	if !m.running && msg.Text != "" {
-		m.input += msg.Text
+	// Everything else is editing input; gated on idle so keystrokes never corrupt
+	// an in-flight prompt. textarea handles CJK / emoji by rune and Alt+Enter as
+	// a newline.
+	if !m.running {
+		var cmd tea.Cmd
+		m.input, cmd = m.input.Update(msg)
+		return m, cmd
 	}
 	return m, nil
 }
 
-// submit starts a run for the current input line: it appends the user block,
-// clears the buffer, and — when a run starter is wired — flips to running and
+// submit starts a run for the current buffer: it appends the user block, clears
+// and blurs the editor, flips to running, and — when a run starter is wired —
 // returns the first pump Cmd. With no starter (pre-#392) it records the prompt
-// and a system note without launching anything.
+// and a system note without launching anything, and leaves the editor ready for
+// the next line.
 func (m Model) submit() (tea.Model, tea.Cmd) {
-	prompt := strings.TrimSpace(m.input)
+	prompt := strings.TrimSpace(m.input.Value())
 	if prompt == "" {
 		return m, nil
 	}
 	m.transcript.addUser(prompt)
-	m.input = ""
+	m.input.Clear()
 
 	if m.startRunFn == nil {
 		m.transcript.addSystem("（运行未接入：会话装配见 #392）")
 		return m, nil
 	}
 
+	m.input.Blur()
 	ch, cmd := m.startRunFn(prompt)
 	m.runCh = ch
 	m.running = true
@@ -303,10 +337,9 @@ func (m Model) View() tea.View {
 
 	status := m.statusBar.Render(width)
 
-	input := lipgloss.NewStyle().
-		Width(width).
-		Foreground(lipgloss.Color("241")).
-		Render("> " + m.input)
+	// The input editor renders its own prompt column and cursor; keep it to the
+	// single visible row the View row math reserves.
+	input := m.input.View()
 
 	// Reserve one row for the status bar and one for the input line; the rest is
 	// the transcript area. Guard against tiny terminals so the region never goes

--- a/internal/cli/tui/session.go
+++ b/internal/cli/tui/session.go
@@ -50,6 +50,11 @@ type runSession struct {
 	// Messages[persisted:] as a branch from curLeaf (see cli.PersistTurn).
 	curLeaf   string
 	persisted int
+
+	// cancelRun cancels the in-flight run's context; startRun sets it and the
+	// two-stage interrupt (Model.interruptFn → interrupt) calls it. It is nil
+	// before the first run and after a run is cancelled.
+	cancelRun context.CancelFunc
 }
 
 // newRunSession assembles the run session from the resolved Options, opening the
@@ -180,7 +185,21 @@ func (s *runSession) startRun(prompt string) (chan tea.Msg, tea.Cmd) {
 		RoleField: agentcore.RoleUser,
 		Content:   content,
 	})
-	return startRun(context.Background(), s.agentCtx, s.buildConfig())
+	// Use a cancellable context so the two-stage interrupt (FR-14) can stop this
+	// run: cancelling propagates through StartRun/DrainStream, which then emits a
+	// runEndMsg and the model returns to idle.
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancelRun = cancel
+	return startRun(ctx, s.agentCtx, s.buildConfig())
+}
+
+// interrupt cancels the in-flight run, if any. It is bound to Model.interruptFn
+// by withSession so pressing Esc / Ctrl+C while running stops the current run
+// instead of quitting the program (FR-14). Safe to call when no run is active.
+func (s *runSession) interrupt() {
+	if s.cancelRun != nil {
+		s.cancelRun()
+	}
 }
 
 // persist writes the messages produced since the last persist as a new branch


### PR DESCRIPTION
## Summary
- 新增 `internal/cli/tui/input.go`：封装 `charm.land/bubbles/v2/textarea` 为 `input` 组件，按 rune 处理 CJK / emoji（修复旧 REPL `len==1` 丢字节的 bug），Enter 提交、Alt+Enter 换行，暴露 Value/Clear/Focus/Blur/SetWidth/View。
- model.go 两段式中断（FR-14）：运行中 Esc / Ctrl+C 通过 `interruptFn` seam 中断当前运行（不退出）；空闲时退出，Ctrl+D 仅空闲时退出。提交时清空并 blur 输入框，运行结束后重新 focus。
- 补齐 `go.mod` / `go.sum` 中 textarea 的传递依赖 `github.com/atotto/clipboard`。
- 新增 `internal/cli/tui/input_test.go`：CJK/emoji 按 rune 注入、光标停在 rune 边界、Alt+Enter 换行、Enter 提交、两段式中断（运行→中断、空闲→退出）单测。

Closes #390

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./internal/cli/tui/...
- [x] rebase 到 origin/master，保留 #389 工具卡片（ctrl+o）与本节所有功能