### PR TITLE
fix(tui): revert Kitty flag 8 (fix CJK input), newline is Alt+Enter only

### DIFF
--- a/internal/cli/tui/input.go
+++ b/internal/cli/tui/input.go
@@ -47,24 +47,21 @@ type input struct {
 func newInput() input {
 	ta := textarea.New()
 	ta.Prompt = "> "
-	ta.Placeholder = "输入消息…（Enter 发送，Shift+Enter / Ctrl+J 换行）"
+	ta.Placeholder = "输入消息…（Enter 发送，Alt+Enter 换行）"
 	ta.ShowLineNumbers = false
 	ta.CharLimit = 0
 	ta.MaxHeight = maxInputRows
 	ta.SetHeight(1)
-	// Rebind InsertNewline from its default (Enter) to keys that break a line in
-	// the multi-line composer, since plain Enter is the model's submit key
-	// (handleKey intercepts it before textarea sees it). Shift+Enter is the
-	// primary binding, but it is only distinguishable from Enter on terminals
-	// that speak the Kitty keyboard protocol (kitty, ghostty, wezterm, recent
-	// iTerm2). On terminals without it (macOS Terminal.app, tmux by default)
-	// Shift+Enter arrives byte-identical to Enter and would submit — dropping the
-	// line the user meant to continue. Ctrl+J (a literal LF, always distinct from
-	// Enter's CR) and Alt+Enter are reliable fallbacks so a newline works
-	// everywhere; all three split the line at the cursor and keep typed text.
+	// Rebind InsertNewline from its default (Enter) to Alt+Enter, since plain
+	// Enter is the model's submit key (handleKey intercepts it before textarea
+	// sees it). Alt+Enter is used rather than Shift+Enter because Shift+Enter is
+	// only distinguishable from Enter on terminals speaking the Kitty keyboard
+	// protocol, and forcing that protocol on (Kitty flag 8) broke IME / CJK text
+	// input — so we rely on Alt+Enter, which every terminal reports distinctly
+	// (ESC-prefixed) without any keyboard-protocol enhancement.
 	ta.KeyMap.InsertNewline = key.NewBinding(
-		key.WithKeys("shift+enter", "ctrl+j", "alt+enter"),
-		key.WithHelp("shift+enter", "insert newline"),
+		key.WithKeys("alt+enter"),
+		key.WithHelp("alt+enter", "insert newline"),
 	)
 	// Draw the cursor into the rendered string: the model composes View as a
 	// plain string rather than driving textarea's real cursor reporting.

--- a/internal/cli/tui/input_test.go
+++ b/internal/cli/tui/input_test.go
@@ -54,12 +54,12 @@ func TestInputEmojiByRune(t *testing.T) {
 	}
 }
 
-// TestInputShiftEnterNewline verifies Shift+Enter inserts a newline into the
-// buffer (the multi-line key) while plain runes fill each line.
-func TestInputShiftEnterNewline(t *testing.T) {
+// TestInputAltEnterNewline verifies Alt+Enter inserts a newline into the buffer
+// (the sole multi-line key) while plain runes fill each line.
+func TestInputAltEnterNewline(t *testing.T) {
 	in := newInput()
 	in, _ = in.Update(runeKey('你'))
-	in, _ = in.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift})
+	in, _ = in.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModAlt})
 	in, _ = in.Update(runeKey('好'))
 
 	if got := in.Value(); got != "你\n好" {

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -469,7 +469,7 @@ func (m Model) pumpNext() tea.Cmd {
 // screen buffer, so the user's scrollback is restored on quit.
 func (m Model) View() tea.View {
 	if m.quitting {
-		return tea.View{AltScreen: true, KeyboardEnhancements: keyboardEnhancements}
+		return tea.View{AltScreen: true}
 	}
 
 	width := m.width
@@ -518,27 +518,8 @@ func (m Model) View() tea.View {
 	// MouseModeCellMotion enables click/release/wheel events. Without it the
 	// alt-screen swallows the wheel (no native scrollback), so history could only
 	// be reached via PgUp/PgDn; enabling it lets the wheel scroll the transcript.
-	//
-	// keyboardEnhancements requests Kitty flag 8 (report all keys as escape
-	// codes), which forces Kitty-protocol terminals (ghostty, kitty, wezterm) to
-	// report Shift+Enter as a distinct CSI-u sequence instead of a bare CR — so
-	// the primary Shift+Enter newline binding works natively there. Terminals
-	// without the protocol ignore the request and fall back to Ctrl+J / Alt+Enter.
-	return tea.View{
-		Content:              b.String(),
-		AltScreen:            true,
-		MouseMode:            tea.MouseModeCellMotion,
-		KeyboardEnhancements: keyboardEnhancements,
-	}
+	return tea.View{Content: b.String(), AltScreen: true, MouseMode: tea.MouseModeCellMotion}
 }
-
-// keyboardEnhancements is the Kitty keyboard progressive-enhancement level the
-// TUI requests on every rendered View. ReportAllKeysAsEscapeCodes (Kitty flag 8)
-// makes capable terminals report every key — including Shift+Enter, which they
-// otherwise collapse to a bare CR indistinguishable from plain Enter — as a
-// distinct escape code, so the Shift+Enter newline binding works without any
-// terminal config. See internal/cli/tui/input.go for the newline key bindings.
-var keyboardEnhancements = tea.KeyboardEnhancements{ReportAllKeysAsEscapeCodes: true}
 
 // relayout re-sizes the transcript to the rows left after reserving the status
 // bar (1 row), the current input editor height, and any open autocomplete popup.

--- a/internal/cli/tui/model_test.go
+++ b/internal/cli/tui/model_test.go
@@ -45,30 +45,24 @@ func TestModelViewShell(t *testing.T) {
 	}
 }
 
-// TestModelNewlineKeys verifies that the newline keys (Shift+Enter and its
-// terminal-independent fallbacks Ctrl+J / Alt+Enter) insert a line break at the
-// cursor and preserve the already-typed text, rather than submitting. Plain
-// Enter still submits, so the buffer is cleared. This guards the multi-line
-// composer against terminals that can't disambiguate Shift+Enter from Enter.
+// TestModelNewlineKeys verifies that Alt+Enter inserts a line break at the
+// cursor and preserves the already-typed text, rather than submitting. Plain
+// Enter still submits, so it does not leave a newline in the buffer. Alt+Enter
+// is the sole newline key: it arrives ESC-prefixed and distinct from Enter in
+// every terminal, without needing any keyboard-protocol enhancement (which broke
+// CJK / IME input).
 func TestModelNewlineKeys(t *testing.T) {
-	newlineKeys := []tea.KeyPressMsg{
-		{Code: tea.KeyEnter, Mod: tea.ModShift},
-		{Code: tea.KeyEnter, Mod: tea.ModAlt},
-		{Code: 'j', Mod: tea.ModCtrl},
+	var mm tea.Model = NewModel(Options{})
+	mm, _ = mm.Update(tea.WindowSizeMsg{Width: 60, Height: 10})
+	for _, r := range "abc" {
+		mm, _ = mm.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
 	}
-	for _, nl := range newlineKeys {
-		var mm tea.Model = NewModel(Options{})
-		mm, _ = mm.Update(tea.WindowSizeMsg{Width: 60, Height: 10})
-		for _, r := range "abc" {
-			mm, _ = mm.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
-		}
-		mm, _ = mm.Update(nl)
-		for _, r := range "def" {
-			mm, _ = mm.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
-		}
-		if got := mm.(Model).input.Value(); got != "abc\ndef" {
-			t.Errorf("%s: input = %q, want %q", nl.String(), got, "abc\ndef")
-		}
+	mm, _ = mm.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModAlt})
+	for _, r := range "def" {
+		mm, _ = mm.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+	if got := mm.(Model).input.Value(); got != "abc\ndef" {
+		t.Errorf("input = %q, want %q", got, "abc\ndef")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Revert Kitty flag 8 (ReportAllKeysAsEscapeCodes) which broke Chinese/IME input in the composer
- Narrow newline binding to Alt+Enter only (Shift+Enter needed the now-removed Kitty protocol)

## Test plan
- [x] go build ./...
- [x] go vet ./internal/cli/tui/
- [x] go test ./internal/cli/tui/