### PR TITLE
feat(remotecontrol): HTTP + WebSocket server (#441)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/coder/websocket v1.8.13
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSE
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
+github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9FE=
+github.com/coder/websocket v1.8.13/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=

--- a/internal/remotecontrol/protocol.go
+++ b/internal/remotecontrol/protocol.go
@@ -1,0 +1,47 @@
+package remotecontrol
+
+// FrameType enumerates the WebSocket message kinds exchanged between the server
+// and the paired browser. It is the wire contract shared with the embedded SPA.
+type FrameType string
+
+const (
+	// FrameOutput streams session text from server to client.
+	FrameOutput FrameType = "output"
+	// FrameInput carries a prompt line submitted by the client to the server.
+	FrameInput FrameType = "input"
+	// FrameConfirm asks the client to approve/reject a risky tool call.
+	FrameConfirm FrameType = "confirm"
+	// FrameDecide carries the client's approval decision back to the server.
+	FrameDecide FrameType = "decide"
+	// FrameStatus reports session lifecycle changes to the client.
+	FrameStatus FrameType = "status"
+)
+
+// Status values carried in Frame.State for FrameStatus frames.
+const (
+	StatusConnected    = "connected"
+	StatusEnded        = "ended"
+	StatusDisconnected = "disconnected"
+)
+
+// Frame is a single WebSocket message. Fields are populated according to Type;
+// unused fields are omitted from the JSON encoding.
+type Frame struct {
+	Type FrameType `json:"type"`
+
+	// Output
+	Text string `json:"text,omitempty"`
+
+	// Confirm
+	ConfirmID string `json:"confirmId,omitempty"`
+	Tool      string `json:"tool,omitempty"`
+	Summary   string `json:"summary,omitempty"`
+
+	// Decide
+	Approve bool `json:"approve,omitempty"`
+	Always  bool `json:"always,omitempty"`
+
+	// Status
+	State  string `json:"state,omitempty"`  // connected | ended | disconnected
+	Reason string `json:"reason,omitempty"` // human-readable detail for State
+}

--- a/internal/remotecontrol/server.go
+++ b/internal/remotecontrol/server.go
@@ -1,0 +1,349 @@
+package remotecontrol
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+)
+
+// spaFiles holds the embedded browser SPA. The placeholder shipped here is
+// fleshed out by the web-SPA node; the server only needs a valid FS to embed.
+//
+//go:embed web
+var spaFiles embed.FS
+
+// Default configuration values (see tasks/spec-remote-control.md §3.2).
+const (
+	defaultPairTTL = 10 * time.Minute
+	cookieName     = "pigo_rc"
+	maxFrameBytes  = 64 * 1024
+)
+
+// Config controls a remote-control server instance.
+type Config struct {
+	PairTTL        time.Duration // pairing-token lifetime; 0 → defaultPairTTL
+	Host           string        // LAN IP for the printed URL; "" → auto-detect
+	Port           int           // 0 → auto-pick, fall back on conflict
+	ConfirmTimeout time.Duration // 0 → wait forever for a remote decision
+}
+
+// Handler receives frames the browser sends. The REPL bridge implements it;
+// tests supply a fake. Callbacks run on the WebSocket read goroutine and must
+// not block for long.
+type Handler interface {
+	// OnInput is called when the client submits a prompt line.
+	OnInput(text string)
+	// OnDecide is called when the client answers a confirmation request.
+	OnDecide(confirmID string, approve, always bool)
+}
+
+// serverState tracks the lifecycle for gating requests.
+type serverState int
+
+const (
+	stateIdle serverState = iota
+	stateListening
+	stateEnded
+)
+
+// Server is an in-process HTTP + WebSocket server that mirrors the CLI session
+// to a single paired browser on the LAN.
+type Server struct {
+	cfg     Config
+	tokens  *TokenStore
+	handler Handler
+	spa     fs.FS
+
+	mu         sync.Mutex
+	state      serverState
+	ln         net.Listener
+	httpServer *http.Server
+	host       string
+	port       int
+
+	client       *websocket.Conn
+	clientCtx    context.Context
+	clientCancel context.CancelFunc
+	writeMu      sync.Mutex // serializes writes to client
+}
+
+// NewServer builds a server. handler may be nil (frames from the client are
+// then ignored), which is useful for output-only smoke tests.
+func NewServer(cfg Config, handler Handler) *Server {
+	if cfg.PairTTL <= 0 {
+		cfg.PairTTL = defaultPairTTL
+	}
+	sub, err := fs.Sub(spaFiles, "web")
+	if err != nil {
+		// The embed path is a compile-time constant, so this cannot fail in a
+		// correctly built binary; fall back to the raw FS defensively.
+		sub = spaFiles
+	}
+	return &Server{
+		cfg:     cfg,
+		tokens:  NewTokenStore(),
+		handler: handler,
+		spa:     sub,
+		state:   stateIdle,
+	}
+}
+
+// Start resolves a LAN address, binds a listener, mints a one-time pairing
+// token, begins serving, and returns the full pairing URL to print. It is
+// non-blocking: the HTTP server runs on its own goroutine.
+func (s *Server) Start() (string, error) {
+	host := s.cfg.Host
+	if host == "" {
+		detected, err := DetectRoutableIP()
+		if err != nil {
+			return "", err
+		}
+		host = detected
+	}
+	ln, port, err := ListenFreePort(host, s.cfg.Port)
+	if err != nil {
+		return "", err
+	}
+	token, err := s.tokens.NewPairing(s.cfg.PairTTL)
+	if err != nil {
+		ln.Close()
+		return "", err
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.handleHealthz)
+	mux.HandleFunc("/pair", s.handlePair)
+	mux.HandleFunc("/ws", s.handleWS)
+	mux.HandleFunc("/", s.handleRoot)
+
+	s.mu.Lock()
+	s.ln = ln
+	s.host = host
+	s.port = port
+	s.httpServer = &http.Server{Handler: mux}
+	s.state = stateListening
+	s.mu.Unlock()
+
+	go s.httpServer.Serve(ln)
+
+	return fmt.Sprintf("http://%s:%d/pair?t=%s", host, port, token), nil
+}
+
+// Stop notifies the client, closes the WebSocket, shuts down the HTTP server,
+// and wipes all tokens. It is safe to call more than once.
+func (s *Server) Stop(ctx context.Context) error {
+	s.mu.Lock()
+	if s.state == stateEnded {
+		s.mu.Unlock()
+		return nil
+	}
+	s.state = stateEnded
+	srv := s.httpServer
+	client := s.client
+	cancel := s.clientCancel
+	s.mu.Unlock()
+
+	if client != nil {
+		// Best-effort: tell the browser the session ended, then close.
+		s.writeFrame(client, Frame{Type: FrameStatus, State: StatusEnded})
+		client.Close(websocket.StatusNormalClosure, "session ended")
+	}
+	if cancel != nil {
+		cancel()
+	}
+	s.tokens.Clear()
+	if srv != nil {
+		return srv.Shutdown(ctx)
+	}
+	return nil
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+// handlePair validates the one-time token, issues a session cookie, and
+// redirects to the SPA root. Invalid/expired/used tokens get 401.
+func (s *Server) handlePair(w http.ResponseWriter, r *http.Request) {
+	if s.ended() {
+		http.Error(w, "session ended", http.StatusGone)
+		return
+	}
+	token := r.URL.Query().Get("t")
+	if token == "" || !s.tokens.ConsumePairing(token) {
+		http.Error(w, "pairing link invalid or expired", http.StatusUnauthorized)
+		return
+	}
+	cred, err := s.tokens.IssueSession()
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     cookieName,
+		Value:    cred,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	})
+	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+// handleRoot serves the SPA to authenticated clients and an instructional page
+// otherwise.
+func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
+	if s.ended() {
+		http.Error(w, "session ended", http.StatusGone)
+		return
+	}
+	if !s.authed(r) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`<!doctype html><meta charset="utf-8">` +
+			`<p>Open the pairing link printed in your terminal to connect.</p>`))
+		return
+	}
+	http.FileServer(http.FS(s.spa)).ServeHTTP(w, r)
+}
+
+// handleWS upgrades to a WebSocket for the single controlling client.
+func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
+	if s.ended() {
+		http.Error(w, "session ended", http.StatusGone)
+		return
+	}
+	if !s.authed(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	s.mu.Lock()
+	if s.client != nil {
+		s.mu.Unlock()
+		http.Error(w, "another device is controlling this session", http.StatusConflict)
+		return
+	}
+	s.mu.Unlock()
+
+	conn, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		return
+	}
+	conn.SetReadLimit(maxFrameBytes)
+
+	ctx, cancel := context.WithCancel(r.Context())
+	s.mu.Lock()
+	s.client = conn
+	s.clientCtx = ctx
+	s.clientCancel = cancel
+	s.mu.Unlock()
+
+	// Announce connection to the client.
+	s.writeFrame(conn, Frame{Type: FrameStatus, State: StatusConnected})
+
+	defer func() {
+		cancel()
+		s.mu.Lock()
+		if s.client == conn {
+			s.client = nil
+			s.clientCtx = nil
+			s.clientCancel = nil
+		}
+		s.mu.Unlock()
+		conn.Close(websocket.StatusNormalClosure, "")
+	}()
+
+	for {
+		var f Frame
+		if err := wsjson.Read(ctx, conn, &f); err != nil {
+			return // client disconnected or context cancelled
+		}
+		s.dispatch(f)
+	}
+}
+
+// dispatch routes an inbound client frame to the handler.
+func (s *Server) dispatch(f Frame) {
+	if s.handler == nil {
+		return
+	}
+	switch f.Type {
+	case FrameInput:
+		s.handler.OnInput(f.Text)
+	case FrameDecide:
+		s.handler.OnDecide(f.ConfirmID, f.Approve, f.Always)
+	}
+}
+
+// Broadcast sends a frame to the connected client, if any. It is safe to call
+// from any goroutine.
+func (s *Server) Broadcast(f Frame) {
+	s.mu.Lock()
+	conn := s.client
+	s.mu.Unlock()
+	if conn == nil {
+		return
+	}
+	s.writeFrame(conn, f)
+}
+
+// SendOutput streams session text to the client.
+func (s *Server) SendOutput(text string) {
+	s.Broadcast(Frame{Type: FrameOutput, Text: text})
+}
+
+// SendConfirm asks the client to approve a risky tool call.
+func (s *Server) SendConfirm(confirmID, tool, summary string) {
+	s.Broadcast(Frame{Type: FrameConfirm, ConfirmID: confirmID, Tool: tool, Summary: summary})
+}
+
+// HasClient reports whether a controlling client is currently connected.
+func (s *Server) HasClient() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.client != nil
+}
+
+// Addr returns the bound host:port, or "" before Start.
+func (s *Server) Addr() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.ln == nil {
+		return ""
+	}
+	return net.JoinHostPort(s.host, fmt.Sprint(s.port))
+}
+
+func (s *Server) writeFrame(conn *websocket.Conn, f Frame) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = wsjson.Write(ctx, conn, f)
+}
+
+func (s *Server) ended() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state == stateEnded
+}
+
+func (s *Server) authed(r *http.Request) bool {
+	c, err := r.Cookie(cookieName)
+	if err != nil {
+		return false
+	}
+	return s.tokens.ValidateSession(c.Value)
+}
+
+// ErrNotStarted is returned by operations that require a running server.
+var ErrNotStarted = errors.New("remotecontrol: server not started")

