### PR TITLE
Wire remote-control bridge into REPL + server hardening (#443, #445)

### DIFF
--- a/internal/cli/repl/remotecontrol.go
+++ b/internal/cli/repl/remotecontrol.go
@@ -1,0 +1,237 @@
+// This file wires the remote-control bridge (internal/remotecontrol, #442) into
+// the interactive REPL (#443). It adds the "/remote-control" command that
+// starts/stops an in-process HTTP+WebSocket server mirroring the session to a
+// paired browser on the LAN, tees REPL output to that browser, merges
+// browser-submitted prompts into the input loop, and routes tool-call
+// confirmations to the browser while a client is connected.
+//
+// The design keeps the non-remote path byte-identical: when no remote session
+// is active, teeWriter forwards only to stdout, the input select degenerates to
+// a plain editor read (the remote channel is nil), and confirmations use the
+// local stdin prompt unchanged.
+package repl
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/remotecontrol"
+	"github.com/smallnest/pigo/internal/trust"
+)
+
+// teeWriter is an io.Writer that always forwards to a primary writer (the
+// terminal) and, when a secondary is set, mirrors the same bytes to it (the
+// remote browser). It is safe for concurrent Write/setSecondary because the
+// bridge output writer is fed from the REPL goroutine while the secondary is
+// toggled by the /remote-control command on the same goroutine, but writes to
+// the WebSocket happen on other goroutines; the mutex keeps the swap atomic.
+type teeWriter struct {
+	primary io.Writer
+	mu      sync.Mutex
+	second  io.Writer
+}
+
+func newTeeWriter(primary io.Writer) *teeWriter { return &teeWriter{primary: primary} }
+
+func (t *teeWriter) setSecondary(w io.Writer) {
+	t.mu.Lock()
+	t.second = w
+	t.mu.Unlock()
+}
+
+func (t *teeWriter) Write(p []byte) (int, error) {
+	// The primary write is authoritative for the returned count/err so terminal
+	// behavior is unchanged; a mirror failure never breaks the local session.
+	n, err := t.primary.Write(p)
+	t.mu.Lock()
+	second := t.second
+	t.mu.Unlock()
+	if second != nil {
+		_, _ = second.Write(p)
+	}
+	return n, err
+}
+
+// remoteSession owns the running server + bridge for one /remote-control
+// activation. It is nil in deps until the command starts a session, and is
+// cleared on stop.
+type remoteSession struct {
+	server *remotecontrol.Server
+	bridge *remotecontrol.Bridge
+	url    string
+}
+
+// inputChan returns the bridge's remote-input channel while a session is
+// active, or nil when inactive. A nil channel blocks forever in a select, so
+// the input loop transparently ignores remote input when remote control is off.
+func (rs *remoteSession) inputChan() <-chan string {
+	if rs == nil || rs.bridge == nil {
+		return nil
+	}
+	return rs.bridge.RemoteInput()
+}
+
+// hasClient reports whether a browser is currently paired and connected.
+func (rs *remoteSession) hasClient() bool {
+	return rs != nil && rs.bridge != nil && rs.bridge.Enabled()
+}
+
+// runRemoteControl handles the "/remote-control" command and its "stop"/"status"
+// subcommands. It mutates deps in place (deps.remote, deps.tee) so the input
+// loop and output tee pick up the change on the next iteration.
+func runRemoteControl(out io.Writer, deps *replDeps, line string) {
+	arg := strings.TrimSpace(strings.TrimPrefix(line, "/remote-control"))
+	switch arg {
+	case "stop":
+		stopRemoteControl(out, deps)
+	case "status", "":
+		if arg == "status" {
+			remoteControlStatus(out, deps)
+			return
+		}
+		startRemoteControl(out, deps)
+	default:
+		fmt.Fprintf(out, "usage: /remote-control [stop|status]\n")
+	}
+}
+
+func startRemoteControl(out io.Writer, deps *replDeps) {
+	if deps.remote != nil {
+		fmt.Fprintf(out, "remote control already running: %s\n", deps.remote.url)
+		return
+	}
+	// Handler is set after the server is built (SetHandler), but NewServer takes
+	// it up front; the bridge's Sink is the server itself, so build the server
+	// first with the bridge as handler once the bridge exists. To break the
+	// cycle we construct the server, then the bridge (Sink=server), then tell the
+	// server to route client frames to the bridge.
+	// The connect/disconnect callbacks print a terminal notice so the operator
+	// sees when a browser gains or loses remote access to this session (§7.3).
+	// They run on the server's WebSocket goroutine and only write a line, so they
+	// don't block.
+	cfg := remotecontrol.Config{
+		OnClientConnect: func(remoteAddr string) {
+			fmt.Fprintf(out, "\n[remote-control] browser connected from %s\n", remoteAddr)
+		},
+		OnClientDisconnect: func() {
+			fmt.Fprintf(out, "\n[remote-control] browser disconnected\n")
+		},
+	}
+	srv := remotecontrol.NewServer(cfg, nil)
+	bridge := remotecontrol.NewBridge(srv)
+	srv.SetHandler(bridge)
+
+	url, err := srv.Start()
+	if err != nil {
+		fmt.Fprintf(out, "remote control: %v\n", err)
+		return
+	}
+	rs := &remoteSession{server: srv, bridge: bridge, url: url}
+	deps.remote = rs
+	if deps.tee != nil {
+		deps.tee.setSecondary(bridge.OutputWriter())
+	}
+
+	fmt.Fprintf(out, "\nRemote control started. Open this URL on a device on the same network:\n\n  %s\n\n", url)
+	if qr, qerr := remotecontrol.Render(url); qerr == nil {
+		fmt.Fprintln(out, qr)
+	}
+	fmt.Fprintln(out, "Run /remote-control stop to end the session.")
+}
+
+func stopRemoteControl(out io.Writer, deps *replDeps) {
+	if deps.remote == nil {
+		fmt.Fprintln(out, "remote control is not running")
+		return
+	}
+	if deps.tee != nil {
+		deps.tee.setSecondary(nil)
+	}
+	_ = deps.remote.server.Stop(context.Background())
+	deps.remote = nil
+	fmt.Fprintln(out, "remote control stopped")
+}
+
+func remoteControlStatus(out io.Writer, deps *replDeps) {
+	if deps.remote == nil {
+		fmt.Fprintln(out, "remote control: off")
+		return
+	}
+	state := "waiting for a browser to connect"
+	if deps.remote.hasClient() {
+		state = "browser connected"
+	}
+	fmt.Fprintf(out, "remote control: on (%s)\n  %s\n", state, deps.remote.url)
+}
+
+// beforeToolCall builds the tool-call confirmation seam for a turn. It always
+// constructs the local stdin prompt (trust.BeforeToolCall) and, when a remote
+// session exists, wraps it with bridgeBeforeToolCall so confirmations route to a
+// paired browser while one is connected. When deps.remote is nil the wrapper is
+// skipped entirely, so the returned func is exactly the local seam — the
+// non-remote path is byte-identical to before (#443).
+func beforeToolCall(deps replDeps, out io.Writer) agentcore.BeforeToolCallFunc {
+	local := trust.BeforeToolCall(deps.trust, deps.cwd, deps.in, out, deps.confirmMu)
+	if deps.remote == nil {
+		return local
+	}
+	return bridgeBeforeToolCall(deps.trust, deps.cwd, deps.remote, out, deps.confirmMu, local)
+}
+
+// bridgeBeforeToolCall wraps the local stdin confirmation seam so that while a
+// browser is connected, side-effect tool-call confirmations are routed to the
+// browser instead of blocking on the local terminal. When no browser is
+// connected it delegates to the local prompt so behavior is unchanged.
+//
+// This mirrors trust.BeforeToolCall's gating (side-effect tools only, honoring
+// session trust) but delegates the allow/always decision to the remote client
+// via Bridge.Confirm. A ctx cancellation (e.g. SIGINT) makes Confirm return
+// remote=false, which we treat as a denial so an interrupted run does not
+// silently proceed. Refinements (local-answer race, timeouts) are the hardening
+// node's job (#445).
+func bridgeBeforeToolCall(mgr *trust.Manager, cwd string, rs *remoteSession, out io.Writer, mu *sync.Mutex, local agentcore.BeforeToolCallFunc) agentcore.BeforeToolCallFunc {
+	return func(ctx context.Context, call agentcore.AgentToolCall) *agentcore.BeforeToolCallDecision {
+		if !rs.hasClient() || mgr == nil {
+			if local != nil {
+				return local(ctx, call)
+			}
+			return nil
+		}
+		if !trust.SideEffectTools[call.Name] {
+			return nil
+		}
+		if mu != nil {
+			mu.Lock()
+			defer mu.Unlock()
+		}
+		if mgr.IsTrusted(cwd) {
+			return nil
+		}
+		summary := trust.ToolCallSummary(call)
+		fmt.Fprintf(out, "\npigo wants to run %q — approve on the paired device…\n", call.Name)
+		d, remote := rs.bridge.Confirm(ctx, call.Name, summary)
+		if !remote {
+			// Interrupted / cancelled before the browser answered: deny.
+			return blockToolCall(call, cwd)
+		}
+		if d.Always {
+			mgr.SetSessionTrust(cwd)
+		}
+		if !d.Approve {
+			return blockToolCall(call, cwd)
+		}
+		return nil
+	}
+}
+
+func blockToolCall(call agentcore.AgentToolCall, cwd string) *agentcore.BeforeToolCallDecision {
+	msg := fmt.Sprintf("tool %q blocked: %s is not trusted (use /trust to trust this project)", call.Name, cwd)
+	return &agentcore.BeforeToolCallDecision{
+		Block:   true,
+		Content: &agentcore.ContentList{agentcore.NewTextContent(msg)},
+	}
+}

