### PR TITLE
feat(headless): print sub-agent progress to stderr (#457)

### DIFF
--- a/internal/runtime/headless.go
+++ b/internal/runtime/headless.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/smallnest/pigo/internal/agentcore"
@@ -48,6 +49,11 @@ type HeadlessConfig struct {
 	// handling. It is the seam plugin lifecycle-event delivery (US-017, #133)
 	// hooks into, independent of the output mode. It must not block.
 	OnEvent func(ev agentcore.AgentEvent)
+	// Progress receives human-readable sub-agent progress lines
+	// (SubAgentProgressEvent). Defaults to os.Stderr when nil. Progress is
+	// stderr-only by contract: it is never serialised onto Out (stdout), so it
+	// cannot pollute the final result text or the stream-json envelope stream.
+	Progress io.Writer
 }
 
 // ErrRunFailed is the sentinel returned by RunHeadless when the agent run ended
@@ -86,17 +92,31 @@ func RunHeadless(ctx context.Context, agentCtx *agentcore.AgentContext, cfg Head
 	// external OnEvent (plugin lifecycle delivery, US-017). Both observe every
 	// event; the serialiser runs first so a write failure is recorded even when a
 	// plugin observer is also wired.
+	//
+	// SubAgentProgressEvent (D-9) is special-cased: it is written as a
+	// human-readable line to the progress writer (stderr) and is deliberately
+	// excluded from the stream-json stdout path so it never pollutes the result
+	// output or the machine-readable envelope stream (progress is stderr-only).
+	progress := cfg.Progress
+	if progress == nil {
+		progress = os.Stderr
+	}
 	streamJSON := cfg.Mode == StreamJSONMode
-	if streamJSON || cfg.OnEvent != nil {
-		h.OnEvent = func(ev agentcore.AgentEvent) {
-			if streamJSON && writeErr == nil {
-				if err := writeEventJSON(cfg.Out, ev); err != nil {
-					writeErr = err
-				}
-			}
+	h.OnEvent = func(ev agentcore.AgentEvent) {
+		if pe, ok := ev.(agentcore.SubAgentProgressEvent); ok {
+			writeProgressLine(progress, pe)
 			if cfg.OnEvent != nil {
 				cfg.OnEvent(ev)
 			}
+			return
+		}
+		if streamJSON && writeErr == nil {
+			if err := writeEventJSON(cfg.Out, ev); err != nil {
+				writeErr = err
+			}
+		}
+		if cfg.OnEvent != nil {
+			cfg.OnEvent(ev)
 		}
 	}
 	lastAssistant, resErr := DrainStream(ctx, stream, h)
@@ -135,6 +155,19 @@ func RunHeadless(ctx context.Context, agentCtx *agentcore.AgentContext, cfg Head
 		}
 	}
 	return nil
+}
+
+// writeProgressLine renders one SubAgentProgressEvent as a human-readable line
+// on w (stderr by contract). When the task supplied a description it is shown
+// alongside the activity; otherwise the line degrades to the activity alone
+// (Description MAY be empty, Activity never is). Write errors are ignored:
+// progress is a non-critical, best-effort side channel.
+func writeProgressLine(w io.Writer, ev agentcore.SubAgentProgressEvent) {
+	if ev.Description != "" {
+		fmt.Fprintf(w, "  ⏺ %s · %s\n", ev.Description, ev.Activity)
+		return
+	}
+	fmt.Fprintf(w, "  ⏺ %s\n", ev.Activity)
 }
 
 // writeEventJSON serializes one AgentEvent as a single line of JSON, terminated

--- a/internal/runtime/headless_test.go
+++ b/internal/runtime/headless_test.go
@@ -184,6 +184,93 @@ func TestRunHeadlessNilWriter(t *testing.T) {
 	}
 }
 
+// emitTool returns a tool that surfaces ev on the run stream via the run-level
+// progress emitter the loop injects into ctx (WithProgressEmitter), then returns
+// a trivial text result. This mirrors how a dispatched sub-agent surfaces a
+// SubAgentProgressEvent up the parent stream.
+func emitTool(name string, ev agentcore.AgentEvent) execTool {
+	return execTool{
+		name: name,
+		mode: agentcore.ToolExecutionParallel,
+		run: func(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+			if emit := agentcore.ProgressEmitterFromContext(ctx); emit != nil {
+				_ = emit(ctx, ev)
+			}
+			return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent(name)}}, nil
+		},
+	}
+}
+
+// TestRunHeadlessSubAgentProgressToStderr verifies the D-9 contract: a
+// SubAgentProgressEvent emitted during the run is rendered as a human-readable
+// line to the progress writer (stderr) and is NEVER serialised onto stdout —
+// neither the final result text nor the stream-json envelope stream may contain
+// it. The event is injected via a faux tool whose execution fires it on the
+// run's event stream (the same seam the loop uses).
+func TestRunHeadlessSubAgentProgressToStderr(t *testing.T) {
+	const desc = "investigate the parser"
+	const activity = "Editing"
+
+	run := func(mode HeadlessMode) (stdout, stderr string) {
+		p := &fauxProvider{
+			name:   "faux",
+			models: []provider.Model{{Provider: "faux", ID: "faux"}},
+			turns: []fauxTurn{
+				toolCallTurn("call-1", "task", `{"description":"investigate the parser"}`),
+				textTurn("done"),
+			},
+		}
+		// The tool emits a SubAgentProgressEvent onto the run stream, mimicking a
+		// dispatched sub-agent surfacing progress up the parent stream.
+		tool := emitTool("task", agentcore.SubAgentProgressEvent{
+			ToolCallID:  "call-1",
+			Description: desc,
+			Activity:    activity,
+		})
+		cfg := newFauxRunCfg(p, tool)
+		var out, prog bytes.Buffer
+		agentCtx := &agentcore.AgentContext{Messages: agentcore.MessageList{agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("start")}}}}
+		if err := RunHeadless(context.Background(), agentCtx, HeadlessConfig{Run: cfg, Mode: mode, Out: &out, Progress: &prog}); err != nil {
+			t.Fatalf("RunHeadless: unexpected error %v", err)
+		}
+		return out.String(), prog.String()
+	}
+
+	for _, mode := range []struct {
+		name string
+		mode HeadlessMode
+	}{{"print", PrintMode}, {"stream-json", StreamJSONMode}} {
+		t.Run(mode.name, func(t *testing.T) {
+			stdout, stderr := run(mode.mode)
+			// (a) stderr carries the progress line with description + activity.
+			if !strings.Contains(stderr, desc) || !strings.Contains(stderr, activity) {
+				t.Errorf("stderr = %q, want it to contain description %q and activity %q", stderr, desc, activity)
+			}
+			// (b) stdout must not contain the progress event in any form.
+			if strings.Contains(stdout, "subagent_progress") {
+				t.Errorf("stdout must not contain the subagent_progress envelope, got %q", stdout)
+			}
+			if strings.Contains(stdout, desc) {
+				t.Errorf("stdout must not leak the progress description, got %q", stdout)
+			}
+		})
+	}
+}
+
+// TestWriteProgressLineEmptyDescription verifies the line degrades gracefully to
+// the activity alone when the task supplied no description.
+func TestWriteProgressLineEmptyDescription(t *testing.T) {
+	var buf bytes.Buffer
+	writeProgressLine(&buf, agentcore.SubAgentProgressEvent{Activity: "Thinking"})
+	got := buf.String()
+	if !strings.Contains(got, "Thinking") {
+		t.Errorf("line = %q, want it to contain the activity", got)
+	}
+	if strings.Contains(got, "·") {
+		t.Errorf("line = %q, want no separator when description is empty", got)
+	}
+}
+
 // contains reports whether s contains v.
 func contains(s []string, v string) bool {
 	for _, x := range s {


### PR DESCRIPTION
## Summary
- Headless event handling now recognizes `agentcore.SubAgentProgressEvent` and prints a human-readable progress line (`  ⏺ <Description> · <Activity>`) to a `Progress` writer, defaulting to `os.Stderr` (D-9).
- The progress event is excluded from the stream-json stdout path, so it never pollutes the final result text or the machine-readable envelope stream — progress is stderr-only.
- Degrades gracefully to activity-only when `Description` is empty.

## Test
- `go build ./... && go vet ./... && go test ./...` all pass.
- New `TestRunHeadlessSubAgentProgressToStderr` (print + stream-json subtests) asserts stderr carries the line and stdout does not contain `subagent_progress` or the description.
- New `TestWriteProgressLineEmptyDescription` covers the empty-description degrade path.

Closes #457