### PR TITLE
hooks: UserPromptSubmit dispatch with block + one-shot injection

### DIFF
--- a/docs/issue#0421.html
+++ b/docs/issue#0421.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0421</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/421">#421</a> &mdash; hooks: UserPromptSubmit 接线 (注入 + 阻断) &mdash; 2026-07-30</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> additionalContext injected via a one-shot reminder, not a persisted message</h3>
+      <p><strong>Ambiguity:</strong> The spec requires the hook's <code>additionalContext</code> to reach the model on this turn but NOT enter persisted history. <code>ReminderRegistry</code> providers fire every turn.</p>
+      <p><strong>Choice:</strong> Added <code>OneShotReminderProvider</code> (<code>sync.Once</code>) that emits its body on the first consultation, then stays silent. <code>DispatchUserPromptSubmit</code> registers one onto <code>cfg.Reminders</code>.</p>
+      <p><strong>Rationale:</strong> Reminders are already ephemeral (injected into the per-turn request copy via <code>TransformContext</code>, never written back to <code>AgentContext.Messages</code>), so a one-shot provider gives exactly "this turn only, not persisted" — matching SPEC §11.3's explicit assumption.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Block takes strict priority over injection</h3>
+      <p><strong>Ambiguity:</strong> What if a hook both blocks and returns additionalContext?</p>
+      <p><strong>Choice:</strong> On <code>dec.Block</code>, return <code>(true, reason)</code> immediately and register no reminder.</p>
+      <p><strong>Rationale:</strong> A blocked prompt is never submitted, so there is no turn to inject into. Injecting would leak orphaned context into the next unrelated prompt.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Helper reports (block, reason); callers own the abort</h3>
+      <p><strong>Ambiguity:</strong> Block behavior differs per driver (REPL returns to input + shows reason; headless exits non-zero).</p>
+      <p><strong>Choice:</strong> <code>DispatchUserPromptSubmit</code> only reports the decision; it does not abort. The two drivers map (block, reason) to their own control flow.</p>
+      <p><strong>Rationale:</strong> Keeps the cli-layer helper driver-agnostic and testable in isolation, consistent with the #419/#420 seam-helper pattern.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Per-driver call sites deferred to #425</h3>
+      <p><strong>Spec said:</strong> "REPL 与 headless 提示词入口均在提交前同步分发 UserPromptSubmit".</p>
+      <p><strong>Implemented instead:</strong> #421 delivers the reusable mechanism (<code>DispatchUserPromptSubmit</code> + <code>OneShotReminderProvider</code>) and integration tests; the actual REPL/headless call-site wiring lands in #425 (全 driver 收敛), which converges every driver's InstallHooks + prompt gate at once.</p>
+      <p><strong>Why:</strong> Same staging as #420 — wiring one driver in isolation would be undone by #425's convergence. The mechanism is complete and independently tested now.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> One-shot state lives in the provider, not the registry</h3>
+      <p><strong>Alternatives:</strong> (a) fire-once flag inside the provider, (b) a registry that removes a provider after it fires.</p>
+      <p><strong>Chosen (a):</strong> <code>sync.Once</code> in the provider keeps the registry a dumb append-only list and needs no mutation/removal API.</p>
+      <p><strong>Con:</strong> A spent provider stays in the slice and is consulted (cheaply) every turn. Acceptable — a handful of prompt-submit reminders per session, each an O(1) no-op after firing.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should the one-shot reminder survive a compaction boundary?</h3>
+      <p><strong>Assumption:</strong> If the prompt turn triggers compaction before the model consults reminders, the one-shot may fire against the post-compaction turn instead. In practice injection happens on the immediate next request, so this is not observed.</p>
+      <p><strong>Verify:</strong> When #425 wires the real call sites, confirm the reminder is registered right before the loop's next request so the "next turn" is always the intended one.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/cli/run/hooks_prompt.go
+++ b/internal/cli/run/hooks_prompt.go
@@ -1,0 +1,55 @@
+// This file provides the cli-layer helper that runs the UserPromptSubmit hook
+// event (US-007, FR-9) at the two prompt entry points (REPL + headless) before a
+// prompt is submitted to the loop. It lives in the cli layer alongside the other
+// hook assembly (hooks_install.go) because it bridges the resolved Dispatcher and
+// the runtime.RunConfig, which runtime itself must not know about.
+//
+// Two hook effects are supported, with block taking priority over injection:
+//
+//   - block (decision=block / exit 2): the prompt is NOT submitted. The caller
+//     decides how to surface the reason — the REPL returns to its input state and
+//     shows it, the headless driver exits non-zero. DispatchUserPromptSubmit only
+//     reports (block, reason); it does not itself abort.
+//   - additionalContext: registered as a ONE-SHOT reminder on cfg.Reminders so the
+//     text is injected into THIS turn's provider context via the existing
+//     TransformContext seam, then never again. It is not written to the persisted
+//     message history (the reminder mechanism is ephemeral by construction).
+package run
+
+import (
+	"context"
+
+	"github.com/smallnest/pigo/internal/hooks"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// DispatchUserPromptSubmit runs the UserPromptSubmit event for a prompt about to
+// be submitted. It returns (block, reason): when block is true the caller must
+// NOT submit the prompt and should surface reason. When block is false and the
+// hook returned additionalContext, that context is registered as a one-shot
+// reminder on cfg.Reminders (allocating a registry when cfg.Reminders is nil) so
+// it is injected into this turn only. Block takes priority: a blocking decision
+// never also injects.
+//
+// A nil dispatcher (no hooks configured) is a no-op that returns (false, "").
+func DispatchUserPromptSubmit(ctx context.Context, d *hooks.Dispatcher, cfg *runtime.RunConfig, deps HookDeps, prompt string) (block bool, reason string) {
+	if d == nil {
+		return false, ""
+	}
+	dec := d.Dispatch(ctx, "UserPromptSubmit", "", hooks.HookInput{
+		EventType:  "UserPromptSubmit",
+		SessionID:  deps.SessionID,
+		ProjectDir: deps.ProjectDir,
+		Prompt:     prompt,
+	})
+	if dec.Block {
+		return true, hookReason(dec.Reason, "UserPromptSubmit")
+	}
+	if dec.AdditionalContext != "" && cfg != nil {
+		if cfg.Reminders == nil {
+			cfg.Reminders = runtime.NewReminderRegistry()
+		}
+		cfg.Reminders.Register(runtime.NewOneShotReminder("user-prompt-submit", dec.AdditionalContext))
+	}
+	return false, ""
+}

--- a/internal/cli/run/hooks_prompt_test.go
+++ b/internal/cli/run/hooks_prompt_test.go
@@ -1,0 +1,97 @@
+package run
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/hooks"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// promptDispatcher builds a Dispatcher for a single UserPromptSubmit matcher.
+func promptDispatcher(t *testing.T, cmd string) *hooks.Dispatcher {
+	t.Helper()
+	set := hooks.HookSet{
+		"UserPromptSubmit": {{Matcher: "*", Hooks: []hooks.HookConfig{{Command: cmd}}}},
+	}
+	d := hooks.NewDispatcher(set, t.TempDir(), nil)
+	if d == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	return d
+}
+
+// TestUserPromptSubmitBlocks: a hook exiting 2 with a stderr reason blocks the
+// prompt; DispatchUserPromptSubmit reports (true, reason) and injects nothing.
+func TestUserPromptSubmitBlocks(t *testing.T) {
+	d := promptDispatcher(t, `echo "prompt rejected" 1>&2; exit 2`)
+	var cfg runtime.RunConfig
+	block, reason := DispatchUserPromptSubmit(context.Background(), d, &cfg, HookDeps{SessionID: "s1"}, "hello")
+
+	if !block {
+		t.Fatal("expected block")
+	}
+	if !strings.Contains(reason, "prompt rejected") {
+		t.Fatalf("block reason not surfaced, got %q", reason)
+	}
+	if cfg.Reminders != nil && !cfg.Reminders.Empty() {
+		t.Fatal("a blocking decision must not register a reminder")
+	}
+}
+
+// TestUserPromptSubmitInjectsOnce: a hook printing additionalContext registers a
+// one-shot reminder that fires exactly once, then goes silent.
+func TestUserPromptSubmitInjectsOnce(t *testing.T) {
+	d := promptDispatcher(t, `echo '{"additionalContext":"remember: run gofmt"}'`)
+	var cfg runtime.RunConfig
+	block, _ := DispatchUserPromptSubmit(context.Background(), d, &cfg, HookDeps{SessionID: "s1"}, "hello")
+
+	if block {
+		t.Fatal("additionalContext must not block")
+	}
+	if cfg.Reminders == nil || cfg.Reminders.Empty() {
+		t.Fatal("additionalContext should register a reminder")
+	}
+
+	// First turn: the injected context appears.
+	first := cfg.Reminders.Messages(context.Background(), nil)
+	if len(first) != 1 {
+		t.Fatalf("expected 1 reminder message on first turn, got %d", len(first))
+	}
+	if txt := textOfUserMsg(first[0]); !strings.Contains(txt, "remember: run gofmt") {
+		t.Fatalf("injected context missing, got %q", txt)
+	}
+
+	// Second turn: the one-shot provider is silent.
+	if second := cfg.Reminders.Messages(context.Background(), nil); len(second) != 0 {
+		t.Fatalf("one-shot reminder must not fire twice, got %d", len(second))
+	}
+}
+
+// TestUserPromptSubmitNilDispatcher: no hooks configured is a no-op.
+func TestUserPromptSubmitNilDispatcher(t *testing.T) {
+	var cfg runtime.RunConfig
+	block, reason := DispatchUserPromptSubmit(context.Background(), nil, &cfg, HookDeps{}, "hello")
+	if block || reason != "" {
+		t.Fatalf("nil dispatcher should be a no-op, got (%v, %q)", block, reason)
+	}
+	if cfg.Reminders != nil {
+		t.Fatal("nil dispatcher must not allocate a registry")
+	}
+}
+
+func textOfUserMsg(m agentcore.AgentMessage) string {
+	um, ok := m.(agentcore.UserMessage)
+	if !ok {
+		return ""
+	}
+	var b strings.Builder
+	for _, c := range um.Content {
+		if tc, ok := c.(agentcore.TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}

--- a/internal/runtime/reminder.go
+++ b/internal/runtime/reminder.go
@@ -25,6 +25,7 @@ package runtime
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
@@ -188,6 +189,48 @@ func (p *TodoReminderProvider) Reminder(ctx context.Context, _ agentcore.Message
 	}
 	return "Your todo list has unfinished items. Keep it up to date with the todo tool.\n\n" +
 		agenttool.RenderTodoList(items), true
+}
+
+// OneShotReminderProvider injects a fixed body on the NEXT turn only, then stays
+// silent forever. Unlike the always-on providers (todo/goal) it does not depend
+// on live state — it carries a snapshot of text captured at registration time.
+// It exists for events that produce a single ephemeral injection, such as a
+// UserPromptSubmit hook's additionalContext (US-007, FR-9): the hook's context
+// must reach the model on the turn the prompt is sent, but must not persist into
+// history or re-fire on later turns. sync.Once makes the single-fire transition
+// safe even if the loop consults providers concurrently.
+type OneShotReminderProvider struct {
+	name string
+	body string
+	once sync.Once
+}
+
+// NewOneShotReminder builds a one-shot provider that will inject body exactly
+// once. An empty body yields a provider that never fires.
+func NewOneShotReminder(name, body string) *OneShotReminderProvider {
+	return &OneShotReminderProvider{name: name, body: body}
+}
+
+// Name implements ReminderProvider.
+func (p *OneShotReminderProvider) Name() string {
+	if p.name == "" {
+		return "one-shot"
+	}
+	return p.name
+}
+
+// Reminder implements ReminderProvider. It returns its body and true on the very
+// first consultation, then ("", false) on every subsequent turn.
+func (p *OneShotReminderProvider) Reminder(ctx context.Context, _ agentcore.MessageList) (string, bool) {
+	if strings.TrimSpace(p.body) == "" {
+		return "", false
+	}
+	var body string
+	p.once.Do(func() { body = p.body })
+	if body == "" {
+		return "", false
+	}
+	return body, true
 }
 
 // GoalReminderProvider surfaces the active goal as background context each turn


### PR DESCRIPTION
## Summary
- Add `DispatchUserPromptSubmit` cli-layer helper: runs the UserPromptSubmit event before a prompt is submitted, reporting `(block, reason)` for the caller to abort.
- Add `OneShotReminderProvider` (sync.Once) so a hook's `additionalContext` is injected into this turn's provider context via the existing ephemeral reminder seam, then never re-fires and is never persisted.
- Block takes strict priority over injection.
- Per-driver (REPL/headless) call sites are deferred to #425 (全 driver 收敛), matching the #419/#420 staging.

Closes #421

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite green)
- [x] New: block intercepts, additionalContext fires once then silent, nil dispatcher no-op