### PR TITLE
feat(remotecontrol): terminal Unicode QR renderer (#440)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/text v0.40.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/sebdah/goldie/v2 v2.8.0 h1:dZb9wR8q5++oplmEiJT+U/5KyotVD+HNGCAc5gNr8r
 github.com/sebdah/goldie/v2 v2.8.0/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/internal/remotecontrol/qr.go
+++ b/internal/remotecontrol/qr.go
@@ -1,0 +1,51 @@
+package remotecontrol
+
+import (
+	"strings"
+
+	qrcode "github.com/skip2/go-qrcode"
+)
+
+// Render encodes url as a QR code drawn with Unicode half-block characters,
+// suitable for scanning off a terminal by a phone camera. Two matrix rows are
+// packed into each text line (▀ ▄ █ and space), halving the printed height.
+//
+// The rendering assumes a dark-background terminal: light QR modules are drawn
+// as bright block glyphs and dark modules as the terminal background. go-qrcode
+// includes the mandatory quiet-zone border in its bitmap.
+//
+// On any encoding error Render returns ("", err); callers should degrade
+// gracefully by printing the URL alone (the QR is a convenience, not required).
+func Render(url string) (string, error) {
+	q, err := qrcode.New(url, qrcode.Medium)
+	if err != nil {
+		return "", err
+	}
+	bm := q.Bitmap() // true = dark module; includes quiet-zone border.
+
+	var b strings.Builder
+	for y := 0; y < len(bm); y += 2 {
+		row := bm[y]
+		for x := 0; x < len(row); x++ {
+			// A "light" pixel is drawn as a block; a "dark" pixel is left as
+			// background. Rows beyond the matrix are treated as light (quiet).
+			topLight := !bm[y][x]
+			botLight := true
+			if y+1 < len(bm) {
+				botLight = !bm[y+1][x]
+			}
+			switch {
+			case topLight && botLight:
+				b.WriteRune('█')
+			case topLight && !botLight:
+				b.WriteRune('▀')
+			case !topLight && botLight:
+				b.WriteRune('▄')
+			default:
+				b.WriteByte(' ')
+			}
+		}
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
+}

--- a/internal/remotecontrol/qr_test.go
+++ b/internal/remotecontrol/qr_test.go
@@ -1,0 +1,60 @@
+package remotecontrol
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderProducesBlockOutput(t *testing.T) {
+	out, err := Render("http://192.168.1.42:8080/pair?t=deadbeef")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if out == "" {
+		t.Fatal("Render returned empty output")
+	}
+	// Output must consist only of the half-block glyphs, spaces, and newlines.
+	for _, r := range out {
+		switch r {
+		case '█', '▀', '▄', ' ', '\n':
+		default:
+			t.Fatalf("unexpected rune %q in QR output", r)
+		}
+	}
+	// Must contain at least one dark-bearing glyph (not all blanks).
+	if !strings.ContainsAny(out, "▀▄ ") {
+		t.Fatal("QR output has no dark modules")
+	}
+}
+
+func TestRenderIsDeterministic(t *testing.T) {
+	const url = "http://10.0.0.9:5000/pair?t=abc123"
+	a, err := Render(url)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	b, err := Render(url)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if a != b {
+		t.Fatal("Render is not deterministic for the same URL")
+	}
+}
+
+func TestRenderSquareRows(t *testing.T) {
+	out, err := Render("http://127.0.0.1:1/pair?t=x")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) == 0 {
+		t.Fatal("no lines")
+	}
+	width := len([]rune(lines[0]))
+	for i, ln := range lines {
+		if got := len([]rune(ln)); got != width {
+			t.Fatalf("line %d width = %d, want uniform %d", i, got, width)
+		}
+	}
+}


### PR DESCRIPTION
Node #440 of the /remote-control graph.

- qr.Render(url): scannable Unicode half-block QR (▀ ▄ █)
- skip2/go-qrcode pinned at v0.0.0-20200617195104-da1b6568686e
- Returns error on encode failure so callers print URL-only
- Tests: glyph set, determinism, uniform row width

SPEC: tasks/spec-remote-control.md §2.2, §6.3

Closes #440