### PR TITLE
feat(prompt): advertise task tool fan-out in system prompt (#458)

### DIFF
--- a/internal/runtime/prompt.go
+++ b/internal/runtime/prompt.go
@@ -68,7 +68,8 @@ type PromptConfig struct {
 // PromptConfig.BaseInstruction is empty.
 const DefaultBaseInstruction = "You are pigo, a helpful coding agent. " +
 	"Use the available tools to inspect files and accomplish the user's request precisely and concisely.\n\n" +
-	todoGuide
+	todoGuide + "\n\n" +
+	taskGuide
 
 // todoGuide instructs the model on how to drive the todo tool. It is appended to
 // the default base instruction so multi-step work is planned and its progress is
@@ -78,6 +79,18 @@ const todoGuide = "When a task has multiple steps or is non-trivial, use the tod
 	"list); each item has a content string and a status of pending, in_progress, or completed. " +
 	"Keep exactly one item in_progress at a time, and mark an item completed as soon as it is " +
 	"done before starting the next. Skip the todo tool for trivial single-step requests."
+
+// taskGuide instructs the model on how to use the generic `task` tool (US-008,
+// #458). The task tool dispatches an independent sub-agent that runs its own
+// agent loop with a fresh context and returns its final report, so it is the
+// mechanism for delegation and fan-out. The key affordance advertised here is
+// that emitting MULTIPLE task calls in a single assistant message runs those
+// sub-agents in parallel, letting skills like /graph achieve real concurrency.
+const taskGuide = "When work splits into independent subtasks, delegate them with the task tool: each " +
+	"task call dispatches an independent sub-agent that completes its subtask on a fresh context and " +
+	"returns its final report. To fan out, emit MULTIPLE task calls in a single message — they run in " +
+	"parallel. Give each a complete, self-contained prompt, since a sub-agent shares none of this " +
+	"conversation's context. Do the work directly for a single, sequential, or trivial task."
 
 // BuildSystemPrompt assembles the full system prompt from cfg: base instruction,
 // environment block, then AGENTS.md files ordered general-to-specific from Root

--- a/internal/runtime/prompt_test.go
+++ b/internal/runtime/prompt_test.go
@@ -42,6 +42,31 @@ func TestBuildSystemPromptBaseAndEnv(t *testing.T) {
 	}
 }
 
+// TestBuildSystemPromptAdvertisesTaskFanout verifies the base instruction tells
+// the model about the generic task tool: that it dispatches an independent
+// sub-agent (delegation) and that multiple task calls in one message run in
+// parallel (fan-out, US-008/#458).
+func TestBuildSystemPromptAdvertisesTaskFanout(t *testing.T) {
+	got, err := BuildSystemPrompt(PromptConfig{
+		WorkingDir: "/work/proj",
+		Now:        fixedTime,
+		ReadFile:   func(string) ([]byte, error) { return nil, os.ErrNotExist },
+	})
+	if err != nil {
+		t.Fatalf("BuildSystemPrompt: %v", err)
+	}
+	lower := strings.ToLower(got)
+	if !strings.Contains(lower, "task tool") {
+		t.Errorf("prompt should advertise the task tool:\n%s", got)
+	}
+	if !strings.Contains(lower, "sub-agent") || !strings.Contains(lower, "independent") {
+		t.Errorf("prompt should describe the task tool as an independent sub-agent (delegation):\n%s", got)
+	}
+	if !strings.Contains(lower, "parallel") {
+		t.Errorf("prompt should state that multiple task calls run in parallel (fan-out):\n%s", got)
+	}
+}
+
 // TestBuildSystemPromptAGENTSOrdering is the acceptance-critical test: with an
 // AGENTS.md at the root and at a nested working directory, the root's content
 // must appear BEFORE the nested one (general → specific).


### PR DESCRIPTION
## Summary
Makes the model aware of the generic `task` tool (added in #454) and WHEN to use it for fan-out delegation, so skills like `/graph` can trigger real parallelism.

Adds a `taskGuide` to `DefaultBaseInstruction` in `internal/runtime/prompt.go`, mirroring the existing `todoGuide` convention. It tells the model:
- the `task` tool dispatches an independent sub-agent on a fresh context that returns its final report (delegation)
- emitting MULTIPLE `task` calls in a single message runs them in parallel (fan-out)
- each call needs a self-contained prompt; do trivial/sequential work directly

Uses the existing system-prompt mechanism (same as `todoGuide`), no new mechanism invented. The task tool's own `Description()` (in task.go, #454) already covers this too; this adds the system-prompt "when to use" guidance without touching task.go (avoids conflict with #455 in the same wave).

## Test
- Added `TestBuildSystemPromptAdvertisesTaskFanout` asserting the prompt mentions the task tool, an independent sub-agent, and parallel execution.
- `go build ./... && go vet ./... && go test ./...` all pass.

Closes #458