### PR TITLE
feat(hooks): InstallHooks assembly helper + seam combinators

### DIFF
--- a/docs/issue#0419.html
+++ b/docs/issue#0419.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0419</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/419">#419</a> &mdash; hooks: Dispatcher 接线骨架 + 单一 InstallHooks 装配 helper &mdash; 2026-07-30</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Helper lives in cli/run, not runtime</h3>
+      <p><strong>Ambiguity:</strong> Where does hook→seam assembly belong?</p>
+      <p><strong>Choice:</strong> <code>internal/cli/run/hooks_install.go</code>. runtime exposes only generic seams and never imports hooks; cli knows both <code>Config.Hooks</code> and the seams.</p>
+      <p><strong>Rationale:</strong> Prevents a <code>runtime→hooks→runtime</code> import cycle and keeps runtime hook-agnostic, exactly as the issue and SPEC §2.2/§2.3 require.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Combinator semantics per seam</h3>
+      <p><strong>Ambiguity:</strong> "generic combinators" — how should two seams merge?</p>
+      <p><strong>Choice:</strong> BeforeToolCall: prev-first, block short-circuits (earlier gate authoritative). AfterToolCall: next's non-nil result wins (last-writer). ShouldStop: OR, prev short-circuits.</p>
+      <p><strong>Rationale:</strong> Matches the trust→hook chain design (trust blocks authoritatively) and the last-writer-wins merge already used inside the Dispatcher (§5.4).</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> InstallHooks wires no seam yet</h3>
+      <p><strong>Spec said:</strong> InstallHooks composes hook dispatch into RunConfig's seams.</p>
+      <p><strong>Implemented instead:</strong> It builds (or nil-short-circuits) the Dispatcher and accepts <code>*runtime.RunConfig</code> for a stable signature, but attaches nothing. The <code>chain*</code> combinators are provided for #420–#424 to do the actual attaching.</p>
+      <p><strong>Why:</strong> The issue explicitly scopes this to "骨架与空短路"; wiring concrete events here would be dead code until the event payloads (#420–#424) exist.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> AfterToolCall combinator: sequential vs field-merge</h3>
+      <p><strong>Alternatives:</strong> (a) last-writer-wins on the whole result, (b) field-by-field merge of two <code>AfterToolCallResult</code>s.</p>
+      <p><strong>Chosen (a):</strong> Simpler and predictable; the executor already applies a single result field-by-field over the tool output.</p>
+      <p><strong>Con:</strong> Two After seams both wanting to override different fields can't co-exist — acceptable now since only PostToolUse uses this seam; revisit if a second consumer appears.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should InstallHooks also thread SessionID into HookInput now?</h3>
+      <p><strong>Assumption:</strong> <code>HookDeps.SessionID</code> is captured but unused until an event is wired.</p>
+      <p><strong>Verify:</strong> Whether #420 will read SessionID from HookDeps or from the RunConfig.SessionID field directly — the two must not diverge.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/cli/run/hooks_install.go
+++ b/internal/cli/run/hooks_install.go
@@ -1,0 +1,105 @@
+// This file provides the single cli-layer assembly helper that composes hook
+// dispatch into a runtime.RunConfig. It lives in the cli layer (not runtime) to
+// avoid a runtime→hooks→runtime import cycle: runtime stays hook-agnostic and
+// only exposes the generic seams (BeforeToolCall/AfterToolCall/ShouldStopAfterTurn),
+// while this helper knows about both the resolved Config.Hooks and the seams.
+//
+// #419 establishes the skeleton: InstallHooks builds a Dispatcher (or short-
+// circuits to nil when no hooks are configured, FR-18) and offers generic
+// decorator combinators for the seams. The concrete per-event wiring is filled
+// in by later issues (#420–#424); this file deliberately wires no event yet.
+package run
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/hooks"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// HookDeps carries the run-scoped context a Dispatcher needs: the session id and
+// project directory that populate each HookInput / the hook process environment,
+// and the writer that receives isolation warnings. WarnLog may be nil (defaults
+// to os.Stderr), matching the plugin.EventNotifier convention.
+type HookDeps struct {
+	SessionID  string
+	ProjectDir string
+	WarnLog    io.Writer
+}
+
+// InstallHooks builds the Dispatcher for a run from the resolved hook set and
+// returns it for later per-event wiring. It short-circuits when no hooks are
+// configured: NewDispatcher returns nil for an empty set, so the hot path pays
+// nothing (FR-18) and callers can hold the possibly-nil dispatcher safely.
+//
+// This skeleton does not yet attach the dispatcher to any RunConfig seam; the
+// cfg parameter is accepted now so the signature is stable for #420–#424, which
+// will wrap cfg's seams via the chain* combinators below.
+func InstallHooks(cfg *runtime.RunConfig, set hooks.HookSet, deps HookDeps) *hooks.Dispatcher {
+	warn := deps.WarnLog
+	if warn == nil {
+		warn = os.Stderr
+	}
+	return hooks.NewDispatcher(set, deps.ProjectDir, warn)
+}
+
+// chainBeforeToolCall composes two BeforeToolCall seams into one that runs prev
+// first, then next. A blocking decision from prev short-circuits (next does not
+// run), so an earlier gate (e.g. trust) is authoritative over a later hook. A
+// nil operand is treated as identity, so composing onto an unset seam returns
+// the other unchanged.
+func chainBeforeToolCall(prev, next agentcore.BeforeToolCallFunc) agentcore.BeforeToolCallFunc {
+	if prev == nil {
+		return next
+	}
+	if next == nil {
+		return prev
+	}
+	return func(ctx context.Context, call agentcore.AgentToolCall) *agentcore.BeforeToolCallDecision {
+		if dec := prev(ctx, call); dec != nil && dec.Block {
+			return dec
+		}
+		return next(ctx, call)
+	}
+}
+
+// chainAfterToolCall composes two AfterToolCall seams into one that runs prev
+// first, then next. next's non-nil result wins (last writer), so a hook layered
+// after an existing seam can override it; when next returns nil, prev's result
+// is preserved. A nil operand is identity.
+func chainAfterToolCall(prev, next agentcore.AfterToolCallFunc) agentcore.AfterToolCallFunc {
+	if prev == nil {
+		return next
+	}
+	if next == nil {
+		return prev
+	}
+	return func(ctx context.Context, call agentcore.AgentToolCall, result agentcore.AgentToolResult, isError bool) *agentcore.AfterToolCallResult {
+		prevRes := prev(ctx, call, result, isError)
+		if nextRes := next(ctx, call, result, isError); nextRes != nil {
+			return nextRes
+		}
+		return prevRes
+	}
+}
+
+// chainShouldStop composes two ShouldStopAfterTurn seams with OR semantics: the
+// run stops after a turn if either predicate says so. prev runs first and
+// short-circuits when true. A nil operand is identity.
+func chainShouldStop(prev, next func(context.Context, *agentcore.AgentContext) bool) func(context.Context, *agentcore.AgentContext) bool {
+	if prev == nil {
+		return next
+	}
+	if next == nil {
+		return prev
+	}
+	return func(ctx context.Context, agentCtx *agentcore.AgentContext) bool {
+		if prev(ctx, agentCtx) {
+			return true
+		}
+		return next(ctx, agentCtx)
+	}
+}

--- a/internal/cli/run/hooks_install_test.go
+++ b/internal/cli/run/hooks_install_test.go
@@ -1,0 +1,108 @@
+package run
+
+import (
+	"context"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/hooks"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+func TestInstallHooksEmptyShortCircuits(t *testing.T) {
+	var cfg runtime.RunConfig
+	if d := InstallHooks(&cfg, nil, HookDeps{ProjectDir: t.TempDir()}); d != nil {
+		t.Fatalf("expected nil dispatcher for empty hook set, got %v", d)
+	}
+	if d := InstallHooks(&cfg, hooks.HookSet{}, HookDeps{}); d != nil {
+		t.Fatalf("expected nil dispatcher for empty map, got %v", d)
+	}
+}
+
+func TestInstallHooksBuildsDispatcher(t *testing.T) {
+	set := hooks.HookSet{
+		"PreToolUse": {{Matcher: "*", Hooks: []hooks.HookConfig{{Command: "true"}}}},
+	}
+	var cfg runtime.RunConfig
+	d := InstallHooks(&cfg, set, HookDeps{ProjectDir: t.TempDir()})
+	if d == nil {
+		t.Fatal("expected non-nil dispatcher for non-empty hook set")
+	}
+}
+
+func TestChainBeforeToolCall(t *testing.T) {
+	block := &agentcore.BeforeToolCallDecision{Block: true}
+	allow := func(context.Context, agentcore.AgentToolCall) *agentcore.BeforeToolCallDecision { return nil }
+	deny := func(context.Context, agentcore.AgentToolCall) *agentcore.BeforeToolCallDecision { return block }
+
+	// nil operands act as identity.
+	if got := chainBeforeToolCall(nil, deny); got == nil {
+		t.Fatal("nil prev should return next")
+	}
+	if got := chainBeforeToolCall(allow, nil); got == nil {
+		t.Fatal("nil next should return prev")
+	}
+
+	// prev blocks → short-circuit, next never runs.
+	nextRan := false
+	spy := func(context.Context, agentcore.AgentToolCall) *agentcore.BeforeToolCallDecision {
+		nextRan = true
+		return nil
+	}
+	if dec := chainBeforeToolCall(deny, spy)(context.Background(), agentcore.AgentToolCall{}); dec == nil || !dec.Block {
+		t.Fatalf("expected block decision, got %v", dec)
+	}
+	if nextRan {
+		t.Fatal("next should not run after prev blocks")
+	}
+
+	// prev allows → next runs and decides.
+	if dec := chainBeforeToolCall(allow, deny)(context.Background(), agentcore.AgentToolCall{}); dec == nil || !dec.Block {
+		t.Fatalf("expected next's block decision, got %v", dec)
+	}
+}
+
+func TestChainAfterToolCall(t *testing.T) {
+	content := agentcore.ContentList{}
+	prevRes := &agentcore.AfterToolCallResult{Content: &content}
+	nextRes := &agentcore.AfterToolCallResult{Content: &content}
+	prev := func(context.Context, agentcore.AgentToolCall, agentcore.AgentToolResult, bool) *agentcore.AfterToolCallResult {
+		return prevRes
+	}
+	nilNext := func(context.Context, agentcore.AgentToolCall, agentcore.AgentToolResult, bool) *agentcore.AfterToolCallResult {
+		return nil
+	}
+	next := func(context.Context, agentcore.AgentToolCall, agentcore.AgentToolResult, bool) *agentcore.AfterToolCallResult {
+		return nextRes
+	}
+
+	// next returns nil → prev's result preserved.
+	if got := chainAfterToolCall(prev, nilNext)(context.Background(), agentcore.AgentToolCall{}, agentcore.AgentToolResult{}, false); got != prevRes {
+		t.Fatalf("expected prev result when next is nil, got %v", got)
+	}
+	// next returns non-nil → next wins.
+	if got := chainAfterToolCall(prev, next)(context.Background(), agentcore.AgentToolCall{}, agentcore.AgentToolResult{}, false); got != nextRes {
+		t.Fatalf("expected next result to win, got %v", got)
+	}
+}
+
+func TestChainShouldStop(t *testing.T) {
+	yes := func(context.Context, *agentcore.AgentContext) bool { return true }
+	no := func(context.Context, *agentcore.AgentContext) bool { return false }
+
+	if got := chainShouldStop(no, no)(context.Background(), nil); got {
+		t.Fatal("both false should be false")
+	}
+	if got := chainShouldStop(no, yes)(context.Background(), nil); !got {
+		t.Fatal("next true should stop")
+	}
+	// prev true short-circuits without consulting next.
+	nextRan := false
+	spy := func(context.Context, *agentcore.AgentContext) bool { nextRan = true; return false }
+	if got := chainShouldStop(yes, spy)(context.Background(), nil); !got {
+		t.Fatal("prev true should stop")
+	}
+	if nextRan {
+		t.Fatal("next should not run after prev returns true")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/cli/run/hooks_install.go` with `InstallHooks(*runtime.RunConfig, hooks.HookSet, HookDeps) *hooks.Dispatcher`
- Builds the Dispatcher from resolved `Config.Hooks`; returns nil (no wiring, zero hot-path cost) when no hooks configured (FR-18)
- Lives in cli layer to avoid `runtime→hooks→runtime` import cycle (SPEC §2.2/§2.3)
- Generic decorator combinators for the seams: `chainBeforeToolCall` (prev-first, block short-circuits), `chainAfterToolCall` (next non-nil wins), `chainShouldStop` (OR) — for #420–#424 to attach concrete events
- Warn writer parameterized, defaults to os.Stderr
- Skeleton: wires no seam yet

Closes #419

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/cli/run/...`
- [x] `go vet` + gofmt clean
- [x] Tests: empty short-circuit, non-empty construction, all three combinators (identity, short-circuit, last-writer)