### PR TITLE
docs(hooks): README Hooks 章节、可运行示例与安全须知

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pigo 可以读写文件、执行命令、检索代码、抓取网页，并借助
 
 > 📖 配套电子书《用 Go 编写 pi Agent》：[write_pi_agent_in_go.pdf](https://github.com/smallnest/ebooks/blob/master/write_pi_agent_in_go.pdf)
 
-![](docs/pigo.png)
+![](docs/pigo-tui.png)
 
 ---
 
@@ -30,6 +30,7 @@ pigo 可以读写文件、执行命令、检索代码、抓取网页，并借助
 - [技能 Skills](#技能-skills)
 - [提示词模板](#提示词模板)
 - [插件](#插件)
+- [Hooks](#hooks)
 - [包管理](#包管理)
 - [发布release](#发布release)
 - [目录与环境变量](#目录与环境变量)
@@ -401,6 +402,165 @@ Review the PR at $1. Focus on:
 - 容错发现——启动失败的插件会被记录并跳过。
 - 插件可提供额外工具，并订阅 Agent 生命周期事件。
 - `--no-tools` 会整体跳过插件发现。
+
+---
+
+## Hooks
+
+Hooks 让你在 Agent 生命周期的关键节点运行**自定义 shell 命令**，无需写 Go 或编译插件即可拦截、注入或观察 Agent 行为（对标 Claude Code 的 hooks）。命令以你**当前用户身份**执行，通过 stdin 收到一份 JSON、通过退出码与 stdout JSON 影响 Agent。
+
+### Hook 点一览（9 个）
+
+| 事件 | 触发时机 | 能否阻断 | 关键输入字段 |
+|------|---------|:-------:|-------------|
+| `PreToolUse` | 工具执行前 | ✅ | `tool_name`, `tool_input` |
+| `PostToolUse` | 工具执行后 | 反馈 | `tool_name`, `tool_input`, `tool_response` |
+| `UserPromptSubmit` | 用户提交 prompt 后、进入模型前 | ✅ | `prompt` |
+| `Stop` | 主 Agent 一轮自然结束时 | ✅（要求继续） | `stop_reason` |
+| `SubagentStop` | 子 Agent 结束时 | ✅（要求继续） | `stop_reason` |
+| `SessionStart` | 会话开始 / 恢复 | 注入 | `source`（`startup`/`resume`） |
+| `SessionEnd` | 会话结束 | 观察 | `stop_reason` |
+| `PreCompact` | 上下文压缩前 | 观察 | `trigger`（`manual`/`auto`） |
+| `Notification` | Agent 发出通知时 | 观察 | `message` |
+
+### 输入 JSON（写入 hook 的 stdin）
+
+pigo 向 hook 命令的 stdin 写入**单行 JSON**。只包含可观察、非敏感字段，**绝不包含 API Key 或任何凭证**。按事件类型只携带相关字段：
+
+```json
+{
+  "event_type": "PreToolUse",
+  "session_id": "0f9d…",
+  "project_dir": "/path/to/repo",
+  "tool_name": "bash",
+  "tool_input": { "command": "rm -rf /" }
+}
+```
+
+| 字段 | 说明 |
+|------|------|
+| `event_type` | 事件名（见上表） |
+| `session_id` | 会话 id（子 Agent 无会话时省略） |
+| `project_dir` | 当前工作目录 |
+| `tool_name` / `tool_input` | 工具名与入参（Pre/PostToolUse） |
+| `tool_response` | 工具返回（PostToolUse） |
+| `prompt` | 用户输入（UserPromptSubmit） |
+| `stop_reason` | 结束原因（Stop/SessionEnd） |
+| `source` | `startup` 或 `resume`（SessionStart） |
+| `trigger` | `manual` 或 `auto`（PreCompact） |
+| `message` | 通知内容（Notification） |
+
+### 输出协议（退出码 + stdout JSON）
+
+hook 通过**退出码**给出决定：
+
+- **`0`**：放行。若 stdout 是合法 JSON，则按下表解析；非 JSON 视为无操作。
+- **`2`**：阻断。stderr 作为阻断原因（等价于 stdout 输出 `{"decision":"block"}`）。
+- **其它非 0**：执行失败，记录警告并对阻断型 hook **fail-open**（不阻断 Agent）。
+
+退出码 0 时，可选地在 stdout 打印 JSON 精细控制：
+
+| 字段 | 类型 | 作用 |
+|------|------|------|
+| `decision` | string | `"block"` 阻断；`"approve"` 或空放行 |
+| `reason` | string | 阻断原因 / 反馈文本 |
+| `additionalContext` | string | 注入给模型的额外上下文（UserPromptSubmit / SessionStart） |
+| `continue` | bool | `false` 等价于阻断 |
+| `updatedInput` | object | 仅 PreToolUse：改写工具入参后再执行 |
+
+多个 hook 命中同一事件时：任一阻断即阻断；`additionalContext` 按顺序累加；`updatedInput` 以最后一个为准。每个 hook 默认 60s 超时（`timeout` 字段可覆盖），超时按失败处理。
+
+### Matcher 规则
+
+`matcher` 仅对带工具名的事件（Pre/PostToolUse）生效，语义对标 Claude Code：
+
+- 空或 `"*"`：匹配所有工具。
+- 精确工具名（如 `bash`）：只匹配该工具。
+- `"|"` 分隔列表（如 `bash|write|edit`）：匹配其中任一。
+- 其它：作为 **Go 正则**对工具名求值（如 `"Notebook.*"`）。
+
+不带工具名的事件（UserPromptSubmit、Stop、SessionStart 等）忽略 matcher，全部 hook 触发。
+
+### 分层配置
+
+hook 配置写在 `config.json` 的 `hooks` 字段，按 `event → [{matcher, hooks}]` 组织。多层配置**按事件追加合并**（默认 < 全局 < 项目 < 环境），优先级低的先执行：
+
+- **全局**：`$PIGO_HOME/config.json`（默认 `~/.pigo/config.json`），对所有项目生效。
+- **项目**：`./.pigo/config.json`，**仅当项目被信任时加载**（见下方安全须知）。
+
+```jsonc
+// ~/.pigo/config.json —— 全局：所有会话都注入 git 分支
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "~/.pigo/hooks/inject-branch.sh" }] }
+    ]
+  }
+}
+```
+
+```jsonc
+// ./.pigo/config.json —— 项目级：仅本仓库拦截危险命令、写文件后跑格式化
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "bash", "hooks": [{ "type": "command", "command": "./.pigo/hooks/block-rm-rf.sh" }] }
+    ],
+    "PostToolUse": [
+      { "matcher": "write|edit", "hooks": [{ "type": "command", "command": "./.pigo/hooks/gofmt.sh", "timeout": 30 }] }
+    ]
+  }
+}
+```
+
+单个 hook 条目字段：`type`（当前为 `"command"`，可省略）、`command`（要执行的 shell 命令）、`timeout`（秒，默认 60，非正数忽略）。
+
+### 可运行示例
+
+以下脚本记得 `chmod +x`。
+
+**1. PreToolUse — 拦截 `rm -rf`**（退出码 2 阻断，stderr 作为原因）：
+
+```bash
+#!/usr/bin/env bash
+# ~/.pigo/hooks/block-rm-rf.sh
+payload=$(cat)
+cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // ""')
+if printf '%s' "$cmd" | grep -Eq 'rm[[:space:]]+(-[a-zA-Z]*r[a-zA-Z]*[[:space:]]+)*-?[a-zA-Z]*f'; then
+  echo "blocked: 'rm -rf' is not allowed by project policy" >&2
+  exit 2
+fi
+exit 0
+```
+
+**2. UserPromptSubmit — 注入当前 git 分支**（退出码 0 + stdout JSON 的 `additionalContext`）：
+
+```bash
+#!/usr/bin/env bash
+# ~/.pigo/hooks/inject-branch.sh
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "no-git")
+printf '{"additionalContext": "Current git branch: %s"}\n' "$branch"
+exit 0
+```
+
+**3. PostToolUse — 写文件后跑格式化**（观察型，读 `tool_input` 里的路径）：
+
+```bash
+#!/usr/bin/env bash
+# ~/.pigo/hooks/gofmt.sh
+payload=$(cat)
+path=$(printf '%s' "$payload" | jq -r '.tool_input.path // .tool_input.file_path // ""')
+case "$path" in
+  *.go) [ -f "$path" ] && gofmt -w "$path" ;;
+esac
+exit 0
+```
+
+### 安全须知
+
+- **以当前用户身份执行**：hook 就是普通 shell 命令，拥有你本人的全部权限。只配置你信任的命令，谨慎对待第三方脚本。
+- **payload 不含凭证**：写入 hook stdin 的 JSON 只有可观察的非敏感字段，**绝不包含 API Key 或任何凭证**。
+- **项目级 hook 仅受信任项目启用**：`./.pigo/config.json` 里的 hook 只有当项目被信任（`--approve` 或信任存储记录）时才加载；不受信任的目录一律忽略项目级 hook，避免克隆仓库即执行任意命令（fail-closed）。
 
 ---
 

--- a/docs/issue#0426.html
+++ b/docs/issue#0426.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #426</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.8em; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/426">#426</a> &mdash; hooks: 文档、示例 hook 与 README Hooks 章节 &mdash; 2026-07-30</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 文档直接内联到 README，而非独立 docs/hooks.md</h3>
+      <p><strong>Ambiguity:</strong> AC 只要求「README 新增 Hooks 章节」，未规定是否拆分独立文档。</p>
+      <p><strong>Choice:</strong> 在 README 的「插件」与「包管理」之间插入完整 <code>## Hooks</code> 章节，并在目录加锚点。</p>
+      <p><strong>Rationale:</strong> 与既有插件/包管理章节保持同一层级和风格，用户在同一页即可发现 hooks 能力，无需跳转。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 示例脚本用 <code>jq</code> 解析 stdin JSON</h3>
+      <p><strong>Ambiguity:</strong> 「可运行示例」未规定用何种解析方式读取 payload。</p>
+      <p><strong>Choice:</strong> 三个示例均以 <code>payload=$(cat)</code> + <code>jq -r</code> 提取字段。</p>
+      <p><strong>Rationale:</strong> jq 是 shell 处理单行 JSON 的事实标准，示例简洁可读；字段名严格对齐 <code>internal/hooks/protocol.go</code> 的 JSON tag（<code>tool_input</code>/<code>additionalContext</code>）。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> PostToolUse 示例兼容 <code>path</code> 与 <code>file_path</code> 两个键</h3>
+      <p><strong>Spec:</strong> AC 只说「写文件后跑格式化」。</p>
+      <p><strong>Implemented:</strong> 脚本用 <code>.tool_input.path // .tool_input.file_path</code> 兜底两种可能的入参键名。</p>
+      <p><strong>Why:</strong> write/edit 工具的入参字段名随工具而异，兜底可让示例对更多工具开箱即用，避免用户复制后因键名不符而静默失效。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> <code>rm -rf</code> 拦截用正则启发式而非精确解析</h3>
+      <p><strong>Alternatives:</strong> (a) 完整 shell 词法解析命令行；(b) 正则匹配 <code>rm ... -rf</code> 变体。</p>
+      <p><strong>Chosen:</strong> 正则启发式，覆盖 <code>rm -rf</code> / <code>rm -r -f</code> / <code>rm -fr</code>。</p>
+      <p><strong>Why:</strong> 文档示例重在演示「PreToolUse 退出码 2 阻断」的机制，而非提供生产级命令防火墙；完整解析会喧宾夺主。已在正文注明这是示例策略。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 是否需要提供开箱即用的 hook 脚本目录</h3>
+      <p><strong>Assumption:</strong> 用户会把示例脚本自行放到 <code>~/.pigo/hooks/</code> 并 <code>chmod +x</code>。</p>
+      <p><strong>Verify:</strong> 未来可考虑随发行版附带 <code>examples/hooks/</code> 目录，或 <code>pigo install</code> 一键装配常用 hook；本 issue 范围内仅提供文档内可复制脚本。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- README 新增 `## Hooks` 章节：9 个 hook 点一览表、stdin 输入 JSON schema、输出协议（退出码 0/2/其它 + stdout JSON 字段与合并规则）、matcher 规则、分层配置示例（全局 vs 受信任项目）
- 3 个可运行示例：PreToolUse 拦截 `rm -rf`、UserPromptSubmit 注入 git 分支、PostToolUse 写文件后跑 gofmt
- 安全须知：hook 以当前用户身份执行、payload 不含凭证、项目级 hook 仅受信任项目启用
- 文档字段/行为与 `internal/hooks` 实现交叉核对一致

Closes #426

## Test plan
- [x] go build ./... 通过（文档改动，无代码变更）
- [x] README 字段名对齐 internal/hooks/protocol.go 的 JSON tag
- [x] docs/issue#0426.html 实现笔记已生成