### PR TITLE
hooks: 观察型 hook (SessionEnd/PreCompact/Notification) via HookNotifier

### DIFF
--- a/docs/issue#0424.html
+++ b/docs/issue#0424.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0424</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/424">#424</a> &mdash; hooks: 观察型 hook (SessionEnd/PreCompact/Notification) via HookNotifier &mdash; 2026-07-30</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> HookNotifier lives in <code>internal/hooks</code> and now imports agentcore</h3>
+      <p><strong>Ambiguity:</strong> The hooks package was kept a stdlib leaf to dodge a <code>runtime→hooks→runtime</code> cycle, but the notifier must consume <code>agentcore.AgentEvent</code>.</p>
+      <p><strong>Choice:</strong> Add a single <code>agentcore</code> import to hooks for <code>notifier.go</code>. Verified no cycle: agentcore is itself a leaf (imports no first-party package), so <code>hooks→agentcore</code> is acyclic and <code>runtime→hooks</code> is unaffected.</p>
+      <p><strong>Rationale:</strong> The acceptance criteria name <code>internal/hooks/notifier.go</code> explicitly, and the mapping (event→HookInput) is hook-domain logic. The earlier "no agentcore" note was about avoiding a cycle, not agentcore specifically — and agentcore introduces none.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> session_id / project_dir captured at construction, not per event</h3>
+      <p><strong>Ambiguity:</strong> <code>AgentEndEvent</code> and <code>CompactionEvent</code> do not carry a session id or project dir, yet the payloads must include <code>session_id</code>.</p>
+      <p><strong>Choice:</strong> <code>NewHookNotifier(d, sessionID, projectDir)</code> captures both once per run (they are run-invariant) and stamps every emitted HookInput.</p>
+      <p><strong>Rationale:</strong> Mirrors how <code>plugin.EventNotifier</code> is constructed per run. Avoids threading run identity through every event type.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Notification is a method, not an event-stream mapping</h3>
+      <p><strong>Ambiguity:</strong> Notification fires on "trust 确认/等待场景", which is not an <code>AgentEvent</code>.</p>
+      <p><strong>Choice:</strong> Expose <code>Notify(message string)</code> separately from <code>Handle(ev)</code>. The trust gate calls <code>Notify</code> directly; <code>Handle</code> only maps stream events (SessionEnd/PreCompact).</p>
+      <p><strong>Rationale:</strong> Trust confirmation is out-of-band relative to the event stream. Forcing it through <code>Handle</code> would require inventing a synthetic event; a plain method is clearer and independently testable.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> OnEvent chaining + trust-gate <code>Notify</code> call site deferred to #425</h3>
+      <p><strong>Spec said:</strong> "挂到 <code>RunConfig.OnEvent</code>,与现有 plugin notifier 并存" and "Notification ← trust 确认/等待场景".</p>
+      <p><strong>Implemented instead:</strong> <code>HookNotifier</code> + its mappings + nil-safety are delivered and fully tested; wiring its <code>Handle</code> onto the OnEvent chain alongside the plugin notifier, and calling <code>Notify</code> from the trust gate, happen during driver convergence in #425 (same staging as #420–#423).</p>
+      <p><strong>Why:</strong> All OnEvent chaining converges once in #425 so the drivers are touched a single time; the notifier's behavior is exercised now via the capture-file tests.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> SessionEnd reason derived from the terminal assistant message</h3>
+      <p><strong>Alternatives:</strong> (a) thread an explicit terminal StopReason into <code>AgentEndEvent</code>, (b) infer it from the last assistant message in <code>AgentEndEvent.Messages</code>.</p>
+      <p><strong>Chosen (b):</strong> Scan backwards for the last <code>AssistantMessage</code> and map <code>error</code>/<code>aborted</code> through, everything else (including no assistant message) to <code>natural</code>.</p>
+      <p><strong>Con:</strong> If a run ends without any assistant message the reason defaults to <code>natural</code>, which is a reasonable but not provably-correct label. Revisit if <code>AgentEndEvent</code> ever gains an explicit terminal reason field.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should observer-hook dispatch run off the hot path?</h3>
+      <p><strong>Assumption:</strong> <code>Handle</code> dispatches synchronously on the OnEvent callback thread (the Runner bounds each hook with a timeout, so it cannot hang the loop indefinitely).</p>
+      <p><strong>Verify:</strong> During #425, confirm whether SessionEnd/PreCompact hooks running inline on the event thread is acceptable, or whether they should be dispatched fire-and-forget like <code>plugin.Manager.DispatchEvent</code> does for plugins.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/hooks/notifier.go
+++ b/internal/hooks/notifier.go
@@ -1,0 +1,118 @@
+// This file bridges the agent's event stream to observer-only hooks (US-011/012/
+// 013, FR-1). Where PreToolUse/UserPromptSubmit/Stop are decision hooks wired at
+// dedicated seams, SessionEnd/PreCompact/Notification only observe: the agent
+// emits lifecycle events, HookNotifier maps each to a HookInput and fires the
+// matching hooks via the Dispatcher, discarding the decision (an observer hook
+// cannot block).
+//
+// It mirrors plugin.EventNotifier: created once per run, its Handle method is
+// wired as an event-stream OnEvent callback and coexists with the plugin
+// notifier (RunConfig.OnEvent already chains multiple observers). A nil
+// *Dispatcher makes NewHookNotifier return nil, and every method is a no-op on a
+// nil receiver, so callers can wire it unconditionally.
+//
+// Session id and project dir are fixed for a run, so they are captured at
+// construction rather than read from each event (AgentEndEvent/CompactionEvent
+// do not carry them).
+package hooks
+
+import (
+	"context"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// HookNotifier forwards agent lifecycle events to observer-only hooks. Handle
+// maps AgentEndEvent→SessionEnd and CompactionEvent→PreCompact; Notify emits a
+// Notification event for out-of-band prompts (e.g. a trust confirmation). The
+// merged decision is intentionally discarded — these events have no in-flight
+// action to veto.
+type HookNotifier struct {
+	d          *Dispatcher
+	sessionID  string
+	projectDir string
+}
+
+// NewHookNotifier returns a notifier over d, or nil when d is nil (no hooks) so
+// the caller can skip the OnEvent wiring entirely. sessionID and projectDir
+// populate every emitted HookInput.
+func NewHookNotifier(d *Dispatcher, sessionID, projectDir string) *HookNotifier {
+	if d == nil {
+		return nil
+	}
+	return &HookNotifier{d: d, sessionID: sessionID, projectDir: projectDir}
+}
+
+// Handle maps an observed event to its observer hook and fires it. Events with
+// no observer mapping (turn/message/tool events) are ignored. It is a no-op on a
+// nil notifier, so it can be chained onto OnEvent unconditionally.
+func (n *HookNotifier) Handle(ev agentcore.AgentEvent) {
+	if n == nil {
+		return
+	}
+	switch e := ev.(type) {
+	case agentcore.AgentEndEvent:
+		n.dispatch("SessionEnd", HookInput{
+			EventType:  "SessionEnd",
+			SessionID:  n.sessionID,
+			ProjectDir: n.projectDir,
+			StopReason: sessionEndReason(e.Messages),
+		})
+	case agentcore.CompactionEvent:
+		n.dispatch("PreCompact", HookInput{
+			EventType:  "PreCompact",
+			SessionID:  n.sessionID,
+			ProjectDir: n.projectDir,
+			Trigger:    compactionTrigger(e.Reason),
+		})
+	}
+}
+
+// Notify fires the Notification event with a human-readable message. It is used
+// for out-of-band prompts that are not part of the event stream, such as a trust
+// confirmation for an untrusted-directory bash/write. A no-op on a nil notifier
+// or an empty message.
+func (n *HookNotifier) Notify(message string) {
+	if n == nil || message == "" {
+		return
+	}
+	n.dispatch("Notification", HookInput{
+		EventType:  "Notification",
+		SessionID:  n.sessionID,
+		ProjectDir: n.projectDir,
+		Message:    message,
+	})
+}
+
+// dispatch fires the hooks for an observer event and discards the decision.
+func (n *HookNotifier) dispatch(event string, input HookInput) {
+	n.d.Dispatch(context.Background(), event, "", input)
+}
+
+// sessionEndReason derives the SessionEnd reason from the run's terminal
+// assistant message: "error"/"aborted" pass through, everything else (end_turn/
+// tool_use/length or no assistant message) is a "natural" end.
+func sessionEndReason(msgs []agentcore.AgentMessage) string {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if am, ok := msgs[i].(agentcore.AssistantMessage); ok {
+			switch am.StopReason {
+			case agentcore.StopReasonError:
+				return "error"
+			case agentcore.StopReasonAborted:
+				return "aborted"
+			default:
+				return "natural"
+			}
+		}
+	}
+	return "natural"
+}
+
+// compactionTrigger maps a CompactionEvent.Reason to the PreCompact trigger:
+// "manual" stays manual; "threshold"/"overflow" (and anything else) are "auto".
+func compactionTrigger(reason string) string {
+	if reason == "manual" {
+		return "manual"
+	}
+	return "auto"
+}

