### PR TITLE
hooks: Stop + SubagentStop 接线 (阻止结束 + 死循环上限)

### DIFF
--- a/docs/issue#0422.html
+++ b/docs/issue#0422.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0422</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/422">#422</a> &mdash; hooks: Stop + SubagentStop 接线 (阻止结束 + 死循环上限) &mdash; 2026-07-30</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> New OnStop seam instead of overloading ShouldStopAfterTurn</h3>
+      <p><strong>Ambiguity:</strong> The loop already has <code>ShouldStopAfterTurn</code>, but its semantics are "return true to END". A Stop hook needs the opposite — PREVENT ending and force a continuation.</p>
+      <p><strong>Choice:</strong> Added a dedicated <code>OnStop func(...) *StopDecision</code> seam consulted at the loop's natural-end point (inner loop settled, no follow-up messages). <code>Block=true</code> appends <code>Guidance</code> and continues the outer loop.</p>
+      <p><strong>Rationale:</strong> Keeps the two concerns distinct — <code>ShouldStopAfterTurn</code> adds stop conditions (OR), <code>OnStop</code> vetoes a stop. Overloading one seam with both polarities would be error-prone.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Consecutive-block counter lives in the cli-layer decorator, not the loop</h3>
+      <p><strong>Ambiguity:</strong> Where does the FR-12 force-stop limit (default 5) live?</p>
+      <p><strong>Choice:</strong> <code>stopHook</code> in <code>internal/cli/run</code> closes over a per-run <code>consecutive</code> counter; past <code>maxBlocks</code> it warns and returns nil (force stop). The runtime <code>OnStop</code> seam stays a pure "block or not" question.</p>
+      <p><strong>Rationale:</strong> The issue explicitly asks for "装饰器闭包持有 per-run 计数". Keeping the ceiling out of the loop means runtime carries no hook policy, matching the layer boundary set in #419.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> SubagentStop reuses the same loop seam, differing only by event name</h3>
+      <p><strong>Ambiguity:</strong> Sub-agents run through the same <code>StartRun</code> loop; how does SubagentStop differ from Stop?</p>
+      <p><strong>Choice:</strong> Identical mechanism; the sub-agent's <code>RunConfig.OnStop</code> is wired via <code>InstallSubagentStop</code>, which dispatches the <code>"SubagentStop"</code> event with its own independent block counter.</p>
+      <p><strong>Rationale:</strong> Avoids duplicating loop logic. The only real distinction is the event name and the (child) session context, both set at assembly time.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Sub-agent call site not yet invoked; helper exported for #425</h3>
+      <p><strong>Spec said:</strong> "SubagentStop 在 subagent.go 结束路径触发".</p>
+      <p><strong>Implemented instead:</strong> <code>RunSubAgentOnce</code> runs the shared loop, which already consults <code>cfg.OnStop</code>. #422 exports <code>InstallSubagentStop</code> for the sub-agent assembly to call; the actual call is wired during driver convergence in #425 (same staging as #420/#421).</p>
+      <p><strong>Why:</strong> The trigger point (loop natural-end) is live now for any RunConfig with OnStop set; only the assembly-time wiring is deferred so all call sites converge once.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> stop_reason payload is a fixed "end_turn" string</h3>
+      <p><strong>Alternatives:</strong> (a) thread the real terminal StopReason from the loop into OnStop, (b) send a constant.</p>
+      <p><strong>Chosen (b):</strong> The natural-end seam only fires on an ordinary end-of-turn, so "end_turn" is accurate for the v1 event. Error/aborted terminals bypass OnStop entirely (they <code>finish()</code> directly).</p>
+      <p><strong>Con:</strong> A hook can't distinguish nuanced stop reasons yet. Revisit if a consumer needs the loop to pass the concrete StopReason through the seam.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should the block counter reset across follow-up message rounds?</h3>
+      <p><strong>Assumption:</strong> The counter resets only on a non-blocking stop. A run driven by external follow-up messages between blocks still accrues toward the limit.</p>
+      <p><strong>Verify:</strong> Confirm with real Stop-hook usage in #425 whether the intended budget is "consecutive blocks" (current) or "blocks since last user turn".</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/cli/run/hooks_install.go
+++ b/internal/cli/run/hooks_install.go
@@ -55,6 +55,11 @@ func InstallHooks(cfg *runtime.RunConfig, set hooks.HookSet, deps HookDeps) *hoo
 	tec := &cfg.Batch.ToolExecutorConfig
 	tec.BeforeToolCall = chainBeforeToolCall(tec.BeforeToolCall, preToolCallHook(d, deps))
 	tec.AfterToolCall = chainAfterToolCall(tec.AfterToolCall, postToolCallHook(d, deps))
