### PR TITLE
feat(tui): separate consecutive turns with a blank line

### DIFF
--- a/internal/cli/tui/transcript.go
+++ b/internal/cli/tui/transcript.go
@@ -218,6 +218,11 @@ func (t *transcript) reflow() {
 	for i, blk := range t.blocks {
 		if i > 0 {
 			b.WriteByte('\n')
+			// Separate a new user turn from the previous turn with a blank line so
+			// consecutive requests are visually distinct.
+			if blk.role == roleUser {
+				b.WriteByte('\n')
+			}
 		}
 		b.WriteString(t.renderBlock(blk, i == t.activeAssistant))
 	}


### PR DESCRIPTION
## Summary
- In the transcript reflow, prefix each user turn (every block after the first) with a blank line so consecutive requests are visually separated.

## Test plan
- [x] go build ./...
- [x] go test ./internal/cli/tui/