### PR TITLE
fix(tui): bottom status bar, Enter-submit multi-line input, markdown, scrollbar, tool args

### DIFF
--- a/internal/cli/tui/input.go
+++ b/internal/cli/tui/input.go
@@ -16,12 +16,16 @@ import (
 // class of bug the old REPL input had — it keyed on byte length (len==1) and
 // silently dropped the trailing bytes of every multi-byte rune. We deliberately
 // delegate all character handling to textarea and never touch bytes ourselves.
+//
+// Shift+Enter inserts a newline so the editor is a true multi-line composer;
+// plain Enter submits (intercepted by the model, never reaching textarea). The
+// default InsertNewline binding (Enter) is therefore rebound to Shift+Enter. See
+// model.handleKey.
 
-// newlineKey is the key chord that inserts a literal newline into the buffer.
-// Enter is reserved by the model for submitting the prompt, so a hard line break
-// is entered with Alt+Enter (ctrl+j is kept as a fallback for terminals that
-// cannot emit alt+enter).
-const newlineKey = "alt+enter"
+// maxInputRows caps how tall the editor grows as the user adds lines. Past this
+// the buffer keeps growing but textarea scrolls its own viewport, so the shell's
+// row accounting stays bounded and the transcript never collapses to nothing.
+const maxInputRows = 6
 
 // input is the prompt editor. It embeds a textarea.Model and exposes just the
 // surface the root model needs: value/clear, focus/blur (input is blurred while
@@ -31,22 +35,23 @@ type input struct {
 	ta textarea.Model
 }
 
-// newInput builds a focused single-visible-row editor. The visible height stays
-// at one row so the model's View row accounting (transcript + status + input)
-// is unchanged; the buffer itself is unbounded and grows across newlines, and
-// textarea scrolls its own viewport when the content exceeds the visible row.
+// newInput builds a focused editor. It starts one row tall and grows with the
+// buffer (up to maxInputRows) as the user inserts newlines with Enter. The
+// buffer itself is unbounded; beyond maxInputRows textarea scrolls internally.
 func newInput() input {
 	ta := textarea.New()
 	ta.Prompt = "> "
+	ta.Placeholder = "输入消息…（Enter 发送，Shift+Enter 换行）"
 	ta.ShowLineNumbers = false
 	ta.CharLimit = 0
+	ta.MaxHeight = maxInputRows
 	ta.SetHeight(1)
-	// Enter must NOT insert a newline: the model intercepts it as submit. Rebind
-	// the newline action to Alt+Enter (see newlineKey) so multi-line input still
-	// works while Enter stays free for submission.
+	// Rebind InsertNewline from its default (Enter) to Shift+Enter: plain Enter is
+	// the model's submit key (handleKey intercepts it before textarea sees it), so
+	// only Shift+Enter breaks a line in the multi-line composer.
 	ta.KeyMap.InsertNewline = key.NewBinding(
-		key.WithKeys(newlineKey, "ctrl+j"),
-		key.WithHelp(newlineKey, "insert newline"),
+		key.WithKeys("shift+enter"),
+		key.WithHelp("shift+enter", "insert newline"),
 	)
 	// Draw the cursor into the rendered string: the model composes View as a
 	// plain string rather than driving textarea's real cursor reporting.
@@ -57,23 +62,50 @@ func newInput() input {
 
 // Update forwards a message (typically a key press) to the underlying textarea
 // and returns the updated component. The model calls this only for keys it does
-// not intercept itself (submit / newline / interrupt / quit), so textarea sees
-// ordinary editing keys — including CJK and emoji runes, which it inserts whole.
+// not intercept itself (submit / interrupt / quit), so textarea sees ordinary
+// editing keys — including Enter (newline) and CJK / emoji runes, which it
+// inserts whole. The visible height is re-synced to the line count afterwards so
+// the editor grows and shrinks with the content.
 func (in input) Update(msg tea.Msg) (input, tea.Cmd) {
 	var cmd tea.Cmd
 	in.ta, cmd = in.ta.Update(msg)
+	in.syncHeight()
 	return in, cmd
 }
+
+// syncHeight resizes the visible editor to the buffer's line count, clamped to
+// [1, maxInputRows]. It is called after every edit and after programmatic value
+// changes so the shell reserves exactly as many rows as the input needs.
+func (in *input) syncHeight() {
+	n := in.ta.LineCount()
+	if n < 1 {
+		n = 1
+	}
+	if n > maxInputRows {
+		n = maxInputRows
+	}
+	in.ta.SetHeight(n)
+}
+
+// Height reports the current visible row count of the editor so the model can
+// reserve that many rows in its View layout.
+func (in input) Height() int { return in.ta.Height() }
 
 // Value returns the current buffer contents, including any embedded newlines.
 func (in input) Value() string { return in.ta.Value() }
 
 // SetValue replaces the buffer contents and moves the cursor to the end. It is
 // used by slash autocomplete (Tab) to complete the buffer to the chosen command.
-func (in *input) SetValue(s string) { in.ta.SetValue(s) }
+func (in *input) SetValue(s string) {
+	in.ta.SetValue(s)
+	in.syncHeight()
+}
 
 // Clear empties the buffer and resets the cursor to the start.
-func (in *input) Clear() { in.ta.Reset() }
+func (in *input) Clear() {
+	in.ta.Reset()
+	in.syncHeight()
+}
 
 // Focus enables editing and returns the cursor-blink Cmd.
 func (in *input) Focus() tea.Cmd { return in.ta.Focus() }

--- a/internal/cli/tui/input_test.go
+++ b/internal/cli/tui/input_test.go
@@ -54,12 +54,12 @@ func TestInputEmojiByRune(t *testing.T) {
 	}
 }
 
-// TestInputAltEnterNewline verifies Alt+Enter inserts a newline into the buffer
-// (the documented multi-line key) while plain runes fill each line.
-func TestInputAltEnterNewline(t *testing.T) {
+// TestInputShiftEnterNewline verifies Shift+Enter inserts a newline into the
+// buffer (the multi-line key) while plain runes fill each line.
+func TestInputShiftEnterNewline(t *testing.T) {
 	in := newInput()
 	in, _ = in.Update(runeKey('你'))
-	in, _ = in.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModAlt})
+	in, _ = in.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift})
 	in, _ = in.Update(runeKey('好'))
 
 	if got := in.Value(); got != "你\n好" {
@@ -69,7 +69,7 @@ func TestInputAltEnterNewline(t *testing.T) {
 
 // TestInputEnterIsNotNewline confirms plain Enter does NOT insert a newline in
 // the editor: the model intercepts it as submit, so the editor must leave it
-// alone (only Alt+Enter breaks a line).
+// alone (only Shift+Enter breaks a line).
 func TestInputEnterIsNotNewline(t *testing.T) {
 	in := newInput()
 	in, _ = in.Update(runeKey('a'))
@@ -101,10 +101,11 @@ func TestInputClearBlurFocus(t *testing.T) {
 	}
 }
 
-// TestModelEnterSubmits feeds a typed line and Enter to the model and asserts the
-// prompt is submitted: the user turn lands in the transcript and the editor is
-// cleared (Enter yields a submit, not a newline). With no startRunFn wired the
-// model stays idle and records the pre-#392 system note.
+// TestModelEnterSubmits feeds a typed line and Enter to the model and asserts
+// the prompt is submitted: the user turn lands in the transcript and the editor
+// is cleared. Enter submits; Shift+Enter is the newline key in the multi-line
+// composer. With no startRunFn wired the model stays idle and records the
+// pre-#392 system note.
 func TestModelEnterSubmits(t *testing.T) {
 	m := NewModel(Options{})
 	var model tea.Model = m

--- a/internal/cli/tui/markdown.go
+++ b/internal/cli/tui/markdown.go
@@ -1,0 +1,76 @@
+package tui
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/charmbracelet/glamour"
+
+	"github.com/smallnest/pigo/internal/cli/ui"
+)
+
+// This file renders finalized assistant turns as Markdown inside the TUI
+// transcript (fix #3, mirroring the REPL's ui.RenderMarkdown). The REPL renders
+// once at turn-end because Markdown can only be laid out when the whole block is
+// known; the transcript does the same — only a finalized assistant block is
+// passed through here, never the still-streaming one.
+//
+// Unlike the REPL's shared renderer (WithWordWrap(0), which relies on the raw
+// terminal to soft-wrap), the transcript lives inside a fixed-width viewport
+// that does NOT soft-wrap, so we must wrap the Markdown to the content width
+// ourselves. Renderers are therefore cached per width and rebuilt when the width
+// changes (a resize), which is rare enough that the rebuild cost is negligible.
+
+var (
+	mdMu    sync.Mutex
+	mdCache = map[int]*glamour.TermRenderer{}
+)
+
+// rendererFor returns a glamour renderer that word-wraps to width columns,
+// building and caching one per distinct width. A build failure caches nothing
+// and returns nil so callers fall back to the raw source.
+func rendererFor(width int) *glamour.TermRenderer {
+	mdMu.Lock()
+	defer mdMu.Unlock()
+	if r, ok := mdCache[width]; ok {
+		return r
+	}
+	wrap := width
+	if wrap < 0 {
+		wrap = 0
+	}
+	r, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(wrap),
+	)
+	if err != nil {
+		return nil
+	}
+	mdCache[width] = r
+	return r
+}
+
+// renderMarkdown returns src rendered as styled terminal Markdown wrapped to
+// width columns. It is gated exactly like the REPL's renderer: when output is
+// not an interactive terminal (pipes, tests) the raw source is returned so
+// golden tests and machine consumers are unaffected. A nil/broken renderer or a
+// render error also returns the raw source, so content is never dropped. The
+// trailing newline glamour appends is trimmed so the block joins cleanly with
+// its neighbors in the transcript.
+func renderMarkdown(src string, width int) string {
+	if !ui.Enabled() {
+		return src
+	}
+	if strings.TrimSpace(src) == "" {
+		return src
+	}
+	r := rendererFor(width)
+	if r == nil {
+		return src
+	}
+	out, err := r.Render(src)
+	if err != nil {
+		return src
+	}
+	return strings.Trim(out, "\n")
+}

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -174,8 +174,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		m.transcript.setSize(msg.Width, transcriptHeight(msg.Height))
-		m.input.SetWidth(msg.Width)
+		m.relayout()
 		return m, nil
 
 	case gitInfoMsg:
@@ -276,9 +275,12 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.menu.moveDown()
 			return m, nil
 		case "tab":
-			return m.completeSlash(), nil
+			m = m.completeSlash()
+			m.relayout()
+			return m, nil
 		case "esc":
 			m.menu.close()
+			m.relayout()
 			return m, nil
 		case "enter":
 			return m.submitSlashSelected()
@@ -316,6 +318,10 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case "enter":
+		// Enter submits the composed buffer (FR-13). Shift+Enter inserts a newline
+		// (rebound in newInput) so the editor is a true multi-line composer; when
+		// the slash menu is open, Enter runs the highlighted command (handled
+		// above), so this branch is only reached with the menu closed.
 		if !m.running {
 			return m.submit()
 		}
@@ -337,6 +343,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		m.input, cmd = m.input.Update(msg)
 		m.menu.refresh(m.input.Value(), m.slash)
+		m.relayout()
 		return m, cmd
 	}
 	return m, nil
