### PR TITLE
feat(remotecontrol): LAN address & free-port resolver (#439)

### DIFF
--- a/internal/remotecontrol/lanaddr.go
+++ b/internal/remotecontrol/lanaddr.go
@@ -1,0 +1,65 @@
+package remotecontrol
+
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
+// ErrNoLAN is returned by DetectRoutableIP when no routable, non-loopback IPv4
+// address can be found. Binding loopback would produce a URL the phone cannot
+// reach, so the caller must surface this rather than fall back silently.
+var ErrNoLAN = errors.New("remotecontrol: no routable LAN address found; are you connected to Wi-Fi?")
+
+// addrLister returns the machine's network addresses. It is a package variable
+// so tests can inject a fake set of interfaces without real hardware.
+var addrLister = net.InterfaceAddrs
+
+// DetectRoutableIP returns the first routable, non-loopback IPv4 address of the
+// host, suitable for embedding in the printed pairing URL. On a multi-NIC host
+// it returns the first match; callers that need a specific interface should
+// override via Config.Host. It returns ErrNoLAN when nothing routable exists.
+func DetectRoutableIP() (string, error) {
+	addrs, err := addrLister()
+	if err != nil {
+		return "", fmt.Errorf("remotecontrol: list interfaces: %w", err)
+	}
+	for _, a := range addrs {
+		var ip net.IP
+		switch v := a.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		default:
+			continue
+		}
+		v4 := ip.To4()
+		if v4 == nil {
+			continue // skip IPv6 for the LAN URL
+		}
+		if v4.IsLoopback() || v4.IsLinkLocalUnicast() || v4.IsLinkLocalMulticast() || v4.IsUnspecified() {
+			continue
+		}
+		return v4.String(), nil
+	}
+	return "", ErrNoLAN
+}
+
+// ListenFreePort binds a TCP listener on host. It first tries the requested
+// port; if port is 0 or already in use it falls back to a kernel-assigned free
+// port (:0). It returns the listener and the actual port bound.
+func ListenFreePort(host string, port int) (net.Listener, int, error) {
+	if port != 0 {
+		ln, err := net.Listen("tcp", net.JoinHostPort(host, fmt.Sprint(port)))
+		if err == nil {
+			return ln, ln.Addr().(*net.TCPAddr).Port, nil
+		}
+		// Requested port unavailable — fall through to an auto-assigned one.
+	}
+	ln, err := net.Listen("tcp", net.JoinHostPort(host, "0"))
+	if err != nil {
+		return nil, 0, fmt.Errorf("remotecontrol: bind %s: %w", host, err)
+	}
+	return ln, ln.Addr().(*net.TCPAddr).Port, nil
+}

--- a/internal/remotecontrol/lanaddr_test.go
+++ b/internal/remotecontrol/lanaddr_test.go
@@ -1,0 +1,107 @@
+package remotecontrol
+
+import (
+	"net"
+	"testing"
+)
+
+// withAddrLister swaps the package addrLister for the duration of a test.
+func withAddrLister(t *testing.T, fn func() ([]net.Addr, error)) {
+	t.Helper()
+	orig := addrLister
+	addrLister = fn
+	t.Cleanup(func() { addrLister = orig })
+}
+
+func TestDetectRoutableIPPicksRoutableV4(t *testing.T) {
+	withAddrLister(t, func() ([]net.Addr, error) {
+		return []net.Addr{
+			&net.IPNet{IP: net.IPv6loopback},
+			&net.IPNet{IP: net.ParseIP("127.0.0.1")},
+			&net.IPNet{IP: net.ParseIP("169.254.1.5")}, // link-local
+			&net.IPNet{IP: net.ParseIP("192.168.1.42")},
+			&net.IPNet{IP: net.ParseIP("10.0.0.9")},
+		}, nil
+	})
+	ip, err := DetectRoutableIP()
+	if err != nil {
+		t.Fatalf("DetectRoutableIP: %v", err)
+	}
+	if ip != "192.168.1.42" {
+		t.Fatalf("ip = %q, want 192.168.1.42 (first routable v4)", ip)
+	}
+}
+
+func TestDetectRoutableIPSkipsLoopbackAndLinkLocal(t *testing.T) {
+	withAddrLister(t, func() ([]net.Addr, error) {
+		return []net.Addr{
+			&net.IPNet{IP: net.ParseIP("127.0.0.1")},
+			&net.IPNet{IP: net.ParseIP("169.254.1.5")},
+		}, nil
+	})
+	if _, err := DetectRoutableIP(); err != ErrNoLAN {
+		t.Fatalf("err = %v, want ErrNoLAN", err)
+	}
+}
+
+func TestDetectRoutableIPNoInterfaces(t *testing.T) {
+	withAddrLister(t, func() ([]net.Addr, error) {
+		return nil, nil
+	})
+	if _, err := DetectRoutableIP(); err != ErrNoLAN {
+		t.Fatalf("err = %v, want ErrNoLAN", err)
+	}
+}
+
+func TestListenFreePortAutoAssign(t *testing.T) {
+	ln, port, err := ListenFreePort("127.0.0.1", 0)
+	if err != nil {
+		t.Fatalf("ListenFreePort: %v", err)
+	}
+	defer ln.Close()
+	if port <= 0 {
+		t.Fatalf("port = %d, want > 0", port)
+	}
+	if got := ln.Addr().(*net.TCPAddr).Port; got != port {
+		t.Fatalf("listener port %d != returned %d", got, port)
+	}
+}
+
+func TestListenFreePortFallsBackWhenOccupied(t *testing.T) {
+	// Occupy a port, then ask ListenFreePort for that same port; it must fall
+	// back to a different, free one instead of failing.
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("occupy: %v", err)
+	}
+	defer occupied.Close()
+	busyPort := occupied.Addr().(*net.TCPAddr).Port
+
+	ln, port, err := ListenFreePort("127.0.0.1", busyPort)
+	if err != nil {
+		t.Fatalf("ListenFreePort: %v", err)
+	}
+	defer ln.Close()
+	if port == busyPort {
+		t.Fatalf("port = %d, expected fallback away from occupied %d", port, busyPort)
+	}
+}
+
+func TestListenFreePortUsesRequestedWhenFree(t *testing.T) {
+	// Find a free port, release it, then request it explicitly.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	want := probe.Addr().(*net.TCPAddr).Port
+	probe.Close()
+
+	ln, port, err := ListenFreePort("127.0.0.1", want)
+	if err != nil {
+		t.Fatalf("ListenFreePort: %v", err)
+	}
+	defer ln.Close()
+	if port != want {
+		t.Fatalf("port = %d, want requested %d", port, want)
+	}
+}


### PR DESCRIPTION
Node #439 of the /remote-control graph.

- DetectRoutableIP: first routable non-loopback IPv4; skips loopback/link-local; ErrNoLAN when none (never binds loopback)
- ListenFreePort: requested port with :0 fallback when occupied
- Injectable interface lister; multi-NIC picks first routable
- Tests: routable pick, skip loopback/link-local, no-interface error, free-port fallback, requested-when-free

SPEC: tasks/spec-remote-control.md §2.2, §5.1

Closes #439