--- a/internal/remotecontrol/server_test.go
+++ b/internal/remotecontrol/server_test.go
@@ -1,0 +1,251 @@
+package remotecontrol
+
+import (
+	"context"
+	"net/http"
+	"net/http/cookiejar"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+)
+
+type fakeHandler struct {
+	mu      sync.Mutex
+	inputs  []string
+	decides []decision
+}
+
+type decision struct {
+	id      string
+	approve bool
+	always  bool
+}
+
+func (h *fakeHandler) OnInput(text string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.inputs = append(h.inputs, text)
+}
+
+func (h *fakeHandler) OnDecide(id string, approve, always bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.decides = append(h.decides, decision{id, approve, always})
+}
+
+func (h *fakeHandler) lastInput() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.inputs) == 0 {
+		return ""
+	}
+	return h.inputs[len(h.inputs)-1]
+}
+
+// startTestServer boots a server on loopback and returns it plus the pairing
+// URL. The caller must Stop it.
+func startTestServer(t *testing.T, h Handler) (*Server, string) {
+	t.Helper()
+	s := NewServer(Config{Host: "127.0.0.1", Port: 0}, h)
+	url, err := s.Start()
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = s.Stop(ctx)
+	})
+	return s, url
+}
+
+func TestHealthz(t *testing.T) {
+	_, pairURL := startTestServer(t, nil)
+	base := pairURL[:strings.Index(pairURL, "/pair")]
+	resp, err := http.Get(base + "/healthz")
+	if err != nil {
+		t.Fatalf("get healthz: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("healthz status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestPairRejectsBadToken(t *testing.T) {
+	_, pairURL := startTestServer(t, nil)
+	base := pairURL[:strings.Index(pairURL, "/pair")]
+	resp, err := http.Get(base + "/pair?t=bogus")
+	if err != nil {
+		t.Fatalf("get pair: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("bad-token status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestPairSetsCookieAndServesSPA(t *testing.T) {
+	_, pairURL := startTestServer(t, nil)
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	resp, err := client.Get(pairURL)
+	if err != nil {
+		t.Fatalf("pair: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK { // followed redirect to /
+		t.Fatalf("pair->root status = %d, want 200", resp.StatusCode)
+	}
+
+	// A second use of the same one-time token must fail.
+	resp2, err := http.Get(pairURL)
+	if err != nil {
+		t.Fatalf("pair reuse: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("token reuse status = %d, want 401", resp2.StatusCode)
+	}
+}
+
+func TestRootRequiresAuth(t *testing.T) {
+	_, pairURL := startTestServer(t, nil)
+	base := pairURL[:strings.Index(pairURL, "/pair")]
+	resp, err := http.Get(base + "/")
+	if err != nil {
+		t.Fatalf("get root: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauth root status = %d, want 401", resp.StatusCode)
+	}
+}
+
+// sessionCred pairs and extracts the pigo_rc cookie value for WS dialing.
+func sessionCred(t *testing.T, pairURL string) (base, cred string) {
+	t.Helper()
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse // stop at the 302 to read the cookie
+		},
+	}
+	resp, err := client.Get(pairURL)
+	if err != nil {
+		t.Fatalf("pair: %v", err)
+	}
+	defer resp.Body.Close()
+	for _, c := range resp.Cookies() {
+		if c.Name == cookieName {
+			cred = c.Value
+		}
+	}
+	if cred == "" {
+		t.Fatal("no session cookie issued")
+	}
+	return pairURL[:strings.Index(pairURL, "/pair")], cred
+}
+
+func dialWS(t *testing.T, base, cred string) (*websocket.Conn, *http.Response, error) {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(base, "http") + "/ws"
+	opts := &websocket.DialOptions{
+		HTTPHeader: http.Header{"Cookie": []string{cookieName + "=" + cred}},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return websocket.Dial(ctx, wsURL, opts)
+}
+
+func TestWSRoundTrip(t *testing.T) {
+	h := &fakeHandler{}
+	s, pairURL := startTestServer(t, h)
+	base, cred := sessionCred(t, pairURL)
+
+	conn, _, err := dialWS(t, base, cred)
+	if err != nil {
+		t.Fatalf("dial ws: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// First frame should be the connected status.
+	var connected Frame
+	if err := wsjson.Read(ctx, conn, &connected); err != nil {
+		t.Fatalf("read connected: %v", err)
+	}
+	if connected.Type != FrameStatus || connected.State != StatusConnected {
+		t.Fatalf("first frame = %+v, want status/connected", connected)
+	}
+
+	// Client -> server input reaches the handler.
+	if err := wsjson.Write(ctx, conn, Frame{Type: FrameInput, Text: "hello"}); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for h.lastInput() != "hello" {
+		if time.Now().After(deadline) {
+			t.Fatalf("handler never received input, got %q", h.lastInput())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Server -> client output reaches the browser.
+	s.SendOutput("world")
+	var out Frame
+	if err := wsjson.Read(ctx, conn, &out); err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if out.Type != FrameOutput || out.Text != "world" {
+		t.Fatalf("output frame = %+v, want output/world", out)
+	}
+}
+
+func TestWSRejectsUnauth(t *testing.T) {
+	_, pairURL := startTestServer(t, nil)
+	base := pairURL[:strings.Index(pairURL, "/pair")]
+	_, resp, err := dialWS(t, base, "not-a-valid-cred")
+	if err == nil {
+		t.Fatal("dial with bad cred succeeded, want failure")
+	}
+	if resp != nil && resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestWSSingleClient(t *testing.T) {
+	s, pairURL := startTestServer(t, &fakeHandler{})
+	base, cred := sessionCred(t, pairURL)
+
+	conn1, _, err := dialWS(t, base, cred)
+	if err != nil {
+		t.Fatalf("dial first: %v", err)
+	}
+	defer conn1.Close(websocket.StatusNormalClosure, "")
+
+	// Wait until the server registers the first client.
+	deadline := time.Now().Add(time.Second)
+	for !s.HasClient() {
+		if time.Now().After(deadline) {
+			t.Fatal("server never registered first client")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	_, resp, err := dialWS(t, base, cred)
+	if err == nil {
+		t.Fatal("second client connected, want rejection")
+	}
+	if resp != nil && resp.StatusCode != http.StatusConflict {
+		t.Fatalf("second-client status = %d, want 409", resp.StatusCode)
+	}
+}

--- a/internal/remotecontrol/web/index.html
+++ b/internal/remotecontrol/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>pigo remote</title>
+</head>
+<body>
+  <!-- Placeholder SPA. Replaced by the responsive web SPA node (#444). -->
+  <main id="app">pigo remote-control</main>
+</body>
+</html>


### PR DESCRIPTION
Node #441 of the /remote-control graph.

- /pair validates one-time token -> issues HttpOnly, SameSite=Strict pigo_rc cookie -> redirect to SPA
- Gated / (embedded SPA) and /ws; /healthz liveness
- JSON Frame protocol: output/input/confirm/decide/status; 64KiB read limit
- Single controlling client (second gets 409); graceful Stop notifies client + wipes tokens
- Handler interface decouples the REPL bridge (#442/#443)
- coder/websocket pinned v1.8.13; embeds placeholder web/ SPA (replaced by #444)
- Integration tests: healthz, bad/good/reused token, root auth gate, WS round-trip (input+output), unauth WS, single-client 409

SPEC: tasks/spec-remote-control.md §3.2, §5.x, §7.1

Closes #441