--- a/internal/hooks/notifier_test.go
+++ b/internal/hooks/notifier_test.go
@@ -1,0 +1,122 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// captureNotifier builds a HookNotifier whose hook for `event` appends its stdin
+// payload to a file, returning the notifier and the capture-file path so a test
+// can assert on the payload the hook received.
+func captureNotifier(t *testing.T, event string) (*HookNotifier, string) {
+	t.Helper()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "capture.json")
+	set := HookSet{
+		event: {{Matcher: "*", Hooks: []HookConfig{{Command: "cat >> " + out}}}},
+	}
+	d := NewDispatcher(set, dir, nil)
+	if d == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	return NewHookNotifier(d, "sess-1", dir), out
+}
+
+func readCapture(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("capture not written: %v", err)
+	}
+	return string(b)
+}
+
+// TestSessionEndNaturalReason: an end_turn terminal message yields reason
+// "natural"; an aborted terminal message yields "aborted".
+func TestSessionEndReason(t *testing.T) {
+	cases := []struct {
+		name   string
+		stop   string
+		expect string
+	}{
+		{"natural", agentcore.StopReasonEndTurn, `"stop_reason":"natural"`},
+		{"aborted", agentcore.StopReasonAborted, `"stop_reason":"aborted"`},
+		{"error", agentcore.StopReasonError, `"stop_reason":"error"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n, out := captureNotifier(t, "SessionEnd")
+			n.Handle(agentcore.AgentEndEvent{Messages: []agentcore.AgentMessage{
+				agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant, StopReason: tc.stop},
+			}})
+			if got := readCapture(t, out); !strings.Contains(got, tc.expect) {
+				t.Fatalf("SessionEnd reason: want %q in %q", tc.expect, got)
+			}
+		})
+	}
+}
+
+// TestPreCompactTrigger: a manual CompactionEvent maps to trigger "manual";
+// threshold/overflow map to "auto".
+func TestPreCompactTrigger(t *testing.T) {
+	cases := []struct {
+		reason string
+		expect string
+	}{
+		{"manual", `"trigger":"manual"`},
+		{"threshold", `"trigger":"auto"`},
+		{"overflow", `"trigger":"auto"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.reason, func(t *testing.T) {
+			n, out := captureNotifier(t, "PreCompact")
+			n.Handle(agentcore.CompactionEvent{Reason: tc.reason})
+			if got := readCapture(t, out); !strings.Contains(got, tc.expect) {
+				t.Fatalf("PreCompact trigger: want %q in %q", tc.expect, got)
+			}
+		})
+	}
+}
+
+// TestNotification: Notify fires the Notification event carrying the message.
+func TestNotification(t *testing.T) {
+	n, out := captureNotifier(t, "Notification")
+	n.Notify("approve bash in untrusted dir?")
+	got := readCapture(t, out)
+	if !strings.Contains(got, `"event_type":"Notification"`) || !strings.Contains(got, "approve bash in untrusted dir?") {
+		t.Fatalf("Notification payload missing message, got %q", got)
+	}
+}
+
+// TestNotifierNilSafe: a nil dispatcher yields a nil notifier whose methods are
+// safe no-ops; an empty Notify message is dropped.
+func TestNotifierNilSafe(t *testing.T) {
+	if n := NewHookNotifier(nil, "s", "d"); n != nil {
+		t.Fatal("nil dispatcher must yield a nil notifier")
+	}
+	var n *HookNotifier
+	n.Handle(agentcore.AgentEndEvent{})
+	n.Notify("x") // must not panic
+
+	// A live notifier with an empty message writes nothing.
+	live, out := captureNotifier(t, "Notification")
+	live.Notify("")
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatal("empty Notify message must not fire the hook")
+	}
+}
+
+// TestNotifierIgnoresUnmappedEvents: turn/message/tool events have no observer
+// mapping and must not fire any hook.
+func TestNotifierIgnoresUnmappedEvents(t *testing.T) {
+	n, out := captureNotifier(t, "SessionEnd")
+	n.Handle(agentcore.TurnStartEvent{})
+	n.Handle(agentcore.ToolExecutionStartEvent{ToolName: "bash"})
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatal("unmapped events must not fire the SessionEnd hook")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/hooks/notifier.go`: `HookNotifier.Handle` maps `AgentEndEvent`→SessionEnd (reason natural/error/aborted) and `CompactionEvent`→PreCompact (trigger manual/auto, from threshold/overflow→auto)
- `Notify(message)` emits a Notification event for out-of-band prompts (trust confirmation)
- Coexists with `plugin.EventNotifier` (OnEvent already chains observers); nil-safe; observer decisions discarded
- OnEvent chaining + trust-gate `Notify` call site converge in #425 (same staging as #420–#423)

Closes #424

## Test plan
- [x] `go build ./...` clean (verified `hooks→agentcore` introduces no import cycle)
- [x] SessionEnd reason natural/aborted/error; PreCompact trigger manual/auto; Notification carries message; nil-safe; unmapped events ignored
- [x] `go test ./internal/hooks/... ./internal/compaction/...` + full `go test ./...` green