+	// Stop hook: chained onto the loop's natural-end seam so a hook may block the
+	// run from ending and force a continuation (FR-10), bounded by the decorator's
+	// consecutive-block counter (FR-12). The sub-agent assembly wires the
+	// SubagentStop variant via installStopHook with the "SubagentStop" event.
+	installStopHook(cfg, d, deps, "Stop")
 	return d
 }
 

--- a/internal/cli/run/hooks_stop.go
+++ b/internal/cli/run/hooks_stop.go
@@ -1,0 +1,105 @@
+// This file provides the cli-layer decorator that runs the Stop and SubagentStop
+// hook events (US-008/009, FR-10/12) at the loop's natural-end seam
+// (runtime.RunConfig.OnStop). It lives in the cli layer because it bridges the
+// resolved Dispatcher and runtime, which must not depend on hooks.
+//
+// A Stop hook may block the run from ending and force a continuation, feeding
+// its reason back as guidance. Left unchecked a hook that always blocks would
+// loop forever, so the decorator holds a per-run consecutive-block counter and
+// force-stops after maxConsecutiveStopBlocks (FR-12). The counter resets on any
+// natural (non-blocking) stop, so an occasional block does not erode the budget.
+package run
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/hooks"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// maxConsecutiveStopBlocks is the default FR-12 ceiling on how many times a Stop
+// (or SubagentStop) hook may consecutively block the run from ending before the
+// decorator forces a stop and warns. Overridable via the builder.
+const maxConsecutiveStopBlocks = 5
+
+// stopHook builds a runtime.OnStop seam that dispatches the given event
+// ("Stop" for a top-level run, "SubagentStop" inside a sub-agent) each time the
+// loop is about to end. On a blocking decision it returns a StopDecision that
+// keeps the run alive with the hook's reason as guidance, up to maxBlocks
+// consecutive blocks; past that it forces a stop and warns. maxBlocks <= 0 uses
+// maxConsecutiveStopBlocks. A nil dispatcher yields a nil seam (no wrapping).
+func stopHook(d *hooks.Dispatcher, deps HookDeps, event string, maxBlocks int) func(context.Context, *agentcore.AgentContext) *runtime.StopDecision {
+	if d == nil {
+		return nil
+	}
+	if maxBlocks <= 0 {
+		maxBlocks = maxConsecutiveStopBlocks
+	}
+	warn := deps.WarnLog
+	if warn == nil {
+		warn = os.Stderr
+	}
+	consecutive := 0
+	return func(ctx context.Context, _ *agentcore.AgentContext) *runtime.StopDecision {
+		dec := d.Dispatch(ctx, event, "", hooks.HookInput{
+			EventType:  event,
+			SessionID:  deps.SessionID,
+			ProjectDir: deps.ProjectDir,
+			StopReason: "end_turn",
+		})
+		if !dec.Block {
+			consecutive = 0
+			return nil
+		}
+		consecutive++
+		if consecutive > maxBlocks {
+			fmt.Fprintf(warn, "%s hook blocked the run %d times consecutively; forcing stop\n", event, consecutive-1)
+			consecutive = 0
+			return nil
+		}
+		return &runtime.StopDecision{Block: true, Guidance: hookReason(dec.Reason, event)}
+	}
+}
+
+// InstallSubagentStop wires the SubagentStop hook onto a sub-agent's RunConfig,
+// so a SubagentStop hook can block a sub-agent from ending (same semantics as
+// Stop, evaluated in the sub-agent context, with its own consecutive-block
+// budget). The sub-agent assembly calls this on the child runCfg (converged in
+// #425). A nil dispatcher is a no-op.
+func InstallSubagentStop(cfg *runtime.RunConfig, d *hooks.Dispatcher, deps HookDeps) {
+	installStopHook(cfg, d, deps, "SubagentStop")
+}
+
+// installStopHook wires a Stop-family decorator onto cfg.OnStop, chaining onto
+// any existing seam (an earlier OnStop is consulted first and its block wins,
+// mirroring the block-short-circuit combinator convention). It is called by the
+// tool-execution wiring for the top-level run and by the sub-agent assembly for
+// the SubagentStop variant.
+func installStopHook(cfg *runtime.RunConfig, d *hooks.Dispatcher, deps HookDeps, event string) {
+	next := stopHook(d, deps, event, 0)
+	if next == nil {
+		return
+	}
+	cfg.OnStop = chainOnStop(cfg.OnStop, next)
+}
+
+// chainOnStop composes two OnStop seams: prev is consulted first and a blocking
+// decision short-circuits (next does not run), so an earlier gate stays
+// authoritative. A nil operand is identity.
+func chainOnStop(prev, next func(context.Context, *agentcore.AgentContext) *runtime.StopDecision) func(context.Context, *agentcore.AgentContext) *runtime.StopDecision {
+	if prev == nil {
+		return next
+	}
+	if next == nil {
+		return prev
+	}
+	return func(ctx context.Context, agentCtx *agentcore.AgentContext) *runtime.StopDecision {
+		if dec := prev(ctx, agentCtx); dec != nil && dec.Block {
+			return dec
+		}
+		return next(ctx, agentCtx)
+	}
+}

