### PR TITLE
feat(tui): slash commands + autocomplete popup

### DIFF
--- a/internal/cli/tui/input.go
+++ b/internal/cli/tui/input.go
@@ -68,6 +68,10 @@ func (in input) Update(msg tea.Msg) (input, tea.Cmd) {
 // Value returns the current buffer contents, including any embedded newlines.
 func (in input) Value() string { return in.ta.Value() }
 
+// SetValue replaces the buffer contents and moves the cursor to the end. It is
+// used by slash autocomplete (Tab) to complete the buffer to the chosen command.
+func (in *input) SetValue(s string) { in.ta.SetValue(s) }
+
 // Clear empties the buffer and resets the cursor to the start.
 func (in *input) Clear() { in.ta.Reset() }
 

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -7,6 +7,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/runtime"
 )
 
 // Model is the root Bubble Tea model for the full-screen TUI. It composes a
@@ -77,6 +79,21 @@ type Model struct {
 	// the git probe and the status bar's path display.
 	cwd string
 
+	// slash is the shared slash-command registry (#383) the TUI consults exactly
+	// as the REPL does: /model, /help, user templates, plugin commands and skills.
+	// It is bound to live so a /model switch mutates the same config the run loop
+	// reads. Built in NewModel (built-ins + disk templates) and rebuilt in
+	// withSession against the session's live config.
+	slash *runtime.SlashRegistry
+	// live is the mutable run configuration the /model command switches. In a
+	// session-bound model it is the SAME pointer the run loop reads (set by
+	// withSession), so a switch takes effect on the next turn.
+	live *cli.LiveConfig
+	// menu is the autocomplete popup shown while a "/name" is being typed (#391).
+	// It filters slash by the typed prefix; the model intercepts arrow/Tab/Enter
+	// keys to drive it before delegating to the textarea.
+	menu slashMenu
+
 	// toolCards indexes the rich tool-call cards (#389, US-006) by tool-call id so
 	// a toolEndMsg can locate the card started earlier and flip its state / attach
 	// the parsed response. Each card is also appended to the transcript as an
@@ -88,16 +105,28 @@ type Model struct {
 	lastToolCard *toolCard
 }
 
-// NewModel builds the root model from the assembled Options. It performs no I/O
-// beyond reading the current working directory (for the status bar's path
-// display and git probe); session/live/slash/trust assembly is deferred to
-// downstream nodes.
+// NewModel builds the root model from the assembled Options. It reads the
+// current working directory (for the status bar's path display and git probe)
+// and assembles the shared slash-command registry (#391), which reads the user
+// prompt-template dirs (~/.pigo/{commands,prompts}) and the pre-loaded skills;
+// missing dirs are not an error. The registry is bound here to a live config
+// derived from Options; withSession rebinds it to the session's live config so a
+// /model switch reaches the run loop.
 func NewModel(opts Options) Model {
 	cwd, err := os.Getwd()
 	if err != nil {
 		cwd = ""
 	}
 	theme := DefaultTheme()
+	live := &cli.LiveConfig{
+		Model:         opts.Model,
+		ProviderName:  opts.ProviderName,
+		Provider:      opts.Provider,
+		BaseURL:       opts.BaseURL,
+		Protocol:      opts.Protocol,
+		ThinkingLevel: opts.ThinkingLevel,
+		ContextWindow: cli.DefaultContextWindow,
+	}
 	return Model{
 		opts:       opts,
 		theme:      theme,
@@ -106,6 +135,9 @@ func NewModel(opts Options) Model {
 		cwd:        cwd,
 		statusBar:  newStatusBar(theme, opts, cwd),
 		toolCards:  make(map[string]*toolCard),
+		slash:      newSlashRegistry(opts, live),
+		live:       live,
+		menu:       newSlashMenu(theme),
 	}
 }
 
@@ -118,6 +150,10 @@ func (m Model) withSession(s *runSession, history []agentcore.Message) Model {
 	m.session = s
 	m.startRunFn = s.startRun
 	m.interruptFn = s.interrupt
+	// Rebind the registry to the session's live config so /model mutates the very
+	// config the run loop reads (buildConfig), not the throwaway one NewModel made.
+	m.live = s.live
+	m.slash = newSlashRegistry(m.opts, s.live)
 	seedTranscript(&m.transcript, history)
 	return m
 }
@@ -226,6 +262,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // newline) to the input editor while idle. Keys are matched via KeyPressMsg
 // .String() so the mapping is terminal-independent.
 func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	// While idle with the autocomplete popup open, the arrow / Tab / Esc keys
+	// drive the menu instead of the transcript or textarea (FR-15). Enter is left
+	// to the main switch below, which routes through submit → runSlash so the
+	// selected/typed command runs. These are matched via KeyPressMsg.String() so
+	// the mapping is terminal-independent.
+	if !m.running && m.menu.active {
+		switch msg.String() {
+		case "up":
+			m.menu.moveUp()
+			return m, nil
+		case "down":
+			m.menu.moveDown()
+			return m, nil
+		case "tab":
+			return m.completeSlash(), nil
+		case "esc":
+			m.menu.close()
+			return m, nil
+		case "enter":
+			return m.submitSlashSelected()
+		}
+	}
+
 	switch msg.String() {
 	case "esc", "ctrl+c":
 		// Two-stage interrupt (FR-14): while a run is in flight the first press
@@ -272,10 +331,12 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Everything else is editing input; gated on idle so keystrokes never corrupt
 	// an in-flight prompt. textarea handles CJK / emoji by rune and Alt+Enter as
-	// a newline.
+	// a newline. After the buffer changes, refresh the autocomplete popup so it
+	// opens/filters/closes as the user types a "/name" prefix.
 	if !m.running {
 		var cmd tea.Cmd
 		m.input, cmd = m.input.Update(msg)
+		m.menu.refresh(m.input.Value(), m.slash)
 		return m, cmd
 	}
 	return m, nil
@@ -291,14 +352,80 @@ func (m Model) submit() (tea.Model, tea.Cmd) {
 	if prompt == "" {
 		return m, nil
 	}
+	// A "/name ..." line is a slash-command invocation, not a prompt: resolve it
+	// against the shared registry (same as the REPL) rather than sending it to the
+	// agent verbatim.
+	if strings.HasPrefix(prompt, "/") {
+		return m.runSlash(prompt)
+	}
 	m.transcript.addUser(prompt)
 	m.input.Clear()
+	m.menu.close()
+	return m.startPrompt(prompt)
+}
 
+// completeSlash fills the buffer with the highlighted candidate's "/name " so the
+// user can go on to type arguments; the trailing space ends name-completion, so
+// the refresh closes the popup. It is the Tab action while the menu is open.
+func (m Model) completeSlash() Model {
+	if c, ok := m.menu.current(); ok {
+		m.input.SetValue("/" + c.Name + " ")
+		m.menu.refresh(m.input.Value(), m.slash)
+	}
+	return m
+}
+
+// submitSlashSelected runs the command the popup highlights (Enter while the
+// menu is open). Navigating with the arrows then pressing Enter runs the
+// selected command even if the typed prefix is shorter; with no selection it
+// falls back to the raw buffer so a fully-typed "/name" still runs.
+func (m Model) submitSlashSelected() (tea.Model, tea.Cmd) {
+	line := strings.TrimSpace(m.input.Value())
+	if c, ok := m.menu.current(); ok {
+		line = "/" + c.Name
+	}
+	return m.runSlash(line)
+}
+
+// runSlash resolves a slash-command line against the shared registry and folds
+// its outcome into the transcript, mirroring the REPL's dispatch: the invocation
+// is echoed as a user block; an action command's status (e.g. /help, /model)
+// renders as a system block; a prompt/skill command's expanded text starts a
+// run; a hybrid (plugin) command shows its notifications then runs its prompt.
+// An unknown command surfaces the resolver error as a system block.
+func (m Model) runSlash(line string) (tea.Model, tea.Cmd) {
+	m.transcript.addUser(line)
+	m.input.Clear()
+	m.menu.close()
+	if m.slash == nil {
+		m.transcript.addSystem("斜杠命令不可用")
+		return m, nil
+	}
+	outcome, err := m.slash.ResolveOutcome(line)
+	if err != nil {
+		m.transcript.addSystem(err.Error())
+		return m, nil
+	}
+	if outcome.Message != "" {
+		m.transcript.addSystem(outcome.Message)
+	}
+	// An action command is complete once its status is shown; a hybrid with no
+	// prompt (notifications only) likewise starts no run.
+	if outcome.Kind == runtime.SlashAction || outcome.Prompt == "" {
+		return m, nil
+	}
+	return m.startPrompt(outcome.Prompt)
+}
+
+// startPrompt launches an agent run for prompt, blurring the editor and flipping
+// to running when a run starter is wired. With no starter (pre-session model /
+// tests) it records the pre-#392 system note and stays idle. It is shared by a
+// plain submit and by a slash prompt/skill command.
+func (m Model) startPrompt(prompt string) (tea.Model, tea.Cmd) {
 	if m.startRunFn == nil {
 		m.transcript.addSystem("（运行未接入：会话装配见 #392）")
 		return m, nil
 	}
-
 	m.input.Blur()
 	ch, cmd := m.startRunFn(prompt)
 	m.runCh = ch
@@ -359,6 +486,13 @@ func (m Model) View() tea.View {
 	}
 	b.WriteString(status)
 	b.WriteByte('\n')
+	// The autocomplete popup, when open, renders just above the input line as an
+	// overlay (it contributes no rows while idle, so the empty-shell layout is
+	// unchanged).
+	if menu := m.menu.view(width); menu != "" {
+		b.WriteString(menu)
+		b.WriteByte('\n')
+	}
 	b.WriteString(input)
 
 	return tea.View{Content: b.String(), AltScreen: true}

--- a/internal/cli/tui/slash.go
+++ b/internal/cli/tui/slash.go
@@ -1,0 +1,192 @@
+// This file implements slash-commands and their autocomplete popup for the
+// full-screen TUI (US-008, FR-15). It is the TUI counterpart to the REPL's
+// slash handling (internal/cli/repl/repl.go): both front-ends consult the SAME
+// shared registry assembled by internal/cli/prompts.BuildSlashRegistry (#383),
+// so /model, /help, user-declared templates (~/.pigo/{commands,prompts}),
+// config/CLI prompt templates, plugin commands and ~/.agents/skills /skill-name
+// commands are identical across the two surfaces.
+//
+// tui deliberately imports prompts/runtime/cli (the shared lower layers), never
+// repl: prompts sits below both front-ends, so there is no import cycle.
+//
+// The autocomplete popup (slashMenu) activates while the input buffer is a
+// "/name" being typed (a leading "/" with no whitespace yet). It filters the
+// registry by the typed prefix, is navigated with the arrow keys, completed with
+// Tab, and run with Enter — the model intercepts those keys before delegating to
+// the textarea (see model.handleKey).
+package tui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/prompts"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// maxMenuRows caps how many candidate rows the popup shows at once; a longer
+// filtered list scrolls a window around the selection so the overlay stays a few
+// lines tall regardless of how many commands are registered.
+const maxMenuRows = 8
+
+// newSlashRegistry assembles the shared slash-command registry for the TUI the
+// same way the REPL does: built-ins seeded from runtime, the live-state /model
+// and /help commands bound to live (so a /model switch mutates the very config
+// the run loop reads), user/plugin/skill/template commands from disk. A load
+// error is non-fatal — BuildSlashRegistry still returns a registry with the
+// built-ins, so the TUI stays usable and the failure is surfaced on stderr.
+func newSlashRegistry(opts Options, live *cli.LiveConfig) *runtime.SlashRegistry {
+	reg, err := prompts.BuildSlashRegistry(live, opts.Skills, opts.Plugins, prompts.PromptTemplateSources{
+		Settings: opts.ConfigPrompts,
+		CLI:      opts.CliPrompts,
+		Disable:  opts.NoPromptTemplates,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pigo: slash-commands: %v\n", err)
+	}
+	return reg
+}
+
+// slashMenu is the autocomplete popup state. It holds the candidates matching
+// the current "/prefix" and the highlighted row; it is inactive (rendered as
+// nothing) whenever the buffer is not a slash-command being typed or no command
+// matches the prefix.
+type slashMenu struct {
+	theme    Theme
+	active   bool
+	filtered []runtime.SlashCommand
+	selected int
+}
+
+// newSlashMenu builds an inactive menu bound to the theme used for its rows.
+func newSlashMenu(theme Theme) slashMenu { return slashMenu{theme: theme} }
+
+// slashToken reports whether buffer is a slash-command name still being typed
+// and returns the text after the leading "/". It is true only for a leading "/"
+// with no whitespace yet: once the user types a space the name is complete and
+// the buffer has moved on to arguments, so name-completion stops.
+func slashToken(buffer string) (token string, ok bool) {
+	trimmed := strings.TrimLeft(buffer, " \t")
+	if !strings.HasPrefix(trimmed, "/") {
+		return "", false
+	}
+	rest := trimmed[1:]
+	if strings.ContainsAny(rest, " \t\n") {
+		return "", false
+	}
+	return rest, true
+}
+
+// refresh recomputes the menu from the current buffer and registry. It activates
+// only when the buffer is a "/name" prefix that matches at least one command;
+// otherwise it deactivates and clears its candidates. The selection is clamped
+// so it stays in range as the filtered set shrinks.
+func (mn *slashMenu) refresh(buffer string, reg *runtime.SlashRegistry) {
+	token, ok := slashToken(buffer)
+	if !ok || reg == nil {
+		mn.close()
+		return
+	}
+	var out []runtime.SlashCommand
+	for _, c := range reg.List() {
+		if strings.HasPrefix(c.Name, token) {
+			out = append(out, c)
+		}
+	}
+	mn.filtered = out
+	mn.active = len(out) > 0
+	if mn.selected >= len(out) || mn.selected < 0 {
+		mn.selected = 0
+	}
+}
+
+// close deactivates the menu and drops its candidates.
+func (mn *slashMenu) close() {
+	mn.active = false
+	mn.filtered = nil
+	mn.selected = 0
+}
+
+// moveUp / moveDown cycle the highlighted candidate, wrapping at the ends so
+// arrow navigation is continuous.
+func (mn *slashMenu) moveUp() {
+	if len(mn.filtered) == 0 {
+		return
+	}
+	mn.selected--
+	if mn.selected < 0 {
+		mn.selected = len(mn.filtered) - 1
+	}
+}
+
+func (mn *slashMenu) moveDown() {
+	if len(mn.filtered) == 0 {
+		return
+	}
+	mn.selected++
+	if mn.selected >= len(mn.filtered) {
+		mn.selected = 0
+	}
+}
+
+// current returns the highlighted candidate, or ok=false when the menu is
+// inactive / empty.
+func (mn slashMenu) current() (runtime.SlashCommand, bool) {
+	if !mn.active || mn.selected < 0 || mn.selected >= len(mn.filtered) {
+		return runtime.SlashCommand{}, false
+	}
+	return mn.filtered[mn.selected], true
+}
+
+// view renders the popup as a block of up to maxMenuRows lines, the highlighted
+// row marked with a "›" caret and accented. Each row is "/name  description",
+// truncated to the width so it never wraps. Returns "" when inactive so the
+// model omits the overlay entirely (and its row) while idle.
+func (mn slashMenu) view(width int) string {
+	if !mn.active || len(mn.filtered) == 0 {
+		return ""
+	}
+	start, end := mn.window()
+	rowWidth := width - 2 // reserve the caret / indent column
+	if rowWidth < 1 {
+		rowWidth = width
+	}
+	var b strings.Builder
+	for i := start; i < end; i++ {
+		c := mn.filtered[i]
+		line := "/" + c.Name
+		if c.Description != "" {
+			line += "  " + c.Description
+		}
+		line = TruncateToWidth(line, rowWidth)
+		if i == mn.selected {
+			b.WriteString(mn.theme.Accent.Render("› " + line))
+		} else {
+			b.WriteString(mn.theme.System.Render("  " + line))
+		}
+		if i < end-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// window returns the [start,end) slice of filtered candidates to display,
+// scrolled to keep the selection visible when the list is taller than
+// maxMenuRows.
+func (mn slashMenu) window() (int, int) {
+	n := len(mn.filtered)
+	if n <= maxMenuRows {
+		return 0, n
+	}
+	start := mn.selected - maxMenuRows + 1
+	if start < 0 {
+		start = 0
+	}
+	if start > n-maxMenuRows {
+		start = n - maxMenuRows
+	}
+	return start, start + maxMenuRows
+}

--- a/internal/cli/tui/slash_test.go
+++ b/internal/cli/tui/slash_test.go
@@ -1,0 +1,197 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// typeInto feeds each rune of s to the model as a key press, returning the
+// evolved model. It mirrors how a terminal delivers typed characters (Code +
+// Text), including the leading "/" of a slash-command.
+func typeInto(t *testing.T, m tea.Model, s string) tea.Model {
+	t.Helper()
+	for _, r := range s {
+		m, _ = m.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+	return m
+}
+
+// menuNames returns the "/name" of every candidate currently in the popup.
+func menuNames(m Model) []string {
+	out := make([]string, len(m.menu.filtered))
+	for i, c := range m.menu.filtered {
+		out[i] = "/" + c.Name
+	}
+	return out
+}
+
+func containsAll(hay []string, needles ...string) bool {
+	set := make(map[string]bool, len(hay))
+	for _, h := range hay {
+		set[h] = true
+	}
+	for _, n := range needles {
+		if !set[n] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSlashMenuOpensOnSlash verifies that typing a bare "/" opens the popup with
+// the built-in commands present (/model, /help among them).
+func TestSlashMenuOpensOnSlash(t *testing.T) {
+	m := typeInto(t, NewModel(Options{}), "/").(Model)
+	if !m.menu.active {
+		t.Fatalf("menu should be active after typing '/'")
+	}
+	names := menuNames(m)
+	if !containsAll(names, "/model", "/help") {
+		t.Errorf("candidate set %v missing /model or /help", names)
+	}
+}
+
+// TestSlashMenuFiltersByPrefix verifies the popup narrows to the typed prefix:
+// "/mo" keeps /model and /models but drops /help.
+func TestSlashMenuFiltersByPrefix(t *testing.T) {
+	m := typeInto(t, NewModel(Options{}), "/mo").(Model)
+	if !m.menu.active {
+		t.Fatalf("menu should be active for '/mo'")
+	}
+	names := menuNames(m)
+	if !containsAll(names, "/model", "/models") {
+		t.Errorf("candidate set %v missing /model or /models", names)
+	}
+	for _, n := range names {
+		if !strings.HasPrefix(n, "/mo") {
+			t.Errorf("candidate %q does not match prefix /mo (set %v)", n, names)
+		}
+	}
+}
+
+// TestSlashMenuClosesOnSpace verifies name-completion stops once the buffer moves
+// on to arguments (a space after the command name closes the popup).
+func TestSlashMenuClosesOnSpace(t *testing.T) {
+	m := typeInto(t, NewModel(Options{}), "/model ").(Model)
+	if m.menu.active {
+		t.Errorf("menu should close once the command name is complete (buffer %q)", m.input.Value())
+	}
+}
+
+// TestSlashMenuNavigation verifies arrow keys move the highlighted candidate and
+// wrap at the ends.
+func TestSlashMenuNavigation(t *testing.T) {
+	m := typeInto(t, NewModel(Options{}), "/").(Model)
+	n := len(m.menu.filtered)
+	if n < 2 {
+		t.Fatalf("need at least two candidates to test navigation, got %d", n)
+	}
+	next, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if got := next.(Model).menu.selected; got != 1 {
+		t.Errorf("after Down, selected = %d, want 1", got)
+	}
+	// Up from index 0 wraps to the last candidate.
+	back, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	if got := back.(Model).menu.selected; got != n-1 {
+		t.Errorf("after Up from 0, selected = %d, want %d (wrap)", got, n-1)
+	}
+}
+
+// TestSlashTabCompletes verifies Tab fills the buffer with the highlighted
+// command and closes the popup (ready for arguments).
+func TestSlashTabCompletes(t *testing.T) {
+	m := typeInto(t, NewModel(Options{}), "/hel").(Model)
+	got, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	gm := got.(Model)
+	if gm.input.Value() != "/help " {
+		t.Errorf("after Tab, buffer = %q, want %q", gm.input.Value(), "/help ")
+	}
+	if gm.menu.active {
+		t.Errorf("menu should close after Tab completion")
+	}
+}
+
+// TestSlashHelpExecutesIntoTranscript verifies executing a built-in action
+// command (/help) renders its output into the transcript as a system block —
+// listing the available commands — without requiring a live provider.
+func TestSlashHelpExecutesIntoTranscript(t *testing.T) {
+	m := typeInto(t, NewModel(Options{}), "/help").(Model)
+	got, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	gm := got.(Model)
+	// No run is started for an action command.
+	if cmd != nil {
+		if msg := cmd(); msg != nil {
+			if _, isQuit := msg.(tea.QuitMsg); isQuit {
+				t.Fatalf("/help should not quit")
+			}
+		}
+	}
+	if gm.running {
+		t.Errorf("/help is an action command; model should stay idle")
+	}
+	joined := strings.Join(blockTexts(gm.transcript), "\n")
+	if !strings.Contains(joined, "/help") || !strings.Contains(joined, "/model") {
+		t.Errorf("/help output should list commands (/help, /model); transcript:\n%s", joined)
+	}
+	if gm.input.Value() != "" {
+		t.Errorf("after executing /help, input = %q, want cleared", gm.input.Value())
+	}
+}
+
+// TestSlashUnknownCommandReported verifies an unknown "/name" surfaces the
+// resolver error into the transcript rather than being sent to the agent.
+func TestSlashUnknownCommandReported(t *testing.T) {
+	m := typeInto(t, NewModel(Options{}), "/definitelynotacommand").(Model)
+	// The popup filters to nothing, so it is inactive; Enter routes through submit.
+	got, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	gm := got.(Model)
+	if gm.running {
+		t.Errorf("an unknown command must not start a run")
+	}
+	joined := strings.Join(blockTexts(gm.transcript), "\n")
+	if !strings.Contains(joined, "unknown command") {
+		t.Errorf("expected an unknown-command notice in transcript, got:\n%s", joined)
+	}
+}
+
+// TestSlashMenuRendersAboveInput verifies the popup appears in the View while
+// active, so the candidate list is visible above the input line.
+func TestSlashMenuRendersAboveInput(t *testing.T) {
+	m := NewModel(Options{})
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = typeInto(t, next, "/mo").(Model)
+	view := m.View()
+	if !strings.Contains(view.Content, "/model") {
+		t.Errorf("active popup should render /model in the view content")
+	}
+}
+
+// TestSlashPromptCommandStartsRun verifies a prompt (Expand) command's expanded
+// text is fed to the run seam, not shown as a bare status. A stub startRunFn
+// stands in for the live provider.
+func TestSlashPromptCommandStartsRun(t *testing.T) {
+	m := NewModel(Options{})
+	// Inject a user prompt command directly into the registry.
+	m.slash.AddUser(runtime.SlashCommand{
+		Name:   "greet",
+		Expand: func(args string) string { return "hello " + args },
+	})
+	var ran string
+	m.startRunFn = func(prompt string) (chan tea.Msg, tea.Cmd) {
+		ran = prompt
+		ch := make(chan tea.Msg, 1)
+		return ch, func() tea.Msg { return nil }
+	}
+	got, _ := m.runSlash("/greet world")
+	gm := got.(Model)
+	if ran != "hello world" {
+		t.Errorf("prompt command should start a run with expanded text; got %q", ran)
+	}
+	if !gm.running {
+		t.Errorf("model should be running after a prompt command")
+	}
+}


### PR DESCRIPTION
## Summary
- Build the shared slash registry (`internal/cli/prompts.BuildSlashRegistry`) in the full-screen TUI exactly as the REPL does, bound to the session's live config so `/model` switches reach the run loop. `/model`, `/help`, user templates, plugin commands and `~/.agents/skills` `/skill-name` commands are all available.
- Add an autocomplete popup (`internal/cli/tui/slash.go`) that opens when the input buffer is a `/name` prefix, filters candidates as you type, navigates with arrow keys (wrapping), completes with Tab, and runs with Enter. Keys matched via `tea.KeyPressMsg.String()`.
- Slash results render into the transcript: action commands (`/help`, `/model`) become system blocks; prompt/skill commands start a run; unknown commands surface the resolver error.

Closes #391

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cli/tui/...` (new slash_test.go: candidate set on `/` and `/mo`, prefix filter, space closes menu, arrow nav, Tab complete, `/help` renders into transcript, unknown command reported, prompt command starts run)
- [x] Full `go test ./internal/cli/...` green