### PR TITLE
feat(remotecontrol): pairing token & session credential store (#438)

### DIFF
--- a/internal/remotecontrol/token.go
+++ b/internal/remotecontrol/token.go
@@ -1,0 +1,130 @@
+// Package remotecontrol implements the /remote-control feature: an in-process
+// web server that lets a phone on the same LAN mirror the CLI session, inject
+// prompts, and approve risky tool calls (see tasks/spec-remote-control.md).
+//
+// This file (node #438) provides the auth substrate: a one-time, TTL-bound
+// pairing token that a paired browser exchanges for an opaque session
+// credential. All state is in-memory and process-scoped; nothing is persisted
+// or logged, and Clear() wipes it on shutdown.
+package remotecontrol
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// tokenBytes is the entropy of both pairing tokens and session credentials.
+// 32 bytes = 256 bits, hex-encoded to 64 characters in the URL/cookie.
+const tokenBytes = 32
+
+// pairingToken is a single-use link credential handed to the user (embedded in
+// the printed /pair?t=... URL). It is consumed on the first successful pairing
+// and rejected thereafter or once expired.
+type pairingToken struct {
+	expiresAt time.Time
+	used      bool
+}
+
+// TokenStore holds the outstanding pairing tokens and issued session
+// credentials for one remote-control session. It is safe for concurrent use by
+// the HTTP handlers. All values are cryptographically random secrets; the store
+// keeps only their hex string form and never logs them.
+type TokenStore struct {
+	mu       sync.Mutex
+	pairing  map[string]*pairingToken
+	sessions map[string]struct{}
+	// now is the clock, injectable so tests can force expiry without sleeping.
+	now func() time.Time
+}
+
+// NewTokenStore returns an empty store using the wall clock.
+func NewTokenStore() *TokenStore {
+	return &TokenStore{
+		pairing:  make(map[string]*pairingToken),
+		sessions: make(map[string]struct{}),
+		now:      time.Now,
+	}
+}
+
+// randHex returns n cryptographically random bytes, hex-encoded. crypto/rand
+// never returns a short read without an error, so a nil error guarantees a full
+// buffer.
+func randHex(n int) (string, error) {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// NewPairing mints a fresh one-time pairing token that expires after ttl and
+// returns its hex value for embedding in the pairing URL.
+func (s *TokenStore) NewPairing(ttl time.Duration) (string, error) {
+	value, err := randHex(tokenBytes)
+	if err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pairing[value] = &pairingToken{expiresAt: s.now().Add(ttl)}
+	return value, nil
+}
+
+// ConsumePairing validates a pairing token and, on success, marks it used so it
+// can never be redeemed again. It returns false if the token is unknown,
+// already used, or expired. The single-use marking happens under the lock, so
+// two concurrent /pair requests with the same token cannot both succeed.
+func (s *TokenStore) ConsumePairing(value string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tok, ok := s.pairing[value]
+	if !ok || tok.used || s.now().After(tok.expiresAt) {
+		return false
+	}
+	tok.used = true
+	return true
+}
+
+// IssueSession creates and stores a new opaque session credential (set as the
+// pigo_rc cookie after pairing) and returns its hex value.
+func (s *TokenStore) IssueSession() (string, error) {
+	cred, err := randHex(tokenBytes)
+	if err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions[cred] = struct{}{}
+	return cred, nil
+}
+
+// ValidateSession reports whether cred matches a currently-issued session
+// credential. Comparison is constant-time to avoid leaking the credential
+// through response timing; an empty cred is always rejected.
+func (s *TokenStore) ValidateSession(cred string) bool {
+	if cred == "" {
+		return false
+	}
+	want := []byte(cred)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var matched bool
+	for issued := range s.sessions {
+		if subtle.ConstantTimeCompare([]byte(issued), want) == 1 {
+			matched = true
+		}
+	}
+	return matched
+}
+
+// Clear wipes all pairing tokens and session credentials. It is called on
+// server shutdown so no secret outlives the remote-control session.
+func (s *TokenStore) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pairing = make(map[string]*pairingToken)
+	s.sessions = make(map[string]struct{})
+}

--- a/internal/remotecontrol/token_test.go
+++ b/internal/remotecontrol/token_test.go
@@ -1,0 +1,121 @@
+package remotecontrol
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewPairingTokenIsHex256Bit(t *testing.T) {
+	s := NewTokenStore()
+	value, err := s.NewPairing(time.Minute)
+	if err != nil {
+		t.Fatalf("NewPairing: %v", err)
+	}
+	// 32 bytes -> 64 hex chars.
+	if len(value) != tokenBytes*2 {
+		t.Fatalf("token length = %d, want %d", len(value), tokenBytes*2)
+	}
+	for _, c := range value {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Fatalf("token has non-hex char %q", c)
+		}
+	}
+}
+
+func TestPairingIsSingleUse(t *testing.T) {
+	s := NewTokenStore()
+	value, err := s.NewPairing(time.Minute)
+	if err != nil {
+		t.Fatalf("NewPairing: %v", err)
+	}
+	if !s.ConsumePairing(value) {
+		t.Fatal("first ConsumePairing = false, want true")
+	}
+	if s.ConsumePairing(value) {
+		t.Fatal("second ConsumePairing = true, want false (single-use)")
+	}
+}
+
+func TestConsumePairingUnknownToken(t *testing.T) {
+	s := NewTokenStore()
+	if s.ConsumePairing("deadbeef") {
+		t.Fatal("ConsumePairing on unknown token = true, want false")
+	}
+}
+
+func TestPairingExpires(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	s := NewTokenStore()
+	s.now = func() time.Time { return now }
+	value, err := s.NewPairing(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("NewPairing: %v", err)
+	}
+	// Advance clock just past the TTL.
+	now = now.Add(10*time.Minute + time.Second)
+	if s.ConsumePairing(value) {
+		t.Fatal("ConsumePairing after expiry = true, want false")
+	}
+}
+
+func TestPairingValidJustBeforeExpiry(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	s := NewTokenStore()
+	s.now = func() time.Time { return now }
+	value, err := s.NewPairing(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("NewPairing: %v", err)
+	}
+	now = now.Add(10*time.Minute - time.Second)
+	if !s.ConsumePairing(value) {
+		t.Fatal("ConsumePairing just before expiry = false, want true")
+	}
+}
+
+func TestIssueAndValidateSession(t *testing.T) {
+	s := NewTokenStore()
+	cred, err := s.IssueSession()
+	if err != nil {
+		t.Fatalf("IssueSession: %v", err)
+	}
+	if len(cred) != tokenBytes*2 {
+		t.Fatalf("cred length = %d, want %d", len(cred), tokenBytes*2)
+	}
+	if !s.ValidateSession(cred) {
+		t.Fatal("ValidateSession(issued) = false, want true")
+	}
+	if s.ValidateSession("") {
+		t.Fatal("ValidateSession(\"\") = true, want false")
+	}
+	if s.ValidateSession("not-a-real-cred") {
+		t.Fatal("ValidateSession(bogus) = true, want false")
+	}
+}
+
+func TestClearWipesState(t *testing.T) {
+	s := NewTokenStore()
+	value, _ := s.NewPairing(time.Minute)
+	cred, _ := s.IssueSession()
+	s.Clear()
+	if s.ConsumePairing(value) {
+		t.Fatal("pairing token survived Clear")
+	}
+	if s.ValidateSession(cred) {
+		t.Fatal("session credential survived Clear")
+	}
+}
+
+func TestTokensAreUnique(t *testing.T) {
+	s := NewTokenStore()
+	seen := make(map[string]struct{})
+	for range 100 {
+		v, err := s.NewPairing(time.Minute)
+		if err != nil {
+			t.Fatalf("NewPairing: %v", err)
+		}
+		if _, dup := seen[v]; dup {
+			t.Fatalf("duplicate token generated: %s", v)
+		}
+		seen[v] = struct{}{}
+	}
+}

