### PR TITLE
Converge hook wiring across all six drivers (#425)

### DIFF
--- a/docs/issue#0425.html
+++ b/docs/issue#0425.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #425</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/425">#425</a> &mdash; 全 driver 收敛 (hook wiring convergence, FR-16) &mdash; 2026-07-30</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Two wiring paths kept, not one</h3>
+      <p><strong>Ambiguity:</strong> The AC says "RunConfig 组装处统一调用 <code>InstallHooks</code>", implying a single entry point.</p>
+      <p><strong>Choice:</strong> Kept two shapes — one-shot drivers (headless, subagent_rpc) call <code>InstallDriverHooks</code>/<code>InstallHooks</code> all-in-one; multi-turn drivers (repl, tui, goal, btw) call <code>BuildDispatcher</code> once at session start (so SessionStart fires exactly once) and <code>InstallSeams</code> per turn.</p>
+      <p><strong>Rationale:</strong> A multi-turn session must not re-fire SessionStart or rebuild the dispatcher every turn. <code>InstallHooks</code> internally delegates to <code>InstallSeams</code>, so both paths converge on the same seam-wiring code — the "统一" requirement is met at the shared helper, not a single call signature.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Host interface gained <code>Dispatcher()</code> / <code>HookDeps()</code></h3>
+      <p><strong>Ambiguity:</strong> Side-runs (/goal, /btw) build their own RunConfig but must reuse the session's already-resolved dispatcher and deps.</p>
+      <p><strong>Choice:</strong> Added two accessors to <code>cli.Host</code>, implemented only by <code>replDeps</code>. Side-run packages read them via the existing <code>cli.Host</code> contract.</p>
+      <p><strong>Rationale:</strong> Avoids an import cycle (<code>cli/run</code> does not import <code>cli</code>) and avoids re-resolving hooks per side-run, keeping trust/session-id consistent with the parent session.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Trust gate for non-interactive drivers via <code>run.Trusted(cwd)</code></h3>
+      <p><strong>Ambiguity:</strong> FR-14 requires project-layer hooks only when trusted, but headless/tui/subagent have no live <code>trust.Manager</code>.</p>
+      <p><strong>Choice:</strong> Added <code>run.Trusted(cwd)</code> reading the shared trust store, fail-closed (missing/unreadable store ⇒ untrusted).</p>
+      <p><strong>Rationale:</strong> A checked-out repo cannot run arbitrary project-layer hook commands until the user explicitly trusts the directory, uniformly across every driver.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> Observer notifier chained onto each driver's event seam, not RunConfig</h3>
+      <p><strong>Spec implied:</strong> A uniform install would suggest one field on RunConfig carries the SessionEnd/PreCompact observer.</p>
+      <p><strong>Implemented:</strong> <code>runtime.RunConfig</code> has no <code>OnEvent</code> field — OnEvent lives on <code>StreamHandler</code> / <code>HeadlessConfig</code>. So the hook notifier is composed into each driver's own event handler (REPL/goal/btw/tui via chain helpers, headless via <code>HeadlessConfig.OnEvent</code>).</p>
+      <p><strong>Why:</strong> Threading a new field through runtime would leak hook concepts into the hook-agnostic runtime layer; chaining at the driver keeps the seam where the driver already owns event delivery.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> TUI bridge signature changed to thread an observer</h3>
+      <p><strong>Spec said:</strong> Wire hooks into the RunConfig assembly.</p>
+      <p><strong>Implemented:</strong> The TUI bridge (<code>newStreamHandler</code>/<code>pump</code>/<code>startRun</code>) previously delivered no observer events at all; added an <code>onEvent func(agentcore.AgentEvent)</code> param so both the plugin notifier and the hook notifier reach the TUI.</p>
+      <p><strong>Why:</strong> Without this the TUI would silently drop SessionEnd/PreCompact hooks (and plugin events), diverging from the other drivers — a correctness gap, not just wiring.</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Regression test at the convergence-helper boundary</h3>
+      <p><strong>Alternatives:</strong> (a) full provider-backed run of each of the six drivers asserting a hook fires end-to-end; (b) pin the two distinct wiring paths at the shared helpers.</p>
+      <p><strong>Chosen (b):</strong> <code>TestHookConvergenceBothPaths</code> drives the one-shot path (<code>InstallDriverHooks</code>) and the multi-turn path (<code>BuildDispatcher</code>+<code>InstallSeams</code>) with the same PreToolUse hook set and asserts the <code>BeforeToolCall</code> seam blocks in both; <code>TestHookConvergenceNoHooksUnchanged</code> pins FR-18.</p>
+      <p><strong>Why it won:</strong> Every driver routes through exactly these two helper shapes, so the boundary test covers "same config fires in both modes" without standing up six fake providers — faster, deterministic, and pinned to the actual convergence point.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> subagent_rpc runs hooks with an empty SessionID</h3>
+      <p><strong>Assumption:</strong> A process-isolated child sub-agent has no backing session, so <code>HookInput.SessionID</code> is empty (omitted from the JSON).</p>
+      <p><strong>Verify:</strong> Confirm downstream hook authors don't rely on a session id for sub-agent PreToolUse/PostToolUse hooks; if they do, a synthetic child id may be needed.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/cli/btw/btw.go
+++ b/internal/cli/btw/btw.go
@@ -33,8 +33,10 @@ import (
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/compaction"
+	"github.com/smallnest/pigo/internal/hooks"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 	"github.com/smallnest/pigo/internal/trust"
@@ -226,8 +228,33 @@ func AskSide(setCancel func(context.CancelFunc), out io.Writer, host cli.Host, s
 		},
 		Reminders: host.Reminders(),
 	}
+	// Wire the per-turn hook seams onto the side run's cfg; nil dispatcher is a
+	// no-op (FR-18).
+	if d := host.Dispatcher(); d != nil {
+		run.InstallSeams(&cfg, d, host.HookDeps())
+	}
 	stream := runtime.StartRun(runCtx, side, cfg)
 	drainSideStream(runCtx, out, host, stream)
+}
+
+// chainBtwEvent returns the OnEvent observer for a /btw side run: the plugin
+// notifier, with the SessionEnd/PreCompact hook notifier chained after it when
+// hooks are configured, mirroring the REPL's OnEvent composition.
+func chainBtwEvent(host cli.Host) func(agentcore.AgentEvent) {
+	notifier := host.NotifierHandle()
+	d := host.Dispatcher()
+	if d == nil {
+		return notifier
+	}
+	deps := host.HookDeps()
+	hookEvent := hooks.NewHookNotifier(d, deps.SessionID, deps.ProjectDir).Handle
+	if notifier == nil {
+		return hookEvent
+	}
+	return func(ev agentcore.AgentEvent) {
+		notifier(ev)
+		hookEvent(ev)
+	}
 }
 
 // drainSideStream prints the streamed assistant text and tool activity of a side
