### PR TITLE
feat(runtime): generic task tool + semaphore + nesting guard (#454)

### DIFF
--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -63,6 +63,28 @@ func SetupEnv(model, baseURL, protocol, providerName string, noTools, noSkills b
 		return Env{}, err
 	}
 	tools := BuiltinTools(cwd, noTools)
+	// Wire the generic task tool (US-002, #454) unless tools are disabled. It
+	// dispatches general-purpose sub-agents that reuse the resolved provider
+	// stream/model. Each spawn gets a fresh child RunConfig whose registry is the
+	// builtins with "task" removed (the nesting guard, so a child cannot fan out
+	// again), and all task calls in a run share one semaphore capping concurrency.
+	if !noTools {
+		sem := runtime.NewSubagentSemaphore()
+		childCreds := provider.NewCredentialStore(nil) // env-resolved, like the subagent RPC child
+		factory := func() runtime.RunConfig {
+			childTools := BuiltinToolsExcept(cwd, false, "task")
+			return runtime.RunConfig{
+				LoopConfig: runtime.LoopConfig{
+					Model:     model,
+					Provider:  resolvedName,
+					Stream:    provider.StreamFnFromProvider(prov),
+					GetAPIKey: childCreds.GetAPIKey,
+				},
+				Batch: agenttool.BatchConfig{ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: ToolRegistry(childTools)}},
+			}
+		}
+		tools = append(tools, runtime.NewTaskTool(factory, sem))
+	}
 	// Discover external plugins (US-016) and append their tools. Plugin loading
 	// is fault-tolerant: a plugin that fails to start is logged and skipped, and
 	// disabling tools (--no-tools) skips plugin discovery entirely.
@@ -162,6 +184,30 @@ func BuiltinTools(cwd string, disabled bool) []agentcore.AgentTool {
 		&agenttool.TodoTool{Store: agenttool.NewTodoStore()},
 		&agenttool.WebFetchTool{},
 	}