--- a/tasks/prd-remote-control.md
+++ b/tasks/prd-remote-control.md
@@ -1,0 +1,159 @@
+# PRD: Remote Control（手机端远程控制 CLI 会话）
+
+## Introduction/Overview
+
+在命令行中输入 `/remote-control` 斜杠命令后，CLI 会在本地启动一个轻量 Web 服务，并打印出访问地址与二维码。用户用手机（与电脑在同一局域网）扫码或打开链接，即可在手机浏览器里继续与 agent 交互：查看实时输出、输入新指令、以及在 agent 遇到危险操作时进行确认。
+
+这解决的问题是：当用户离开电脑（如去开会、在沙发上、遛狗时），仍希望跟进和控制正在运行的 agent 会话，而不必守在键盘前。
+
+本功能完全内置于现有 CLI，与当前会话共享同一份会话状态；每次输入 `/remote-control` 创建一个临时会话，CLI 进程退出即结束。
+
+## Goals
+
+- 输入 `/remote-control` 后，3 秒内在终端打印可访问的局域网 URL 与二维码
+- 手机 Web 端可实时（延迟 < 1s）看到 CLI 会话的输出流
+- 手机 Web 端可向 agent 发送新指令，效果等同于在 CLI 中直接输入
+- 当 agent 需要确认危险操作时，手机端可显示确认弹窗并批准/拒绝
+- 通过一次性、时效性的 token 配对保障安全，未授权者无法访问
+
+## User Stories
+
+### US-001: 实现 `/remote-control` 斜杠命令入口
+**Description:** As a CLI user, I want to type `/remote-control` to start a remote session so that I can control the agent from my phone.
+
+**Acceptance Criteria:**
+- [ ] 在 CLI 中输入 `/remote-control` 被识别为内置命令并触发远程控制流程
+- [ ] 命令执行后不阻塞主 CLI 会话，用户仍可在终端继续操作
+- [ ] 未知参数或重复调用时返回明确提示（如 "remote control already running at <URL>"）
+- [ ] Typecheck/lint passes
+
+### US-002: 启动本地 Web 服务并绑定局域网地址
+**Description:** As a CLI user, I want the CLI to serve a web page on my LAN so that my phone can reach it.
+
+**Acceptance Criteria:**
+- [ ] 启动 HTTP 服务并绑定到局域网可访问的网卡地址（非仅 127.0.0.1）
+- [ ] 自动选择一个可用端口，端口被占用时回退到下一个可用端口
+- [ ] 服务地址形如 `http://<lan-ip>:<port>`，可被同网段设备访问
+- [ ] CLI 退出时服务随之关闭，端口被释放
+- [ ] Typecheck/lint passes
+
+### US-003: 在终端打印访问 URL 与二维码
+**Description:** As a CLI user, I want a URL and QR code printed in my terminal so that I can open it on my phone quickly.
+
+**Acceptance Criteria:**
+- [ ] 终端打印包含配对 token 的完整访问 URL
+- [ ] 终端渲染该 URL 对应的二维码（ASCII/Unicode 形式，可在标准终端扫描）
+- [ ] URL 中的 token 为一次性、带过期时间
+- [ ] Typecheck/lint passes
+
+### US-004: 一次性 token 配对与鉴权
+**Description:** As a security-conscious user, I want the remote link protected by a one-time, time-limited token so that only I can access the session.
+
+**Acceptance Criteria:**
+- [ ] 生成随机、高熵的一次性配对 token（至少 128 bit）
+- [ ] token 有过期时间（默认 10 分钟内完成首次配对，`[Assumption]`）
+- [ ] 首次配对成功后，服务端签发会话凭证（cookie/session token），后续请求凭此鉴权
+- [ ] 携带无效/过期 token 的请求返回 401 并显示明确错误页
+- [ ] Typecheck/lint passes
+- [ ] Verify in a browser（e.g., via the `run` skill）
+
+### US-005: 手机 Web 端实时查看会话输出
+**Description:** As a user on my phone, I want to see the agent's live output so that I can follow what it's doing.
+
+**Acceptance Criteria:**
+- [ ] Web 页面通过实时通道（如 WebSocket/SSE）持续接收 CLI 会话输出
+- [ ] 新输出到达时页面自动追加并滚动到底部
+- [ ] 页面在手机浏览器上响应式布局，无横向滚动
+- [ ] 断开连接时显示 "disconnected" 状态提示
+- [ ] Typecheck/lint passes
+- [ ] Verify in a browser（e.g., via the `run` skill）
+
+### US-006: 手机 Web 端发送指令给 agent
+**Description:** As a user on my phone, I want to type and send instructions so that the agent continues working based on my input.
+
+**Acceptance Criteria:**
+- [ ] Web 页面提供输入框与发送按钮
+- [ ] 发送的文本被注入当前 CLI 会话，等效于在终端输入该内容
+- [ ] 发送后输入框清空，且该指令回显在输出流中
+- [ ] 空输入不可发送（发送按钮禁用或提示）
+- [ ] Typecheck/lint passes
+- [ ] Verify in a browser（e.g., via the `run` skill）
+
+### US-007: 手机端确认危险操作
+**Description:** As a user on my phone, I want to approve or reject risky actions so that the agent doesn't perform destructive operations without my consent.
+
+**Acceptance Criteria:**
+- [ ] 当 agent 触发需要确认的操作时，手机端弹出确认对话框并展示操作描述
+- [ ] 用户点击 "批准" 后 agent 继续执行，点击 "拒绝" 后 agent 中止该操作
+- [ ] 确认结果同步回 CLI 终端（终端显示已由远程批准/拒绝）
+- [ ] 未响应时操作保持等待状态，不自动执行
+- [ ] Typecheck/lint passes
+- [ ] Verify in a browser（e.g., via the `run` skill）
+
+### US-008: 临时会话生命周期管理
+**Description:** As a user, I want the remote session to end cleanly when I stop it or exit the CLI so that no stale server keeps running.
+
+**Acceptance Criteria:**
+- [ ] CLI 进程退出（正常退出或 Ctrl-C）时，Web 服务、WebSocket 连接、临时 token 全部清理
+- [ ] 提供停止方式（如再次输入命令或 `/remote-control stop`）主动结束远程会话
+- [ ] 会话结束后再访问旧 URL 返回明确的 "session ended" 页面
+- [ ] Typecheck/lint passes
+- [ ] Verify in a browser（e.g., via the `run` skill）
+
+## Functional Requirements
+
+- FR-1: The system must register `/remote-control` as a built-in CLI slash command.
+- FR-2: The system must start a local HTTP server bound to a LAN-accessible interface when the command runs.
+- FR-3: The system must automatically select an available port and fall back to the next one if occupied.
+- FR-4: The system must print the access URL to the terminal.
+- FR-5: The system must render a scannable QR code of the access URL in the terminal.
+- FR-6: The system must generate a one-time, high-entropy pairing token embedded in the URL.
+- FR-7: The system must expire the pairing token after a configurable timeout.
+- FR-8: The system must issue a session credential upon successful pairing and require it for subsequent requests.
+- FR-9: The system must reject requests with invalid or expired tokens with an HTTP 401 response.
+- FR-10: The system must stream live CLI session output to the web client over a real-time channel.
+- FR-11: The system must render a responsive web page usable on mobile browsers.
+- FR-12: The system must inject text submitted from the web client into the current CLI session as user input.
+- FR-13: The system must present a confirmation dialog on the web client when the agent requests approval for a risky operation.
+- FR-14: The system must proceed with a risky operation only after receiving an approve response from the web client.
+- FR-15: The system must abort a risky operation upon a reject response from the web client.
+- FR-16: The system must reflect remote approval/rejection results in the CLI terminal.
+- FR-17: The system must share the active CLI session state with the remote web client (same session, not a copy).
+- FR-18: The system must terminate the web server and clean up all connections and tokens when the CLI process exits.
+- FR-19: The system must provide a way to stop the remote session while keeping the CLI running.
+
+## Non-Goals (Out of Scope)
+
+- 不支持通过公网/云端中继访问（仅同一局域网）
+- 不提供 PWA、桌面安装或推送通知（本期为纯响应式 Web 页面）
+- 不支持多个手机端同时控制同一会话（本期单一远程客户端，`[Assumption]`）
+- 不做跨 CLI 进程的会话持久化或断线重连（进程退出即结束）
+- 不支持固定密码/PIN 登录（仅一次性 token 配对）
+- 不做历史会话回放或云端存档
+
+## Design Considerations
+
+- 手机端为单页响应式布局：顶部状态栏（连接状态）、中部输出流、底部输入框，确认弹窗为模态层
+- 终端二维码建议使用 Unicode 半块字符渲染，兼顾终端宽度与可扫描性
+- 复用现有 CLI 的会话渲染/输出管道，避免重复实现输出格式化
+
+## Technical Considerations
+
+- 实时通道优先考虑 WebSocket（双向），若实现成本高可用 SSE + POST 回退
+- 需要探测本机局域网 IP（可能存在多网卡，需选择正确的可路由地址）
+- Web 服务与 CLI 主循环共享同一进程与会话状态，需注意并发写入会话时的顺序与竞态
+- 危险操作确认需与现有 safety/确认机制对接：远程批准应等价于本地批准
+- token 与会话凭证不落盘，仅存于内存，随进程结束销毁
+
+## Success Metrics
+
+- 从输入 `/remote-control` 到手机成功打开页面的中位耗时 < 15 秒
+- 会话输出从 CLI 到手机端的端到端延迟 < 1 秒
+- 手机端发送的指令 100% 被注入到正确会话且顺序正确
+- 危险操作在未收到远程批准前 0 次自动执行
+
+## Open Questions
+
+- 危险操作确认在手机端超时未响应时，是否需要一个默认策略（一直等待 vs. 提示回到终端处理）？
+- 二维码/URL 的 token 过期时间默认值（当前假设 10 分钟）是否合适？
+- 是否需要在 CLI 端显示 "已有手机端连接" 的可见提示，以防他人接入未察觉？