@@ -247,7 +274,7 @@ func drainSideStream(ctx context.Context, out io.Writer, host cli.Host, stream *
 		reply.Reset()
 	}
 	_, err := runtime.DrainStream(ctx, stream, runtime.StreamHandler{
-		OnEvent: host.NotifierHandle(),
+		OnEvent: chainBtwEvent(host),
 		OnText: func(delta string) {
 			reply.WriteString(delta)
 		},

--- a/internal/cli/goal/goal.go
+++ b/internal/cli/goal/goal.go
@@ -28,8 +28,10 @@ import (
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/compaction"
+	"github.com/smallnest/pigo/internal/hooks"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 	"github.com/smallnest/pigo/internal/trust"
@@ -249,6 +251,12 @@ func runGoalLoop(setCancel func(context.CancelFunc), out io.Writer, host cli.Hos
 		},
 	}
 
+	// Wire the per-turn hook seams (PreToolUse/PostToolUse/Stop) onto this goal
+	// run's cfg from the session dispatcher; a nil dispatcher is a no-op (FR-18).
+	if d := host.Dispatcher(); d != nil {
+		run.InstallSeams(&cfg, d, host.HookDeps())
+	}
+
 	// The first turn is driven by the goal reminder alone (the objective is
 	// injected as background context); no explicit user prompt is appended so the
 	// objective is not duplicated in the durable history.
@@ -313,6 +321,26 @@ func goalTurnActivity(tail []agentcore.AgentMessage) (outputTokens int, hadTool 
 
 // drainGoalStream prints the streamed assistant text and tool activity of a goal
 // run to out, mirroring streamRun's rendering. It blocks until the run ends.
+// chainGoalEvent returns the OnEvent observer for a goal run: the plugin
+// notifier, with the SessionEnd/PreCompact hook notifier chained after it when
+// hooks are configured, mirroring the REPL's OnEvent composition.
+func chainGoalEvent(host cli.Host) func(agentcore.AgentEvent) {
+	notifier := host.NotifierHandle()
+	d := host.Dispatcher()
+	if d == nil {
+		return notifier
+	}
+	deps := host.HookDeps()
+	hookEvent := hooks.NewHookNotifier(d, deps.SessionID, deps.ProjectDir).Handle
+	if notifier == nil {
+		return hookEvent
+	}
+	return func(ev agentcore.AgentEvent) {
+		notifier(ev)
+		hookEvent(ev)
+	}
+}
+
 func drainGoalStream(ctx context.Context, out io.Writer, host cli.Host, stream *runtime.LoopEventStream) {
 	var reply strings.Builder
 	flushReply := func() {
@@ -327,7 +355,7 @@ func drainGoalStream(ctx context.Context, out io.Writer, host cli.Host, stream *
 		reply.Reset()
 	}
 	_, err := runtime.DrainStream(ctx, stream, runtime.StreamHandler{
-		OnEvent: host.NotifierHandle(),
+		OnEvent: chainGoalEvent(host),
 		OnText: func(delta string) {
 			reply.WriteString(delta)
 		},

--- a/internal/cli/headless/headless.go
+++ b/internal/cli/headless/headless.go
@@ -85,17 +85,44 @@ func Run(ctx context.Context, p RunParams, out, errOut io.Writer) int {
 	creds.SetOverride(env.ProviderName, p.APIKey)
 	runCfg := run.NewConfig(p.Model, env.ProviderName, thinking, env.Provider, creds, run.ToolRegistry(env.Tools), run.TodoReminders(env.Tools))
 	runCfg.SessionID = hs.header.ID
+
+	// Wire hooks uniformly with every other driver (#425): resolve the trust-gated
+	// hook set, install the tool-execution + Stop seams, dispatch SessionStart, and
+	// chain the SessionEnd/PreCompact observer onto the plugin event notifier. A
+	// malformed hook layer is a config error (exit 2), matching thinking-level.
+	source := "startup"
+	if p.ResumeID != "" {
+		source = "resume"
+	}
+	set, herr := run.ResolveHookSet(env.Cwd, run.Trusted(env.Cwd))
+	if herr != nil {
+		fmt.Fprintf(errOut, "pigo: %v\n", herr)
+		return 2
+	}
+	hookDeps := run.HookDeps{SessionID: hs.header.ID, ProjectDir: env.Cwd, WarnLog: errOut}
+	// Deliver agent lifecycle events to any subscribed plugin (US-017, #133).
+	// NewEventNotifier returns nil when no plugin subscribes, so the base handler
+	// stays nil in the common no-plugin case.
+	var baseOnEvent func(agentcore.AgentEvent)
+	if n := plugin.NewEventNotifier(env.Plugins, errOut); n != nil {
+		baseOnEvent = n.Handle
+	}
+	d, onEvent := run.InstallDriverHooks(ctx, &runCfg, set, hookDeps, source, baseOnEvent)
+	// UserPromptSubmit runs before the prompt is handed to the loop: a block aborts
+	// the headless run non-zero; additionalContext is injected into this run only.
+	if d != nil {
+		if block, reason := run.DispatchUserPromptSubmit(ctx, d, &runCfg, hookDeps, headlessPrompt); block {
+			fmt.Fprintf(errOut, "pigo: prompt blocked by hook: %s\n", reason)
+			return 1
+		}
+	}
+
 	cfg := runtime.HeadlessConfig{
 		Mode: p.Mode,
 		Out:  out,
 		Run:  runCfg,
 	}
-	// Deliver agent lifecycle events to any subscribed plugin (US-017, #133).
-	// NewEventNotifier returns nil when no plugin subscribes, so the OnEvent hook
-	// stays unset in the common no-plugin case.
-	if n := plugin.NewEventNotifier(env.Plugins, errOut); n != nil {
-		cfg.OnEvent = n.Handle
-	}
+	cfg.OnEvent = onEvent
 	runErr := runtime.RunHeadless(ctx, agentCtx, cfg)
 	// Persist the run's messages regardless of run outcome so a partial run is
 	// still resumable; a persistence failure is reported but does not mask a run

--- a/internal/cli/headless/subagent_rpc.go
+++ b/internal/cli/headless/subagent_rpc.go
@@ -106,6 +106,16 @@ func handleSubAgentRequest(ctx context.Context, enc *json.Encoder, req *jsonrpc.
 		},
 		Batch: agenttool.BatchConfig{ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: reg}},
 	}
+	// Wire hooks uniformly with every other driver (#425): the child sub-agent runs
+	// its own PreToolUse/PostToolUse (and Stop) hooks from the trust-gated hook set
+	// rooted at its working directory. It has no backing session, so SessionID is
+	// empty (omitted from HookInput). A malformed hook layer disables hooks with a
+	// warning rather than failing the child run.
+	if set, herr := run.ResolveHookSet(cwd, run.Trusted(cwd)); herr != nil {
+		fmt.Fprintf(os.Stderr, "pigo: hooks disabled: %v\n", herr)
+	} else {
+		run.InstallHooks(&runCfg, set, run.HookDeps{ProjectDir: cwd, WarnLog: os.Stderr})
+	}
 	text, err := runtime.RunSubAgentOnce(ctx, params.SystemPrompt, params.Prompt, tools, runCfg)
 	if err != nil {
 		// A failed child run is an RPC error so the parent's defaultProcessCall

--- a/internal/cli/host.go
+++ b/internal/cli/host.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/cli/run"
+	"github.com/smallnest/pigo/internal/hooks"
 	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
@@ -50,6 +52,13 @@ type Host interface {
 	Trust() *trust.Manager
 	Goal() *agenttool.GoalState
 	Telemetry() *TelemetryHolder
+
+	// Dispatcher returns the session's hook dispatcher, or nil when no hooks are
+	// configured (FR-18). Side-runs (/goal, /btw) install the per-turn seams onto
+	// their own cfg via run.InstallSeams(cfg, host.Dispatcher(), host.HookDeps()).
+	Dispatcher() *hooks.Dispatcher
+	// HookDeps carries the session id / project dir stamped onto every HookInput.
+	HookDeps() run.HookDeps
 
 	// Cwd is the directory pigo was launched in; it does not change during a
 	// session and gates side-effect tools.

--- a/internal/cli/repl/host.go
+++ b/internal/cli/repl/host.go
@@ -12,6 +12,8 @@ import (
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/run"
+	"github.com/smallnest/pigo/internal/hooks"
 	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
@@ -34,6 +36,8 @@ func (d *replDeps) NotifierHandle() func(agentcore.AgentEvent) { return d.notifi
 func (d *replDeps) Trust() *trust.Manager                      { return d.trust }
 func (d *replDeps) Goal() *agenttool.GoalState                 { return d.goal }
 func (d *replDeps) Telemetry() *cli.TelemetryHolder            { return d.telemetry }
+func (d *replDeps) Dispatcher() *hooks.Dispatcher              { return d.dispatcher }
+func (d *replDeps) HookDeps() run.HookDeps                     { return d.hookDeps }
 func (d *replDeps) Cwd() string                                { return d.cwd }
 func (d *replDeps) Input() *bufio.Reader                       { return d.in }
 func (d *replDeps) ConfirmMu() *sync.Mutex                     { return d.confirmMu }

--- a/internal/cli/repl/repl.go
+++ b/internal/cli/repl/repl.go
@@ -29,10 +29,12 @@ import (
 	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/cli/btw"
 	"github.com/smallnest/pigo/internal/cli/goal"
+	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/status"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/clipboard"
 	"github.com/smallnest/pigo/internal/compaction"
+	"github.com/smallnest/pigo/internal/hooks"
 	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
@@ -116,6 +118,15 @@ type replDeps struct {
 	// It is reset to "no telemetry yet" on any session switch (/fork, /clone,
 	// /import).
 	telemetry *cli.TelemetryHolder
+
+	// dispatcher is the run's hook dispatcher (#425), nil when no hooks are
+	// configured (FR-18) so every hook path is skipped. It is resolved once per
+	// session (trust-gated, FR-14) at the top of runREPL, which also fires
+	// SessionStart. Each turn's streamRun installs the per-turn seams
+	// (PreToolUse/PostToolUse/Stop) and runs UserPromptSubmit through it.
+	dispatcher *hooks.Dispatcher
+	// hookDeps carries the session id / project dir stamped onto every HookInput.
+	hookDeps run.HookDeps
 }
 
 // replScanBufInit is the initial size of the shared input reader. A REPL user
@@ -154,6 +165,26 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 	// deps.in, and is ignored once deps.in is populated.
 	if deps.in == nil {
 		deps.in = bufio.NewReaderSize(in, replScanBufInit)
+	}
+
+	// Resolve the run's hooks once per session and fire SessionStart so any
+	// injected context lands in the first turn (#423/#425). The project layer is
+	// honored only when the working directory is trusted (FR-14). A malformed hook
+	// layer disables hooks with a warning rather than aborting an interactive
+	// session. deps.dispatcher stays nil when no hooks are configured (FR-18), so
+	// streamRun skips all hook work.
+	deps.hookDeps = run.HookDeps{SessionID: deps.header.ID, ProjectDir: deps.cwd, WarnLog: out}
+	trusted := deps.trust != nil && deps.trust.IsTrusted(deps.cwd)
+	if set, err := run.ResolveHookSet(deps.cwd, trusted); err != nil {
+		fmt.Fprintf(out, "pigo: hooks disabled: %v\n", err)
+	} else if d := run.BuildDispatcher(set, deps.hookDeps); d != nil {
+		deps.dispatcher = d
+		if deps.reminders == nil {
+			deps.reminders = runtime.NewReminderRegistry()
+		}
+		ssCfg := runtime.RunConfig{Reminders: deps.reminders}
+		run.DispatchSessionStart(context.Background(), d, &ssCfg, deps.hookDeps, "startup")
+		deps.reminders = ssCfg.Reminders
 	}
 	var priorInputs []string
 	for _, msg := range deps.agentCtx.Messages {
@@ -369,6 +400,17 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 		fmt.Fprintf(out, "pigo: %v\n", err)
 		return
 	}
+	// UserPromptSubmit runs before the prompt is committed to the shared context,
+	// so a block aborts the turn without leaving a dangling user message; any
+	// additionalContext is injected into this turn only (one-shot reminder).
+	if deps.dispatcher != nil {
+		pc := runtime.RunConfig{Reminders: deps.reminders}
+		if block, reason := run.DispatchUserPromptSubmit(ctx, deps.dispatcher, &pc, deps.hookDeps, prompt); block {
+			fmt.Fprintf(out, "pigo: prompt blocked by hook: %s\n", reason)
+			return
+		}
+		deps.reminders = pc.Reminders
+	}
 	deps.agentCtx.Messages = append(deps.agentCtx.Messages, agentcore.UserMessage{
 		RoleField: agentcore.RoleUser,
 		Content:   content,
@@ -391,6 +433,12 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 		},
 		Reminders: deps.reminders,
 	}
+	// Per-turn wiring of the tool-execution + Stop seams (PreToolUse/PostToolUse/
+	// Stop) onto this turn's freshly-built cfg; a nil dispatcher is a no-op so the
+	// hot path pays nothing when no hooks are configured (FR-18).
+	if deps.dispatcher != nil {
+		run.InstallSeams(&cfg, deps.dispatcher, deps.hookDeps)
+	}
 	stream := runtime.StartRun(ctx, deps.agentCtx, cfg)
 
 	// The assistant reply is Markdown, which can only be laid out once the whole
@@ -410,6 +458,12 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 		}
 		reply.Reset()
 	}
+	// The SessionEnd/PreCompact observer chains onto the existing OnEvent closure
+	// (plugin notifier + telemetry). Nil when no hooks are configured.
+	var hookEvent func(agentcore.AgentEvent)
+	if deps.dispatcher != nil {
+		hookEvent = hooks.NewHookNotifier(deps.dispatcher, deps.hookDeps.SessionID, deps.hookDeps.ProjectDir).Handle
+	}
 	_, err = runtime.DrainStream(ctx, stream, runtime.StreamHandler{
 		OnEvent: func(ev agentcore.AgentEvent) {
 			// First call the notifier if present.
@@ -419,6 +473,10 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 			// Capture TelemetryEvent and fold it into the holder.
 			if telemetry, ok := ev.(agentcore.TelemetryEvent); ok && deps.telemetry != nil {
 				deps.telemetry.Fold(telemetry)
+			}
+			// Deliver SessionEnd/PreCompact to any configured hook.
+			if hookEvent != nil {
+				hookEvent(ev)
 			}
 		},
 		OnText: func(delta string) {

--- a/internal/cli/run/hooks_converge_test.go
+++ b/internal/cli/run/hooks_converge_test.go
@@ -1,0 +1,106 @@
+package run
+
+// Regression coverage for the #425 driver convergence (FR-16): the SAME resolved
+// hook set must fire in every driver mode. Rather than stand up a provider-backed
+// run for each of the six drivers, this pins the two DISTINCT wiring paths they
+// route through — the one-shot path (headless / subagent_rpc via InstallDriverHooks
+// / InstallHooks) and the multi-turn path (repl / tui / goal / btw via
+// BuildDispatcher once + InstallSeams per turn) — and asserts a PreToolUse hook
+// installed through either path reaches the BeforeToolCall seam and blocks. It
+// also pins FR-18: an empty hook set wires no seam in either path, so a run with
+// no hooks configured behaves exactly as before.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/hooks"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// blockingPreToolUse is a hook set whose PreToolUse hook exits 2 (Claude Code
+// block semantics), so any wired BeforeToolCall seam must return a blocking
+// decision when it fires.
+func blockingPreToolUse() hooks.HookSet {
+	return hooks.HookSet{
+		"PreToolUse": {{Matcher: "*", Hooks: []hooks.HookConfig{{Command: "exit 2"}}}},
+	}
+}
+
+// fireBeforeToolCall drives the wired BeforeToolCall seam once and reports
+// whether it produced a blocking decision. A nil seam (no hook wired) reports
+// false.
+func fireBeforeToolCall(cfg *runtime.RunConfig) bool {
+	seam := cfg.Batch.ToolExecutorConfig.BeforeToolCall
+	if seam == nil {
+		return false
+	}
+	dec := seam(context.Background(), agentcore.AgentToolCall{Name: "Bash"})
+	return dec != nil && dec.Block
+}
+
+// TestHookConvergenceBothPaths asserts the same PreToolUse hook set fires in both
+// driver wiring paths: the one-shot headless path and the multi-turn REPL path.
+func TestHookConvergenceBothPaths(t *testing.T) {
+	deps := HookDeps{SessionID: "s1", ProjectDir: t.TempDir()}
+	set := blockingPreToolUse()
+
+	// Headless / subagent_rpc path: InstallDriverHooks wires the seams all-in-one.
+	t.Run("headless", func(t *testing.T) {
+		var cfg runtime.RunConfig
+		d, _ := InstallDriverHooks(context.Background(), &cfg, set, deps, "startup", nil)
+		if d == nil {
+			t.Fatal("expected dispatcher for non-empty hook set")
+		}
+		if !fireBeforeToolCall(&cfg) {
+			t.Fatal("headless path: PreToolUse hook did not block")
+		}
+	})
+
+	// REPL / TUI / goal / btw path: BuildDispatcher once, then InstallSeams per turn.
+	t.Run("repl", func(t *testing.T) {
+		d := BuildDispatcher(set, deps)
+		if d == nil {
+			t.Fatal("expected dispatcher for non-empty hook set")
+		}
+		var cfg runtime.RunConfig
+		InstallSeams(&cfg, d, deps)
+		if !fireBeforeToolCall(&cfg) {
+			t.Fatal("repl path: PreToolUse hook did not block")
+		}
+	})
+}
+
+// TestHookConvergenceNoHooksUnchanged pins FR-18: with no hooks configured neither
+// wiring path installs a BeforeToolCall seam, so both drivers behave exactly as
+// they did before hooks existed.
+func TestHookConvergenceNoHooksUnchanged(t *testing.T) {
+	deps := HookDeps{ProjectDir: t.TempDir()}
+
+	t.Run("headless", func(t *testing.T) {
+		var cfg runtime.RunConfig
+		d, ev := InstallDriverHooks(context.Background(), &cfg, nil, deps, "startup", nil)
+		if d != nil {
+			t.Fatalf("expected nil dispatcher for empty hook set, got %v", d)
+		}
+		if ev != nil {
+			t.Fatal("expected event handler unchanged (nil) for empty hook set")
+		}
+		if cfg.Batch.ToolExecutorConfig.BeforeToolCall != nil {
+			t.Fatal("headless path: seam wired despite no hooks")
+		}
+	})
+
+	t.Run("repl", func(t *testing.T) {
+		d := BuildDispatcher(nil, deps)
+		if d != nil {
+			t.Fatalf("expected nil dispatcher for empty hook set, got %v", d)
+		}
+		var cfg runtime.RunConfig
+		InstallSeams(&cfg, d, deps) // nil dispatcher must be a no-op
+		if cfg.Batch.ToolExecutorConfig.BeforeToolCall != nil {
+			t.Fatal("repl path: seam wired despite no hooks")
+		}
+	})
+}

--- a/internal/cli/run/hooks_driver.go
+++ b/internal/cli/run/hooks_driver.go
@@ -1,0 +1,64 @@
+// This file provides the single convergence entry point every driver calls to
+// wire hooks into its run (#425, FR-16). Before this, each of the six RunConfig
+// assembly sites (repl/goal/btw/tui/headless/subagent_rpc) built the loop config
+// independently, which was the main risk of a hook point being silently dropped
+// in one mode but not another. Routing them all through InstallDriverHooks makes
+// "which hook points a run has" a single decision rather than six.
+//
+// InstallDriverHooks resolves the trust-gated hook set (FR-14), installs the
+// tool-execution and Stop seams via InstallHooks, dispatches SessionStart inline
+// so injected context reaches turn one (#423), and chains the observer notifier
+// (SessionEnd/PreCompact, #424) onto the driver's event seam. It returns the
+// Dispatcher so a caller can additionally run UserPromptSubmit (prompt entry) or
+// InstallSubagentStop (sub-agent), and the possibly-wrapped event handler to
+// install on whatever OnEvent seam the driver owns (HeadlessConfig.OnEvent for
+// headless, the DrainStream handler for the REPL/TUI).
+package run
+
+import (
+	"context"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/hooks"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// InstallDriverHooks is the uniform hook-wiring seam for every driver. It
+// installs the tool-execution + Stop hook points onto cfg, dispatches
+// SessionStart (registering any additionalContext as a one-shot reminder so it
+// lands in turn one), and chains the SessionEnd/PreCompact observer onto onEvent.
+//
+// set is the already-resolved, trust-gated hook set (see ResolveHookSet). When
+// it is empty NewDispatcher returns nil, so this is a no-op that returns
+// (nil, onEvent) and the hot path pays nothing (FR-18): the run behaves exactly
+// as it did before hooks existed.
+//
+// The returned dispatcher (nil when no hooks) lets the caller wire the remaining
+// prompt-scoped / sub-agent hooks. The returned handler is onEvent unchanged when
+// there are no hooks, or onEvent with the notifier chained after it otherwise —
+// so the driver installs one handler regardless.
+func InstallDriverHooks(ctx context.Context, cfg *runtime.RunConfig, set hooks.HookSet, deps HookDeps, source string, onEvent func(agentcore.AgentEvent)) (*hooks.Dispatcher, func(agentcore.AgentEvent)) {
+	d := InstallHooks(cfg, set, deps)
+	if d == nil {
+		return nil, onEvent
+	}
+	DispatchSessionStart(ctx, d, cfg, deps, source)
+	n := hooks.NewHookNotifier(d, deps.SessionID, deps.ProjectDir)
+	return d, chainEvent(onEvent, n.Handle)
+}
+
+// chainEvent composes two AgentEvent observers into one that calls prev then
+// next. A nil operand is identity, so chaining onto an unset seam returns the
+// other unchanged (and returns nil when both are nil, keeping the seam unset).
+func chainEvent(prev, next func(agentcore.AgentEvent)) func(agentcore.AgentEvent) {
+	if prev == nil {
+		return next
+	}
+	if next == nil {
+		return prev
+	}
+	return func(ev agentcore.AgentEvent) {
+		prev(ev)
+		next(ev)
+	}
+}

--- a/internal/cli/run/hooks_install.go
+++ b/internal/cli/run/hooks_install.go
@@ -51,16 +51,43 @@ func InstallHooks(cfg *runtime.RunConfig, set hooks.HookSet, deps HookDeps) *hoo
 	if d == nil {
 		return nil
 	}
+	InstallSeams(cfg, d, deps)
+	return d
+}
 
+// BuildDispatcher builds the run's Dispatcher from the resolved hook set without
+// touching a RunConfig. It is the entry point for the multi-turn drivers (REPL /
+// TUI) that resolve hooks and fire SessionStart once per session, then install
+// the per-turn seams (InstallSeams) on each turn's freshly-built RunConfig. It
+// returns nil for an empty set (FR-18), so callers gate all hook work on non-nil.
+func BuildDispatcher(set hooks.HookSet, deps HookDeps) *hooks.Dispatcher {
+	warn := deps.WarnLog
+	if warn == nil {
+		warn = os.Stderr
+	}
+	return hooks.NewDispatcher(set, deps.ProjectDir, warn)
+}
+
+// InstallSeams wires the tool-execution and Stop hook points onto cfg from an
+// already-built dispatcher. It is the shared body of InstallHooks and the
+// per-turn install path for multi-turn drivers. A nil dispatcher is a no-op, so
+// callers can invoke it unconditionally.
+//
+// PreToolUse is CHAINED onto the existing BeforeToolCall seam (occupied by the
+// trust gate) rather than replacing it: trust runs first and stays authoritative
+// (a trust block short-circuits before the user hook runs). PostToolUse is
+// chained onto AfterToolCall as a last-writer so it can append feedback to an
+// already-executed tool's result without undoing it. The Stop hook is chained
+// onto the loop's natural-end seam (FR-10), bounded by the decorator's
+// consecutive-block counter (FR-12).
+func InstallSeams(cfg *runtime.RunConfig, d *hooks.Dispatcher, deps HookDeps) {
+	if d == nil {
+		return
+	}
 	tec := &cfg.Batch.ToolExecutorConfig
 	tec.BeforeToolCall = chainBeforeToolCall(tec.BeforeToolCall, preToolCallHook(d, deps))
 	tec.AfterToolCall = chainAfterToolCall(tec.AfterToolCall, postToolCallHook(d, deps))
-	// Stop hook: chained onto the loop's natural-end seam so a hook may block the
-	// run from ending and force a continuation (FR-10), bounded by the decorator's
-	// consecutive-block counter (FR-12). The sub-agent assembly wires the
-	// SubagentStop variant via installStopHook with the "SubagentStop" event.
 	installStopHook(cfg, d, deps, "Stop")
-	return d
 }
 
 // preToolCallHook adapts the dispatcher's PreToolUse event to the BeforeToolCall

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -16,9 +16,11 @@ import (
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/builtinskills"
+	"github.com/smallnest/pigo/internal/hooks"
 	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
+	"github.com/smallnest/pigo/internal/trust"
 )
 
 // Env is the environment every run shares: the working directory, the tool set
@@ -301,6 +303,56 @@ func ResolveThinkingLevel(cliLevel string) (agentcore.ThinkingLevel, error) {
 		return "", err
 	}
 	return cfg.ThinkingLevel, nil
+}
+
+// ResolveHookSet resolves the effective hook set through the same layered config
+// chain as ResolveThinkingLevel (default < global < project < env), with one
+// difference required by FR-14: the project layer (./.pigo/config.json under
+// cwd) is only merged when the directory is trusted. An untrusted directory
+// therefore contributes no hooks, so a checked-out repo cannot run arbitrary
+// commands until the user trusts it. A malformed layer file is a hard error,
+// surfaced to the caller. The returned set is empty (len 0) when no layer
+// defines hooks, which InstallHooks treats as "no hooks" (FR-18).
+func ResolveHookSet(cwd string, trusted bool) (hooks.HookSet, error) {
+	def := runtime.DefaultConfigLayer()
+	layers := []*runtime.ConfigLayer{&def}
+
+	if dir := ConfigDir(); dir != "" {
+		global, err := runtime.LoadConfigLayer(filepath.Join(dir, "config.json"))
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, global)
+	}
+	if trusted {
+		project, err := runtime.LoadConfigLayer(filepath.Join(cwd, ".pigo", "config.json"))
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, project)
+	}
+	env := runtime.EnvConfigLayer(os.Getenv)
+	layers = append(layers, &env)
+
+	cfg, err := runtime.ResolveConfig(layers...)
+	if err != nil {
+		return nil, err
+	}
+	return cfg.Hooks, nil
+}
+
+// Trusted reports whether cwd is a trusted directory per the shared trust store
+// ($PIGO_HOME/trust.json). It is the trust gate for the non-interactive drivers
+// (headless / TUI / sub-agent) that have no live trust.Manager to consult, so
+// ResolveHookSet can honor FR-14 uniformly. A missing or unreadable store is
+// treated as untrusted (fail closed): a directory only runs project-layer hooks
+// after the user has explicitly trusted it.
+func Trusted(cwd string) bool {
+	m, err := trust.NewManager(trust.DefaultPath())
+	if err != nil || m == nil {
+		return false
+	}
+	return m.IsTrusted(cwd)
 }
 
 // NewConfig builds the loop configuration shared by every driver: the provider

--- a/internal/cli/tui/bridge.go
+++ b/internal/cli/tui/bridge.go
@@ -40,7 +40,7 @@ func newEventChan() chan tea.Msg {
 // back-pressure to the draining goroutine so no event is lost. It is factored
 // out of pump so the callback→msg conversion can be unit-tested without a real
 // provider run (see bridge_test.go).
-func newStreamHandler(ch chan tea.Msg) runtime.StreamHandler {
+func newStreamHandler(ch chan tea.Msg, extra func(agentcore.AgentEvent)) runtime.StreamHandler {
 	return runtime.StreamHandler{
 		OnText: func(delta string) {
 			ch <- textDeltaMsg{delta: delta}
@@ -49,6 +49,11 @@ func newStreamHandler(ch chan tea.Msg) runtime.StreamHandler {
 			ch <- turnEndMsg{msg: msg, results: results}
 		},
 		OnEvent: func(ev agentcore.AgentEvent) {
+			// Deliver observer events (plugin notifier, SessionEnd/PreCompact hook)
+			// first, then translate into TUI messages.
+			if extra != nil {
+				extra(ev)
+			}
 			switch e := ev.(type) {
 			case agentcore.ToolExecutionStartEvent:
 				ch <- toolStartMsg{id: e.ToolCallID, name: e.ToolName, input: argsToMap(e.Args)}
@@ -79,9 +84,9 @@ func argsToMap(args any) map[string]any {
 // pump runs the agent loop to completion on the calling goroutine, converting
 // every event to a tea.Msg on ch, and finally sends a runEndMsg carrying the
 // run's result error. It is meant to be launched as a goroutine by startRun.
-func pump(ctx context.Context, ch chan tea.Msg, agentCtx *agentcore.AgentContext, cfg runtime.RunConfig) {
+func pump(ctx context.Context, ch chan tea.Msg, agentCtx *agentcore.AgentContext, cfg runtime.RunConfig, onEvent func(agentcore.AgentEvent)) {
 	stream := runtime.StartRun(ctx, agentCtx, cfg)
-	_, err := runtime.DrainStream(ctx, stream, newStreamHandler(ch))
+	_, err := runtime.DrainStream(ctx, stream, newStreamHandler(ch, onEvent))
 	ch <- runEndMsg{err: err}
 }
 
@@ -101,8 +106,8 @@ func waitForEvent(ch chan tea.Msg) tea.Cmd {
 // again to pull the next msg. Returning the channel keeps the bridge
 // self-contained: the model owns the handle and decides when to stop pulling
 // (after runEndMsg).
-func startRun(ctx context.Context, agentCtx *agentcore.AgentContext, cfg runtime.RunConfig) (chan tea.Msg, tea.Cmd) {
+func startRun(ctx context.Context, agentCtx *agentcore.AgentContext, cfg runtime.RunConfig, onEvent func(agentcore.AgentEvent)) (chan tea.Msg, tea.Cmd) {
 	ch := newEventChan()
-	go pump(ctx, ch, agentCtx, cfg)
+	go pump(ctx, ch, agentCtx, cfg, onEvent)
 	return ch, waitForEvent(ch)
 }

--- a/internal/cli/tui/bridge_test.go
+++ b/internal/cli/tui/bridge_test.go
@@ -31,7 +31,7 @@ func drain(ch chan tea.Msg) []tea.Msg {
 // the callback→msg conversion + channel ordering in isolation.
 func TestStreamHandlerConversion(t *testing.T) {
 	ch := newEventChan()
-	h := newStreamHandler(ch)
+	h := newStreamHandler(ch, nil)
 
 	// A representative sequence: two text deltas, a tool start/update/end, a
 	// telemetry summary, a compaction, and a turn end.
@@ -100,7 +100,7 @@ func TestStreamHandlerConversion(t *testing.T) {
 // TestToolEndError verifies the ok flag inverts IsError.
 func TestToolEndError(t *testing.T) {
 	ch := newEventChan()
-	h := newStreamHandler(ch)
+	h := newStreamHandler(ch, nil)
 	h.OnEvent(agentcore.ToolExecutionEndEvent{
 		ToolCallID: "c",
 		Result:     agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent("boom")}},

--- a/internal/cli/tui/session.go
+++ b/internal/cli/tui/session.go
@@ -14,6 +14,8 @@ package tui
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -25,6 +27,8 @@ import (
 	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/compaction"
+	"github.com/smallnest/pigo/internal/hooks"
+	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
 	"github.com/smallnest/pigo/internal/session"
@@ -44,6 +48,15 @@ type runSession struct {
 	reg       *agenttool.ToolRegistry
 	reminders *runtime.ReminderRegistry
 	creds     *provider.CredentialStore
+
+	// dispatcher is the session's hook dispatcher, nil when no hooks are
+	// configured (FR-18). hookDeps carries the session id / project dir stamped
+	// onto every HookInput and hook process environment.
+	dispatcher *hooks.Dispatcher
+	hookDeps   run.HookDeps
+	// onEvent is the observer chain delivered to every run: the plugin notifier
+	// (US-017) with the SessionEnd/PreCompact hook notifier chained after it.
+	onEvent func(agentcore.AgentEvent)
 
 	// curLeaf is the id of the on-disk entry the next turn descends from; persisted
 	// is the number of agentCtx.Messages already written. persist() appends only
@@ -138,7 +151,60 @@ func newRunSessionWithStore(store *session.Store, opts Options) (*runSession, []
 		curLeaf:   curLeaf,
 		persisted: len(history),
 	}
+	// Wire hooks uniformly with every other driver (#425): resolve the trust-gated
+	// hook set, build the dispatcher, dispatch SessionStart once, and compose the
+	// SessionEnd/PreCompact observer with the plugin notifier. Trust is granted by
+	// --approve (Options.Approve) or the shared trust store; project-layer hooks
+	// only apply when trusted (FR-14). A malformed hook layer disables hooks with a
+	// warning rather than failing the TUI launch.
+	cwd, _ := os.Getwd()
+	s.hookDeps = run.HookDeps{SessionID: header.ID, ProjectDir: cwd, WarnLog: os.Stderr}
+	trusted := opts.Approve || run.Trusted(cwd)
+	var baseOnEvent func(agentcore.AgentEvent)
+	if n := plugin.NewEventNotifier(opts.Plugins, os.Stderr); n != nil {
+		baseOnEvent = n.Handle
+	}
+	if set, err := run.ResolveHookSet(cwd, trusted); err != nil {
+		fmt.Fprintf(os.Stderr, "pigo: hooks disabled: %v\n", err)
+		s.onEvent = baseOnEvent
+	} else if d := run.BuildDispatcher(set, s.hookDeps); d != nil {
+		s.dispatcher = d
+		if s.reminders == nil {
+			s.reminders = runtime.NewReminderRegistry()
+		}
+		ssCfg := runtime.RunConfig{Reminders: s.reminders}
+		run.DispatchSessionStart(context.Background(), d, &ssCfg, s.hookDeps, sessionStartSource(opts))
+		s.reminders = ssCfg.Reminders
+		n := hooks.NewHookNotifier(d, s.hookDeps.SessionID, s.hookDeps.ProjectDir)
+		s.onEvent = chainTUIEvent(baseOnEvent, n.Handle)
+	} else {
+		s.onEvent = baseOnEvent
+	}
 	return s, history, nil
+}
+
+// sessionStartSource maps the resolved run options to the SessionStart source
+// tag: "resume" when continuing an existing session, "startup" otherwise.
+func sessionStartSource(opts Options) string {
+	if opts.ResumeID != "" {
+		return "resume"
+	}
+	return "startup"
+}
+
+// chainTUIEvent composes the plugin notifier with the hook notifier into one
+// observer; a nil operand is identity.
+func chainTUIEvent(prev, next func(agentcore.AgentEvent)) func(agentcore.AgentEvent) {
+	if prev == nil {
+		return next
+	}
+	if next == nil {
+		return prev
+	}
+	return func(ev agentcore.AgentEvent) {
+		prev(ev)
+		next(ev)
+	}
 }
 
 // buildConfig assembles the RunConfig for one turn from the live config and
@@ -149,7 +215,7 @@ func newRunSessionWithStore(store *session.Store, opts Options) (*runSession, []
 // per-call BeforeToolCall prompt. The stream fn is derived from the live provider
 // and the API key resolved through the credential store, exactly as the REPL does.
 func (s *runSession) buildConfig() runtime.RunConfig {
-	return runtime.RunConfig{
+	cfg := runtime.RunConfig{
 		LoopConfig: runtime.LoopConfig{
 			Model:         s.live.Model,
 			Provider:      s.live.ProviderName,
@@ -166,6 +232,12 @@ func (s *runSession) buildConfig() runtime.RunConfig {
 		},
 		Reminders: s.reminders,
 	}
+	// Per-turn wiring of the tool-execution + Stop seams; nil dispatcher is a
+	// no-op so the hot path pays nothing when no hooks are configured (FR-18).
+	if s.dispatcher != nil {
+		run.InstallSeams(&cfg, s.dispatcher, s.hookDeps)
+	}
+	return cfg
 }
 
 // startRun is the real binding for Model.startRunFn: it appends the submitted
@@ -181,6 +253,18 @@ func (s *runSession) startRun(prompt string) (chan tea.Msg, tea.Cmd) {
 		// raw prompt as plain text so the run still starts.
 		content = agentcore.ContentList{agentcore.NewTextContent(prompt)}
 	}
+	// UserPromptSubmit runs before the prompt is committed to the context: a block
+	// aborts the turn (emitting a runEndMsg carrying the reason) without leaving a
+	// dangling user message; additionalContext is injected into this turn only.
+	if s.dispatcher != nil {
+		pc := runtime.RunConfig{Reminders: s.reminders}
+		if block, reason := run.DispatchUserPromptSubmit(context.Background(), s.dispatcher, &pc, s.hookDeps, prompt); block {
+			ch := newEventChan()
+			go func() { ch <- runEndMsg{err: fmt.Errorf("prompt blocked by hook: %s", reason)} }()
+			return ch, waitForEvent(ch)
+		}
+		s.reminders = pc.Reminders
+	}
 	s.agentCtx.Messages = append(s.agentCtx.Messages, agentcore.UserMessage{
 		RoleField: agentcore.RoleUser,
 		Content:   content,
@@ -190,7 +274,7 @@ func (s *runSession) startRun(prompt string) (chan tea.Msg, tea.Cmd) {
 	// runEndMsg and the model returns to idle.
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancelRun = cancel
-	return startRun(ctx, s.agentCtx, s.buildConfig())
+	return startRun(ctx, s.agentCtx, s.buildConfig(), s.onEvent)
 }
 
 // interrupt cancels the in-flight run, if any. It is bound to Model.interruptFn


### PR DESCRIPTION
## Summary
- Route repl, goal, btw, tui, headless, subagent_rpc through the shared `run`-layer hook helpers so every driver wires the same trust-gated hook set with correct session_id/cwd (FR-16)
- Multi-turn drivers fire SessionStart once + install seams per turn; one-shot drivers install all-in-one via `InstallDriverHooks`/`InstallHooks`
- Add `Dispatcher()`/`HookDeps()` to `cli.Host` so /goal and /btw side-runs reuse the session dispatcher; thread an observer through the TUI bridge (previously dropped all observer events)
- Add `run.ResolveHookSet`/`run.Trusted` (fail-closed) so non-interactive drivers honor FR-14 project-layer trust gating
- Regression test covers both wiring paths asserting the same hook fires, plus FR-18 (no hooks ⇒ behavior unchanged)

Closes #425

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `TestHookConvergenceBothPaths` (headless + repl paths block via same PreToolUse hook)
- [x] `TestHookConvergenceNoHooksUnchanged` (FR-18)