### PR TITLE
feat(runtime): sub-agent progress reporting (loop emitter + OnEvent translate) (#455)

### DIFF
--- a/internal/runtime/loop.go
+++ b/internal/runtime/loop.go
@@ -226,7 +226,13 @@ func runLoop(ctx context.Context, agentCtx *agentcore.AgentContext, cfg RunConfi
 				break // exit inner loop → consult follow-up messages
 			}
 
-			toolResults, allTerminate := agenttool.ExecuteToolCalls(ctx, cfg.Batch, calls, emitFrom)
+			// Inject the run-level emitter into the context so tools (notably the
+			// generic task tool) can retrieve it via ProgressEmitterFromContext and
+			// surface a dispatched sub-agent's progress up this parent event stream.
+			// emitFrom feeds the parent stream and is run-scoped, so a child's
+			// SubAgentProgressEvent lands on the right run's stream.
+			toolCtx := agentcore.WithProgressEmitter(ctx, emitFrom)
+			toolResults, allTerminate := agenttool.ExecuteToolCalls(toolCtx, cfg.Batch, calls, emitFrom)
 			for _, tr := range toolResults {
 				agentCtx.Messages = append(agentCtx.Messages, tr)
 			}

--- a/internal/runtime/progress_test.go
+++ b/internal/runtime/progress_test.go
@@ -1,0 +1,149 @@
+package runtime
+
+// Tests for sub-agent progress reporting (US-005, #455): a dispatched task's
+// child tool-execution / turn boundaries are translated into
+// SubAgentProgressEvent and surfaced through the run-level emitter the parent
+// loop injects into ctx (WithProgressEmitter). The parent tool-call id must ride
+// on the event, the activity must map from the child event, and a nil emitter
+// (the tool called outside a loop, e.g. a direct unit test) must be a silent
+// no-op rather than a panic. The child loop is driven through the faux provider
+// seam; only the provider boundary is faked.
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+// TestActivityOf pins the child-event → activity mapping (D-8 / §5.3): tool
+// starts map to their display verb, a turn start maps to "Thinking", and
+// everything else maps to "" (no emission).
+func TestActivityOf(t *testing.T) {
+	cases := []struct {
+		ev   agentcore.AgentEvent
+		want string
+	}{
+		{agentcore.ToolExecutionStartEvent{ToolName: "read"}, "Reading"},
+		{agentcore.ToolExecutionStartEvent{ToolName: "edit"}, "Editing"},
+		{agentcore.ToolExecutionStartEvent{ToolName: "write"}, "Editing"},
+		{agentcore.ToolExecutionStartEvent{ToolName: "bash"}, "Running bash"},
+		{agentcore.ToolExecutionStartEvent{ToolName: "grep"}, "Searching"},
+		{agentcore.ToolExecutionStartEvent{ToolName: "find"}, "Searching"},
+		{agentcore.ToolExecutionStartEvent{ToolName: "ls"}, "Searching"},
+		{agentcore.ToolExecutionStartEvent{ToolName: "webfetch"}, "Fetching"},
+		{agentcore.ToolExecutionStartEvent{ToolName: "todo"}, ""},
+		{agentcore.TurnStartEvent{}, "Thinking"},
+		{agentcore.ToolExecutionEndEvent{ToolName: "read"}, ""},
+		{agentcore.MessageStartEvent{}, ""},
+	}
+	for _, c := range cases {
+		if got := activityOf(c.ev); got != c.want {
+			t.Errorf("activityOf(%T{%v}) = %q, want %q", c.ev, c.ev, got, c.want)
+		}
+	}
+}
+
+// TestTaskEmitsSubAgentProgress verifies a child that executes a tool triggers a
+// SubAgentProgressEvent carrying the parent task's tool-call id and the mapped
+// activity ("Reading" for a child "read" tool), plus the "Thinking" boundary at
+// each turn start.
+func TestTaskEmitsSubAgentProgress(t *testing.T) {
+	// A child tool named "read" so its ToolExecutionStart maps to "Reading".
+	readTool := execTool{
+		name: "read",
+		run: func(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+			return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent("file body")}}, nil
+		},
+	}
+	child := &fauxProvider{
+		name:   "faux-child",
+		models: []provider.Model{{Provider: "faux-child", ID: "child"}},
+		turns:  []fauxTurn{toolCallTurn("t1", "read", `{}`), textTurn("child final report")},
+	}
+	factory := func() RunConfig {
+		reg := agenttool.NewToolRegistry()
+		_ = reg.Register(readTool)
+		return RunConfig{
+			LoopConfig: LoopConfig{Model: "child", Stream: provider.StreamFnFromProvider(child)},
+			Batch:      agenttool.BatchConfig{ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: reg}},
+		}
+	}
+	tool := NewTaskTool(factory, nil)
+
+	var mu sync.Mutex
+	var progress []agentcore.SubAgentProgressEvent
+	emit := func(ctx context.Context, ev agentcore.AgentEvent) error {
+		if p, ok := ev.(agentcore.SubAgentProgressEvent); ok {
+			mu.Lock()
+			progress = append(progress, p)
+			mu.Unlock()
+		}
+		return nil
+	}
+	ctx := agentcore.WithProgressEmitter(context.Background(), emit)
+
+	const parentID = "parent-call-id"
+	res, err := tool.Execute(ctx, parentID, json.RawMessage(`{"description":"read the file","prompt":"do the work"}`), nil)
+	if err != nil {
+		t.Fatalf("Execute err = %v", err)
+	}
+	if got := agentcore.ContentToText(res.Content); got != "child final report" {
+		t.Errorf("task result = %q, want 'child final report'", got)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(progress) == 0 {
+		t.Fatal("expected at least one SubAgentProgressEvent, got none")
+	}
+	var sawReading bool
+	for _, p := range progress {
+		if p.ToolCallID != parentID {
+			t.Errorf("progress ToolCallID = %q, want %q", p.ToolCallID, parentID)
+		}
+		if p.Description != "read the file" {
+			t.Errorf("progress Description = %q, want 'read the file'", p.Description)
+		}
+		if p.Activity == "" {
+			t.Errorf("progress emitted with empty Activity (should be skipped)")
+		}
+		if p.Activity == "Reading" {
+			sawReading = true
+		}
+	}
+	if !sawReading {
+		t.Errorf("expected a 'Reading' activity from the child read tool, got %+v", progress)
+	}
+}
+
+// TestTaskNilEmitterNoPanic verifies that when no progress emitter is present in
+// ctx (the tool called outside a loop, as in direct unit tests) the child still
+// runs, returns its text, and emits no progress — without panicking.
+func TestTaskNilEmitterNoPanic(t *testing.T) {
+	child := &fauxProvider{
+		name:   "faux-child",
+		models: []provider.Model{{Provider: "faux-child", ID: "child"}},
+		turns:  []fauxTurn{textTurn("child final report")},
+	}
+	factory := func() RunConfig {
+		return RunConfig{
+			LoopConfig: LoopConfig{Model: "child", Stream: provider.StreamFnFromProvider(child)},
+			Batch:      agenttool.BatchConfig{ToolExecutorConfig: agenttool.ToolExecutorConfig{Registry: agenttool.NewToolRegistry()}},
+		}
+	}
+	tool := NewTaskTool(factory, nil)
+
+	// Plain ctx: no WithProgressEmitter, so ProgressEmitterFromContext is nil.
+	res, err := tool.Execute(context.Background(), "id", json.RawMessage(`{"prompt":"go"}`), nil)
+	if err != nil {
+		t.Fatalf("Execute err = %v", err)
+	}
+	if got := agentcore.ContentToText(res.Content); got != "child final report" {
+		t.Errorf("task result = %q, want 'child final report'", got)
+	}
+}