--- a/internal/cli/repl/repl.go
+++ b/internal/cli/repl/repl.go
@@ -127,6 +127,18 @@ type replDeps struct {
 	dispatcher *hooks.Dispatcher
 	// hookDeps carries the session id / project dir stamped onto every HookInput.
 	hookDeps run.HookDeps
+
+	// remote holds the active remote-control session (#443), or nil when remote
+	// control is off. The /remote-control command sets/clears it in place; the
+	// input loop selects on its RemoteInput channel and the confirm seam routes
+	// tool-call approvals to the paired browser while it is non-nil. When nil the
+	// REPL behaves exactly as before (byte-identical).
+	remote *remoteSession
+	// tee wraps out so REPL output can be mirrored to the remote browser while a
+	// session is active. It is created at the top of runREPL; the /remote-control
+	// command toggles its secondary writer. When no remote session is active it
+	// forwards only to the terminal.
+	tee *teeWriter
 }
 
 // replScanBufInit is the initial size of the shared input reader. A REPL user
@@ -166,6 +178,26 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 	if deps.in == nil {
 		deps.in = bufio.NewReaderSize(in, replScanBufInit)
 	}
+
+	// Mirror all REPL output to the remote browser while a /remote-control
+	// session is active (#443). teeWriter forwards to the terminal
+	// unconditionally and, when the command toggles a secondary, also to the
+	// bridge's output writer. When remote control is off it is a thin
+	// pass-through, so terminal output is byte-identical to before.
+	deps.tee = newTeeWriter(out)
+	out = deps.tee
+
+	// Stop a still-running remote-control server when the REPL exits (FR-16), so
+	// quitting pigo tears down the LAN listener rather than leaking it. The
+	// closure reads deps.remote at exit time, so it covers a session started mid
+	// run; an explicit /remote-control stop clears deps.remote and makes this a
+	// no-op.
+	defer func() {
+		if deps.remote != nil {
+			_ = deps.remote.server.Stop(context.Background())
+			deps.remote = nil
+		}
+	}()
 
 	// Resolve the run's hooks once per session and fire SessionStart so any
 	// injected context lands in the first turn (#423/#425). The project layer is