--- a/internal/cli/run/hooks_stop_test.go
+++ b/internal/cli/run/hooks_stop_test.go
@@ -1,0 +1,84 @@
+package run
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/hooks"
+)
+
+func stopDispatcher(t *testing.T, event, cmd string) *hooks.Dispatcher {
+	t.Helper()
+	set := hooks.HookSet{
+		event: {{Matcher: "*", Hooks: []hooks.HookConfig{{Command: cmd}}}},
+	}
+	d := hooks.NewDispatcher(set, t.TempDir(), nil)
+	if d == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	return d
+}
+
+// TestStopHookBlocksThenForceStops: a Stop hook that always blocks (exit 2) is
+// honored up to the limit, then the decorator force-stops (returns nil) so the
+// run cannot loop forever (FR-12).
+func TestStopHookBlocksThenForceStops(t *testing.T) {
+	d := stopDispatcher(t, "Stop", `echo "not done yet" 1>&2; exit 2`)
+	var warn strings.Builder
+	seam := stopHook(d, HookDeps{SessionID: "s1", WarnLog: &warn}, "Stop", 3)
+	if seam == nil {
+		t.Fatal("expected non-nil seam")
+	}
+
+	// First 3 consultations block with the reason as guidance.
+	for i := 0; i < 3; i++ {
+		dec := seam(context.Background(), nil)
+		if dec == nil || !dec.Block {
+			t.Fatalf("consult %d: expected a blocking decision", i+1)
+		}
+		if !strings.Contains(dec.Guidance, "not done yet") {
+			t.Fatalf("consult %d: block reason not surfaced as guidance, got %q", i+1, dec.Guidance)
+		}
+	}
+	// 4th consultation exceeds the limit: force stop (nil) + a warning.
+	if dec := seam(context.Background(), nil); dec != nil {
+		t.Fatalf("expected force-stop (nil) past the limit, got %+v", dec)
+	}
+	if !strings.Contains(warn.String(), "forcing stop") {
+		t.Fatalf("force-stop should warn, got %q", warn.String())
+	}
+}
+
+// TestStopHookResetsCounterOnAllow: a non-blocking hook always returns nil, so
+// the run is free to end and the consecutive-block counter never accrues.
+func TestStopHookResetsCounterOnAllow(t *testing.T) {
+	d := stopDispatcher(t, "Stop", `exit 0`)
+	seam := stopHook(d, HookDeps{SessionID: "s1"}, "Stop", 2)
+	for i := 0; i < 5; i++ {
+		if dec := seam(context.Background(), nil); dec != nil {
+			t.Fatalf("consult %d: a non-blocking hook must let the run end (nil), got %+v", i+1, dec)
+		}
+	}
+}
+
+// TestStopHookNilDispatcher: no hooks configured yields a nil seam (no wrapping).
+func TestStopHookNilDispatcher(t *testing.T) {
+	if seam := stopHook(nil, HookDeps{}, "Stop", 0); seam != nil {
+		t.Fatal("nil dispatcher must yield a nil seam")
+	}
+}
+
+// TestSubagentStopEvent: InstallSubagentStop wires a SubagentStop decorator whose
+// block keeps a sub-agent running with the hook's reason.
+func TestSubagentStopEvent(t *testing.T) {
+	d := stopDispatcher(t, "SubagentStop", `echo "sub not done" 1>&2; exit 2`)
+	seam := stopHook(d, HookDeps{SessionID: "child"}, "SubagentStop", 5)
+	if seam == nil {
+		t.Fatal("expected non-nil SubagentStop seam")
+	}
+	dec := seam(context.Background(), nil)
+	if dec == nil || !dec.Block || !strings.Contains(dec.Guidance, "sub not done") {
+		t.Fatalf("SubagentStop block not honored, got %+v", dec)
+	}
+}