--- a/internal/runtime/subagent.go
+++ b/internal/runtime/subagent.go
@@ -244,12 +244,21 @@ func (t *SubAgentTool) Execute(ctx context.Context, id string, args json.RawMess
 		// forwarded here; a caller supplying a sink gets no deltas in this mode.
 		return t.executeProcess(ctx, a.Prompt)
 	}
-	return t.executeGoroutine(ctx, a.Prompt, onUpdate)
+	return t.executeGoroutine(ctx, id, a.Prompt, a.Description, onUpdate)
 }
 
 // executeGoroutine runs the child agent loop in-process and returns its final
 // text. This is the default mode and the original sub-agent behavior.
-func (t *SubAgentTool) executeGoroutine(ctx context.Context, prompt string, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+//
+// id is the parent tool call's id and description is the (optional) task
+// description; both are threaded onto any SubAgentProgressEvent emitted for this
+// run so a consumer can key status by the parent task call. When the parent loop
+// injected a run-level progress emitter into ctx (WithProgressEmitter), the
+// child's tool-execution / turn boundaries are translated into
+// SubAgentProgressEvent and surfaced up the parent stream; when no emitter is
+// present (e.g. the tool is called directly in a unit test) progress reporting is
+// silently skipped.
+func (t *SubAgentTool) executeGoroutine(ctx context.Context, id, prompt, description string, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
 	// Concurrency guard: when a shared semaphore is configured, acquire a slot
 	// before spawning the child and release it via defer so a panic or error
 	// still frees the slot. A full channel blocks (queues) the acquire; a
@@ -278,6 +287,37 @@ func (t *SubAgentTool) executeGoroutine(ctx context.Context, prompt string, onUp
 	if onUpdate != nil {
 		h.OnText = func(delta string) {
 			onUpdate(agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent(delta)}})
+		}
+	}
+	// Progress reporting: when the parent loop injected a run-level emitter into
+	// ctx, translate the child's tool-execution / turn boundaries into
+	// SubAgentProgressEvent and emit them up the parent stream. Reporting is at
+	// activity granularity (per child tool start / turn boundary), NOT per text
+	// delta, so event volume stays proportional to the child's tool calls. When
+	// no emitter is present the OnEvent hook is left nil and progress is skipped.
+	if parentEmit := agentcore.ProgressEmitterFromContext(ctx); parentEmit != nil {
+		// chars accumulates the child's streamed text length so a coarse output
+		// token estimate can ride along on each progress event (0 = unknown).
+		chars := 0
+		if prev := h.OnText; prev != nil {
+			h.OnText = func(delta string) {
+				chars += len(delta)
+				prev(delta)
+			}
+		} else {
+			h.OnText = func(delta string) { chars += len(delta) }
+		}
+		h.OnEvent = func(ev agentcore.AgentEvent) {
+			act := activityOf(ev)
+			if act == "" {
+				return
+			}
+			_ = parentEmit(ctx, agentcore.SubAgentProgressEvent{
+				ToolCallID:  id,
+				Description: description,
+				Activity:    act,
+				Tokens:      estimateTokens(chars),
+			})
 		}
 	}
 	final, err := DrainStream(ctx, stream, h)

--- a/internal/runtime/task.go
+++ b/internal/runtime/task.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/smallnest/pigo/internal/agentcore"
 )
 
 // DefaultMaxSubagents is the concurrency cap applied when PIGO_MAX_SUBAGENTS is
