### PR TITLE
fix(tui): make transcript scrollbar visible with shaded track

### DIFF
--- a/internal/cli/tui/theme.go
+++ b/internal/cli/tui/theme.go
@@ -35,8 +35,10 @@ type Theme struct {
 	Warn lipgloss.Style
 	// Success styles successful outcomes (green).
 	Success lipgloss.Style
-	// ScrollThumb styles the transcript scrollbar thumb (light gray).
+	// ScrollThumb styles the transcript scrollbar thumb (medium gray block).
 	ScrollThumb lipgloss.Style
+	// ScrollTrack styles the transcript scrollbar track (dim shaded column).
+	ScrollTrack lipgloss.Style
 }
 
 // Palette color numbers use the ANSI 256-color cube so the theme renders
@@ -47,7 +49,8 @@ const (
 	colorWarn    = "214" // yellow/amber
 	colorAccent  = "39"  // blue (file names, highlights)
 	colorGray    = "245" // secondary / muted text
-	colorScroll  = "250" // light gray (scrollbar thumb)
+	colorScroll  = "245" // scrollbar thumb (medium gray, visible on light+dark)
+	colorTrack   = "238" // scrollbar track (dim gray)
 	colorUser    = "15"  // bright white
 	colorAssist  = "252" // near-white
 	colorStatus  = "62"  // status bar background (violet)
@@ -86,6 +89,8 @@ func DefaultTheme() Theme {
 			Foreground(lipgloss.Color(colorSuccess)),
 		ScrollThumb: lipgloss.NewStyle().
 			Foreground(lipgloss.Color(colorScroll)),
+		ScrollTrack: lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colorTrack)),
 	}
 }
 

--- a/internal/cli/tui/transcript.go
+++ b/internal/cli/tui/transcript.go
@@ -171,8 +171,10 @@ func (t transcript) view() string {
 // scrollbar renders the one-column vertical thumb the height of the viewport. It
 // is only called while the transcript overflows: a proportional thumb marks the
 // visible window and its position marks the scroll offset, so scrolling up
-// through history moves the thumb. Non-thumb rows are blank spaces (no track
-// line) that hold the column width stable so the body does not shift.
+// through history moves the thumb. Non-thumb rows draw a dim shaded track (░) so
+// the scrollbar is always visible as a column when scrolling is possible; the
+// solid thumb (█) contrasts against it on any terminal background. This is not
+// the thin │ rule that was removed — it is a full-width shaded gutter.
 func (t transcript) scrollbar() string {
 	h := t.vp.Height()
 	if h <= 0 {
@@ -203,7 +205,7 @@ func (t transcript) scrollbar() string {
 		if i >= pos && i < pos+thumb {
 			b.WriteString(t.theme.ScrollThumb.Render("█"))
 		} else {
-			b.WriteByte(' ')
+			b.WriteString(t.theme.ScrollTrack.Render("░"))
 		}
 	}
 	return b.String()


### PR DESCRIPTION
## Summary
- The light-gray thumb blended into the terminal background, so the scrollbar looked absent even while the transcript overflowed
- Draw a dim shaded track (░) on non-thumb rows and a contrasting medium-gray █ thumb, visible on light and dark backgrounds
- Shaded gutter, not the thin │ rule that was removed earlier

## Test plan
- [x] go build ./...
- [x] go test ./internal/cli/tui/