--- a/internal/runtime/loop.go
+++ b/internal/runtime/loop.go
@@ -45,6 +45,15 @@ type TurnUpdate struct {
 	ThinkingLevel *agentcore.ThinkingLevel
 }
 
+// StopDecision is the result of the OnStop seam. Block=true prevents the run
+// from ending; Guidance, when non-empty, is appended as a user-role message to
+// steer the forced continuation (the Stop / SubagentStop hook's reason). The
+// zero value (Block=false) lets the run end.
+type StopDecision struct {
+	Block    bool
+	Guidance string
+}
+
 // RunConfig is the full configuration for a loop run: the per-turn streaming
 // config (embedded LoopConfig), the batch tool-execution config, and the four
 // loop-level hooks. Every hook is optional (nil = default behavior).
@@ -67,6 +76,15 @@ type RunConfig struct {
 	// ShouldStopAfterTurn runs after each turn_end; true ends the run with an
 	// agent_end event (FR-7).
 	ShouldStopAfterTurn func(ctx context.Context, agentCtx *agentcore.AgentContext) bool
+
+	// OnStop, when set, is consulted right before the run would end naturally (no
+	// tool calls and no follow-up messages). Returning a decision with Block=true
+	// keeps the loop running: any Guidance is appended as a user-role message to
+	// steer the continued run (Stop / SubagentStop hooks, US-008/009, FR-10). The
+	// seam carries no loop-protection itself — the caller's decorator owns the
+	// consecutive-block counter and the FR-12 force-stop limit, so an ill-behaved
+	// hook cannot loop forever. nil or a non-blocking decision lets the run end.
+	OnStop func(ctx context.Context, agentCtx *agentcore.AgentContext) *StopDecision
 
 	// Reminders holds the per-turn system-reminder providers (US-002, FR-1/FR-2).
 	// When non-empty, ephemeral <system-reminder> messages are injected into each
@@ -233,6 +251,21 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 			if follow := cfg.GetFollowUpMessages(ctx, agentCtx); len(follow) > 0 {
 				agentCtx.Messages = append(agentCtx.Messages, follow...)
 				continue // outer loop with the follow-ups as new input
+			}
+		}
+		// Stop hook: the run is about to end naturally. A hook may block the end
+		// and force a continuation, feeding its guidance back as the next input
+		// (US-008/009, FR-10). The consecutive-block counter and force-stop limit
+		// (FR-12) live in the decorator behind OnStop, so this seam stays simple.
+		if cfg.OnStop != nil {
+			if dec := cfg.OnStop(ctx, agentCtx); dec != nil && dec.Block {
+				if dec.Guidance != "" {
+					agentCtx.Messages = append(agentCtx.Messages, agentcore.UserMessage{
+						RoleField: agentcore.RoleUser,
+						Content:   agentcore.ContentList{agentcore.NewTextContent(dec.Guidance)},
+					})
+				}
+				continue // outer loop: keep the run alive
 			}
 		}
 		break