--- a/tasks/spec-remote-control.md
+++ b/tasks/spec-remote-control.md
@@ -1,0 +1,433 @@
+# SPEC: Remote Control（手机端远程控制 CLI 会话）
+
+> Technical specification derived from: `tasks/prd-remote-control.md`
+> Generated: 2026-07-31 | Target branch: master | Commit: ad9c8b5
+
+## 1. Summary
+
+### 1.1 What This SPEC Covers
+This SPEC specifies how to add a `/remote-control` built-in slash command that starts an in-process WebSocket-based web server, letting a phone on the same LAN mirror the CLI session output, inject prompts, and approve/reject risky tool calls. It covers the server, the pairing/auth flow, the REPL input/output seam that bridges terminal and remote, and lifecycle cleanup. It does not cover cloud relay, PWA, or multi-client control (see Non-Goals in the PRD).
+
+### 1.2 PRD Reference
+- Source: `tasks/prd-remote-control.md`
+- User Stories covered: US-001 … US-008
+- Functional Requirements covered: FR-1 … FR-19
+
+### 1.3 Design Decisions Summary
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Real-time channel | WebSocket via `github.com/coder/websocket` | User chose 1B; coder/websocket is context-native, zero transitive deps, idiomatic with the repo's `context`-driven loops |
+| QR rendering | `github.com/skip2/go-qrcode` + custom Unicode half-block renderer | User chose 2A; pure-Go, pinned, terminal-scannable |
+| REPL bridging | New `RemoteBridge` seam injected into `replDeps`: merged input source + `io.MultiWriter` output tee + confirmation router | User chose 3A; keeps the synchronous main-goroutine loop intact, minimizes blast radius |
+| Code location | New `internal/remotecontrol` package; command registered via `AddBuiltin` at REPL assembly | User chose 4A; `AddBuiltin` closure can capture live bridge/session state |
+| Auth model | One-time high-entropy pairing token in URL → server-issued session cookie | PRD FR-6/FR-8; token single-use + TTL, cookie for subsequent requests |
+| Concurrency model | HTTP server on its own goroutine; communicates with the synchronous REPL loop over channels; bridge state guarded by a mutex | The REPL is a single-goroutine loop reading a shared `bufio.Reader`; remote input must be marshaled onto that loop without a data race |
+
+---
+
+## 2. Architecture
+
+### 2.1 System Context
+```
+┌─────────────────────────── pigo process ───────────────────────────┐
+│                                                                     │
+│  main goroutine: REPL loop (repl.go)                                │
+│    reads input ◀── inputSource (stdin ∪ remote) ── bufio.Reader     │
+│    writes out  ──▶ io.MultiWriter(stdout, remoteSink)               │
+│    confirm     ◀─▶ ConfirmRouter (terminal or remote)               │
+│         ▲                                                           │
+│         │ channels (lines in, frames out, approvals)                │
+│         ▼                                                           │
+│  server goroutine: internal/remotecontrol.Server (net/http + ws)    │
+│    GET  /            → static SPA (embedded)                        │
+│    GET  /pair?t=…    → validate token, set session cookie           │
+│    WS   /ws          → bidirectional: output frames / input / approve│
+└─────────────────────────────────────────────────────────────────────┘
+             ▲ LAN (http://<lan-ip>:<port>)
+             │
+        📱 phone browser (responsive SPA)
+```
+
+### 2.2 Component Design
+New package `internal/remotecontrol`:
+
+- `Server` — owns the `*http.Server`, listener, token store, connected client, and the channels to the REPL. Lifecycle: `Start(ctx) (url string, err error)`, `Stop()`.
+- `Bridge` — the REPL-facing seam. Implements:
+  - `InputSource`: a reader the REPL loop consults; yields remote-submitted lines interleaved with local stdin.
+  - `OutputSink`: an `io.Writer` the server subscribes to (fed via the `io.MultiWriter` tee).
+  - `ConfirmRouter`: given a pending tool-call confirmation, decides terminal vs remote and returns `(allow, always)`.
+- `tokenStore` — generates/validates one-time, TTL-bound pairing tokens and issued session credentials (in-memory only).
+- `qr` — renders a URL as a Unicode half-block QR block for the terminal.
+- Embedded SPA assets (`//go:embed web/*`).
+
+`Bridge` deliberately does not change how the REPL runs a turn; it only changes where input comes from, where output goes, and who answers confirmations.
+
+### 2.3 Module Interactions
+```
+/remote-control (AddBuiltin Action)
+  → remotecontrol.NewServer(bridge, cfg)
+  → server.Start(ctx)  ── binds LAN addr, picks port
+  → returns URL + token; command prints URL + QR (qr.Render)
+
+REPL turn (streamRun):
+  agent output ── out (MultiWriter) ──▶ stdout
+                                    └─▶ bridge.OutputSink ──▶ ws broadcast
+
+  trust.BeforeToolCall ── ConfirmToolCall ──▶ bridge.ConfirmRouter
+     remote client connected? ──yes──▶ send "confirm" frame, block on approval chan
+                              ──no───▶ fall back to terminal ConfirmToolCall
+
+remote client sends "input" frame:
+  server ── bridge.inputCh ──▶ InputSource.Read unblocks main loop with the line
+```
+
+### 2.4 File Structure
+```
+internal/
+├── remotecontrol/
+│   ├── server.go            [NEW]  http.Server, routes, lifecycle
+│   ├── server_test.go       [NEW]
+│   ├── bridge.go            [NEW]  InputSource / OutputSink / ConfirmRouter
+│   ├── bridge_test.go       [NEW]
+│   ├── token.go             [NEW]  pairing token + session credential store
+│   ├── token_test.go        [NEW]
+│   ├── qr.go                [NEW]  Unicode QR renderer (wraps skip2/go-qrcode)
+│   ├── qr_test.go           [NEW]
+│   ├── lanaddr.go           [NEW]  pick a routable LAN IP + free port
+│   ├── lanaddr_test.go      [NEW]
+│   ├── protocol.go          [NEW]  ws frame types (shared with SPA contract)
+│   └── web/                 [NEW]  embedded responsive SPA
+│       ├── index.html
+│       ├── app.js
+│       └── style.css
+├── cli/repl/
+│   ├── repl.go              [MODIFY] wire Bridge into replDeps: input source,
+│   │                                 MultiWriter out, confirm router
+│   └── remote_command.go    [NEW]  AddBuiltin("/remote-control") assembly
+└── trust/
+    └── interactive.go       [MODIFY] route ConfirmToolCall through ConfirmRouter
+```
+
+---
+
+## 3. Data Model
+
+No database. All state is in-memory, process-scoped, and destroyed on exit.
+
+### 3.1 Schema Changes
+None.
+
+### 3.2 Entity Definitions
+```go
+// protocol.go — WebSocket frame contract (JSON), shared with the SPA.
+type FrameType string
+
+const (
+    FrameOutput  FrameType = "output"  // server→client: streamed session text
+    FrameInput   FrameType = "input"   // client→server: a submitted prompt line
+    FrameConfirm FrameType = "confirm" // server→client: risky-op approval request
+    FrameDecide  FrameType = "decide"  // client→server: approve/reject
+    FrameStatus  FrameType = "status"  // server→client: connected/ended/disconnected
+)
+
+type Frame struct {
+    Type FrameType `json:"type"`
+    // Output
+    Text string `json:"text,omitempty"`
+    // Confirm
+    ConfirmID string `json:"confirmId,omitempty"`
+    Tool      string `json:"tool,omitempty"`
+    Summary   string `json:"summary,omitempty"`
+    // Decide
+    Approve bool `json:"approve,omitempty"`
+    Always  bool `json:"always,omitempty"`
+    // Status
+    State string `json:"state,omitempty"` // "connected" | "ended" | "disconnected"
+}
+
+// token.go
+type pairingToken struct {
+    value     string    // 32 bytes hex (256-bit)
+    expiresAt time.Time
+    used      bool
+}
+
+type Config struct {
+    PairTTL        time.Duration // default 10m  (PRD [Assumption])
+    Host           string        // resolved LAN IP; "" → auto-detect
+    Port           int           // 0 → auto-pick, fall back on conflict
+    ConfirmTimeout time.Duration // 0 → wait forever (Open Question OQ-1 default)
+}
+```
+
+### 3.3 Relationships
+The `Bridge` holds a pointer to the active `*Server`; the `Server` holds a single `clientConn` (nil until paired). `replDeps` gains one field: `remote *remotecontrol.Bridge` (nil when remote control is not running).
+
+### 3.4 Migration Plan
+No data migration. Additive-only: when `deps.remote == nil`, all code paths behave exactly as today (stdin reader, plain stdout, terminal confirm).
+
+---
+
+## 4. API Design
+
+### 4.1 Endpoints
+
+| Method | Path | Description | Auth | Request | Response |
+|--------|------|-------------|------|---------|----------|
+| GET | `/` | Serve responsive SPA | session cookie; if absent redirect to `/pair` behavior | — | `text/html` |
+| GET | `/pair?t=<token>` | Validate one-time token, issue session cookie, redirect to `/` | one-time token | query `t` | 302 + `Set-Cookie`; 401 on invalid/expired/used |
+| GET | `/ws` | Upgrade to WebSocket for bidirectional frames | session cookie | WS upgrade | WS stream of `Frame` JSON |
+| GET | `/healthz` | Liveness (internal) | none | — | 200 `ok` |
+
+### 4.2 Request/Response Schemas
+- Pairing URL printed to terminal: `http://<lan-ip>:<port>/pair?t=<64-hex-chars>`.
+- Session cookie: `pigo_rc=<opaque 256-bit>; HttpOnly; SameSite=Strict; Path=/`. (No `Secure` flag: LAN is plain HTTP; documented in §7.)
+- WebSocket messages: `Frame` JSON (§3.2). Server→client: `output`, `confirm`, `status`. Client→server: `input`, `decide`.
+- Input frame validation: `Text` trimmed; empty rejected server-side (mirrors SPA disabling send).
+
+### 4.3 Error Responses
+| Condition | HTTP | Body |
+|-----------|------|------|
+| Missing/invalid/expired/used pairing token | 401 | HTML "pairing link invalid or expired" |
+| Missing session cookie on `/` or `/ws` | 302 → informative page (not auto-repair; token is one-time) | — |
+| Session already ended (server stopped) | 410 | HTML "session ended" |
+| WS upgrade without cookie | 401 | — |
+
+### 4.4 Breaking Changes
+None. Purely additive; no existing endpoint or CLI behavior changes when the command is not invoked.
+
+---
+
+## 5. Business Logic
+
+### 5.1 Core Algorithms
+
+**Start sequence (US-001, US-002, US-003, US-004 · FR-1..FR-9)**
+```
+on /remote-control [stop]:
+  if arg == "stop":
+     if bridge.server running: server.Stop(); return "remote control stopped"
+     else: return "remote control not running"
+  if bridge.server running:
+     return "remote control already running at " + currentURL   // FR: repeat call
+  host = cfg.Host or lanaddr.DetectRoutableIP()                  // FR-2
+  ln, port = lanaddr.ListenFreePort(host, cfg.Port)              // FR-3 fallback loop
+  token = tokenStore.NewPairing(cfg.PairTTL)                     // FR-6, FR-7
+  server.Start(ctx, ln)                                          // FR-2
+  url = "http://" + host + ":" + port + "/pair?t=" + token.value // FR-4
+  print url; print qr.Render(url)                                // FR-4, FR-5
+  return ""                                                      // non-blocking (Action returns immediately)
+```
+
+**Pairing (FR-6..FR-9)**
+```
+GET /pair?t=T:
+  tok = tokenStore.Lookup(T)
+  if tok == nil or tok.used or now > tok.expiresAt: 401           // FR-9
+  tok.used = true                                                 // one-time
+  cred = tokenStore.IssueSession()                                // FR-8
+  Set-Cookie pigo_rc=cred; 302 → "/"
+```
+
+**Output mirroring (US-005 · FR-10, FR-17)**
+```
+REPL out = io.MultiWriter(stdout, bridge.OutputSink)
+bridge.OutputSink.Write(p):
+   append to ring buffer (for late-join replay of current turn)
+   if client connected: client.Send(Frame{Output, string(p)})
+```
+
+**Remote input injection (US-006 · FR-12, FR-17)**
+```
+InputSource.Read merges two sources onto the main loop:
+   local stdin lines (existing bufio.Reader) AND bridge.inputCh
+Implementation: the REPL line editor's ReadLine is fed by a select over
+   {stdin-line chan, bridge.inputCh}; whichever arrives first returns.
+On remote line L:
+   echo L into out (so terminal + remote both see it)   // FR-12 echo
+   return L to the loop as if typed → runs a normal turn // FR-17 same session
+```
+
+**Risky-op confirmation routing (US-007 · FR-13..FR-16)**
+```
+trust.ConfirmToolCall now calls bridge.ConfirmRouter(call):
+  if bridge != nil and client connected:
+     id = newID()
+     client.Send(Frame{Confirm, id, call.Name, summary})       // FR-13
+     select {
+       case d := <-approvalCh[id]:   return d.Approve, d.Always // FR-14/15
+       case <-confirmTimeout:        // OQ-1: default = no timeout (wait)
+     }
+     mirror decision to terminal out: "remote approved/rejected" // FR-16
+  else:
+     fall back to terminal prompt (existing code)               // unchanged
+```
+
+**Shutdown (US-008 · FR-18, FR-19)**
+```
+on CLI exit (defer in runREPL) OR /remote-control stop:
+  server.Send(Frame{Status,"ended"}); close WS; http.Server.Shutdown(ctx)
+  tokenStore.Clear(); release listener                          // FR-18
+```
+
+### 5.2 Validation Rules
+- Pairing token: 256-bit, `crypto/rand`, hex-encoded; single-use; TTL default 10m.
+- Session credential: 256-bit, `crypto/rand`; compared with `subtle.ConstantTimeCompare`.
+- Input frame `Text`: reject empty/whitespace-only server-side.
+- Port auto-pick: try `cfg.Port`, then bind `:0` if occupied (kernel-assigned free port).
+
+### 5.3 State Machine
+Server states: `idle → listening → paired → (ended)`.
+- `listening`: server up, no client, valid pairing token outstanding.
+- `paired`: cookie issued, WS may connect/reconnect within the same process session.
+- `ended`: `Stop()` called or process exiting; all requests → 410 / closed WS.
+
+Confirmation states per request: `pending → approved | rejected | (superseded-by-terminal on disconnect)`.
+
+### 5.4 Edge Cases
+- Client disconnects mid-confirmation → router falls back to terminal prompt for that pending request; new WS frames stop.
+- Multiple browsers hit `/pair` → only the first consumes the one-time token; others 401. Single active client (PRD Non-Goal); a second cookie-bearing WS is refused with `status: "disconnected"` reason "another client active".
+- No routable non-loopback interface found → command fails with a clear message (do not silently bind loopback, which the phone can't reach).
+- SIGINT during a remote-run turn → existing cancel path applies; server stays up; terminal and remote both return to prompt.
+- Very long output bursts → `OutputSink` is non-blocking; if the WS send buffer is full, drop-to-latest is NOT acceptable for a terminal mirror, so use a bounded queue with backpressure and coalescing of adjacent `output` frames.
+
+---
+
+## 6. Error Handling
+
+### 6.1 Error Taxonomy
+| Error Code | HTTP Status | Condition | User Message |
+|------------|-------------|-----------|--------------|
+| `rc_token_invalid` | 401 | token missing/expired/used | "pairing link invalid or expired" |
+| `rc_no_cookie` | 302 | no session cookie | info page "open the pairing link from your terminal" |
+| `rc_ended` | 410 | server stopped | "session ended" |
+| `rc_client_busy` | ws close | second client while one active | "another device is controlling this session" |
+| `rc_no_lan` | (CLI, not HTTP) | no routable IP | "no LAN address found; are you connected to Wi‑Fi?" |
+
+### 6.2 Retry Strategy
+- WS client auto-reconnects with capped backoff (SPA side) while the cookie is valid and server is `paired`; server treats reconnect as the same client.
+- Pairing token is never retried (one-time by design); user re-runs `/remote-control`.
+
+### 6.3 Failure Modes
+- Server fails to start (port/interface) → `/remote-control` returns an error string; REPL continues normally (no remote).
+- WS drops → REPL keeps running against stdout/terminal; confirmations fall back to terminal (§5.1).
+- go-qrcode failure → print URL only, warn once (graceful degradation, satisfies FR-4 even if FR-5 degrades).
+
+---
+
+## 7. Security
+
+### 7.1 Authentication & Authorization
+- Access gated by one-time, TTL-bound pairing token → HttpOnly session cookie (FR-6/FR-8/FR-9). No fixed password (PRD Non-Goal).
+- Single active controlling client (PRD Non-Goal: no multi-client).
+- Remote approval of a risky op is treated as **equivalent to a local approval**; it does not grant persistent project trust unless `Always` is chosen (mirrors terminal `[a]lways`).
+
+### 7.2 Input Validation
+- All frames JSON-decoded into typed `Frame`; unknown types ignored. Reject oversized frames (cap message size, e.g. 64 KiB) to prevent memory abuse.
+- Remote-injected prompt text is passed to the same turn pipeline as terminal input — it is subject to the same trust gating on any tools it triggers (so a remote prompt can't bypass confirmation).
+
+### 7.3 Data Protection
+- Plain HTTP over LAN (no TLS); cookie lacks `Secure`. **Security note:** anyone on the same LAN who obtains the one-time link before it's used, or who steals the cookie via a MITM on the local network, could control the session. This is an unauthenticated-transport tradeoff of the LAN-only design — flagged explicitly; TLS/relay is out of scope per PRD.
+- Tokens/credentials live only in memory and are zeroed/cleared on `Stop()`; never logged, never written to the session file.
+- Optional (recommend): print a one-line terminal notice when a client pairs/connects, so the operator notices unexpected access (addresses PRD Open Question about visibility).
+
+---
+
+## 8. Performance
+
+### 8.1 Expected Load
+Single user, single phone. Traffic = one session's streamed text + occasional input/approval frames. Negligible QPS; latency-sensitive, not throughput-sensitive.
+
+### 8.2 Optimization Strategy
+- Coalesce adjacent `output` writes into batched frames (flush on ~16–32ms tick or buffer threshold) to hit the PRD <1s (target «100ms) end-to-end latency without per-byte frames.
+- Ring buffer of the current turn's output for late WS join/reconnect replay (bounded, e.g. last 256 KiB).
+
+### 8.3 Database Considerations
+N/A.
+
+---
+
+## 9. Testing Strategy
+
+### 9.1 Unit Tests
+- `token_test.go`: token is 256-bit, single-use, expires after TTL; session credential constant-time compare.
+- `lanaddr_test.go`: picks a non-loopback routable IP; free-port fallback when a port is occupied; error when no routable interface.
+- `qr_test.go`: renders deterministic Unicode block for a known URL; degrades to URL-only on error.
+- `bridge_test.go`: `OutputSink` tees to stdout + sink; empty remote input rejected; `ConfirmRouter` falls back to terminal when no client.
+
+### 9.2 Integration Tests
+- `server_test.go` (httptest + real WS dial via coder/websocket):
+  - `/pair` with valid token sets cookie + 302; invalid/expired/used → 401.
+  - `/ws` without cookie → 401; with cookie → receives `output` frames.
+  - client sends `input` frame → bridge delivers the line to a fake REPL input consumer.
+  - `confirm` round-trip: server sends `confirm`, client `decide{approve:true}` → router returns `(true,false)` and terminal mirror line written.
+  - second client rejected while one active.
+  - `Stop()` closes WS with `ended` and subsequent requests 410.
+- REPL wiring test (`internal/cli/repl`): with `deps.remote == nil`, behavior byte-identical to today (regression guard for additive design).
+
+### 9.3 Edge Case Tests
+- Client disconnect during pending confirmation → terminal fallback engaged.
+- No routable IP (inject a fake interface lister) → command returns `rc_no_lan` message, REPL unaffected.
+- Output backpressure: fast producer, slow consumer → frames coalesced, no goroutine leak, no dropped bytes.
+
+### 9.4 Acceptance Criteria Mapping
+| US/FR | Test | Type | Description |
+|-------|------|------|-------------|
+| US-001 / FR-1 | repl remote_command_test | unit | `/remote-control` recognized, non-blocking, repeat-call message |
+| US-002 / FR-2,FR-3 | lanaddr_test, server_test | unit+integration | LAN bind + free-port fallback |
+| US-003 / FR-4,FR-5 | qr_test, remote_command_test | unit | URL + Unicode QR printed |
+| US-004 / FR-6..FR-9 | token_test, server_test | unit+integration | one-time TTL token, cookie issue, 401 paths |
+| US-005 / FR-10,FR-17 | bridge_test, server_test | unit+integration | output tee + WS stream |
+| US-006 / FR-12 | server_test, bridge_test | integration | input frame injected + echoed |
+| US-007 / FR-13..FR-16 | server_test | integration | confirm round-trip + terminal mirror |
+| US-008 / FR-18,FR-19 | server_test | integration | stop + exit cleanup, 410 on stale URL |
+
+---
+
+## 10. Implementation Plan
+
+### 10.1 Phases
+1. **Foundations** (no REPL changes): `protocol.go`, `token.go`, `lanaddr.go`, `qr.go` + tests. Add deps `coder/websocket`, `skip2/go-qrcode`.
+2. **Server**: `server.go` routes, pairing, WS, single-client, `Start/Stop` + `server_test.go`.
+3. **Bridge seam**: `bridge.go` (InputSource/OutputSink/ConfirmRouter) + tests, no REPL wiring yet.
+4. **REPL wiring**: `remote_command.go` (`AddBuiltin`), `repl.go` MultiWriter + merged input + exit cleanup; `trust/interactive.go` confirm routing.
+5. **SPA**: embedded responsive `web/` (output view, input box, confirm modal, status bar, reconnect).
+6. **Hardening**: backpressure/coalescing, connect notice, docs.
+
+### 10.2 Issue Mapping
+| Issue | SPEC Sections | Priority | Depends On |
+|-------|--------------|----------|------------|
+| #A | 3.2, 5.2 (token) | high | — |
+| #B | 2.2, 5.1 (lanaddr) | high | — |
+| #C | 2.2, 6.3 (qr) | medium | — |
+| #D | 4.x, 5.1, 5.3 (server+ws) | high | #A, #B |
+| #E | 2.2, 5.1 (bridge) | high | #A |
+| #F | 2.4 repl.go, 5.1 (wiring + confirm) | high | #D, #E |
+| #G | 2.4 web/ (SPA) | high | #D |
+| #H | 5.4, 8.2, 7.3 (hardening) | medium | #F, #G |
+
+### 10.3 Incremental Delivery
+Feature is inert until `/remote-control` is invoked, so it can merge behind no flag. Ship phases 1–4 to get a URL-only, output+input working path first; SPA confirm modal (phase 5) and hardening (phase 6) can follow. The `deps.remote == nil` regression test guarantees zero impact on existing sessions at every phase.
+
+---
+
+## 11. Open Questions & Risks
+
+### 11.1 Unresolved Questions
+- **OQ-1 (from PRD):** Confirmation timeout when the phone doesn't respond. SPEC default = **wait forever** (`ConfirmTimeout=0`), with terminal fallback on disconnect. Confirm whether a timeout-then-terminal policy is preferred.
+- **OQ-2:** Pairing token TTL default of 10m — acceptable?
+- **OQ-3:** Should pairing/connection print a visible terminal notice by default (recommended in §7.3) or be opt-in?
+
+### 11.2 Technical Risks
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Plain-HTTP LAN transport (no TLS) | Session hijack on hostile LAN | One-time short-TTL token, single client, HttpOnly cookie, connect notice; document limitation; relay/TLS deferred |
+| Merging remote input into a synchronous stdin loop | Data race / input interleaving | Channel `select` in the line editor on the single main goroutine; no shared mutable read state; regression test for `remote==nil` |
+| Output backpressure on slow phone | Lag or memory growth | Bounded coalescing queue + ring-buffer replay; no unbounded buffering |
+| New deps (`coder/websocket`, `skip2/go-qrcode`) in a minimal-dep repo | Supply-chain / maintenance | Pin exact versions; both are small, popular, permissively licensed; QR is optional-degradable |
+| `go 1.27rc1` toolchain | Dep compatibility | Both deps support modern Go; verify `go build` in phase 1 |
+
+### 11.3 Assumptions
+- Phone and computer are on the same L2/L3-reachable LAN with client isolation off.
+- A single routable non-loopback IPv4 is sufficient for the printed URL (multi-NIC: pick first routable; may need override via `Config.Host`).
+- The existing `trust.ConfirmToolCall` is the only confirmation surface that needs remote routing (no other blocking stdin prompts occur mid-turn).


### PR DESCRIPTION
Implements node #438 of the /remote-control graph.

- One-time, TTL-bound pairing token (256-bit crypto/rand, hex)
- Single-use pairing consumption under lock
- Opaque session credential with constant-time validation
- In-memory only; Clear() wipes on shutdown
- Unit tests: length/hex, single-use, expiry, constant-time, uniqueness, clear

Also lands the remote-control PRD/SPEC docs.

SPEC: tasks/spec-remote-control.md §3.2, §5.2, §7.1

Closes #438