### PR TITLE
fix(tui): drop custom scrollbar, use system scroll

### DIFF
--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -522,11 +522,10 @@ func (m Model) View() tea.View {
 }
 
 // relayout re-sizes the transcript to the rows left after reserving the status
-// bar (1 row), the current input editor height, and any open autocomplete popup,
-// and reserves one content column for the transcript scrollbar. It is called on
-// every resize and after any edit that changes the input height or menu row
-// count, so the transcript region always fills exactly the space above the
-// input/status chrome.
+// bar (1 row), the current input editor height, and any open autocomplete popup.
+// It is called on every resize and after any edit that changes the input height
+// or menu row count, so the transcript region always fills exactly the space
+// above the input/status chrome.
 func (m *Model) relayout() {
 	if m.width <= 0 || m.height <= 0 {
 		return
@@ -535,11 +534,7 @@ func (m *Model) relayout() {
 	if rows < 0 {
 		rows = 0
 	}
-	content := m.width - 1 // reserve a column for the scrollbar
-	if content < 0 {
-		content = 0
-	}
-	m.transcript.setSize(content, rows)
+	m.transcript.setSize(m.width, rows)
 	m.input.SetWidth(m.width)
 }
 

--- a/internal/cli/tui/transcript.go
+++ b/internal/cli/tui/transcript.go
@@ -5,7 +5,6 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 )
@@ -147,61 +146,12 @@ func (t *transcript) update(msg tea.Msg) tea.Cmd {
 	return cmd
 }
 
-// view renders the current visible slice of the transcript with a vertical
-// scrollbar column attached on the right (FR-10), so history is scrollable and
-// the user can see where they are in the log. The scrollbar occupies the single
-// content column relayout reserved (width-1 for the blocks, +1 for the bar).
+// view renders the current visible slice of the transcript. Scrolling is driven
+// by the mouse wheel and PgUp/PgDn (see model); the transcript itself draws no
+// decorative scrollbar, so history occupies the full content width and the
+// terminal's own scroll affordance is the only one shown.
 func (t transcript) view() string {
-	body := t.vp.View()
-	bar := t.scrollbar()
-	if bar == "" {
-		return body
-	}
-	return lipgloss.JoinHorizontal(lipgloss.Top, body, bar)
-}
-
-// scrollbar renders a one-column vertical scrollbar the height of the viewport.
-// When all content fits it is a blank track (keeping the column width stable);
-// otherwise a proportional thumb marks the visible window and its position marks
-// the scroll offset, so scrolling up through history moves the thumb.
-func (t transcript) scrollbar() string {
-	h := t.vp.Height()
-	if h <= 0 {
-		return ""
-	}
-	total := t.vp.TotalLineCount()
-	if total <= h {
-		lines := make([]string, h)
-		for i := range lines {
-			lines[i] = " "
-		}
-		return strings.Join(lines, "\n")
-	}
-	thumb := h * h / total
-	if thumb < 1 {
-		thumb = 1
-	}
-	maxOff := total - h
-	off := t.vp.YOffset()
-	if off > maxOff {
-		off = maxOff
-	}
-	pos := 0
-	if maxOff > 0 {
-		pos = off * (h - thumb) / maxOff
-	}
-	var b strings.Builder
-	for i := 0; i < h; i++ {
-		if i > 0 {
-			b.WriteByte('\n')
-		}
-		if i >= pos && i < pos+thumb {
-			b.WriteString(t.theme.Accent.Render("█"))
-		} else {
-			b.WriteString(t.theme.System.Render("│"))
-		}
-	}
-	return b.String()
+	return t.vp.View()
 }
 
 // reflow re-renders every block to the current width and pushes the joined


### PR DESCRIPTION
## Summary
- 移除 transcript 里彩色装饰滚动条（蓝色 thumb / 灰色 track）及其预留列
- transcript 现使用终端全宽；历史通过鼠标滚轮和 PgUp/PgDn 滚动
- 依赖系统/终端自身的滚动条，不再绘制 in-app 滚动装饰

## Test plan
- [x] go build ./...
- [x] go vet ./internal/cli/tui/...
- [x] go test ./internal/cli/tui/... (TestModelViewShell 仍满足全高布局不变量)