### PR TITLE
feat(tui): multi-line subagent status panel (#456)

### DIFF
--- a/internal/cli/tui/bridge.go
+++ b/internal/cli/tui/bridge.go
@@ -62,6 +62,8 @@ func newStreamHandler(ch chan tea.Msg, extra func(agentcore.AgentEvent)) runtime
 				ch <- toolUpdateMsg{id: e.ToolCallID, partial: agentcore.ContentToText(e.PartialResult.Content)}
 			case agentcore.ToolExecutionEndEvent:
 				ch <- toolEndMsg{id: e.ToolCallID, ok: !e.IsError, result: agentcore.ContentToText(e.Result.Content)}
+			case agentcore.SubAgentProgressEvent:
+				ch <- subagentProgressMsg{id: e.ToolCallID, desc: e.Description, activity: e.Activity, tokens: e.Tokens}
 			case agentcore.TelemetryEvent:
 				ch <- telemetryMsg{ev: e}
 			case agentcore.CompactionEvent:

--- a/internal/cli/tui/bridge_test.go
+++ b/internal/cli/tui/bridge_test.go
@@ -140,6 +140,31 @@ func TestArgsToMap(t *testing.T) {
 	}
 }
 
+// TestSubAgentProgressConversion verifies a SubAgentProgressEvent maps to a
+// subagentProgressMsg carrying the id (parent task tool-call id), description,
+// activity, and token estimate.
+func TestSubAgentProgressConversion(t *testing.T) {
+	ch := newEventChan()
+	h := newStreamHandler(ch, nil)
+	h.OnEvent(agentcore.SubAgentProgressEvent{
+		ToolCallID:  "task-1",
+		Description: "build parser",
+		Activity:    "Editing",
+		Tokens:      256,
+	})
+	got := drain(ch)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 msg, got %d", len(got))
+	}
+	m, ok := got[0].(subagentProgressMsg)
+	if !ok {
+		t.Fatalf("got %#v, want subagentProgressMsg", got[0])
+	}
+	if m.id != "task-1" || m.desc != "build parser" || m.activity != "Editing" || m.tokens != 256 {
+		t.Errorf("got %#v, want {id:task-1 desc:build parser activity:Editing tokens:256}", m)
+	}
+}
+
 // TestWaitForEvent verifies the pump Cmd returns the next queued msg.
 func TestWaitForEvent(t *testing.T) {
 	ch := newEventChan()

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -123,6 +123,13 @@ type Model struct {
 	// stats) shown on the row above the input while a run is in flight.
 	spinner spinner
 
+	// subagents is the ordered set of live sub-agents dispatched by the `task`
+	// tool (SPEC 4.4, US-006). A toolStartMsg with name=="task" adds a row (and
+	// records its start time), subagentProgressMsg refreshes activity/tokens, and
+	// the task's toolEndMsg removes it. View renders it as a multi-line panel just
+	// above the spinner; it contributes zero rows when empty.
+	subagents subagentPanel
+
 	// pastes stores the full text of collapsed multi-line pastes, keyed by the id
 	// shown in the "[Pasted text #N +M lines]" placeholder left in the composer.
 	// submit expands the placeholders back to their content before sending, so a
@@ -338,9 +345,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.toolCards[msg.id] = card
 		m.lastToolCard = card
 		m.transcript.addToolCard(card)
+		// A `task` tool call dispatches a sub-agent: open a status-panel row keyed by
+		// the tool-call id (matching the later progress/end events) and record its
+		// start so elapsed can be shown live (SPEC 4.4).
+		if msg.name == "task" {
+			m.subagents.add(msg.id, taskDescription(msg.input), time.Now())
+			m.relayout() // the new panel row shrinks the transcript to fit
+		}
 		return m, m.pumpNext()
 
 	case toolUpdateMsg:
+		return m, m.pumpNext()
+
+	case subagentProgressMsg:
+		// A running sub-agent reported structured progress: refresh its panel row's
+		// activity/tokens. update adds the row if it is missing so a late/out-of-order
+		// progress (arriving before the task's start) is still shown (SPEC 5.4).
+		m.subagents.update(msg.id, msg.desc, msg.activity, msg.tokens, time.Now())
+		m.relayout() // a first-seen id adds a row; keep the transcript sized to it
 		return m, m.pumpNext()
 
 	case toolEndMsg:
@@ -354,6 +376,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			card.response = parseToolResult(msg.result)
 			m.transcript.reflow()
+		}
+		// Retire the sub-agent's status-panel row (a no-op for non-task tools whose id
+		// was never added), reclaiming its reserved height.
+		if _, wasSub := m.subagents.byID[msg.id]; wasSub {
+			m.subagents.remove(msg.id)
+			m.relayout()
 		}
 		return m, m.pumpNext()
 
@@ -377,6 +405,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.running = false
 		m.runCh = nil
 		m.spinner.stop()
+		// The run is over: any still-open sub-agent rows are stale (their tasks ended
+		// with the run), so clear the panel to reclaim its height.
+		m.subagents = subagentPanel{}
 		m.relayout()
 		if msg.err != nil {
 			m.transcript.addSystem("运行结束：" + msg.err.Error())
@@ -665,6 +696,17 @@ func (m Model) thinkingLabel() string {
 	return string(m.opts.ThinkingLevel)
 }
 
+// taskDescription pulls the human-readable "description" out of a `task` tool
+// call's decoded arguments for the sub-agent panel's row label. It returns ""
+// when absent or non-string (the description field is optional in the schema),
+// in which case the panel row leads with the activity instead.
+func taskDescription(input map[string]any) string {
+	if s, ok := input["description"].(string); ok {
+		return s
+	}
+	return ""
+}
+
 // tickSpinner schedules the next spinner animation frame. The model re-issues it
 // on each spinnerTickMsg while running, so the animation self-sustains until the
 // run ends (the tick is simply not re-issued once idle).
@@ -859,8 +901,14 @@ func (m Model) renderContent() string {
 		}
 	}
 	// The working spinner sits on its own row just above the input while a run is
-	// in flight (relayout reserves the row so the transcript shrinks to fit).
+	// in flight (relayout reserves the row so the transcript shrinks to fit). The
+	// sub-agent status panel, when any `task` sub-agents are live, renders on the
+	// rows just ABOVE the spinner: one line each, elapsed refreshed every tick.
 	if m.running {
+		if panel := m.subagents.view(m.theme, width, time.Now()); panel != "" {
+			b.WriteString(panel)
+			b.WriteByte('\n')
+		}
 		if line := m.spinner.view(width); line != "" {
 			b.WriteString(line)
 			b.WriteByte('\n')
@@ -951,6 +999,9 @@ func (m *Model) relayout() {
 	rows := m.height - 1 - m.input.Height() - m.menu.rows()
 	if m.running {
 		rows-- // the working spinner occupies the row just above the input
+		// Each live sub-agent adds one status-panel row above the spinner; an empty
+		// panel reserves nothing so the single-run layout is unchanged.
+		rows -= m.subagents.active()
 	}
 	if rows < 0 {
 		rows = 0

--- a/internal/cli/tui/model_test.go
+++ b/internal/cli/tui/model_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -278,5 +279,65 @@ func TestModelSuperVPastes(t *testing.T) {
 	m := apply(t, NewModel(Options{}), tea.WindowSizeMsg{Width: 40, Height: 12})
 	if _, cmd := m.Update(keyPress("super+v")); cmd == nil {
 		t.Fatal("super+v should emit a clipboard read command when idle")
+	}
+}
+
+// TestModelSubagentPanelLifecycle drives the sub-agent status panel through a
+// task tool's lifecycle on the running model: a toolStartMsg(name=="task") opens
+// a row, subagentProgressMsg refreshes it and it appears in the rendered View
+// above the input, and the task's toolEndMsg retires it (empty panel → no rows).
+func TestModelSubagentPanelLifecycle(t *testing.T) {
+	m := apply(t, NewModel(Options{}), tea.WindowSizeMsg{Width: 80, Height: 20})
+	m.running = true // the panel only renders while a run is in flight
+	m.spinner.begin(time.Now(), "")
+
+	m = apply(t, m, toolStartMsg{id: "task-1", name: "task", input: map[string]any{"description": "build parser"}})
+	if got := m.subagents.active(); got != 1 {
+		t.Fatalf("active after task start = %d, want 1", got)
+	}
+
+	m = apply(t, m, subagentProgressMsg{id: "task-1", desc: "build parser", activity: "Editing", tokens: 64})
+	if row := m.subagents.byID["task-1"]; row == nil || row.activity != "Editing" {
+		t.Fatalf("row after progress = %+v, want activity=Editing", row)
+	}
+	// The panel line is identified by its ⏺ glyph (distinct from the tool card,
+	// which also mentions the description) plus the live activity.
+	if view := m.View().Content; !strings.Contains(view, "⏺") || !strings.Contains(view, "Editing") {
+		t.Errorf("view missing panel line: %q", view)
+	}
+
+	// A non-task tool must not open a panel row.
+	m = apply(t, m, toolStartMsg{id: "read-1", name: "read_file", input: map[string]any{"path": "/x"}})
+	if got := m.subagents.active(); got != 1 {
+		t.Errorf("active after non-task start = %d, want 1", got)
+	}
+
+	m = apply(t, m, toolEndMsg{id: "task-1", ok: true, result: "done"})
+	if got := m.subagents.active(); got != 0 {
+		t.Errorf("active after task end = %d, want 0", got)
+	}
+	if view := m.View().Content; strings.Contains(view, "⏺") {
+		t.Errorf("view still shows retired panel line: %q", view)
+	}
+}
+
+// TestModelSubagentPanelHeightReservation verifies the panel's rows are reserved
+// out of the transcript height so the total shell height is unchanged whether or
+// not sub-agents are active.
+func TestModelSubagentPanelHeightReservation(t *testing.T) {
+	m := apply(t, NewModel(Options{}), tea.WindowSizeMsg{Width: 80, Height: 20})
+	m.running = true
+	m.spinner.begin(time.Now(), "")
+	m.relayout()
+	base := m.transcript.viewportHeight()
+
+	m = apply(t, m, toolStartMsg{id: "t1", name: "task", input: map[string]any{"description": "a"}})
+	m = apply(t, m, toolStartMsg{id: "t2", name: "task", input: map[string]any{"description": "b"}})
+	if got := m.transcript.viewportHeight(); got != base-2 {
+		t.Errorf("transcript height with 2 panel rows = %d, want %d (base %d - 2)", got, base-2, base)
+	}
+	// Every rendered frame stays exactly Height rows tall regardless of the panel.
+	if got := strings.Count(m.View().Content, "\n"); got != 19 {
+		t.Errorf("newline count = %d, want 19 (20 rows)", got)
 	}
 }

--- a/internal/cli/tui/msgs.go
+++ b/internal/cli/tui/msgs.go
@@ -45,6 +45,20 @@ type toolEndMsg struct {
 	result string
 }
 
+// subagentProgressMsg carries a running sub-agent's structured progress
+// (translated from agentcore.SubAgentProgressEvent). id is the parent task
+// tool-call id (the row key, matching the task's toolStartMsg/toolEndMsg id);
+// desc is the task description (may be empty); activity is the current phase
+// ("Reading"/"Editing"/…, never empty); tokens is a coarse output estimate
+// (0 = unknown). Elapsed is NOT carried — the model computes it from the row's
+// start time so the panel stays live without an event per frame.
+type subagentProgressMsg struct {
+	id       string
+	desc     string
+	activity string
+	tokens   int
+}
+
 // telemetryMsg carries the run's end-of-run telemetry summary.
 type telemetryMsg struct{ ev agentcore.TelemetryEvent }
 

--- a/internal/cli/tui/subagentpanel.go
+++ b/internal/cli/tui/subagentpanel.go
@@ -1,0 +1,134 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// This file renders the multi-line sub-agent status panel (SPEC 4.4, US-006): a
+// block shown just above the working spinner while one or more sub-agents
+// dispatched by the `task` tool are running. Each active sub-agent contributes
+// exactly one line of the form:
+//
+//	⏺ {desc} · {activity} ({elapsed} · ↓{tokens})
+//
+// The panel is a pure function of the model's ordered active-subagent set; it is
+// re-rendered every spinner tick so the elapsed clock stays live without a
+// dedicated timer. When there are no active sub-agents it renders nothing (zero
+// lines, zero height), leaving the existing single-run layout untouched.
+
+// subagentRow is one live sub-agent's status, keyed by the parent task tool-call
+// id. start is recorded when the row is added so elapsed can be computed at
+// render time; activity/tokens are refreshed by subagentProgressMsg.
+type subagentRow struct {
+	id       string
+	desc     string
+	activity string
+	tokens   int
+	start    time.Time
+}
+
+// subagentPanel is the ordered set of live sub-agents. order preserves insertion
+// order (so rows render stably, oldest first) while byID gives O(1) lookup for
+// progress updates and removal. The zero value is a valid empty panel.
+type subagentPanel struct {
+	order []string
+	byID  map[string]*subagentRow
+}
+
+// add records a newly dispatched sub-agent (a toolStartMsg with name=="task").
+// It is idempotent on the id: a duplicate start refreshes the description and
+// resets the start clock rather than adding a second row.
+func (p *subagentPanel) add(id, desc string, now time.Time) {
+	if p.byID == nil {
+		p.byID = make(map[string]*subagentRow)
+	}
+	if row, ok := p.byID[id]; ok {
+		row.desc = desc
+		row.start = now
+		return
+	}
+	p.byID[id] = &subagentRow{id: id, desc: desc, start: now}
+	p.order = append(p.order, id)
+}
+
+// update folds a progress event into the row for id, refreshing its activity and
+// token estimate. A progress for an unknown id (late/out-of-order, arriving
+// before or without a start) adds the row so no update is lost; now seeds its
+// start clock in that case.
+func (p *subagentPanel) update(id, desc, activity string, tokens int, now time.Time) {
+	if p.byID == nil {
+		p.byID = make(map[string]*subagentRow)
+	}
+	row, ok := p.byID[id]
+	if !ok {
+		row = &subagentRow{id: id, desc: desc, start: now}
+		p.byID[id] = row
+		p.order = append(p.order, id)
+	}
+	if activity != "" {
+		row.activity = activity
+	}
+	if desc != "" {
+		row.desc = desc
+	}
+	row.tokens = tokens
+}
+
+// remove drops the row for id (the task's toolEndMsg). It is a no-op when id is
+// absent, so an end without a matching start — or a duplicate end — is safe.
+func (p *subagentPanel) remove(id string) {
+	if _, ok := p.byID[id]; !ok {
+		return
+	}
+	delete(p.byID, id)
+	for i, v := range p.order {
+		if v == id {
+			p.order = append(p.order[:i], p.order[i+1:]...)
+			break
+		}
+	}
+}
+
+// active reports the number of live sub-agents (rows the panel would render).
+func (p *subagentPanel) active() int { return len(p.order) }
+
+// view renders the panel to a string, one line per active sub-agent in insertion
+// order, each truncated to width display columns. It returns "" when there are
+// no active sub-agents or width is non-positive, so an empty panel contributes
+// zero rows and zero height. now is the reference time elapsed is measured from
+// (the spinner tick's time) so the clock advances each frame.
+func (p subagentPanel) view(theme Theme, width int, now time.Time) string {
+	if len(p.order) == 0 || width <= 0 {
+		return ""
+	}
+	lines := make([]string, 0, len(p.order))
+	for _, id := range p.order {
+		row := p.byID[id]
+		if row == nil {
+			continue
+		}
+		lines = append(lines, TruncateToWidth(row.render(theme, now), width))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// render builds one status line for a row: "⏺ {desc} · {activity} ({elapsed} ·
+// ↓{tokens})". A blank description is omitted (the line leads with the glyph and
+// activity); a zero token estimate drops the "↓" stat. The glyph + head take the
+// accent color and the parenthetical stats are dim, mirroring the spinner line.
+func (r subagentRow) render(theme Theme, now time.Time) string {
+	var head strings.Builder
+	head.WriteString("⏺")
+	if r.desc != "" {
+		fmt.Fprintf(&head, " %s ·", r.desc)
+	}
+	fmt.Fprintf(&head, " %s", r.activity)
+
+	stats := formatElapsed(now.Sub(r.start))
+	if r.tokens > 0 {
+		stats += " · ↓" + humanizeInt(r.tokens)
+	}
+	return theme.Spinner.Render(head.String()) + " " + theme.System.Render("("+stats+")")
+}

--- a/internal/cli/tui/subagentpanel_test.go
+++ b/internal/cli/tui/subagentpanel_test.go
@@ -1,0 +1,136 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/smallnest/pigo/internal/cli/ui"
+)
+
+// TestSubagentPanelLifecycle exercises the ordered add/update/remove set: rows
+// keep insertion order, a progress refreshes activity/tokens, a progress for an
+// unknown id adds a row (late/out-of-order safe), and remove drops exactly one
+// row (a no-op for an absent id).
+func TestSubagentPanelLifecycle(t *testing.T) {
+	now := time.Now()
+	var p subagentPanel
+
+	p.add("a", "task A", now)
+	p.add("b", "task B", now)
+	if got := p.active(); got != 2 {
+		t.Fatalf("active after two adds = %d, want 2", got)
+	}
+	if p.order[0] != "a" || p.order[1] != "b" {
+		t.Errorf("order = %v, want [a b]", p.order)
+	}
+
+	p.update("a", "task A", "Editing", 120, now)
+	if row := p.byID["a"]; row.activity != "Editing" || row.tokens != 120 {
+		t.Errorf("row a after update = %+v, want activity=Editing tokens=120", row)
+	}
+
+	// A progress for an id that never started adds the row (SPEC 5.4).
+	p.update("c", "task C", "Reading", 0, now)
+	if got := p.active(); got != 3 {
+		t.Fatalf("active after late progress = %d, want 3", got)
+	}
+	if p.order[2] != "c" {
+		t.Errorf("order = %v, want c appended last", p.order)
+	}
+
+	// Removing a middle row preserves the order of the rest.
+	p.remove("a")
+	if got := p.active(); got != 2 {
+		t.Fatalf("active after remove = %d, want 2", got)
+	}
+	if p.order[0] != "b" || p.order[1] != "c" {
+		t.Errorf("order after remove(a) = %v, want [b c]", p.order)
+	}
+
+	// Removing an absent id is a no-op.
+	p.remove("zzz")
+	if got := p.active(); got != 2 {
+		t.Errorf("active after remove(absent) = %d, want 2", got)
+	}
+}
+
+// TestSubagentPanelEmptyView verifies an empty panel renders nothing — zero
+// lines, zero height — so the single-run layout is untouched.
+func TestSubagentPanelEmptyView(t *testing.T) {
+	var p subagentPanel
+	if got := p.view(DefaultTheme(), 80, time.Now()); got != "" {
+		t.Errorf("empty panel view = %q, want empty", got)
+	}
+	// A non-empty panel with a non-positive width also renders nothing.
+	p.add("a", "task", time.Now())
+	if got := p.view(DefaultTheme(), 0, time.Now()); got != "" {
+		t.Errorf("zero-width view = %q, want empty", got)
+	}
+}
+
+// TestSubagentPanelViewLines verifies one line per active sub-agent, each
+// carrying the description, activity, and token stat.
+func TestSubagentPanelViewLines(t *testing.T) {
+	now := time.Now()
+	var p subagentPanel
+	p.add("a", "build parser", now)
+	p.update("a", "build parser", "Editing", 1200, now)
+	p.add("b", "run tests", now)
+	p.update("b", "run tests", "Running bash", 0, now)
+
+	view := p.view(DefaultTheme(), 200, now.Add(65*time.Second))
+	lines := strings.Split(view, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("view has %d lines, want 2: %q", len(lines), view)
+	}
+	if !strings.Contains(lines[0], "build parser") || !strings.Contains(lines[0], "Editing") {
+		t.Errorf("line[0] = %q, want desc + activity", lines[0])
+	}
+	if !strings.Contains(lines[0], "1m 5s") {
+		t.Errorf("line[0] = %q, want elapsed 1m 5s", lines[0])
+	}
+	if !strings.Contains(lines[0], "1,200") {
+		t.Errorf("line[0] = %q, want token stat 1,200", lines[0])
+	}
+	if !strings.Contains(lines[1], "run tests") || !strings.Contains(lines[1], "Running bash") {
+		t.Errorf("line[1] = %q, want desc + activity", lines[1])
+	}
+	// A zero token estimate omits the ↓ stat.
+	if strings.Contains(lines[1], "↓") {
+		t.Errorf("line[1] = %q, should omit ↓ for zero tokens", lines[1])
+	}
+}
+
+// TestSubagentPanelViewTruncation verifies each rendered line is clipped to the
+// given terminal width (display columns), never exceeding it.
+func TestSubagentPanelViewTruncation(t *testing.T) {
+	now := time.Now()
+	var p subagentPanel
+	p.add("a", strings.Repeat("very long description ", 10), now)
+	p.update("a", "", "Searching", 42, now)
+
+	const width = 30
+	view := p.view(DefaultTheme(), width, now)
+	for _, line := range strings.Split(view, "\n") {
+		if w := ui.Width(line); w > width {
+			t.Errorf("line width = %d, want <= %d: %q", w, width, line)
+		}
+	}
+}
+
+// TestSubagentPanelViewBlankDescription verifies a row with no description still
+// renders (leading with the activity) rather than producing a dangling "·".
+func TestSubagentPanelViewBlankDescription(t *testing.T) {
+	now := time.Now()
+	var p subagentPanel
+	p.add("a", "", now)
+	p.update("a", "", "Thinking", 0, now)
+	line := p.view(DefaultTheme(), 100, now)
+	if !strings.Contains(line, "Thinking") {
+		t.Errorf("view = %q, want activity", line)
+	}
+	if strings.Contains(line, " · Thinking") {
+		t.Errorf("view = %q, blank desc should not leave a leading ' · '", line)
+	}
+}


### PR DESCRIPTION
## Summary
Adds a multi-line sub-agent status panel to the interactive TUI (SPEC 4.4, US-006). While one or more `task` sub-agents are running, a block appears just above the working spinner with one line per sub-agent:

`⏺ {desc} · {activity} ({elapsed} · ↓{tokens})`

## Changes
- `msgs.go`: new `subagentProgressMsg` (id/desc/activity/tokens).
- `bridge.go`: map `agentcore.SubAgentProgressEvent` → `subagentProgressMsg` in `newStreamHandler`.
- `model.go`: ordered active-subagent set (slice for order + map by tool-call id) with per-row `{id, desc, activity, tokens, start}`. Handlers — add on `toolStartMsg`(name=="task"), refresh on `subagentProgressMsg` (adds late/out-of-order rows), remove on `toolEndMsg`; cleared on run end. Panel inserted above the spinner; height reserved in `relayout` (0 when empty). Elapsed computed from row start, refreshed each spinner tick.
- `subagentpanel.go` (new): width-truncated multi-line rendering via existing `TruncateToWidth`; empty set → zero lines/height.

## Test plan
- [x] `bridge_test`: `SubAgentProgressEvent` → `subagentProgressMsg`.
- [x] panel unit tests: add/update/remove lifecycle, ordering, late progress adds row, width truncation, empty → no lines, blank description handling.
- [x] model tests: start→progress→end lifecycle visible in `View`, non-task tools open no row, height reservation keeps total shell height constant.
- [x] `go build ./... && go vet ./... && go test ./...` all pass.
- [ ] Visual confirmation of the interactive TUI is pending — cannot run the interactive TUI in CI; covered by unit tests on rendering + lifecycle instead.

Closes #456