### PR TITLE
fix(tui): reliable Shift+Enter newline with Ctrl+J/Alt+Enter fallbacks

### DIFF
--- a/internal/cli/tui/input.go
+++ b/internal/cli/tui/input.go
@@ -47,16 +47,23 @@ type input struct {
 func newInput() input {
 	ta := textarea.New()
 	ta.Prompt = "> "
-	ta.Placeholder = "输入消息…（Enter 发送，Shift+Enter 换行）"
+	ta.Placeholder = "输入消息…（Enter 发送，Shift+Enter / Ctrl+J 换行）"
 	ta.ShowLineNumbers = false
 	ta.CharLimit = 0
 	ta.MaxHeight = maxInputRows
 	ta.SetHeight(1)
-	// Rebind InsertNewline from its default (Enter) to Shift+Enter: plain Enter is
-	// the model's submit key (handleKey intercepts it before textarea sees it), so
-	// only Shift+Enter breaks a line in the multi-line composer.
+	// Rebind InsertNewline from its default (Enter) to keys that break a line in
+	// the multi-line composer, since plain Enter is the model's submit key
+	// (handleKey intercepts it before textarea sees it). Shift+Enter is the
+	// primary binding, but it is only distinguishable from Enter on terminals
+	// that speak the Kitty keyboard protocol (kitty, ghostty, wezterm, recent
+	// iTerm2). On terminals without it (macOS Terminal.app, tmux by default)
+	// Shift+Enter arrives byte-identical to Enter and would submit — dropping the
+	// line the user meant to continue. Ctrl+J (a literal LF, always distinct from
+	// Enter's CR) and Alt+Enter are reliable fallbacks so a newline works
+	// everywhere; all three split the line at the cursor and keep typed text.
 	ta.KeyMap.InsertNewline = key.NewBinding(
-		key.WithKeys("shift+enter"),
+		key.WithKeys("shift+enter", "ctrl+j", "alt+enter"),
 		key.WithHelp("shift+enter", "insert newline"),
 	)
 	// Draw the cursor into the rendered string: the model composes View as a

--- a/internal/cli/tui/model_test.go
+++ b/internal/cli/tui/model_test.go
@@ -45,6 +45,33 @@ func TestModelViewShell(t *testing.T) {
 	}
 }
 
+// TestModelNewlineKeys verifies that the newline keys (Shift+Enter and its
+// terminal-independent fallbacks Ctrl+J / Alt+Enter) insert a line break at the
+// cursor and preserve the already-typed text, rather than submitting. Plain
+// Enter still submits, so the buffer is cleared. This guards the multi-line
+// composer against terminals that can't disambiguate Shift+Enter from Enter.
+func TestModelNewlineKeys(t *testing.T) {
+	newlineKeys := []tea.KeyPressMsg{
+		{Code: tea.KeyEnter, Mod: tea.ModShift},
+		{Code: tea.KeyEnter, Mod: tea.ModAlt},
+		{Code: 'j', Mod: tea.ModCtrl},
+	}
+	for _, nl := range newlineKeys {
+		var mm tea.Model = NewModel(Options{})
+		mm, _ = mm.Update(tea.WindowSizeMsg{Width: 60, Height: 10})
+		for _, r := range "abc" {
+			mm, _ = mm.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+		}
+		mm, _ = mm.Update(nl)
+		for _, r := range "def" {
+			mm, _ = mm.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+		}
+		if got := mm.(Model).input.Value(); got != "abc\ndef" {
+			t.Errorf("%s: input = %q, want %q", nl.String(), got, "abc\ndef")
+		}
+	}
+}
+
 // keyPress builds a KeyPressMsg matching String()==s for the simple keys used
 // in these tests (ctrl+<letter>).
 func keyPress(s string) tea.KeyPressMsg {


### PR DESCRIPTION
## Summary
- Shift+Enter 只有在支持 Kitty 键盘协议的终端（kitty/ghostty/wezterm/新版 iTerm2）才能与 Enter 区分；在 macOS Terminal.app、默认 tmux 等终端下 Shift+Enter 与 Enter 字节完全相同，会触发提交，导致当前行输入丢失
- 为 InsertNewline 增加终端无关的可靠回退键：Ctrl+J（字面 LF，永远区别于 Enter 的 CR）和 Alt+Enter
- 三个键都在光标处换行并保留已输入文本；Enter 仍然提交
- 更新输入框占位提示为「Enter 发送，Shift+Enter / Ctrl+J 换行」

## Test plan
- [x] go build ./...
- [x] go vet ./internal/cli/tui/...
- [x] go test ./internal/cli/tui/... （新增 TestModelNewlineKeys 验证三个换行键均保留 "abc\ndef"）