### PR TITLE
fix(tui): light-gray scrollbar thumb, gutter only while scrolling

### DIFF
--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -541,8 +541,10 @@ func (m Model) View() tea.View {
 var keyboardEnhancements = tea.KeyboardEnhancements{ReportAllKeysAsEscapeCodes: true}
 
 // relayout re-sizes the transcript to the rows left after reserving the status
-// bar (1 row), the current input editor height, and any open autocomplete popup,
-// and reserves one content column for the transcript scrollbar. It is called on
+// bar (1 row), the current input editor height, and any open autocomplete popup.
+// It reserves one content column for the transcript scrollbar only while there
+// is history to scroll (the transcript overflows its viewport); when everything
+// fits, the transcript uses the full width and no column is held. It is called on
 // every resize and after any edit that changes the input height or menu row
 // count, so the transcript region always fills exactly the space above the
 // input/status chrome.
@@ -554,11 +556,16 @@ func (m *Model) relayout() {
 	if rows < 0 {
 		rows = 0
 	}
-	content := m.width - 1 // reserve a column for the scrollbar
-	if content < 0 {
-		content = 0
+	// Size at full width first; the scrollbar column is only reserved when the
+	// content overflows, so a non-scrolling transcript keeps the whole width.
+	m.transcript.setSize(m.width, rows)
+	if m.transcript.overflowing() {
+		content := m.width - 1 // reserve a column for the scrollbar
+		if content < 0 {
+			content = 0
+		}
+		m.transcript.setSize(content, rows)
 	}
-	m.transcript.setSize(content, rows)
 	m.input.SetWidth(m.width)
 }
 

--- a/internal/cli/tui/theme.go
+++ b/internal/cli/tui/theme.go
@@ -35,6 +35,8 @@ type Theme struct {
 	Warn lipgloss.Style
 	// Success styles successful outcomes (green).
 	Success lipgloss.Style
+	// ScrollThumb styles the transcript scrollbar thumb (light gray).
+	ScrollThumb lipgloss.Style
 }
 
 // Palette color numbers use the ANSI 256-color cube so the theme renders
@@ -45,6 +47,7 @@ const (
 	colorWarn    = "214" // yellow/amber
 	colorAccent  = "39"  // blue (file names, highlights)
 	colorGray    = "245" // secondary / muted text
+	colorScroll  = "250" // light gray (scrollbar thumb)
 	colorUser    = "15"  // bright white
 	colorAssist  = "252" // near-white
 	colorStatus  = "62"  // status bar background (violet)
@@ -81,6 +84,8 @@ func DefaultTheme() Theme {
 			Foreground(lipgloss.Color(colorWarn)),
 		Success: lipgloss.NewStyle().
 			Foreground(lipgloss.Color(colorSuccess)),
+		ScrollThumb: lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colorScroll)),
 	}
 }
 

--- a/internal/cli/tui/transcript.go
+++ b/internal/cli/tui/transcript.go
@@ -147,23 +147,32 @@ func (t *transcript) update(msg tea.Msg) tea.Cmd {
 	return cmd
 }
 
