### PR TITLE
fix(hooks): bound runner timeout with WaitDelay

### DIFF
--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -62,6 +62,13 @@ func (r *Runner) Run(ctx context.Context, h HookConfig, input HookInput) (HookOu
 	cmd.Dir = r.ProjectDir
 	cmd.Env = r.env(input)
 	cmd.Stdin = bytes.NewReader(payload)
+	// On timeout, CommandContext kills the shell, but a grandchild it spawned
+	// (e.g. `sh -c "sleep 5"` forking sleep) can inherit the stdout/stderr pipes
+	// and keep them open, blocking cmd.Run until that grandchild exits on its own
+	// — so Run would return only after the full command duration, not the timeout.
+	// WaitDelay bounds that wait: after the process is killed, Go force-closes the
+	// I/O pipes so Run returns promptly.
+	cmd.WaitDelay = time.Second
 
 	var stdout, stderr cappedBuffer
 	stdout.limit = MaxOutputBytes


### PR DESCRIPTION
## Summary
- CI 上 `TestRunnerTimeout` 失败：`sh -c "sleep 5"` 超时后 `CommandContext` 只 kill 了 shell，被 fork 出的 `sleep` 孙进程继承了 stdout/stderr 管道并保持打开，导致 `cmd.Run` 一直阻塞到命令跑满 5s 才返回（超过测试的 3s 上限）
- 设置 `cmd.WaitDelay = 1s`：进程被 kill 后 Go 会强制关闭 I/O 管道，`Run` 立即返回并正确报告超时

## Test plan
- [x] `go test -race -run TestRunnerTimeout -count=5 ./internal/hooks/` 连续 5 次通过
- [x] `go test -race ./internal/hooks/` 全包通过