### PR TITLE
hooks: wire PreToolUse + PostToolUse into tool execution

### DIFF
--- a/docs/issue#0420.html
+++ b/docs/issue#0420.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0420</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/420">#420</a> &mdash; hooks: PreToolUse + PostToolUse 接线 &mdash; 2026-07-30</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> PreToolUse chains after the trust gate, never replaces it</h3>
+      <p><strong>Ambiguity:</strong> The <code>BeforeToolCall</code> seam is already occupied by <code>trust.BeforeToolCall</code>. How to add a hook without losing the trust gate?</p>
+      <p><strong>Choice:</strong> <code>InstallHooks</code> wraps the existing seam via <code>chainBeforeToolCall(existingTrust, preToolCallHook)</code>. Trust runs first; a trust block short-circuits before the user hook runs.</p>
+      <p><strong>Rationale:</strong> Keeps the trust gate authoritative (issue's key constraint) while layering user hooks on top. Matches the block-short-circuit combinator semantics defined in #419.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> updatedInput is re-validated against the tool schema</h3>
+      <p><strong>Ambiguity:</strong> Spec says a PreToolUse hook may rewrite tool args; it does not say whether the rewrite is trusted.</p>
+      <p><strong>Choice:</strong> The executor replaces <code>args</code> with <code>UpdatedInput</code> and re-runs <code>Registry.Validate</code>; a schema-invalid rewrite becomes a validation error result.</p>
+      <p><strong>Rationale:</strong> A hook must not be able to smuggle malformed arguments past the tool's own schema contract.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> PostToolUse feedback is appended, block is advisory</h3>
+      <p><strong>Ambiguity:</strong> What does a PostToolUse block mean for an already-executed tool?</p>
+      <p><strong>Choice:</strong> Post cannot undo execution. <code>reason</code> + <code>additionalContext</code> are joined and appended as a new text block onto a clone of the result content via <code>AfterToolCallResult.Content</code>.</p>
+      <p><strong>Rationale:</strong> The tool already ran and had side effects; the only honest action is to surface the hook's feedback to the model, not pretend the call didn't happen.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Added an optional field to BeforeToolCallDecision</h3>
+      <p><strong>Spec said:</strong> Reuse <code>BeforeToolCallDecision{Block, Content}</code> for PreToolUse.</p>
+      <p><strong>Implemented instead:</strong> Added an additive optional <code>UpdatedInput json.RawMessage</code> field, since the original struct could only block, not rewrite args.</p>
+      <p><strong>Why:</strong> The <code>updatedInput</code> acceptance criterion cannot be expressed by the block-only struct. SPEC §4.5 sanctions additive optional fields as non-breaking.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> tool_response payload = marshaled result content, not a typed shape</h3>
+      <p><strong>Alternatives:</strong> (a) marshal the whole <code>AgentToolResult</code>, (b) marshal only <code>result.Content</code>, (c) define a dedicated wire type.</p>
+      <p><strong>Chosen (b):</strong> Passes the content the model would see, which is what a Post hook wants to inspect. Marshal failure degrades to an empty (omitted) field.</p>
+      <p><strong>Con:</strong> Post hooks don't see IsError / Terminate flags. Acceptable for v1 observation/feedback; revisit if a consumer needs the full result.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should InstallHooks be idempotent across repeated calls?</h3>
+      <p><strong>Assumption:</strong> <code>InstallHooks</code> is called once per run. Calling it twice would double-wrap the seams (hooks fire twice).</p>
+      <p><strong>Verify:</strong> When #425 converges all drivers, confirm each driver calls <code>InstallHooks</code> exactly once per run config.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/agentcore/helpers.go
+++ b/internal/agentcore/helpers.go
@@ -40,11 +40,15 @@ type PrepareArgumentsFunc func(ctx context.Context, toolName string, args json.R
 
 // BeforeToolCallDecision is the optional result of the beforeToolCall hook. When
 // Block is true the tool is not executed and an error result is produced;
-// Content/Details override the default block message when set.
+// Content/Details override the default block message when set. When Block is
+// false and UpdatedInput is non-empty, it replaces the tool's raw arguments
+// before execution (PreToolUse rewrite, FR-8); the replacement is re-validated
+// against the tool schema.
 type BeforeToolCallDecision struct {
-	Block   bool
-	Content *ContentList
-	Details *any
+	Block        bool
+	Content      *ContentList
+	Details      *any
+	UpdatedInput json.RawMessage
 }
 
 // BeforeToolCallFunc runs after validation and may block the call (permission /

--- a/internal/agenttool/tool_executor.go
+++ b/internal/agenttool/tool_executor.go
@@ -105,19 +105,30 @@ func prepareToolCall(ctx context.Context, cfg ToolExecutorConfig, call agentcore
 		return nil, nil, &r, true
 	}
 
-	// beforeToolCall hook (may block).
+	// beforeToolCall hook (may block or rewrite arguments).
 	if cfg.BeforeToolCall != nil {
-		if dec := cfg.BeforeToolCall(ctx, agentcore.AgentToolCall{ID: call.ID, Name: call.Name, Arguments: args}); dec != nil && dec.Block {
-			r := agentcore.AgentToolResult{}
-			if dec.Content != nil {
-				r.Content = *dec.Content
-			} else {
-				r.Content = agentcore.ContentList{agentcore.NewTextContent(fmt.Sprintf("tool %q blocked by beforeToolCall", call.Name))}
+		if dec := cfg.BeforeToolCall(ctx, agentcore.AgentToolCall{ID: call.ID, Name: call.Name, Arguments: args}); dec != nil {
+			if dec.Block {
+				r := agentcore.AgentToolResult{}
+				if dec.Content != nil {
+					r.Content = *dec.Content
+				} else {
+					r.Content = agentcore.ContentList{agentcore.NewTextContent(fmt.Sprintf("tool %q blocked by beforeToolCall", call.Name))}
+				}
+				if dec.Details != nil {
+					r.Details = *dec.Details
+				}
+				return nil, nil, &r, true
 			}
-			if dec.Details != nil {
-				r.Details = *dec.Details
+			// Argument rewrite (PreToolUse updatedInput): replace and re-validate
+			// so a hook cannot smuggle schema-invalid args past the tool.
+			if len(dec.UpdatedInput) > 0 {
+				args = dec.UpdatedInput
+				if errs := cfg.Registry.Validate(call.Name, args); len(errs) > 0 {
+					r := ValidationErrorResult(call.Name, errs)
+					return nil, nil, &r, true
+				}
 			}
-			return nil, nil, &r, true
 		}
 	}
 

--- a/internal/cli/run/hooks_install.go
+++ b/internal/cli/run/hooks_install.go
@@ -12,6 +12,7 @@ package run
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 
@@ -31,19 +32,104 @@ type HookDeps struct {
 }
 
 // InstallHooks builds the Dispatcher for a run from the resolved hook set and
-// returns it for later per-event wiring. It short-circuits when no hooks are
-// configured: NewDispatcher returns nil for an empty set, so the hot path pays
-// nothing (FR-18) and callers can hold the possibly-nil dispatcher safely.
+// wires the tool-execution hook points into cfg. It short-circuits when no hooks
+// are configured: NewDispatcher returns nil for an empty set, so the hot path
+// pays nothing (FR-18) and nothing is wrapped. The returned dispatcher is used
+// by later per-event wiring (#421–#424).
 //
-// This skeleton does not yet attach the dispatcher to any RunConfig seam; the
-// cfg parameter is accepted now so the signature is stable for #420–#424, which
-// will wrap cfg's seams via the chain* combinators below.
+// PreToolUse is CHAINED onto the existing BeforeToolCall seam (occupied by the
+// trust gate) rather than replacing it: trust runs first and stays authoritative
+// (a trust block short-circuits before the user hook runs). PostToolUse is
+// chained onto AfterToolCall as a last-writer so it can append feedback to an
+// already-executed tool's result without undoing it.
 func InstallHooks(cfg *runtime.RunConfig, set hooks.HookSet, deps HookDeps) *hooks.Dispatcher {
 	warn := deps.WarnLog
 	if warn == nil {
 		warn = os.Stderr
 	}
-	return hooks.NewDispatcher(set, deps.ProjectDir, warn)
+	d := hooks.NewDispatcher(set, deps.ProjectDir, warn)
+	if d == nil {
+		return nil
+	}
+
+	tec := &cfg.Batch.ToolExecutorConfig
+	tec.BeforeToolCall = chainBeforeToolCall(tec.BeforeToolCall, preToolCallHook(d, deps))
+	tec.AfterToolCall = chainAfterToolCall(tec.AfterToolCall, postToolCallHook(d, deps))
+	return d
+}
+
+// preToolCallHook adapts the dispatcher's PreToolUse event to the BeforeToolCall
+// seam. It dispatches with the tool name and raw arguments; a block becomes a
+// blocking decision whose reason is surfaced as the tool's error result, and an
+// updatedInput becomes an argument rewrite (re-validated by the executor).
+func preToolCallHook(d *hooks.Dispatcher, deps HookDeps) agentcore.BeforeToolCallFunc {
+	return func(ctx context.Context, call agentcore.AgentToolCall) *agentcore.BeforeToolCallDecision {
+		dec := d.Dispatch(ctx, hooks.EventPreToolUse, call.Name, hooks.HookInput{
+			EventType:  hooks.EventPreToolUse,
+			SessionID:  deps.SessionID,
+			ProjectDir: deps.ProjectDir,
+			ToolName:   call.Name,
+			ToolInput:  call.Arguments,
+		})
+		if dec.Block {
+			content := agentcore.ContentList{agentcore.NewTextContent(hookReason(dec.Reason, call.Name))}
+			return &agentcore.BeforeToolCallDecision{Block: true, Content: &content}
+		}
+		if len(dec.UpdatedInput) > 0 {
+			return &agentcore.BeforeToolCallDecision{UpdatedInput: dec.UpdatedInput}
+		}
+		return nil
+	}
+}
+
+// postToolCallHook adapts the dispatcher's PostToolUse event to the AfterToolCall
+// seam. It dispatches with the tool name, raw arguments, and the tool's response,
+// then appends any reason/additionalContext to the result content as a new text
+// block (the executed tool is never undone). A block on Post is treated as
+// feedback only: it cannot retract an already-run tool, so we surface the reason.
+func postToolCallHook(d *hooks.Dispatcher, deps HookDeps) agentcore.AfterToolCallFunc {
+	return func(ctx context.Context, call agentcore.AgentToolCall, result agentcore.AgentToolResult, isError bool) *agentcore.AfterToolCallResult {
+		var resp json.RawMessage
+		if b, err := json.Marshal(result.Content); err == nil {
+			resp = b
+		}
+		dec := d.Dispatch(ctx, "PostToolUse", call.Name, hooks.HookInput{
+			EventType:    "PostToolUse",
+			SessionID:    deps.SessionID,
+			ProjectDir:   deps.ProjectDir,
+			ToolName:     call.Name,
+			ToolInput:    call.Arguments,
+			ToolResponse: resp,
+		})
+		feedback := joinHookText(dec.Reason, dec.AdditionalContext)
+		if feedback == "" {
+			return nil
+		}
+		content := append(agentcore.ContentList{}, result.Content...)
+		content = append(content, agentcore.NewTextContent(feedback))
+		return &agentcore.AfterToolCallResult{Content: &content}
+	}
+}
+
+// hookReason returns the block reason, falling back to a generic message keyed on
+// the tool name when the hook gave no reason.
+func hookReason(reason, toolName string) string {
+	if reason != "" {
+		return reason
+	}
+	return "tool " + toolName + " blocked by PreToolUse hook"
+}
+
+// joinHookText joins two hook text fields with a newline, dropping empties.
+func joinHookText(a, b string) string {
+	switch {
+	case a == "":
+		return b
+	case b == "":
+		return a
+	default:
+		return a + "\n" + b
+	}
 }
 
 // chainBeforeToolCall composes two BeforeToolCall seams into one that runs prev

--- a/internal/cli/run/hooks_tooluse_test.go
+++ b/internal/cli/run/hooks_tooluse_test.go
@@ -1,0 +1,189 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/hooks"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// recordingTool is a fake AgentTool that records whether Execute ran and echoes
+// a fixed result, so a PreToolUse block can be asserted as "never executed".
+type recordingTool struct {
+	name string
+	ran  *bool
+}
+
+func (t recordingTool) Name() string            { return t.name }
+func (t recordingTool) Description() string     { return "fake" }
+func (t recordingTool) Schema() json.RawMessage { return nil }
+func (t recordingTool) ExecutionMode() agentcore.ToolExecutionMode {
+	return agentcore.ToolExecutionSequential
+}
+func (t recordingTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+	*t.ran = true
+	return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent("executed")}}, nil
+}
+
+func wiredConfig(t *testing.T, tool agentcore.AgentTool, set hooks.HookSet) runtime.RunConfig {
+	t.Helper()
+	reg := agenttool.NewToolRegistry()
+	if err := reg.Register(tool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	var cfg runtime.RunConfig
+	cfg.Batch.ToolExecutorConfig.Registry = reg
+	if d := InstallHooks(&cfg, set, HookDeps{SessionID: "s1", ProjectDir: t.TempDir()}); d == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	return cfg
+}
+
+// TestPreToolUseBlocksBashRmRf: a PreToolUse hook matching bash inspects the
+// piped tool_input for "rm -rf" and exits 2 with a reason; the tool must not run
+// and the reason must surface in the result the model receives.
+func TestPreToolUseBlocksBashRmRf(t *testing.T) {
+	ran := false
+	tool := recordingTool{name: "bash", ran: &ran}
+	// Hook: block (exit 2) when stdin JSON contains "rm -rf", printing a reason.
+	cmd := `if grep -q "rm -rf" ; then echo "dangerous command blocked" 1>&2; exit 2; fi`
+	set := hooks.HookSet{
+		"PreToolUse": {{Matcher: "bash", Hooks: []hooks.HookConfig{{Command: cmd}}}},
+	}
+	cfg := wiredConfig(t, tool, set)
+
+	call := agentcore.AgentToolCall{ID: "1", Name: "bash", Arguments: json.RawMessage(`{"command":"rm -rf /tmp/x"}`)}
+	msgs, _ := agenttool.ExecuteToolCalls(context.Background(), cfg.Batch, []agentcore.AgentToolCall{call}, nil)
+
+	if ran {
+		t.Fatal("tool must not execute when PreToolUse blocks")
+	}
+	if len(msgs) != 1 || !msgs[0].IsError {
+		t.Fatalf("blocked call should be an error result: %+v", msgs)
+	}
+	if txt := textOfMsg(msgs[0]); !strings.Contains(txt, "dangerous command blocked") {
+		t.Fatalf("block reason not surfaced to model, got %q", txt)
+	}
+}
+
+// TestPreToolUseAllowsSafeBash: the same hook allows a command without "rm -rf".
+func TestPreToolUseAllowsSafeBash(t *testing.T) {
+	ran := false
+	tool := recordingTool{name: "bash", ran: &ran}
+	cmd := `if grep -q "rm -rf" ; then echo "blocked" 1>&2; exit 2; fi`
+	set := hooks.HookSet{
+		"PreToolUse": {{Matcher: "bash", Hooks: []hooks.HookConfig{{Command: cmd}}}},
+	}
+	cfg := wiredConfig(t, tool, set)
+
+	call := agentcore.AgentToolCall{ID: "1", Name: "bash", Arguments: json.RawMessage(`{"command":"ls"}`)}
+	msgs, _ := agenttool.ExecuteToolCalls(context.Background(), cfg.Batch, []agentcore.AgentToolCall{call}, nil)
+
+	if !ran {
+		t.Fatal("safe command should execute")
+	}
+	if msgs[0].IsError {
+		t.Fatalf("safe command should not error: %+v", msgs[0])
+	}
+}
+
+// TestPostToolUseAppendsFeedback: a PostToolUse hook prints additionalContext,
+// which must be appended to the executed tool's result (not undo it).
+func TestPostToolUseAppendsFeedback(t *testing.T) {
+	ran := false
+	tool := recordingTool{name: "write", ran: &ran}
+	cmd := `echo '{"additionalContext":"linted: 0 issues"}'`
+	set := hooks.HookSet{
+		"PostToolUse": {{Matcher: "write", Hooks: []hooks.HookConfig{{Command: cmd}}}},
+	}
+	cfg := wiredConfig(t, tool, set)
+
+	call := agentcore.AgentToolCall{ID: "1", Name: "write", Arguments: json.RawMessage(`{"path":"a.go"}`)}
+	msgs, _ := agenttool.ExecuteToolCalls(context.Background(), cfg.Batch, []agentcore.AgentToolCall{call}, nil)
+
+	if !ran {
+		t.Fatal("tool should execute; Post hook must not undo it")
+	}
+	txt := allTextOfMsg(msgs[0])
+	if !strings.Contains(txt, "executed") {
+		t.Fatalf("original result lost: %q", txt)
+	}
+	if !strings.Contains(txt, "linted: 0 issues") {
+		t.Fatalf("Post hook feedback not appended: %q", txt)
+	}
+}
+
+// TestPreToolUseUpdatedInputRewritesArgs: a PreToolUse hook returns updatedInput,
+// which must replace the tool's arguments before execution.
+func TestPreToolUseUpdatedInputRewritesArgs(t *testing.T) {
+	var gotArgs json.RawMessage
+	captured := false
+	tool := capturingTool{name: "bash", got: &gotArgs, captured: &captured}
+	reg := agenttool.NewToolRegistry()
+	if err := reg.Register(tool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	cmd := `echo '{"updatedInput":{"command":"echo safe"}}'`
+	set := hooks.HookSet{
+		"PreToolUse": {{Matcher: "*", Hooks: []hooks.HookConfig{{Command: cmd}}}},
+	}
+	var cfg runtime.RunConfig
+	cfg.Batch.ToolExecutorConfig.Registry = reg
+	if d := InstallHooks(&cfg, set, HookDeps{ProjectDir: t.TempDir()}); d == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	call := agentcore.AgentToolCall{ID: "1", Name: "bash", Arguments: json.RawMessage(`{"command":"rm -rf /"}`)}
+	agenttool.ExecuteToolCalls(context.Background(), cfg.Batch, []agentcore.AgentToolCall{call}, nil)
+
+	if !captured {
+		t.Fatal("tool should have executed with rewritten args")
+	}
+	if !strings.Contains(string(gotArgs), "echo safe") {
+		t.Fatalf("args not rewritten by updatedInput, got %q", string(gotArgs))
+	}
+}
+
+type capturingTool struct {
+	name     string
+	got      *json.RawMessage
+	captured *bool
+}
+
+func (t capturingTool) Name() string            { return t.name }
+func (t capturingTool) Description() string     { return "capture" }
+func (t capturingTool) Schema() json.RawMessage { return nil }
+func (t capturingTool) ExecutionMode() agentcore.ToolExecutionMode {
+	return agentcore.ToolExecutionSequential
+}
+func (t capturingTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+	*t.got = args
+	*t.captured = true
+	return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent("ok")}}, nil
+}
+
+func textOfMsg(msg agentcore.ToolResultMessage) string {
+	if len(msg.Content) == 0 {
+		return ""
+	}
+	if tc, ok := msg.Content[0].(agentcore.TextContent); ok {
+		return tc.Text
+	}
+	return ""
+}
+
+func allTextOfMsg(msg agentcore.ToolResultMessage) string {
+	var b strings.Builder
+	for _, c := range msg.Content {
+		if tc, ok := c.(agentcore.TextContent); ok {
+			b.WriteString(tc.Text)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary
- Chain PreToolUse onto the `BeforeToolCall` seam after the trust gate (trust stays authoritative; either block intercepts).
- Support PreToolUse `updatedInput` arg rewrite with schema re-validation via a new additive `BeforeToolCallDecision.UpdatedInput` field.
- Chain PostToolUse onto `AfterToolCall`, appending `reason`/`additionalContext` to the result without undoing the executed tool.

Closes #420

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/agenttool/... ./internal/cli/run/... ./internal/hooks/...`
- [x] Integration: bash+`rm -rf` blocked (not executed, reason surfaced); write→Post feedback appended; updatedInput rewrites args