@@ -222,9 +254,54 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 		}
 	}()
 
+	// Input is acquired by a dedicated reader goroutine so the main loop can
+	// select between a locally-typed line and a line submitted from the paired
+	// browser (#443). The goroutine reads one line per request sent on promptReq
+	// and returns it on localCh; the loop only issues a new request when the
+	// reader is idle (readerBusy == false), so a browser-submitted line that
+	// arrives while a local ReadLine is still blocked does not deadlock or
+	// double-prompt. When remote control is off, remoteCh is nil (blocks
+	// forever), so the select degenerates to a plain local read — behavior is
+	// identical to before.
+	type lineResult struct {
+		raw string
+		err error
+	}
+	promptReq := make(chan string)
+	localCh := make(chan lineResult, 1)
+	go func() {
+		for p := range promptReq {
+			raw, err := editor.ReadLine(p)
+			localCh <- lineResult{raw: raw, err: err}
+		}
+	}()
+	defer close(promptReq)
+	readerBusy := false
+
 	for {
-		fmt.Fprintln(out)
-		raw, err := editor.ReadLine(fmt.Sprintf("pigo(%s)> ", deps.live.Model))
+		replPrompt := fmt.Sprintf("pigo(%s)> ", deps.live.Model)
+		if !readerBusy {
+			fmt.Fprintln(out)
+			promptReq <- replPrompt
+			readerBusy = true
+		}
+		var (
+			raw        string
+			err        error
+			fromRemote bool
+		)
+		select {
+		case res := <-localCh:
+			readerBusy = false
+			raw, err = res.raw, res.err
+		case rl := <-deps.remote.inputChan():
+			// A browser-submitted line. The pending local ReadLine stays blocked
+			// (readerBusy remains true) and will be consumed on a later iteration.
+			raw, fromRemote = rl, true
+			// Echo the remote line locally so the terminal (and, via the tee, the
+			// browser) shows what was submitted, mirroring a typed prompt.
+			fmt.Fprintf(out, "%s%s\n", replPrompt, raw)
+		}
 		if errors.Is(err, errLineInterrupted) {
 			continue
 		}
@@ -237,7 +314,9 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 			return err
 		}
 		line := strings.TrimSpace(raw)