@@ -94,4 +96,46 @@ func MaxSubagents() int {
 // across every task call so the cap is enforced run-wide.
 func NewSubagentSemaphore() chan struct{} {
 	return make(chan struct{}, MaxSubagents())
+}
+
+// activityOf maps a child sub-agent event to the display verb surfaced in a
+// SubAgentProgressEvent (D-8: tool name / phase, no argument summary). A child
+// ToolExecutionStartEvent maps by tool name; a TurnStartEvent (a fresh turn with
+// no tool in progress) maps to "Thinking". Every other event maps to "" so the
+// caller emits nothing — progress is reported only at these activity boundaries,
+// keeping event volume proportional to the child's tool calls rather than its
+// text deltas (D-7).
+func activityOf(ev agentcore.AgentEvent) string {
+	switch e := ev.(type) {
+	case agentcore.ToolExecutionStartEvent:
+		switch e.ToolName {
+		case "read":
+			return "Reading"
+		case "edit", "write":
+			return "Editing"
+		case "bash":
+			return "Running bash"
+		case "grep", "find", "ls":
+			return "Searching"
+		case "webfetch":
+			return "Fetching"
+		default:
+			return ""
+		}
+	case agentcore.TurnStartEvent:
+		return "Thinking"
+	default:
+		return ""
+	}
+}
+
+// estimateTokens gives a coarse output-token estimate from a running character
+// count of the child's streamed text (~4 chars per token). It rides along on
+// each progress event as a rough "↓ tokens" figure; 0 means unknown (no text
+// streamed yet).
+func estimateTokens(chars int) int {
+	if chars <= 0 {
+		return 0
+	}
+	return chars / 4
 }


### PR DESCRIPTION
## Summary
Node #455: 子 agent 进度上报. The parent loop injects its run-level emitter into the tool context so the generic `task` tool can surface a dispatched child's structured progress up the parent event stream.

- `loop.go`: `toolCtx := agentcore.WithProgressEmitter(ctx, emitFrom)` before `ExecuteToolCalls`.
- `subagent.go`: `executeGoroutine` threads the parent tool-call `id` + `description`; installs a child `DrainStream` `OnEvent` handler that translates child tool-execution / turn boundaries into `SubAgentProgressEvent{ToolCallID, Description, Activity, Tokens}` via the ctx emitter. Reporting is per child tool-start / turn boundary (not per text delta). Child text is still forwarded via `onUpdate` (no regression). Nil parent emitter is a silent no-op.
- `task.go`: `activityOf` mapping (read→Reading, edit/write→Editing, bash→Running bash, grep/find/ls→Searching, webfetch→Fetching, TurnStart→Thinking, else "") + coarse `estimateTokens`.

## Test plan
- [x] `TestActivityOf` pins the child-event → activity mapping.
- [x] `TestTaskEmitsSubAgentProgress`: child read tool → `SubAgentProgressEvent` with `ToolCallID == parent id` and `Activity == "Reading"`.
- [x] `TestTaskNilEmitterNoPanic`: nil emitter → no panic, no emission, child text returned.
- [x] `go build ./... && go vet ./... && go test ./internal/agentcore/... ./internal/runtime/...` all pass.

Closes #455