### PR TITLE
fix(tui): keep scrollbar aligned after markdown render

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2
 	github.com/charmbracelet/glamour v1.0.0
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/pflag v1.0.10
@@ -25,7 +26,6 @@ require (
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/internal/cli/tui/markdown.go
+++ b/internal/cli/tui/markdown.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/smallnest/pigo/internal/cli/ui"
 )
@@ -72,5 +73,16 @@ func renderMarkdown(src string, width int) string {
 	if err != nil {
 		return src
 	}
-	return strings.Trim(out, "\n")
+	// Glamour word-wraps prose to width, but its document margin and
+	// non-wrapping elements (code blocks, tables) can still emit lines wider than
+	// the content column. The transcript viewport does not clip horizontally, so
+	// an over-wide line would spill into (and visually erase) the persistent
+	// scrollbar column on its right. Hard-wrap the rendered output — ANSI- and
+	// wide-char-aware — so every line fits within width and the scrollbar stays
+	// put. Prose already within width is untouched.
+	trimmed := strings.Trim(out, "\n")
+	if width > 0 {
+		trimmed = ansi.Hardwrap(trimmed, width, false)
+	}
+	return trimmed
 }


### PR DESCRIPTION
## Summary
- After a turn finalized to markdown, glamour's margins / non-wrapping blocks emitted lines wider than the content column
- The viewport doesn't clip horizontally, so those lines spilled into and erased the persistent scrollbar column
- Hard-wrap rendered markdown (ANSI- and wide-char-aware) to the content width so the scrollbar stays visible

## Test plan
- [x] go build ./...
- [x] go test ./internal/cli/tui/
- [x] go mod tidy