-// view renders the current visible slice of the transcript with a vertical
-// scrollbar column attached on the right (FR-10), so history is scrollable and
-// the user can see where they are in the log. The scrollbar occupies the single
-// content column relayout reserved (width-1 for the blocks, +1 for the bar).
-func (t transcript) view() string {
-	body := t.vp.View()
-	bar := t.scrollbar()
-	if bar == "" {
-		return body
-	}
-	return lipgloss.JoinHorizontal(lipgloss.Top, body, bar)
+// overflowing reports whether the transcript has more content than fits in the
+// viewport, i.e. there is history to scroll. relayout uses this to reserve the
+// scrollbar column only when scrolling is possible, and view uses it to decide
+// whether to attach the thumb at all.
+func (t transcript) overflowing() bool {
+	return t.vp.Height() > 0 && t.vp.TotalLineCount() > t.vp.Height()
 }
 
-// scrollbar renders a one-column vertical scrollbar the height of the viewport.
-// When all content fits it is a blank track (keeping the column width stable);
-// otherwise a proportional thumb marks the visible window and its position marks
-// the scroll offset, so scrolling up through history moves the thumb.
+// view renders the current visible slice of the transcript. While there is
+// history to scroll (FR-10) a light-gray thumb is attached in a one-column
+// gutter on the right so the scroll position is visible; the gutter is only
+// present when the content overflows (relayout reserves the column to match), so
+// a non-scrolling transcript uses the full width. There is no track line — the
+// non-thumb rows are blank, so only the thumb is drawn.
+func (t transcript) view() string {
+	if !t.overflowing() {
+		return t.vp.View()
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Top, t.vp.View(), t.scrollbar())
+}
+
+// scrollbar renders the one-column vertical thumb the height of the viewport. It
+// is only called while the transcript overflows: a proportional thumb marks the
+// visible window and its position marks the scroll offset, so scrolling up
+// through history moves the thumb. Non-thumb rows are blank spaces (no track
+// line) that hold the column width stable so the body does not shift.
 func (t transcript) scrollbar() string {
 	h := t.vp.Height()
 	if h <= 0 {
@@ -171,11 +180,7 @@ func (t transcript) scrollbar() string {
 	}
 	total := t.vp.TotalLineCount()
 	if total <= h {
-		lines := make([]string, h)
-		for i := range lines {
-			lines[i] = " "
-		}
-		return strings.Join(lines, "\n")
+		return ""
 	}
 	thumb := h * h / total
 	if thumb < 1 {
@@ -196,9 +201,9 @@ func (t transcript) scrollbar() string {
 			b.WriteByte('\n')
 		}
 		if i >= pos && i < pos+thumb {
-			b.WriteString(t.theme.Accent.Render("█"))
+			b.WriteString(t.theme.ScrollThumb.Render("█"))
 		} else {
-			b.WriteString(t.theme.System.Render("│"))
+			b.WriteByte(' ')
 		}
 	}
 	return b.String()

--- a/internal/cli/tui/transcript_test.go
+++ b/internal/cli/tui/transcript_test.go
@@ -115,3 +115,36 @@ func TestTranscriptCJKWrap(t *testing.T) {
 		t.Errorf("counted %d 你 runes after wrap, want 5", got)
 	}
 }
+
+// TestTranscriptScrollbar verifies the scrollbar policy: the gutter is absent
+// while the content fits (no overflow → full width, no thumb), and once the
+// content overflows a light-gray thumb "█" appears with no track line "│".
+func TestTranscriptScrollbar(t *testing.T) {
+	tr := newTranscript(DefaultTheme())
+	tr.setSize(20, 4) // 4 visible rows
+
+	// Two short lines fit in 4 rows: no overflow, no scrollbar drawn.
+	tr.addUser("one")
+	tr.addUser("two")
+	if tr.overflowing() {
+		t.Fatal("transcript should not overflow while content fits")
+	}
+	if got := stripANSI(tr.view()); strings.Contains(got, "█") || strings.Contains(got, "│") {
+		t.Errorf("no scrollbar expected while content fits; got:\n%q", got)
+	}
+
+	// Enough lines to exceed 4 rows: now it overflows and the thumb appears.
+	for i := 0; i < 10; i++ {
+		tr.addUser("line")
+	}
+	if !tr.overflowing() {
+		t.Fatal("transcript should overflow once content exceeds the viewport")
+	}
+	view := stripANSI(tr.view())
+	if !strings.Contains(view, "█") {
+		t.Errorf("expected a scrollbar thumb █ while overflowing; got:\n%q", view)
+	}
+	if strings.Contains(view, "│") {
+		t.Errorf("scrollbar must not draw a track line │; got:\n%q", view)
+	}
+}


### PR DESCRIPTION
## Summary
- Scrollbar thumb is now **light gray** (color 250) via a new `Theme.ScrollThumb` style, instead of the blue accent.
- **Removed the `│` track line** — non-thumb rows are blank, so only the thumb is painted.
- The scrollbar gutter is **reserved only while the transcript overflows** its viewport (new `transcript.overflowing()`); when all content fits, the transcript uses the full width and no column is held.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/cli/tui/`
- [x] `go test ./internal/cli/tui/` (added `TestTranscriptScrollbar`)
- [ ] Manual: confirm the gutter appears only when there's history to scroll, thumb is light gray, no vertical line