-		editor.remember(line)
+		if !fromRemote {
+			editor.remember(line)
+		}
 		if line == "" {
 			if err != nil {
 				// A trailing partial line at EOF that trims to empty: exit.
@@ -341,6 +420,15 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 			btw.RunBtw(setCancel, out, &deps, editor, line)
 			continue
 		}
+		if line == "/remote-control" || strings.HasPrefix(line, "/remote-control ") {
+			// /remote-control is intercepted here (not a slash Action) because it
+			// starts/stops the in-process server and toggles deps.remote / the
+			// output tee in place — per-session state a pure string→string Action
+			// closure cannot reach (#443). The exact-or-space-prefix guard keeps a
+			// longer command from being mistaken for it.
+			runRemoteControl(out, &deps, line)
+			continue
+		}
 
 		// Resolve slash-commands: an action command runs and prints its message
 		// (no agent run); a prompt command or skill expands to the text we run; a
@@ -428,7 +516,7 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 		Batch: agenttool.BatchConfig{
 			ToolExecutorConfig: agenttool.ToolExecutorConfig{
 				Registry:       deps.reg,
-				BeforeToolCall: trust.BeforeToolCall(deps.trust, deps.cwd, deps.in, out, deps.confirmMu),
+				BeforeToolCall: beforeToolCall(deps, out),
 			},
 		},
 		Reminders: deps.reminders,

--- a/internal/remotecontrol/server.go
+++ b/internal/remotecontrol/server.go
@@ -26,6 +26,19 @@ const (
 	defaultPairTTL = 10 * time.Minute
 	cookieName     = "pigo_rc"
 	maxFrameBytes  = 64 * 1024
+
+	// outputFlushInterval is the coalescing tick: adjacent output writes buffered
+	// within one interval are sent as a single frame, so a fast stream produces a
+	// few batched frames rather than one per write, while still hitting the PRD's
+	// sub-100ms latency target (§8.2).
+	outputFlushInterval = 16 * time.Millisecond
+	// outputQueueMax bounds the pending buffer. A producer that would push it past
+	// this blocks until the pump drains, applying backpressure — the terminal
+	// mirror must not drop bytes (§5.4), so we never discard, only slow down.
+	outputQueueMax = 256 * 1024
+	// replayRingBytes bounds the rolling output history kept for late-join /
+	// reconnect replay so a freshly connected browser sees recent context (§8.2).
+	replayRingBytes = 256 * 1024
 )
 
 // Config controls a remote-control server instance.
@@ -34,6 +47,15 @@ type Config struct {
 	Host           string        // LAN IP for the printed URL; "" → auto-detect
 	Port           int           // 0 → auto-pick, fall back on conflict
 	ConfirmTimeout time.Duration // 0 → wait forever for a remote decision
+
+	// OnClientConnect, if set, is invoked (on the WebSocket goroutine) when a
+	// browser pairs and connects, with the client's remote address. The REPL uses
+	// it to print a one-line terminal notice so the operator notices remote access
+	// (§7.3). It must not block for long.
+	OnClientConnect func(remoteAddr string)
+	// OnClientDisconnect, if set, is invoked when the controlling client's
+	// WebSocket closes. It must not block for long.
+	OnClientDisconnect func()
 }
 
 // Handler receives frames the browser sends. The REPL bridge implements it;
@@ -74,6 +96,20 @@ type Server struct {
 	clientCtx    context.Context
 	clientCancel context.CancelFunc
 	writeMu      sync.Mutex // serializes writes to client
+
+	// Output coalescing + backpressure + replay (#445). outMu guards all of the
+	// fields below; outCond signals both the pump (new pending output) and any
+	// producer blocked by backpressure (pump drained pending). The pump is the
+	// sole sender of output frames, so replay and live output can never interleave
+	// or duplicate.
+	outMu      sync.Mutex
+	outCond    *sync.Cond
+	outPending []byte     // coalesced, not-yet-sent output
+	outClosed  bool       // set on Stop; releases blocked producers
+	needReplay bool       // a fresh client connected; next flush replays the ring
+	ring       ringBuffer // rolling last-N bytes for late-join replay
+	pumpCancel context.CancelFunc
+	pumpDone   chan struct{}
 }
 
 // NewServer builds a server. handler may be nil (frames from the client are
@@ -88,13 +124,27 @@ func NewServer(cfg Config, handler Handler) *Server {
 		// correctly built binary; fall back to the raw FS defensively.
 		sub = spaFiles
 	}
-	return &Server{
+	s := &Server{
 		cfg:     cfg,
 		tokens:  NewTokenStore(),
 		handler: handler,
 		spa:     sub,
 		state:   stateIdle,
+		ring:    ringBuffer{max: replayRingBytes},
 	}
+	s.outCond = sync.NewCond(&s.outMu)
+	return s
+}
+
+// SetHandler installs the handler that receives client frames. It exists to
+// break the construction cycle between the server (a Bridge's Sink) and the
+// Bridge (the server's Handler): build the server, build the Bridge with the
+// server as Sink, then SetHandler(bridge). It must be called before Start so
+// the WebSocket read goroutine never observes a mid-flight swap.
+func (s *Server) SetHandler(h Handler) {
+	s.mu.Lock()
+	s.handler = h
+	s.mu.Unlock()
 }
 
 // Start resolves a LAN address, binds a listener, mints a one-time pairing
@@ -125,15 +175,21 @@ func (s *Server) Start() (string, error) {
 	mux.HandleFunc("/ws", s.handleWS)
 	mux.HandleFunc("/", s.handleRoot)
 
+	pumpCtx, pumpCancel := context.WithCancel(context.Background())
+	pumpDone := make(chan struct{})
+
 	s.mu.Lock()
 	s.ln = ln
 	s.host = host
 	s.port = port
 	s.httpServer = &http.Server{Handler: mux}
 	s.state = stateListening
+	s.pumpCancel = pumpCancel
+	s.pumpDone = pumpDone
 	s.mu.Unlock()
 
 	go s.httpServer.Serve(ln)
+	go s.outputPump(pumpCtx, pumpDone)
 
 	return fmt.Sprintf("http://%s:%d/pair?t=%s", host, port, token), nil
 }
@@ -150,7 +206,21 @@ func (s *Server) Stop(ctx context.Context) error {
 	srv := s.httpServer
 	client := s.client
 	cancel := s.clientCancel
+	pumpCancel := s.pumpCancel
+	pumpDone := s.pumpDone
 	s.mu.Unlock()
+
+	// Release any producer blocked on backpressure, then stop the output pump and
+	// wait for its final flush so the last buffered output reaches the client
+	// before we announce the session end.
+	s.outMu.Lock()
+	s.outClosed = true
+	s.outCond.Broadcast()
+	s.outMu.Unlock()
+	if pumpCancel != nil {
+		pumpCancel()
+		<-pumpDone
+	}
 
 	if client != nil {
 		// Best-effort: tell the browser the session ended, then close.
@@ -247,8 +317,20 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 	s.clientCancel = cancel
 	s.mu.Unlock()
 
-	// Announce connection to the client.
+	// Announce connection to the client, then arm a replay so the pump resends the
+	// rolling scrollback (last replayRingBytes) as the first output frame. Live
+	// output produced after this point is appended behind the snapshot by the
+	// pump, so ordering is preserved and nothing is duplicated.
 	s.writeFrame(conn, Frame{Type: FrameStatus, State: StatusConnected})
+	s.outMu.Lock()
+	s.needReplay = true
+	s.outCond.Signal()
+	s.outMu.Unlock()
+
+	// Notify the terminal operator that a client connected (§7.3).
+	if s.cfg.OnClientConnect != nil {
+		s.cfg.OnClientConnect(r.RemoteAddr)
+	}
 
 	defer func() {
 		cancel()
@@ -260,6 +342,9 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 		}
 		s.mu.Unlock()
 		conn.Close(websocket.StatusNormalClosure, "")
+		if s.cfg.OnClientDisconnect != nil {
+			s.cfg.OnClientDisconnect()
+		}
 	}()
 
 	for {
@@ -296,9 +381,36 @@ func (s *Server) Broadcast(f Frame) {
 	s.writeFrame(conn, f)
 }
 
-// SendOutput streams session text to the client.
+// SendOutput streams session text to the client. It never drops bytes: the text
+// is appended to the ring (for replay) and to the pending buffer that the pump
+// coalesces and flushes. If pending output has grown past outputQueueMax the
+// call blocks until the pump drains it, applying backpressure to the producer
+// rather than discarding output (§5.4, §8.4). It returns immediately once the
+// server is stopping so a shutting-down producer never wedges.
 func (s *Server) SendOutput(text string) {
-	s.Broadcast(Frame{Type: FrameOutput, Text: text})
+	if text == "" {
+		return
+	}
+	b := []byte(text)
+
+	s.outMu.Lock()
+	defer s.outMu.Unlock()
+
+	// Always record into the ring so a late-joining / reconnecting client can be
+	// replayed the recent scrollback, even while a producer is momentarily blocked
+	// on backpressure below.
+	s.ring.write(b)
+
+	// Backpressure: wait until the pump has drained enough that appending stays
+	// within the bound. Bail out if the server is stopping.
+	for !s.outClosed && len(s.outPending) >= outputQueueMax {
+		s.outCond.Wait()
+	}
+	if s.outClosed {
+		return
+	}
+	s.outPending = append(s.outPending, b...)
+	s.outCond.Signal()
 }
 
 // SendConfirm asks the client to approve a risky tool call.
@@ -343,6 +455,141 @@ func (s *Server) authed(r *http.Request) bool {
 		return false
 	}
 	return s.tokens.ValidateSession(c.Value)
+}
+
+// outputPump is the sole producer of output frames. It coalesces buffered
+// output on a fixed tick and flushes it as a single frame, so a fast stream
+// becomes a few batched frames while staying under the latency target: the
+// first write after an idle period flushes immediately, and writes arriving
+// during the following outputFlushInterval are batched. It also owns replay:
+// when a client
+// (re)connects, it prepends the ring snapshot before the live pending buffer.
+// Being the only writer of output frames, replay and live output can never
+// interleave or duplicate. It exits after a final flush when its context is
+// cancelled (on Stop).
+func (s *Server) outputPump(ctx context.Context, done chan<- struct{}) {
+	defer close(done)
+
+	ticker := time.NewTicker(outputFlushInterval)
+	defer ticker.Stop()
+
+	// A tiny goroutine wakes the Cond wait below whenever the context is
+	// cancelled, so the pump does not sleep past shutdown.
+	go func() {
+		<-ctx.Done()
+		s.outMu.Lock()
+		s.outCond.Broadcast()
+		s.outMu.Unlock()
+	}()
+
+	for {
+		s.outMu.Lock()
+		// Wait until there is something to do: pending output, an armed replay, or
+		// shutdown.
+		for len(s.outPending) == 0 && !s.needReplay && ctx.Err() == nil {
+			s.outCond.Wait()
+		}
+		replay := s.needReplay
+		s.needReplay = false
+		var snapshot []byte
+		if replay {
+			snapshot = s.ring.snapshot()
+		}
+		// Coalesce: take everything buffered so far as one batch.
+		pending := s.outPending
+		s.outPending = nil
+		// Wake any producer blocked on backpressure now that pending is drained.
+		s.outCond.Broadcast()
+		stopping := ctx.Err() != nil
+		s.outMu.Unlock()
+
+		s.mu.Lock()
+		conn := s.client
+		s.mu.Unlock()
+
+		if conn != nil {
+			// Replay first so the reconnecting browser restores context, then the
+			// live batch. The ring already contains everything appended via
+			// SendOutput, so on a fresh connection the snapshot covers pending too;
+			// avoid double-sending by preferring the snapshot when it is present.
+			if len(snapshot) > 0 {
+				s.writeFrame(conn, Frame{Type: FrameOutput, Text: string(snapshot)})
+			} else if len(pending) > 0 {
+				s.writeFrame(conn, Frame{Type: FrameOutput, Text: string(pending)})
+			}
+		}
+
+		if stopping {
+			// Final drain done; exit.
+			return
+		}
+
+		// Rate the loop on the ticker so bursts coalesce instead of spinning.
+		select {
+		case <-ctx.Done():
+			// Loop once more to perform the final flush of anything buffered while
+			// we were writing above.
+			s.finalFlush()
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// finalFlush drains any remaining pending output once during shutdown so the
+// last bytes reach the client before the session-ended notice.
+func (s *Server) finalFlush() {
+	s.outMu.Lock()
+	pending := s.outPending
+	s.outPending = nil
+	s.outCond.Broadcast()
+	s.outMu.Unlock()
+	if len(pending) == 0 {
+		return
+	}
+	s.mu.Lock()
+	conn := s.client
+	s.mu.Unlock()
+	if conn != nil {
+		s.writeFrame(conn, Frame{Type: FrameOutput, Text: string(pending)})
+	}
+}
+
+// ringBuffer is a bounded rolling byte buffer holding the most recent max bytes
+// of session output for late-join / reconnect replay. It is not safe for
+// concurrent use; the server guards it with outMu.
+type ringBuffer struct {
+	buf []byte
+	max int
+}
+
+// write appends p, discarding oldest bytes so the buffer never exceeds max.
+func (r *ringBuffer) write(p []byte) {
+	if r.max <= 0 {
+		return
+	}
+	if len(p) >= r.max {
+		// Keep only the trailing max bytes of the new data.
+		r.buf = append(r.buf[:0], p[len(p)-r.max:]...)
+		return
+	}
+	r.buf = append(r.buf, p...)
+	if len(r.buf) > r.max {
+		// Drop the oldest overflow. Copy down so the backing array does not grow
+		// without bound over the life of the session.
+		drop := len(r.buf) - r.max
+		r.buf = append(r.buf[:0], r.buf[drop:]...)
+	}
+}
+
+// snapshot returns a copy of the current contents.
+func (r *ringBuffer) snapshot() []byte {
+	if len(r.buf) == 0 {
+		return nil
+	}
+	out := make([]byte, len(r.buf))
+	copy(out, r.buf)
+	return out
 }
 
 // ErrNotStarted is returned by operations that require a running server.

--- a/internal/remotecontrol/server_test.go
+++ b/internal/remotecontrol/server_test.go
@@ -222,6 +222,191 @@ func TestWSRejectsUnauth(t *testing.T) {
 	}
 }
 
+// readOutput reads frames until it sees a FrameOutput and returns its text,
+// skipping any interleaved status frames.
+func readOutput(t *testing.T, ctx context.Context, conn *websocket.Conn) string {
+	t.Helper()
+	for {
+		var f Frame
+		if err := wsjson.Read(ctx, conn, &f); err != nil {
+			t.Fatalf("read output: %v", err)
+		}
+		if f.Type == FrameOutput {
+			return f.Text
+		}
+	}
+}
+
+// TestOutputCoalesced verifies that a burst of writes is coalesced into a
+// single output frame by the pump rather than one frame per write, and that no
+// bytes are dropped.
+func TestOutputCoalesced(t *testing.T) {
+	s, pairURL := startTestServer(t, &fakeHandler{})
+	base, cred := sessionCred(t, pairURL)
+
+	conn, _, err := dialWS(t, base, cred)
+	if err != nil {
+		t.Fatalf("dial ws: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	// Drain the connected status frame.
+	var connected Frame
+	if err := wsjson.Read(ctx, conn, &connected); err != nil {
+		t.Fatalf("read connected: %v", err)
+	}
+
+	// Wait for the server to register the client so writes are not lost before
+	// the pump has a live connection.
+	deadline := time.Now().Add(time.Second)
+	for !s.HasClient() {
+		if time.Now().After(deadline) {
+			t.Fatal("client never registered")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Emit a burst within one flush interval.
+	const n = 50
+	want := ""
+	for i := 0; i < n; i++ {
+		s.SendOutput("x")
+		want += "x"
+	}
+
+	// Read frames until we have accumulated all the bytes. They must arrive in
+	// order and total exactly n bytes (no drops, no duplication). Coalescing
+	// should produce far fewer than n frames.
+	got := ""
+	frames := 0
+	for len(got) < len(want) {
+		got += readOutput(t, ctx, conn)
+		frames++
+	}
+	if got != want {
+		t.Fatalf("coalesced output = %q, want %q", got, want)
+	}
+	if frames >= n {
+		t.Fatalf("got %d frames for %d writes, expected coalescing", frames, n)
+	}
+}
+
+// TestReconnectReplay verifies that a client reconnecting mid-session is
+// replayed the recent scrollback from the ring buffer.
+func TestReconnectReplay(t *testing.T) {
+	s, pairURL := startTestServer(t, &fakeHandler{})
+	base, cred := sessionCred(t, pairURL)
+
+	// First client connects, receives some output, then disconnects.
+	conn1, _, err := dialWS(t, base, cred)
+	if err != nil {
+		t.Fatalf("dial ws 1: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var connected Frame
+	if err := wsjson.Read(ctx, conn1, &connected); err != nil {
+		t.Fatalf("read connected 1: %v", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for !s.HasClient() {
+		if time.Now().After(deadline) {
+			t.Fatal("client 1 never registered")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	s.SendOutput("scrollback")
+	if out := readOutput(t, ctx, conn1); out != "scrollback" {
+		t.Fatalf("client 1 output = %q, want scrollback", out)
+	}
+	conn1.Close(websocket.StatusNormalClosure, "")
+
+	// Wait for the server to release the client slot.
+	deadline = time.Now().Add(time.Second)
+	for s.HasClient() {
+		if time.Now().After(deadline) {
+			t.Fatal("client 1 slot never released")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Second client connects and should be replayed the scrollback.
+	conn2, _, err := dialWS(t, base, cred)
+	if err != nil {
+		t.Fatalf("dial ws 2: %v", err)
+	}
+	defer conn2.Close(websocket.StatusNormalClosure, "")
+	if err := wsjson.Read(ctx, conn2, &connected); err != nil {
+		t.Fatalf("read connected 2: %v", err)
+	}
+	if out := readOutput(t, ctx, conn2); out != "scrollback" {
+		t.Fatalf("replay output = %q, want scrollback", out)
+	}
+}
+
+// TestClientConnectDisconnectCallbacks verifies the terminal-notice callbacks
+// fire on connect and disconnect (§7.3).
+func TestClientConnectDisconnectCallbacks(t *testing.T) {
+	var mu sync.Mutex
+	var connectedAddr string
+	connected := make(chan struct{}, 1)
+	disconnected := make(chan struct{}, 1)
+
+	cfg := Config{
+		Host: "127.0.0.1",
+		Port: 0,
+		OnClientConnect: func(addr string) {
+			mu.Lock()
+			connectedAddr = addr
+			mu.Unlock()
+			connected <- struct{}{}
+		},
+		OnClientDisconnect: func() {
+			disconnected <- struct{}{}
+		},
+	}
+	s := NewServer(cfg, &fakeHandler{})
+	pairURL, err := s.Start()
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = s.Stop(ctx)
+	})
+
+	base, cred := sessionCred(t, pairURL)
+	conn, _, err := dialWS(t, base, cred)
+	if err != nil {
+		t.Fatalf("dial ws: %v", err)
+	}
+
+	select {
+	case <-connected:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnClientConnect never fired")
+	}
+	mu.Lock()
+	addr := connectedAddr
+	mu.Unlock()
+	if addr == "" {
+		t.Fatal("OnClientConnect got empty remote addr")
+	}
+
+	conn.Close(websocket.StatusNormalClosure, "")
+	select {
+	case <-disconnected:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnClientDisconnect never fired")
+	}
+}
+
 func TestWSSingleClient(t *testing.T) {
 	s, pairURL := startTestServer(t, &fakeHandler{})
 	base, cred := sessionCred(t, pairURL)

--- a/internal/trust/interactive.go
+++ b/internal/trust/interactive.go
@@ -262,6 +262,11 @@ func ConfirmToolCall(out io.Writer, in *bufio.Reader, call agentcore.AgentToolCa
 	}
 }
 
+// ToolCallSummary is the exported form of toolCallSummary, used by callers
+// outside this package (e.g. the remote-control confirm path) that need the
+// same one-line preview a local confirmation prompt shows.
+func ToolCallSummary(call agentcore.AgentToolCall) string { return toolCallSummary(call) }
+
 // toolCallSummary renders a one-line preview of what a side-effect tool will
 // do, so the user can make an informed allow/deny choice. It best-effort
 // extracts the bash command or the write/edit path from the arguments; if the


### PR DESCRIPTION
## Summary
- **#443** — add `/remote-control [stop|status]` command: starts/stops an in-process HTTP+WebSocket server that mirrors the REPL session to a paired LAN browser (pairing URL + terminal QR), tees output to the browser, merges browser-submitted prompts into the input loop, and routes side-effect tool-call confirmations to the browser (honoring session trust; ctx-cancel denies). Server is stopped on REPL exit.
- **#445** — server hardening: output coalescing pump (16ms tick), backpressure on a 256KB pending bound (never drops bytes), reconnect/late-join replay via a bounded ring buffer, and connect/disconnect terminal notices.
- Non-remote path stays byte-identical: teeWriter forwards only to stdout, the input select degenerates to a plain read (nil remote channel), and confirmations use the local prompt unchanged.

Closes #443
Closes #445

## Test plan
- [x] `go build ./...`
- [x] `go vet` clean (repl / remotecontrol / trust)
- [x] `go test -race ./internal/remotecontrol/ ./internal/cli/repl/` pass
- [x] New tests: TestOutputCoalesced, TestReconnectReplay, TestClientConnectDisconnectCallbacks