@@ -361,6 +368,7 @@ func (m Model) submit() (tea.Model, tea.Cmd) {
 	m.transcript.addUser(prompt)
 	m.input.Clear()
 	m.menu.close()
+	m.relayout()
 	return m.startPrompt(prompt)
 }
 
@@ -397,6 +405,7 @@ func (m Model) runSlash(line string) (tea.Model, tea.Cmd) {
 	m.transcript.addUser(line)
 	m.input.Clear()
 	m.menu.close()
+	m.relayout()
 	if m.slash == nil {
 		m.transcript.addSystem("斜杠命令不可用")
 		return m, nil
@@ -444,8 +453,9 @@ func (m Model) pumpNext() tea.Cmd {
 }
 
 // View implements tea.Model. It renders the shell on the alt-screen: the
-// scrolling transcript filling the top rows, the persistent status bar (#386) on
-// the second-to-last row, and the minimal input line at the bottom. Setting
+// scrolling transcript filling the top rows, then the autocomplete popup (when
+// open) and the multi-line input editor, and finally the persistent status bar
+// (#386) on the very bottom row — below the input, per the layout fix. Setting
 // AltScreen on the returned View is how Bubble Tea v2 enters/leaves the alternate
 // screen buffer, so the user's scrollback is restored on quit.
 func (m Model) View() tea.View {
@@ -464,19 +474,18 @@ func (m Model) View() tea.View {
 
 	status := m.statusBar.Render(width)
 
-	// The input editor renders its own prompt column and cursor; keep it to the
-	// single visible row the View row math reserves.
+	// The input editor renders its own prompt column and cursor across as many
+	// rows as the buffer currently spans (up to maxInputRows).
 	input := m.input.View()
 
-	// Reserve one row for the status bar and one for the input line; the rest is
-	// the transcript area. Guard against tiny terminals so the region never goes
-	// negative.
+	// Fallback transcript rows before the first size message; once sized the
+	// viewport is pre-sized by relayout and pads its own content.
 	rows := transcriptHeight(height)
 	sized := m.width > 0 && m.height > 0
 
 	var b strings.Builder
 	if sized {
-		// The viewport pads its content to exactly `rows` lines.
+		// The viewport pads its content to exactly the rows relayout reserved.
 		b.WriteString(m.transcript.view())
 		b.WriteByte('\n')
 	} else {
@@ -484,8 +493,6 @@ func (m Model) View() tea.View {
 			b.WriteByte('\n')
 		}
 	}
-	b.WriteString(status)
-	b.WriteByte('\n')
 	// The autocomplete popup, when open, renders just above the input line as an
 	// overlay (it contributes no rows while idle, so the empty-shell layout is
 	// unchanged).
@@ -494,13 +501,39 @@ func (m Model) View() tea.View {
 		b.WriteByte('\n')
 	}
 	b.WriteString(input)
+	b.WriteByte('\n')
+	// The status bar is the final line, pinned to the very bottom of the shell
+	// below the input editor.
+	b.WriteString(status)
 
 	return tea.View{Content: b.String(), AltScreen: true}
 }
 
-// transcriptHeight returns the number of rows available to the transcript for a
-// given total terminal height: the total minus the status bar and input rows,
-// floored at zero so tiny terminals never produce a negative extent.
+// relayout re-sizes the transcript to the rows left after reserving the status
+// bar (1 row), the current input editor height, and any open autocomplete popup,
+// and reserves one content column for the transcript scrollbar. It is called on
+// every resize and after any edit that changes the input height or menu row
+// count, so the transcript region always fills exactly the space above the
+// input/status chrome.
+func (m *Model) relayout() {
+	if m.width <= 0 || m.height <= 0 {
+		return
+	}
+	rows := m.height - 1 - m.input.Height() - m.menu.rows()
+	if rows < 0 {
+		rows = 0
+	}
+	content := m.width - 1 // reserve a column for the scrollbar
+	if content < 0 {
+		content = 0
+	}
+	m.transcript.setSize(content, rows)
+	m.input.SetWidth(m.width)
+}
+
+// transcriptHeight returns the fallback number of rows for the transcript before
+// the first size message arrives: the total minus the status bar and a single
+// input row, floored at zero so tiny terminals never produce a negative extent.
 func transcriptHeight(total int) int {
 	h := total - 2
 	if h < 0 {

--- a/internal/cli/tui/slash.go
+++ b/internal/cli/tui/slash.go
@@ -102,6 +102,20 @@ func (mn *slashMenu) refresh(buffer string, reg *runtime.SlashRegistry) {
 	}
 }
 
+// rows reports how many terminal rows the popup occupies when rendered, so the
+// model can reserve that space above the input line during relayout. It is zero
+// while inactive and otherwise the visible window height (min of the candidate
+// count and maxMenuRows).
+func (mn slashMenu) rows() int {
+	if !mn.active || len(mn.filtered) == 0 {
+		return 0
+	}
+	if len(mn.filtered) > maxMenuRows {
+		return maxMenuRows
+	}
+	return len(mn.filtered)
+}
+
 // close deactivates the menu and drops its candidates.
 func (mn *slashMenu) close() {
 	mn.active = false

--- a/internal/cli/tui/toolcard.go
+++ b/internal/cli/tui/toolcard.go
@@ -100,8 +100,12 @@ func (c toolCard) render(theme Theme, width int) string {
 	if nameBudget < 1 {
 		nameBudget = 1
 	}
-	name := TruncateToWidth(c.name, nameBudget)
-	lines = append(lines, icon+" "+theme.ToolHeader.Render(name))
+	header := c.name
+	if arg := c.primaryArg(); arg != "" {
+		header = c.name + "(" + arg + ")"
+	}
+	header = TruncateToWidth(header, nameBudget)
+	lines = append(lines, icon+" "+theme.ToolHeader.Render(header))
 
 	if len(c.input) > 0 {
 		lines = append(lines, theme.ToolBody.Render("调用输入参数"))
@@ -133,6 +137,31 @@ func (c toolCard) render(theme Theme, width int) string {
 		BorderForeground(lipgloss.Color(colorGray)).
 		Width(inner)
 	return border.Render(strings.Join(lines, "\n"))
+}
+
+// primaryArg returns the most salient call argument to inline in the card header
+// so the user can see what the tool is operating on at a glance (FR-6), e.g.
+// Bash(cd /x && git add -A). It picks the command for bash and the file path for
+// the file tools, otherwise the first argument in sorted-key order. Returns ""
+// when the call carried no arguments.
+func (c toolCard) primaryArg() string {
+	if len(c.input) == 0 {
+		return ""
+	}
+	var key string
+	switch strings.ToLower(c.name) {
+	case "bash":
+		key = "command"
+	case "read", "write", "edit", "multiedit":
+		key = "file_path"
+	}
+	if key != "" {
+		if v, ok := c.input[key]; ok {
+			return fmt.Sprintf("%v", v)
+		}
+	}
+	keys := sortedKeys(c.input)
+	return fmt.Sprintf("%v", c.input[keys[0]])
 }
 
 // sortedKeys returns the map keys in a stable (sorted) order so the input

--- a/internal/cli/tui/transcript.go
+++ b/internal/cli/tui/transcript.go
@@ -5,6 +5,7 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 )
@@ -146,9 +147,61 @@ func (t *transcript) update(msg tea.Msg) tea.Cmd {
 	return cmd
 }
 
-// view renders the current visible slice of the transcript.
+// view renders the current visible slice of the transcript with a vertical
+// scrollbar column attached on the right (FR-10), so history is scrollable and
+// the user can see where they are in the log. The scrollbar occupies the single
+// content column relayout reserved (width-1 for the blocks, +1 for the bar).
 func (t transcript) view() string {
-	return t.vp.View()
+	body := t.vp.View()
+	bar := t.scrollbar()
+	if bar == "" {
+		return body
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Top, body, bar)
+}
+
+// scrollbar renders a one-column vertical scrollbar the height of the viewport.
+// When all content fits it is a blank track (keeping the column width stable);
+// otherwise a proportional thumb marks the visible window and its position marks
+// the scroll offset, so scrolling up through history moves the thumb.
+func (t transcript) scrollbar() string {
+	h := t.vp.Height()
+	if h <= 0 {
+		return ""
+	}
+	total := t.vp.TotalLineCount()
+	if total <= h {
+		lines := make([]string, h)
+		for i := range lines {
+			lines[i] = " "
+		}
+		return strings.Join(lines, "\n")
+	}
+	thumb := h * h / total
+	if thumb < 1 {
+		thumb = 1
+	}
+	maxOff := total - h
+	off := t.vp.YOffset()
+	if off > maxOff {
+		off = maxOff
+	}
+	pos := 0
+	if maxOff > 0 {
+		pos = off * (h - thumb) / maxOff
+	}
+	var b strings.Builder
+	for i := 0; i < h; i++ {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		if i >= pos && i < pos+thumb {
+			b.WriteString(t.theme.Accent.Render("█"))
+		} else {
+			b.WriteString(t.theme.System.Render("│"))
+		}
+	}
+	return b.String()
 }
 
 // reflow re-renders every block to the current width and pushes the joined
@@ -164,7 +217,7 @@ func (t *transcript) reflow() {
 		if i > 0 {
 			b.WriteByte('\n')
 		}
-		b.WriteString(t.renderBlock(blk))
+		b.WriteString(t.renderBlock(blk, i == t.activeAssistant))
 	}
 
 	t.vp.SetContent(b.String())
@@ -177,18 +230,23 @@ func (t *transcript) reflow() {
 // renderBlock wraps a block's text to the content width and applies the role's
 // theme style. Wrapping happens on the raw text (measured in display columns via
 // WrapToWidth) before styling so ANSI escapes never confuse the width math and
-// no double-width rune is split.
-func (t transcript) renderBlock(blk transcriptBlock) string {
+// no double-width rune is split. A finalized assistant block is rendered as
+// Markdown (fix #3, mirroring the REPL's turn-end render); the still-streaming
+// block (streaming==true) stays plain text because Markdown can only be laid out
+// once the whole block is known.
+func (t transcript) renderBlock(blk transcriptBlock, streaming bool) string {
 	if blk.role == roleTool && blk.card != nil {
 		return blk.card.render(t.theme, t.width)
 	}
-	wrapped := WrapToWidth(blk.text, t.width)
 	switch blk.role {
 	case roleUser:
-		return t.theme.User.Render(wrapped)
+		return t.theme.User.Render(WrapToWidth(blk.text, t.width))
 	case roleSystem:
-		return t.theme.System.Render(wrapped)
+		return t.theme.System.Render(WrapToWidth(blk.text, t.width))
 	default:
-		return t.theme.Assistant.Render(wrapped)
+		if streaming {
+			return t.theme.Assistant.Render(WrapToWidth(blk.text, t.width))
+		}
+		return renderMarkdown(blk.text, t.width)
 	}
 }


### PR DESCRIPTION
## Summary
Addresses five TUI usability fixes:
1. Status bar moved to the very bottom, below the input box.
2. Multi-line input — **Enter submits, Shift+Enter inserts a newline**; editor grows with the buffer up to `maxInputRows`.
3. Finalized assistant output rendered as Markdown (width-aware cached glamour renderer, gated by `ui.Enabled()` like the REPL); the still-streaming block stays plain.
4. Vertical scrollbar column on the transcript viewport so history is scrollable and the scroll position is visible.
5. Built-in tool cards show the primary argument inline in the header, e.g. `Bash(cd /x && git add -A)`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/cli/tui/...`
- [x] `go test ./internal/cli/tui/...`