### PR TITLE
fix(tui): stop terminal query reply leaking into the input box

### DIFF
--- a/internal/cli/tui/markdown.go
+++ b/internal/cli/tui/markdown.go
@@ -25,11 +25,41 @@ import (
 var (
 	mdMu    sync.Mutex
 	mdCache = map[int]*glamour.TermRenderer{}
+	// mdDark selects the glamour style: a dark palette when true (the default,
+	// matching most terminals), a light palette when false. It is set once from
+	// the terminal's real background via SetMarkdownDark and never queried at
+	// render time — see the comment there.
+	mdDark = true
 )
+
+// SetMarkdownDark records whether the terminal has a dark background and drops
+// the renderer cache so the next render rebuilds with the matching style.
+//
+// This is the fix for the escape-sequence leak into the input box: glamour's
+// WithAutoStyle() detects the palette by issuing its OWN synchronous OSC 11
+// background-color query and reading the reply straight from the tty. Under the
+// alt-screen, bubbletea already owns the input reader, so that reply
+// (\x1b]11;rgb:…\x07) races with — and is swallowed by — bubbletea's parser,
+// which then leaks the unparsed tail (e.g. "1;rgb:0000/0000/0000" plus a stray
+// SGR mouse report) into the textarea as literal text. We instead let bubbletea
+// detect the background the parser-safe way (RequestBackgroundColor →
+// BackgroundColorMsg) and feed the result here, then build glamour with a fixed
+// WithStandardStyle so it never touches the terminal.
+func SetMarkdownDark(dark bool) {
+	mdMu.Lock()
+	defer mdMu.Unlock()
+	if dark == mdDark {
+		return
+	}
+	mdDark = dark
+	mdCache = map[int]*glamour.TermRenderer{}
+}
 
 // rendererFor returns a glamour renderer that word-wraps to width columns,
 // building and caching one per distinct width. A build failure caches nothing
-// and returns nil so callers fall back to the raw source.
+// and returns nil so callers fall back to the raw source. The style is fixed
+// (WithStandardStyle) rather than auto-detected, so building a renderer never
+// queries the terminal.
 func rendererFor(width int) *glamour.TermRenderer {
 	mdMu.Lock()
 	defer mdMu.Unlock()
@@ -40,8 +70,12 @@ func rendererFor(width int) *glamour.TermRenderer {
 	if wrap < 0 {
 		wrap = 0
 	}
+	style := "dark"
+	if !mdDark {
+		style = "light"
+	}
 	r, err := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
+		glamour.WithStandardStyle(style),
 		glamour.WithWordWrap(wrap),
 	)
 	if err != nil {

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -162,7 +162,9 @@ func (m Model) withSession(s *runSession, history []agentcore.Message) Model {
 // can show the branch/dirty state as soon as it resolves; the alt-screen is
 // requested declaratively via the AltScreen field on the View returned by View.
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(fetchGitCmd(m.cwd), m.input.Focus())
+	return tea.Batch(fetchGitCmd(m.cwd), m.input.Focus(), func() tea.Msg {
+		return tea.RequestBackgroundColor()
+	})
 }
 
 // Update implements tea.Model. It tracks the terminal size, drives the minimal
@@ -179,6 +181,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case gitInfoMsg:
 		m.statusBar.SetGit(msg)
+		return m, nil
+
+	case tea.BackgroundColorMsg:
+		// Feed the terminal's real background to the Markdown renderer so glamour
+		// picks a matching light/dark palette WITHOUT issuing its own terminal
+		// query (which would leak its reply into the input — see SetMarkdownDark).
+		// Re-flow so any already-finalized assistant block re-renders in the right
+		// palette.
+		SetMarkdownDark(msg.IsDark())
+		m.transcript.reflow()
 		return m, nil
 
 	case tea.MouseWheelMsg:


### PR DESCRIPTION
## Summary
- Replaced glamour's `WithAutoStyle()` (which issues its own OSC 11 background-color query and reads the reply straight from the tty) with a fixed `WithStandardStyle`, so building a Markdown renderer never touches the terminal.
- Detect the terminal background the parser-safe way: `Init` now issues `RequestBackgroundColor()`, and `Update` handles `BackgroundColorMsg` → `SetMarkdownDark(msg.IsDark())` + reflow.

Under the alt-screen, bubbletea owns the input reader, so glamour's query reply raced with and was swallowed by bubbletea's parser, which leaked the unparsed tail (`1;rgb:0000/0000/0000` + a stray SGR mouse report `[<65;81;15M`) into the input box as literal text after a Markdown render.

## Test plan
- [x] go build ./...
- [x] go vet ./internal/cli/tui/
- [x] go test ./internal/cli/tui/