### PR TITLE
fix(tui): persistent vertical scrollbar always visible

### DIFF
--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -537,16 +537,13 @@ func (m *Model) relayout() {
 	if rows < 0 {
 		rows = 0
 	}
-	// Size at full width first; the scrollbar column is only reserved when the
-	// content overflows, so a non-scrolling transcript keeps the whole width.
-	m.transcript.setSize(m.width, rows)
-	if m.transcript.overflowing() {
-		content := m.width - 1 // reserve a column for the scrollbar
-		if content < 0 {
-			content = 0
-		}
-		m.transcript.setSize(content, rows)
+	// Reserve one content column for the persistent scrollbar so the transcript
+	// body never shifts as history grows past a screen.
+	content := m.width - 1
+	if content < 0 {
+		content = 0
 	}
+	m.transcript.setSize(content, rows)
 	m.input.SetWidth(m.width)
 }
 

--- a/internal/cli/tui/theme.go
+++ b/internal/cli/tui/theme.go
@@ -49,8 +49,8 @@ const (
 	colorWarn    = "214" // yellow/amber
 	colorAccent  = "39"  // blue (file names, highlights)
 	colorGray    = "245" // secondary / muted text
-	colorScroll  = "245" // scrollbar thumb (medium gray, visible on light+dark)
-	colorTrack   = "238" // scrollbar track (dim gray)
+	colorScroll  = "244" // scrollbar thumb (medium gray, visible on light+dark)
+	colorTrack   = "252" // scrollbar track (very light gray, subtle)
 	colorUser    = "15"  // bright white
 	colorAssist  = "252" // near-white
 	colorStatus  = "62"  // status bar background (violet)

--- a/internal/cli/tui/transcript.go
+++ b/internal/cli/tui/transcript.go
@@ -155,47 +155,42 @@ func (t transcript) overflowing() bool {
 	return t.vp.Height() > 0 && t.vp.TotalLineCount() > t.vp.Height()
 }
 
-// view renders the current visible slice of the transcript. While there is
-// history to scroll (FR-10) a light-gray thumb is attached in a one-column
-// gutter on the right so the scroll position is visible; the gutter is only
-// present when the content overflows (relayout reserves the column to match), so
-// a non-scrolling transcript uses the full width. There is no track line — the
-// non-thumb rows are blank, so only the thumb is drawn.
+// view renders the current visible slice of the transcript with a persistent
+// one-column vertical scrollbar down the right edge (FR-10). The scrollbar is
+// always present (relayout reserves its column) so it never flickers in and out:
+// a light-gray track (░) runs the full height and a darker thumb (█) marks the
+// visible window. When the whole transcript fits, the thumb fills the column.
 func (t transcript) view() string {
-	if !t.overflowing() {
-		return t.vp.View()
-	}
 	return lipgloss.JoinHorizontal(lipgloss.Top, t.vp.View(), t.scrollbar())
 }
 
-// scrollbar renders the one-column vertical thumb the height of the viewport. It
-// is only called while the transcript overflows: a proportional thumb marks the
-// visible window and its position marks the scroll offset, so scrolling up
-// through history moves the thumb. Non-thumb rows draw a dim shaded track (░) so
-// the scrollbar is always visible as a column when scrolling is possible; the
-// solid thumb (█) contrasts against it on any terminal background. This is not
-// the thin │ rule that was removed — it is a full-width shaded gutter.
+// scrollbar renders the one-column vertical scrollbar the height of the
+// viewport. A proportional thumb (█) marks the visible window and its position
+// marks the scroll offset, so scrolling up through history moves the thumb; the
+// remaining rows draw a light-gray track (░). When the content fits (no
+// overflow) the thumb fills the full height. This is a shaded gutter, not the
+// thin │ rule that was removed earlier.
 func (t transcript) scrollbar() string {
 	h := t.vp.Height()
 	if h <= 0 {
 		return ""
 	}
 	total := t.vp.TotalLineCount()
-	if total <= h {
-		return ""
-	}
-	thumb := h * h / total
-	if thumb < 1 {
-		thumb = 1
-	}
-	maxOff := total - h
-	off := t.vp.YOffset()
-	if off > maxOff {
-		off = maxOff
-	}
+	thumb := h
 	pos := 0
-	if maxOff > 0 {
-		pos = off * (h - thumb) / maxOff
+	if total > h {
+		thumb = h * h / total
+		if thumb < 1 {
+			thumb = 1
+		}
+		maxOff := total - h
+		off := t.vp.YOffset()
+		if off > maxOff {
+			off = maxOff
+		}
+		if maxOff > 0 {
+			pos = off * (h - thumb) / maxOff
+		}
 	}
 	var b strings.Builder
 	for i := 0; i < h; i++ {

--- a/internal/cli/tui/transcript_test.go
+++ b/internal/cli/tui/transcript_test.go
@@ -116,24 +116,31 @@ func TestTranscriptCJKWrap(t *testing.T) {
 	}
 }
 
-// TestTranscriptScrollbar verifies the scrollbar policy: the gutter is absent
-// while the content fits (no overflow → full width, no thumb), and once the
-// content overflows a light-gray thumb "█" appears with no track line "│".
+// TestTranscriptScrollbar verifies the persistent scrollbar policy: the gutter
+// is always present. While the content fits, the thumb "█" fills the full height
+// (no track). Once the content overflows, a shorter thumb "█" appears alongside
+// the light-gray track "░", and never the thin rule "│".
 func TestTranscriptScrollbar(t *testing.T) {
 	tr := newTranscript(DefaultTheme())
 	tr.setSize(20, 4) // 4 visible rows
 
-	// Two short lines fit in 4 rows: no overflow, no scrollbar drawn.
+	// Two short lines fit in 4 rows: scrollbar present, thumb fills the column,
+	// no track and no rule.
 	tr.addUser("one")
 	tr.addUser("two")
 	if tr.overflowing() {
 		t.Fatal("transcript should not overflow while content fits")
 	}
-	if got := stripANSI(tr.view()); strings.Contains(got, "█") || strings.Contains(got, "│") {
-		t.Errorf("no scrollbar expected while content fits; got:\n%q", got)
+	fit := stripANSI(tr.view())
+	if !strings.Contains(fit, "█") {
+		t.Errorf("expected a full-height thumb █ while content fits; got:\n%q", fit)
+	}
+	if strings.Contains(fit, "░") {
+		t.Errorf("no track ░ expected while content fits (thumb fills column); got:\n%q", fit)
 	}
 
-	// Enough lines to exceed 4 rows: now it overflows and the thumb appears.
+	// Enough lines to exceed 4 rows: now it overflows, thumb shrinks and track
+	// appears.
 	for i := 0; i < 10; i++ {
 		tr.addUser("line")
 	}
@@ -143,6 +150,9 @@ func TestTranscriptScrollbar(t *testing.T) {
 	view := stripANSI(tr.view())
 	if !strings.Contains(view, "█") {
 		t.Errorf("expected a scrollbar thumb █ while overflowing; got:\n%q", view)
+	}
+	if !strings.Contains(view, "░") {
+		t.Errorf("expected a track ░ while overflowing; got:\n%q", view)
 	}
 	if strings.Contains(view, "│") {
 		t.Errorf("scrollbar must not draw a track line │; got:\n%q", view)


### PR DESCRIPTION
## Summary
- The scrollbar was conditional on overflow and drew a lone faint block, so it often looked absent
- Make it persistent: a right-edge column is always reserved; a light-gray track (░) runs full height with a medium-gray █ thumb marking the visible window (thumb fills the column when everything fits)

## Test plan
- [x] go build ./...
- [x] go test ./internal/cli/tui/