--- a/internal/runtime/loop_onstop_test.go
+++ b/internal/runtime/loop_onstop_test.go
@@ -1,0 +1,63 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// TestAgentLoopOnStopBlocksThenAllows: OnStop blocks the natural end twice
+// (injecting guidance each time) then allows it, so the run takes three turns
+// and the guidance messages land in the context.
+func TestAgentLoopOnStopBlocksThenAllows(t *testing.T) {
+	cfg := newRunCfg(scriptedStream(nil)) // always a natural end_turn
+	blocks := 0
+	cfg.OnStop = func(ctx context.Context, agentCtx *agentcore.AgentContext) *StopDecision {
+		if blocks < 2 {
+			blocks++
+			return &StopDecision{Block: true, Guidance: "keep going"}
+		}
+		return nil
+	}
+	agentCtx := &agentcore.AgentContext{Messages: agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser}}}
+
+	kinds, _ := collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+	if got := countKind(kinds, agentcore.EventTurnStart); got != 3 {
+		t.Fatalf("expected 3 turns (2 forced continuations + final), got %d (%v)", got, kinds)
+	}
+	if kinds[len(kinds)-1] != agentcore.EventAgentEnd {
+		t.Fatalf("run must end with agent_end, got %v", kinds)
+	}
+	guidance := 0
+	for _, m := range agentCtx.Messages {
+		if um, ok := m.(agentcore.UserMessage); ok && len(um.Content) == 1 {
+			if tc, ok := um.Content[0].(agentcore.TextContent); ok && tc.Text == "keep going" {
+				guidance++
+			}
+		}
+	}
+	if guidance != 2 {
+		t.Fatalf("expected 2 injected guidance messages, got %d", guidance)
+	}
+}
+
+// TestAgentLoopOnStopNilEndsRun: a nil OnStop decision lets the run end after a
+// single natural turn.
+func TestAgentLoopOnStopNilEndsRun(t *testing.T) {
+	cfg := newRunCfg(scriptedStream(nil))
+	consulted := false
+	cfg.OnStop = func(ctx context.Context, agentCtx *agentcore.AgentContext) *StopDecision {
+		consulted = true
+		return nil
+	}
+	agentCtx := &agentcore.AgentContext{Messages: agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser}}}
+
+	kinds, _ := collectStream(t, agentLoop(context.Background(), agentCtx, cfg))
+	if !consulted {
+		t.Fatal("OnStop was never consulted")
+	}
+	if got := countKind(kinds, agentcore.EventTurnStart); got != 1 {
+		t.Fatalf("nil decision must end after one turn, got %d turns", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `runtime.OnStop` seam consulted at the loop's natural-end; a Stop hook may block the run from ending and force a continuation, injecting its reason as guidance
- cli-layer decorator holds a per-run consecutive-block counter, force-stops after `maxConsecutiveStopBlocks` (default 5, FR-12), resets on any non-blocking stop
- SubagentStop reuses the same loop seam via `InstallSubagentStop`, differing only by event name and child session context

Closes #422

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `internal/runtime/loop_onstop_test.go`: block-then-allow (3 turns, guidance injected), nil ends run
- [x] `internal/cli/run/hooks_stop_test.go`: blocks-then-force-stops with warn, resets on allow, nil dispatcher, SubagentStop event
- [x] full `go test ./...` green