### PR TITLE
feat(agentcore): SubAgentProgressEvent + progress emitter ctx carrier (#453)

### DIFF
--- a/internal/agentcore/event.go
+++ b/internal/agentcore/event.go
@@ -24,6 +24,7 @@ const (
 	EventToolExecutionEnd    = "tool_execution_end"
 	EventCompaction          = "compaction"
 	EventTelemetry           = "telemetry"
+	EventSubAgentProgress    = "subagent_progress"
 )
 
 // AgentStartEvent is emitted once when a loop run begins. SessionID, when set,
@@ -112,6 +113,25 @@ type CompactionEvent struct {
 	ErrorMessage string
 }
 
+// SubAgentProgressEvent carries structured progress from a running sub-agent
+// (dispatched by the task tool). It is reported at the sub-agent's tool
+// execution / turn boundaries so a TUI (multi-line status panel) or headless
+// mode (stderr line) can display live progress. Elapsed time is intentionally
+// omitted: consumers compute it themselves (TUI from tool-start time, headless
+// from when the id was first seen) to avoid emitting an event per frame.
+type SubAgentProgressEvent struct {
+	// ToolCallID is the parent task call's tool-call id, used as the key for
+	// the status line.
+	ToolCallID string
+	// Description is the task call's description, for display (may be empty).
+	Description string
+	// Activity is the current activity: tool name / phase, e.g. "Editing",
+	// "Running bash", "Thinking".
+	Activity string
+	// Tokens is the estimated sub-agent output token count (0 = unknown).
+	Tokens int
+}
+
 // ToolTiming records how long one tool invocation took, keyed by tool name in
 // TelemetryEvent.ToolDurationsMs. It aggregates repeated calls of the same tool
 // so a summary stays compact regardless of turn count.
@@ -166,6 +186,7 @@ func (ToolExecutionUpdateEvent) isAgentEvent() {}
 func (ToolExecutionEndEvent) isAgentEvent()    {}
 func (CompactionEvent) isAgentEvent()          {}
 func (TelemetryEvent) isAgentEvent()           {}
+func (SubAgentProgressEvent) isAgentEvent()    {}
 
 func (AgentStartEvent) EventType() string          { return EventAgentStart }
 func (AgentEndEvent) EventType() string            { return EventAgentEnd }
@@ -179,3 +200,4 @@ func (ToolExecutionUpdateEvent) EventType() string { return EventToolExecutionUp
 func (ToolExecutionEndEvent) EventType() string    { return EventToolExecutionEnd }
 func (CompactionEvent) EventType() string          { return EventCompaction }
 func (TelemetryEvent) EventType() string           { return EventTelemetry }
+func (SubAgentProgressEvent) EventType() string    { return EventSubAgentProgress }

--- a/internal/agentcore/progress_ctx.go
+++ b/internal/agentcore/progress_ctx.go
@@ -1,0 +1,22 @@
+package agentcore
+
+import "context"
+
+// progressEmitterKey is the unexported context key under which a run-level
+// progress EmitFunc is stored.
+type progressEmitterKey struct{}
+
+// WithProgressEmitter returns a child context carrying emit as the run-level
+// progress emitter. The task tool injects the parent loop's EmitFunc here so a
+// dispatched sub-agent can surface SubAgentProgressEvent up the parent stream.
+func WithProgressEmitter(ctx context.Context, emit EmitFunc) context.Context {
+	return context.WithValue(ctx, progressEmitterKey{}, emit)
+}
+
+// ProgressEmitterFromContext returns the run-level progress emitter carried by
+// ctx, or nil if none was set (in which case callers should skip progress
+// reporting rather than panic).
+func ProgressEmitterFromContext(ctx context.Context) EmitFunc {
+	emit, _ := ctx.Value(progressEmitterKey{}).(EmitFunc)
+	return emit
+}

--- a/internal/agentcore/progress_ctx_test.go
+++ b/internal/agentcore/progress_ctx_test.go
@@ -1,0 +1,51 @@
+package agentcore
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestSubAgentProgressEventImplementsAgentEvent(t *testing.T) {
+	var ev AgentEvent = SubAgentProgressEvent{
+		ToolCallID:  "call-1",
+		Description: "do a thing",
+		Activity:    "Editing",
+		Tokens:      42,
+	}
+	if got := ev.EventType(); got != EventSubAgentProgress {
+		t.Fatalf("EventType() = %q, want %q", got, EventSubAgentProgress)
+	}
+	if EventSubAgentProgress != "subagent_progress" {
+		t.Fatalf("EventSubAgentProgress = %q, want %q", EventSubAgentProgress, "subagent_progress")
+	}
+}
+
+func TestProgressEmitterRoundTrip(t *testing.T) {
+	var seen AgentEvent
+	sentinel := errors.New("sentinel")
+	emit := func(ctx context.Context, ev AgentEvent) error {
+		seen = ev
+		return sentinel
+	}
+
+	ctx := WithProgressEmitter(context.Background(), emit)
+	got := ProgressEmitterFromContext(ctx)
+	if got == nil {
+		t.Fatal("ProgressEmitterFromContext returned nil after WithProgressEmitter")
+	}
+
+	want := SubAgentProgressEvent{ToolCallID: "call-2", Activity: "Thinking"}
+	if err := got(ctx, want); !errors.Is(err, sentinel) {
+		t.Fatalf("emitter returned err = %v, want sentinel", err)
+	}
+	if seen != want {
+		t.Fatalf("emitter received %#v, want %#v", seen, want)
+	}
+}
+
+func TestProgressEmitterFromBareContextIsNil(t *testing.T) {
+	if got := ProgressEmitterFromContext(context.Background()); got != nil {
+		t.Fatalf("ProgressEmitterFromContext on bare ctx = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Summary
Foundational event type + context helper for subagent progress reporting (spec §3.1/§3.2).

- Add `SubAgentProgressEvent` (`ToolCallID`, `Description`, `Activity`, `Tokens`) in `internal/agentcore/event.go`, implementing `AgentEvent` with `EventType() == "subagent_progress"` via new const `EventSubAgentProgress`. Follows the existing event pattern.
- Add `internal/agentcore/progress_ctx.go` with `WithProgressEmitter` / `ProgressEmitterFromContext` carrying a run-level `EmitFunc` (reused from helpers.go) via an unexported context key.

## Test
- `progress_ctx_test.go`: event satisfies `AgentEvent` + correct `EventType`; emitter round-trip; bare context returns nil.
- `go build ./... && go vet ./... && go test ./internal/agentcore/...` all pass.

Closes #453