### PR TITLE
feat(selfupdate): built-in self-replace for pigo update

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/tui"
 	"github.com/smallnest/pigo/internal/cli/ui"
+	"github.com/smallnest/pigo/internal/selfupdate"
 )
 
 // Build metadata, injected at release time via -ldflags by goreleaser
@@ -120,6 +121,12 @@ func main() {
 	// positional and distinct from the flag-driven agent modes, so peel them off
 	// before pflag parsing — the agent flags don't apply to them.
 	if len(os.Args) > 1 && pkgcmd.Subcommands[os.Args[1]] {
+		// `pigo update` with no positional package name is self-update (#466):
+		// download the latest release and replace this binary. With a package
+		// name it stays package-update (handled by pkgcmd).
+		if os.Args[1] == "update" && len(os.Args) == 2 {
+			os.Exit(selfupdate.Run(context.Background(), version, os.Stdout, os.Stderr))
+		}
 		os.Exit(pkgcmd.Run(os.Args[1], os.Args[2:], os.Stdout, os.Stderr))
 	}
 

--- a/docs/issue#0466.html
+++ b/docs/issue#0466.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #466</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block; font-size: 0.6875rem; font-weight: 500;
+      padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/466">#466</a> &mdash; 内置自替换执行 pigo update &mdash; 2026-08-01</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Updater 结构体字段作为测试 seam，NewUpdater 填生产默认值</h3>
+      <p><strong>Ambiguity:</strong> PRD 要求"依据当前 GOOS/GOARCH 拼归档名""原子替换 os.Executable()"，但未定义如何在不真正替换运行中二进制、不真正联网的前提下做单测。</p>
+      <p><strong>Choice:</strong> <code>Updater</code> 暴露 <code>HTTPClient / ReleaseBaseURL / GOOS / GOARCH / ExecPath</code> 五个字段；测试用 httptest server 与临时文件注入，生产由 <code>NewUpdater()</code> 填默认值。</p>
+      <p><strong>Rationale:</strong> 纯依赖注入即可端到端覆盖下载→校验→解压→替换，无需 mock 框架，也不触碰真实可执行文件。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Run 复用 US-001 的 UpdateAvailable 做"已是最新"短路</h3>
+      <p><strong>Ambiguity:</strong> US-002 要求"已是最新版本时打印并退出 0，不做替换"，但未说明版本比较来源。</p>
+      <p><strong>Choice:</strong> <code>Run</code> 先 <code>LatestTag</code> 再 <code>UpdateAvailable(current, tag)</code>；<code>comparable && !avail</code> 时打印"已是最新版本"并 return 0，否则进入 <code>Apply</code>。dev 版 comparable=false，直接安装 latest。</p>
+      <p><strong>Rationale:</strong> 与 #465 单一事实来源，避免重复实现版本语义。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 无参 <code>pigo update</code> 的分发语义被改变(遗留 UpdateAll 变为死代码)</h3>
+      <p><strong>Spec said:</strong> US-003 要求"保持 <code>pigo update &lt;包名&gt;</code> 包更新语义"。</p>
+      <p><strong>Implemented instead:</strong> 在 <code>cmd/pigo/main.go</code> 分发处拦截 <code>update</code> 且无位置参数(<code>len(os.Args)==2</code>)的情况路由到 <code>selfupdate.Run</code>；带包名仍走 <code>pkgcmd.Run</code>。这使 pkgcmd 中"无参 = UpdateAll(全量更新包)"的旧路径成为不可达死代码。</p>
+      <p><strong>Why:</strong> 用户明确决策"无参=自更新，删除包全更新"。本 Issue 只做分发拦截;pkgcmd 内 <code>UpdateAll</code> 死代码的正式清理与分发分类测试归属 <a href="https://github.com/smallnest/pigo/issues/468">#468</a>。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> 内置自替换 vs 复用第三方 selfupdate 库</h3>
+      <p><strong>Alternatives:</strong> (a) 引入 <code>minio/selfupdate</code> 或 <code>rhysd/go-github-selfupdate</code>;(b) 手写下载+校验+原子替换。</p>
+      <p><strong>Choice:</strong> 手写。归档命名严格对齐 <code>.goreleaser.yaml</code>,SHA256 对齐 <code>checksums.txt</code>,临时文件 + <code>os.Rename</code> 保证原子。</p>
+      <p><strong>Rationale:</strong> 归档命名/校验约定已由 install.sh 与 goreleaser 固定,第三方库反而要迁就其命名假设;手写零新增依赖且与发布工具单一事实来源。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> review 反馈:<code>string(archive)</code> 转换 vs <code>bytes.NewReader</code></h3>
+      <p><strong>Alternatives:</strong> 解压/校验时把 <code>[]byte</code> 转 <code>string</code> 再喂 <code>strings.NewReader</code>,或直接 <code>bytes.NewReader([]byte)</code>。</p>
+      <p><strong>Choice:</strong> 采纳 review 建议,三处(<code>extractFromTarGz / extractFromZip / checksumFor</code>)统一改 <code>bytes.NewReader</code>。</p>
+      <p><strong>Rationale:</strong> <code>string(archive)</code> 会整块拷贝归档字节;归档可达数十 MB,直接读切片零拷贝更省内存,且语义完全等价。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Windows 下替换正在运行的 .exe</h3>
+      <p><strong>Assumption:</strong> 当前实现对所有平台统一走"临时文件 + os.Rename"。Unix 覆盖已打开的可执行文件安全;Windows 上 <code>os.Rename</code> 覆盖正在运行的 .exe 可能因文件占用失败。</p>
+      <p><strong>Verify:</strong> 是否需要 Windows 专属"旧文件改名 + 写新文件"路径(PRD Open Question #5)。本期未实现,留待有 Windows 用户反馈后跟进。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 下载体积无上限</h3>
+      <p><strong>Assumption:</strong> <code>download</code> 用 <code>io.ReadAll</code> 读全量 body,无大小上限。因下载源固定为可信 GitHub Release,review 中判定不值得加限制。</p>
+      <p><strong>Verify:</strong> 若未来允许自定义 <code>ReleaseBaseURL</code> 指向不可信源,应加入 <code>io.LimitReader</code> 上限。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/selfupdate/update.go
+++ b/internal/selfupdate/update.go
@@ -1,0 +1,264 @@
+// This file implements pigo's binary self-replacement for `pigo update` (issue
+// #466). Given the current build version it discovers the latest release (via
+// version.go), downloads the matching goreleaser archive for the running
+// GOOS/GOARCH, verifies its SHA256 against the release's checksums.txt, and
+// atomically replaces the running executable.
+//
+// The archive naming mirrors .goreleaser.yaml and install.sh exactly, so this
+// stays a single source of truth with the release tooling. Replacement is
+// atomic: the new binary is written to a temp file in the target's directory
+// and os.Rename'd over the current executable, so a failure mid-download never
+// leaves a truncated binary in place.
+package selfupdate
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// checksumsFile is the goreleaser checksums artifact name (see .goreleaser.yaml).
+const checksumsFile = "checksums.txt"
+
+// Updater performs a self-replacement. Its fields are seams for testing;
+// NewUpdater fills them with production defaults.
+type Updater struct {
+	HTTPClient *http.Client
+	// Repo is "owner/name"; ReleaseBaseURL overrides the download host in tests.
+	Repo           string
+	ReleaseBaseURL string // e.g. https://github.com/smallnest/pigo/releases/download
+	GOOS, GOARCH   string
+	// ExecPath is the executable to replace; defaults to os.Executable().
+	ExecPath string
+}
+
+// Run performs `pigo update` (self-update pigo). It discovers the latest
+// release, compares it to current, and replaces the running binary when a
+// newer release exists. When current is a source build ("dev"), it cannot
+// compare and proceeds to install the latest. Returns a process exit code.
+func Run(ctx context.Context, current string, out, errOut io.Writer) int {
+	tag, err := LatestTag(ctx, nil, Repo)
+	if err != nil {
+		fmt.Fprintf(errOut, "pigo: 检查更新失败: %v\n", err)
+		return 1
+	}
+	if avail, comparable := UpdateAvailable(current, tag); comparable && !avail {
+		fmt.Fprintf(out, "已是最新版本 %s\n", current)
+		return 0
+	}
+	u, err := NewUpdater()
+	if err != nil {
+		fmt.Fprintf(errOut, "pigo: %v\n", err)
+		return 1
+	}
+	if err := u.Apply(ctx, tag, out); err != nil {
+		fmt.Fprintf(errOut, "pigo: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(out, "已更新到 %s\n", tag)
+	return 0
+}
+
+// NewUpdater returns an Updater configured for the running process.
+func NewUpdater() (*Updater, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("selfupdate: locate executable: %w", err)
+	}
+	// Resolve symlinks so we replace the real file, not a symlink.
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return &Updater{
+		HTTPClient:     &http.Client{Timeout: 60 * time.Second},
+		Repo:           Repo,
+		ReleaseBaseURL: "https://github.com/" + Repo + "/releases/download",
+		GOOS:           runtime.GOOS,
+		GOARCH:         runtime.GOARCH,
+		ExecPath:       exe,
+	}, nil
+}
+
+// archiveName builds the goreleaser archive filename for a release version
+// (without leading "v") on the updater's platform. It mirrors the
+// name_template and format_overrides in .goreleaser.yaml.
+func (u *Updater) archiveName(versionNoV string) string {
+	osName := map[string]string{"darwin": "Darwin", "linux": "Linux", "windows": "Windows"}[u.GOOS]
+	if osName == "" {
+		osName = u.GOOS
+	}
+	arch := map[string]string{"amd64": "x86_64", "386": "i386"}[u.GOARCH]
+	if arch == "" {
+		arch = u.GOARCH // arm64 and others pass through
+	}
+	ext := "tar.gz"
+	if u.GOOS == "windows" {
+		ext = "zip"
+	}
+	return fmt.Sprintf("pigo_%s_%s_%s.%s", versionNoV, osName, arch, ext)
+}
+
+// binaryName is the executable name inside the archive.
+func (u *Updater) binaryName() string {
+	if u.GOOS == "windows" {
+		return "pigo.exe"
+	}
+	return "pigo"
+}
+
+// Apply downloads the release identified by tag, verifies its checksum, and
+// atomically replaces the target executable. tag is like "v0.4.0".
+func (u *Updater) Apply(ctx context.Context, tag string, out io.Writer) error {
+	versionNoV := strings.TrimPrefix(strings.TrimSpace(tag), "v")
+	archive := u.archiveName(versionNoV)
+	base := fmt.Sprintf("%s/%s", strings.TrimRight(u.ReleaseBaseURL, "/"), tag)
+
+	fmt.Fprintf(out, "下载 %s ...\n", archive)
+	archiveBytes, err := u.download(ctx, base+"/"+archive)
+	if err != nil {
+		return fmt.Errorf("selfupdate: download archive: %w", err)
+	}
+
+	sums, err := u.download(ctx, base+"/"+checksumsFile)
+	if err != nil {
+		return fmt.Errorf("selfupdate: download checksums: %w", err)
+	}
+	want, err := checksumFor(sums, archive)
+	if err != nil {
+		return err
+	}
+	got := sha256.Sum256(archiveBytes)
+	if hex.EncodeToString(got[:]) != want {
+		return fmt.Errorf("selfupdate: checksum mismatch for %s (archive corrupt or tampered)", archive)
+	}
+
+	binary, err := extractBinary(archiveBytes, u.binaryName(), u.GOOS == "windows")
+	if err != nil {
+		return err
+	}
+	if err := u.replace(binary); err != nil {
+		return err
+	}
+	return nil
+}
+
+// download fetches url and returns the full body. A non-200 status is an error.
+func (u *Updater) download(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := u.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// replace atomically swaps the target executable with newBin: it writes a temp
+// file in the target's directory, sets it executable, and renames it over the
+// target. Writing to the same directory keeps the rename atomic (same
+// filesystem). A permission error on the directory yields an actionable message.
+func (u *Updater) replace(newBin []byte) error {
+	dir := filepath.Dir(u.ExecPath)
+	tmp, err := os.CreateTemp(dir, ".pigo-update-*")
+	if err != nil {
+		return fmt.Errorf("selfupdate: cannot write to %s: %w (尝试用 sudo 运行，或将 pigo 安装到可写目录)", dir, err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after successful rename
+
+	if _, err := tmp.Write(newBin); err != nil {
+		tmp.Close()
+		return fmt.Errorf("selfupdate: write new binary: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("selfupdate: close new binary: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0o755); err != nil {
+		return fmt.Errorf("selfupdate: chmod new binary: %w", err)
+	}
+	if err := os.Rename(tmpName, u.ExecPath); err != nil {
+		return fmt.Errorf("selfupdate: replace %s: %w", u.ExecPath, err)
+	}
+	return nil
+}
+
+// checksumFor finds the hex SHA256 for archive in a goreleaser checksums.txt
+// body (lines of "<hex>  <filename>").
+func checksumFor(sums []byte, archive string) (string, error) {
+	sc := bufio.NewScanner(bytes.NewReader(sums))
+	for sc.Scan() {
+		fields := strings.Fields(sc.Text())
+		if len(fields) == 2 && fields[1] == archive {
+			return fields[0], nil
+		}
+	}
+	return "", fmt.Errorf("selfupdate: %s not found in checksums.txt", archive)
+}
+
+// extractBinary pulls the named binary out of an archive (tar.gz, or zip when
+// isZip). It returns the binary bytes.
+func extractBinary(archive []byte, name string, isZip bool) ([]byte, error) {
+	if isZip {
+		return extractFromZip(archive, name)
+	}
+	return extractFromTarGz(archive, name)
+}
+
+func extractFromTarGz(archive []byte, name string) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, fmt.Errorf("selfupdate: gzip reader: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("selfupdate: read tar: %w", err)
+		}
+		if filepath.Base(hdr.Name) == name && hdr.Typeflag == tar.TypeReg {
+			return io.ReadAll(tr)
+		}
+	}
+	return nil, fmt.Errorf("selfupdate: %s not found in archive", name)
+}
+
+func extractFromZip(archive []byte, name string) ([]byte, error) {
+	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		return nil, fmt.Errorf("selfupdate: zip reader: %w", err)
+	}
+	for _, f := range zr.File {
+		if filepath.Base(f.Name) == name {
+			rc, err := f.Open()
+			if err != nil {
+				return nil, fmt.Errorf("selfupdate: open %s in zip: %w", name, err)
+			}
+			defer rc.Close()
+			return io.ReadAll(rc)
+		}
+	}
+	return nil, fmt.Errorf("selfupdate: %s not found in archive", name)
+}

--- a/internal/selfupdate/update_test.go
+++ b/internal/selfupdate/update_test.go
@@ -1,0 +1,175 @@
+package selfupdate
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestArchiveName(t *testing.T) {
+	tests := []struct {
+		goos, goarch, want string
+	}{
+		{"darwin", "arm64", "pigo_0.4.0_Darwin_arm64.tar.gz"},
+		{"darwin", "amd64", "pigo_0.4.0_Darwin_x86_64.tar.gz"},
+		{"linux", "amd64", "pigo_0.4.0_Linux_x86_64.tar.gz"},
+		{"linux", "386", "pigo_0.4.0_Linux_i386.tar.gz"},
+		{"windows", "amd64", "pigo_0.4.0_Windows_x86_64.zip"},
+	}
+	for _, tt := range tests {
+		u := &Updater{GOOS: tt.goos, GOARCH: tt.goarch}
+		if got := u.archiveName("0.4.0"); got != tt.want {
+			t.Errorf("archiveName(%s/%s) = %q, want %q", tt.goos, tt.goarch, got, tt.want)
+		}
+	}
+}
+
+func TestChecksumFor(t *testing.T) {
+	sums := []byte("abc123  pigo_0.4.0_Linux_x86_64.tar.gz\ndef456  pigo_0.4.0_Darwin_arm64.tar.gz\n")
+	got, err := checksumFor(sums, "pigo_0.4.0_Darwin_arm64.tar.gz")
+	if err != nil || got != "def456" {
+		t.Errorf("checksumFor = (%q,%v), want (def456,nil)", got, err)
+	}
+	if _, err := checksumFor(sums, "missing.tar.gz"); err == nil {
+		t.Error("expected error for missing archive")
+	}
+}
+
+func TestExtractBinaryTarGz(t *testing.T) {
+	want := []byte("#!fake pigo binary")
+	archive := makeTarGz(t, "pigo", want)
+	got, err := extractBinary(archive, "pigo", false)
+	if err != nil {
+		t.Fatalf("extractBinary: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("extracted = %q, want %q", got, want)
+	}
+	if _, err := extractBinary(archive, "nope", false); err == nil {
+		t.Error("expected error for missing binary")
+	}
+}
+
+func TestReplaceAtomic(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "pigo")
+	if err := os.WriteFile(target, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	u := &Updater{ExecPath: target}
+	newBin := []byte("new binary content")
+	if err := u.replace(newBin); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	got, _ := os.ReadFile(target)
+	if !bytes.Equal(got, newBin) {
+		t.Errorf("after replace = %q, want %q", got, newBin)
+	}
+	// No leftover temp files in the directory.
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 {
+		t.Errorf("expected 1 file after replace, got %d", len(entries))
+	}
+}
+
+func TestApplyEndToEnd(t *testing.T) {
+	binary := []byte("brand new pigo v0.4.0")
+	archive := makeTarGz(t, "pigo", binary)
+	sum := sha256.Sum256(archive)
+	archiveName := "pigo_0.4.0_Linux_x86_64.tar.gz"
+	sums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), archiveName)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch filepath.Base(r.URL.Path) {
+		case archiveName:
+			_, _ = w.Write(archive)
+		case checksumsFile:
+			_, _ = w.Write([]byte(sums))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "pigo")
+	_ = os.WriteFile(target, []byte("old"), 0o755)
+
+	u := &Updater{
+		HTTPClient:     srv.Client(),
+		Repo:           "smallnest/pigo",
+		ReleaseBaseURL: srv.URL,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		ExecPath:       target,
+	}
+	if err := u.Apply(context.Background(), "v0.4.0", &bytes.Buffer{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	got, _ := os.ReadFile(target)
+	if !bytes.Equal(got, binary) {
+		t.Errorf("target after Apply = %q, want %q", got, binary)
+	}
+}
+
+func TestApplyChecksumMismatch(t *testing.T) {
+	archive := makeTarGz(t, "pigo", []byte("real content"))
+	archiveName := "pigo_0.4.0_Linux_x86_64.tar.gz"
+	// Wrong checksum on purpose.
+	sums := "0000000000000000000000000000000000000000000000000000000000000000  " + archiveName + "\n"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch filepath.Base(r.URL.Path) {
+		case archiveName:
+			_, _ = w.Write(archive)
+		case checksumsFile:
+			_, _ = w.Write([]byte(sums))
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "pigo")
+	_ = os.WriteFile(target, []byte("old"), 0o755)
+
+	u := &Updater{
+		HTTPClient:     srv.Client(),
+		ReleaseBaseURL: srv.URL,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		ExecPath:       target,
+	}
+	if err := u.Apply(context.Background(), "v0.4.0", &bytes.Buffer{}); err == nil {
+		t.Fatal("expected checksum mismatch error")
+	}
+	// Target must be untouched on checksum failure.
+	if got, _ := os.ReadFile(target); string(got) != "old" {
+		t.Errorf("target modified despite checksum failure: %q", got)
+	}
+}
+
+func makeTarGz(t *testing.T, name string, content []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{Name: name, Mode: 0o755, Size: int64(len(content)), Typeflag: tar.TypeReg}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	tw.Close()
+	gz.Close()
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Summary
- 新增 `internal/selfupdate/update.go`：按当前 GOOS/GOARCH 拼 goreleaser 归档名、下载归档与 checksums.txt、校验 SHA256、解压 pigo 二进制、临时文件 + os.Rename 原子替换运行中可执行文件
- `Run` 复用 #465 的 `UpdateAvailable`：已是最新则打印并退出 0，dev 版直接装 latest
- `cmd/pigo/main.go`：无参 `pigo update` 路由到 `selfupdate.Run`，`pigo update <pkg>` 仍走 pkgcmd
- review 修正：解压/校验统一用 `bytes.NewReader` 避免归档整块拷贝

Closes #466

## Test plan
- [x] go build ./...
- [x] go vet ./internal/selfupdate/
- [x] go test ./internal/selfupdate/（含端到端 Apply、checksum 不匹配、原子替换、归档名映射）