+}
+
+// BuiltinToolsExcept returns the default builtin tool set (BuiltinTools) with
+// any tool whose name matches one of the except names removed. It backs the
+// nesting guard for the generic task tool: a child sub-agent's registry is built
+// with "task" excluded so a child can never spawn further sub-agents, capping
+// delegation depth at one. With no except names it is equivalent to BuiltinTools.
+func BuiltinToolsExcept(cwd string, disabled bool, except ...string) []agentcore.AgentTool {
+	all := BuiltinTools(cwd, disabled)
+	if len(except) == 0 || len(all) == 0 {
+		return all
+	}
+	skip := make(map[string]struct{}, len(except))
+	for _, n := range except {
+		skip[n] = struct{}{}
+	}
+	out := make([]agentcore.AgentTool, 0, len(all))
+	for _, t := range all {
+		if _, ok := skip[t.Name()]; ok {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
 }
 
 // ReadableExtraRoots returns trusted directories the file tools may reach beyond

--- a/internal/cli/run/task_wiring_test.go
+++ b/internal/cli/run/task_wiring_test.go
@@ -1,0 +1,39 @@
+package run
+
+// Tests for the generic task tool wiring (US-004, #454): the nesting guard.
+// BuiltinToolsExcept backs the child sub-agent registry, from which "task" is
+// removed so a child cannot spawn further sub-agents.
+
+import "testing"
+
+// TestBuiltinToolsExceptExcludesTask verifies the child tool set produced for a
+// task sub-agent (builtins minus "task") never contains "task", and that
+// excluding a name actually present removes it.
+func TestBuiltinToolsExceptExcludesTask(t *testing.T) {
+	child := BuiltinToolsExcept("/tmp", false, "task")
+	if len(child) == 0 {
+		t.Fatal("expected builtin tools in the child set")
+	}
+	for _, tl := range child {
+		if tl.Name() == "task" {
+			t.Fatal("child tool set must not contain 'task'")
+		}
+	}
+	// Excluding a name that IS present shrinks the set by exactly that tool.
+	full := BuiltinToolsExcept("/tmp", false)
+	dropped := BuiltinToolsExcept("/tmp", false, full[0].Name())
+	if len(dropped) != len(full)-1 {
+		t.Errorf("excluding %q: got %d tools, want %d", full[0].Name(), len(dropped), len(full)-1)
+	}
+}
+
+// TestBuiltinToolsExceptNoExcept verifies that with no except names the result
+// matches BuiltinTools, and that a disabled tool set stays empty.
+func TestBuiltinToolsExceptNoExcept(t *testing.T) {
+	if got, want := len(BuiltinToolsExcept("/tmp", false)), len(BuiltinTools("/tmp", false)); got != want {
+		t.Errorf("no-except size = %d, want %d", got, want)
+	}
+	if got := BuiltinToolsExcept("/tmp", true, "task"); got != nil {
+		t.Errorf("disabled tools should be nil, got %v", got)
+	}
+}

--- a/internal/runtime/subagent.go
+++ b/internal/runtime/subagent.go
@@ -142,12 +142,26 @@ type SubAgentSpec struct {
 	// Process configures process-isolated execution. Required when Isolation is
 	// SubAgentIsolationProcess; ignored otherwise.
 	Process SubAgentProcessConfig
+	// Schema, when non-empty, overrides the default single-prompt argument schema
+	// advertised to the model. The generic task tool uses this to also accept an
+	// optional description; a nil/empty Schema keeps the original prompt-only
+	// schema so existing specs are unaffected.
+	Schema json.RawMessage
+	// Sem, when non-nil, is a shared buffered channel used as a concurrency
+	// semaphore for goroutine-mode runs: executeGoroutine acquires a slot before
+	// spawning the child and releases it when the child settles. A full channel
+	// blocks (queues) the acquire rather than erroring. nil disables limiting, so
+	// existing sub-agent specs run unbounded exactly as before.
+	Sem chan struct{}
 }
 
-// subAgentArgs is the JSON argument shape for a sub-agent tool call: a single
-// free-form prompt describing the delegated task.
+// subAgentArgs is the JSON argument shape for a sub-agent tool call: a
+// free-form prompt describing the delegated task, plus an optional short
+// description used for status display (accepted by the generic task tool;
+// ignored by prompt-only specs).
 type subAgentArgs struct {
-	Prompt string `json:"prompt"`
+	Prompt      string `json:"prompt"`
+	Description string `json:"description,omitempty"`
 }
 
 // subAgentSchema is the JSON Schema validating a sub-agent invocation.
@@ -186,7 +200,12 @@ func (t *SubAgentTool) Name() string { return t.spec.Name }
 
 func (t *SubAgentTool) Description() string { return t.spec.Description }
 
-func (t *SubAgentTool) Schema() json.RawMessage { return subAgentSchema }
+func (t *SubAgentTool) Schema() json.RawMessage {
+	if len(t.spec.Schema) > 0 {
+		return t.spec.Schema
+	}
+	return subAgentSchema
+}
 
 // ExecutionMode is parallel: independent sub-agents may run concurrently, since
 // each spawns its own context and run (goroutine or process) with no shared
@@ -231,6 +250,18 @@ func (t *SubAgentTool) Execute(ctx context.Context, id string, args json.RawMess
 // executeGoroutine runs the child agent loop in-process and returns its final
 // text. This is the default mode and the original sub-agent behavior.
 func (t *SubAgentTool) executeGoroutine(ctx context.Context, prompt string, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+	// Concurrency guard: when a shared semaphore is configured, acquire a slot
+	// before spawning the child and release it via defer so a panic or error
+	// still frees the slot. A full channel blocks (queues) the acquire; a
+	// cancelled parent ctx abandons the wait instead of blocking forever.
+	if t.spec.Sem != nil {
+		select {
+		case t.spec.Sem <- struct{}{}:
+			defer func() { <-t.spec.Sem }()
+		case <-ctx.Done():
+			return agentcore.AgentToolResult{}, ctx.Err()
+		}
+	}
 	childCtx := &agentcore.AgentContext{
 		SystemPrompt: t.spec.SystemPrompt,
 		Messages: agentcore.MessageList{

--- a/internal/runtime/task.go
+++ b/internal/runtime/task.go
@@ -1,0 +1,97 @@
+// This file implements the generic `task` tool (US-002, #454): a general-purpose
+// sub-agent the model can dispatch with a free-form prompt to fan out work in a
+// single assistant message. It is a thin specialization of SubAgentTool - it
+// reuses executeGoroutine's child-loop driving - configured with a generic
+// system prompt (the delegated task comes from the call arguments at runtime),
+// a shared concurrency semaphore, and a child tool set from which `task` itself
+// is excluded (the nesting guard, wired in internal/cli/run).
+package runtime
+
+import (
+	"encoding/json"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// DefaultMaxSubagents is the concurrency cap applied when PIGO_MAX_SUBAGENTS is
+// unset or invalid. It bounds how many task sub-agents run at once so a fan-out
+// cannot overwhelm the provider rate limit.
+const DefaultMaxSubagents = 4
+
+// taskDescription is advertised to the parent model so it knows when to delegate
+// work to a generic sub-agent.
+const taskDescription = "Dispatch a general-purpose sub-agent to autonomously complete a delegated task. " +
+	"The sub-agent runs its own agent loop with a fresh context and the standard tool set, then returns its final report. " +
+	"Provide a complete, self-contained prompt since the sub-agent shares none of this conversation's context. " +
+	"Multiple task calls in one message run in parallel."
+
+// taskSystemPrompt seeds every generic sub-agent's context. It is intentionally
+// generic (the actual work arrives as the runtime prompt) and mirrors the
+// parent agent's operating posture so a delegated task is carried out the same
+// way the parent would.
+const taskSystemPrompt = "You are a focused sub-agent working on one delegated task. " +
+	"You have your own fresh context and the standard tool set, but you cannot spawn further sub-agents. " +
+	"Complete the task fully using the tools available, then respond with a concise final report of what you did and any key findings. " +
+	"Your final message is returned verbatim to the agent that dispatched you, so make it self-contained."
+
+// taskSchema is the JSON Schema for a task invocation: a required self-contained
+// prompt plus an optional short description used for status display.
+var taskSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "description": {
+      "type": "string",
+      "description": "A short (3-5 word) description of the task, for status display."
+    },
+    "prompt": {
+      "type": "string",
+      "description": "The full task for the sub-agent to perform. It must be self-contained since the sub-agent runs with a fresh context and shares none of this conversation."
+    }
+  },
+  "required": ["prompt"],
+  "additionalProperties": false
+}`)
+
+// NewTaskTool builds the generic `task` sub-agent tool. factory produces a fresh
+// child RunConfig per spawn (reusing the parent's provider stream/model and a
+// child tool registry that must exclude `task` for the nesting guard); sem is a
+// shared buffered channel bounding concurrent task runs (nil disables limiting).
+// The child prompt comes from the call arguments at runtime, so a single generic
+// spec serves every delegated task.
+func NewTaskTool(factory func() RunConfig, sem chan struct{}) *SubAgentTool {
+	return NewSubAgentTool(SubAgentSpec{
+		Name:         "task",
+		Description:  taskDescription,
+		SystemPrompt: taskSystemPrompt,
+		Schema:       taskSchema,
+		NewRunConfig: factory,
+		Sem:          sem,
+	})
+}
+
+// MaxSubagents resolves the concurrency cap for task sub-agents from
+// PIGO_MAX_SUBAGENTS: absent or unparseable yields DefaultMaxSubagents (4), and
+// a parsed value below 1 is floored to 1 so the semaphore always admits at least
+// one runner.
+func MaxSubagents() int {
+	v := strings.TrimSpace(os.Getenv("PIGO_MAX_SUBAGENTS"))
+	if v == "" {
+		return DefaultMaxSubagents
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return DefaultMaxSubagents
+	}
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// NewSubagentSemaphore builds the shared concurrency semaphore for task
+// sub-agents, sized by MaxSubagents. One instance per run is created and shared
+// across every task call so the cap is enforced run-wide.
+func NewSubagentSemaphore() chan struct{} {
+	return make(chan struct{}, MaxSubagents())
+}

--- a/internal/runtime/task_test.go
+++ b/internal/runtime/task_test.go
@@ -1,0 +1,194 @@
+package runtime
+
+// Tests for the generic task tool (US-002/003/004, #454): its identity/schema
+// contract, the shared concurrency semaphore (N > cap never exceeds cap), the
+// nesting guard (child tool set excludes "task"), that a task returns the
+// child's final text, and that a failed child surfaces as a tool error. The
+// child loop is driven through the faux provider seam (对标 orchestration_test.go);
+// only the provider boundary is faked.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+// TestTaskToolContract pins the tool identity, parallel execution mode, and the
+// {description?, prompt} schema with prompt required.
+func TestTaskToolContract(t *testing.T) {
+	tool := NewTaskTool(func() RunConfig { return RunConfig{} }, nil)
+	if tool.Name() != "task" {
+		t.Errorf("Name() = %q, want task", tool.Name())
+	}
+	if tool.ExecutionMode() != agentcore.ToolExecutionParallel {
+		t.Errorf("ExecutionMode() = %v, want parallel", tool.ExecutionMode())
+	}
+	var schema struct {
+		Properties struct {
+			Description json.RawMessage `json:"description"`
+			Prompt      json.RawMessage `json:"prompt"`
+		} `json:"properties"`
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(tool.Schema(), &schema); err != nil {
+		t.Fatalf("schema is not valid JSON: %v", err)
+	}
+	if len(schema.Properties.Prompt) == 0 || len(schema.Properties.Description) == 0 {
+		t.Errorf("schema must declare both prompt and description properties")
+	}
+	if len(schema.Required) != 1 || schema.Required[0] != "prompt" {
+		t.Errorf("required = %v, want [prompt]", schema.Required)
+	}
+}
+
+// TestTaskReturnsChildText verifies a dispatched task drives an independent child
+// loop and returns the child's final assistant text as the tool result.
+func TestTaskReturnsChildText(t *testing.T) {
+	child := &fauxProvider{
+		name:   "faux-child",
+		models: []provider.Model{{Provider: "faux-child", ID: "child"}},
+		turns:  []fauxTurn{textTurn("child final report")},
+	}
+	factory := func() RunConfig {
+		return RunConfig{
+			LoopConfig: LoopConfig{Model: "child", Stream: provider.StreamFnFromProvider(child)},
+			Batch:      agenttool.BatchConfig{ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: agenttool.NewToolRegistry()}},
+		}
+	}
+	tool := NewTaskTool(factory, nil)
+	res, err := tool.Execute(context.Background(), "id", json.RawMessage(`{"description":"do x","prompt":"do the work"}`), nil)
+	if err != nil {
+		t.Fatalf("Execute err = %v", err)
+	}
+	if got := agentcore.ContentToText(res.Content); got != "child final report" {
+		t.Errorf("task result = %q, want 'child final report'", got)
+	}
+	if child.callCount() != 1 {
+		t.Errorf("child provider calls = %d, want 1", child.callCount())
+	}
+}
+
+// TestTaskFailedChildErrors verifies a child whose final turn stops on error is
+// surfaced to the parent as a tool error (not a silent success).
+func TestTaskFailedChildErrors(t *testing.T) {
+	// A child turn ending on StopReason=error, carrying diagnostic text as content
+	// (executeGoroutine surfaces the child's Content on failure).
+	errTurn := func(text string) fauxTurn {
+		partial := agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant}
+		withText := partial
+		withText.Content = agentcore.ContentList{agentcore.NewTextContent(text)}
+		final := withText
+		final.StopReason = agentcore.StopReasonError
+		return fauxTurn{
+			provider.StreamStartEvent{Partial: partial},
+			provider.StreamTextEvent{Partial: withText},
+			provider.StreamDoneEvent{Message: final},
+		}
+	}
+	child := &fauxProvider{
+		name:   "faux-child",
+		models: []provider.Model{{Provider: "faux-child", ID: "child"}},
+		turns:  []fauxTurn{errTurn("child exploded")},
+	}
+	factory := func() RunConfig {
+		return RunConfig{
+			LoopConfig: LoopConfig{Model: "child", Stream: provider.StreamFnFromProvider(child)},
+			Batch:      agenttool.BatchConfig{ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: agenttool.NewToolRegistry()}},
+		}
+	}
+	tool := NewTaskTool(factory, nil)
+	_, err := tool.Execute(context.Background(), "id", json.RawMessage(`{"prompt":"go"}`), nil)
+	if err == nil {
+		t.Fatal("a child that stopped on error must surface as a tool error")
+	}
+	if !strings.Contains(err.Error(), "child exploded") {
+		t.Errorf("error should carry the child's diagnostic, got %v", err)
+	}
+}
+
+// TestTaskSemaphoreBoundsConcurrency dispatches N tasks concurrently through a
+// shared semaphore of capacity cap (< N) and asserts the number of children
+// running at once never exceeds cap. Each child calls a blocking fake tool that
+// parks on a barrier, so all admitted children pile up simultaneously and the
+// peak concurrency is observable.
+func TestTaskSemaphoreBoundsConcurrency(t *testing.T) {
+	const capN, n = 2, 6
+	sem := make(chan struct{}, capN)
+
+	var running, peak int64
+	release := make(chan struct{})
+	// blockTool parks until the test closes release, holding a semaphore slot for
+	// the duration and recording the peak number of concurrent children.
+	blockTool := execTool{
+		name: "block",
+		run: func(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+			cur := atomic.AddInt64(&running, 1)
+			for {
+				p := atomic.LoadInt64(&peak)
+				if cur <= p || atomic.CompareAndSwapInt64(&peak, p, cur) {
+					break
+				}
+			}
+			defer atomic.AddInt64(&running, -1)
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent("blocked")}}, nil
+		},
+	}
+	// Each child runs one turn that calls the blocking tool, then (after release)
+	// a final text turn.
+	factory := func() RunConfig {
+		p := &fauxProvider{
+			name:   "faux-child",
+			models: []provider.Model{{Provider: "c", ID: "c"}},
+			turns:  []fauxTurn{toolCallTurn("t", "block", `{}`), textTurn("done")},
+		}
+		reg := agenttool.NewToolRegistry()
+		_ = reg.Register(blockTool)
+		return RunConfig{
+			LoopConfig: LoopConfig{Model: "c", Stream: provider.StreamFnFromProvider(p)},
+			Batch:      agenttool.BatchConfig{ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: reg}},
+		}
+	}
+	tool := NewTaskTool(factory, sem)
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = tool.Execute(context.Background(), "id", json.RawMessage(`{"prompt":"go"}`), nil)
+		}()
+	}
+	// Give the admitted children time to reach the barrier, then let them go.
+	deadline := time.After(2 * time.Second)
+	for atomic.LoadInt64(&running) < int64(capN) {
+		select {
+		case <-deadline:
+			t.Fatalf("only %d children started, expected the semaphore to admit %d", atomic.LoadInt64(&running), capN)
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	// Hold briefly so any over-admission (a semaphore bug) would push peak > cap.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&peak); got > int64(capN) {
+		t.Errorf("peak concurrent children = %d, must not exceed cap %d", got, capN)
+	}
+	if got := atomic.LoadInt64(&peak); got == 0 {
+		t.Error("no child ever ran; the semaphore blocked everything")
+	}
+}


### PR DESCRIPTION
## Summary
Implements node #454 of the subagent-orchestration graph: a generic `task` tool that lets the model dispatch general-purpose sub-agents with a runtime prompt, enabling single-message fan-out.

- New `internal/runtime/task.go`: `NewTaskTool(factory, sem)` builds a generic SubAgentTool spec (generic system prompt, `{description?, prompt}` schema, parallel exec mode). `MaxSubagents()`/`NewSubagentSemaphore()` resolve the concurrency cap (default 4, `PIGO_MAX_SUBAGENTS` override, invalid/absent -> 4, floor 1).
- Generalize `SubAgentTool` (`subagent.go`): optional `Schema` override + shared `Sem` semaphore acquired/released in `executeGoroutine` (blocks/queues when full, ctx-cancel aware, released via defer). Existing prompt-only specs and all existing subagent tests are unaffected.
- Wire the task tool into `run.SetupEnv` (`internal/cli/run/run.go`) with a child RunConfig factory reusing the resolved provider stream/model and an env-resolved credential store. `BuiltinToolsExcept(cwd, disabled, "task")` builds the child registry without `task` (nesting guard: depth capped at 1).

Progress reporting is intentionally NOT included here — `SubAgentProgressEvent` does not yet exist on master (parallel node #453) and is added on top in #455.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] task returns child final text; child failure -> tool error
- [x] semaphore: N > cap dispatched, peak concurrent children never exceeds cap (blocking fake tool + counter)
- [x] child tool set excludes `task` (BuiltinToolsExcept)
- [x] existing `orchestration_test.go` / `subagent_process_test.go` still green (no regression)

Closes #454