### PR TITLE
feat(tui): banner version row + cached update hint

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -308,6 +308,10 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			return 2
 		}
 		if shouldUseTUI(opts, isTTY) {
+			// Refresh the cached latest-release check off the hot path so the banner
+			// can show an upgrade hint on this or the next launch without blocking
+			// startup (US-004). No-ops for dev builds or a fresh cache.
+			selfupdate.StartBackgroundCheck(version)
 			if err := tui.Run(tui.Options{
 				Model:             opts.model,
 				ProviderName:      env.ProviderName,
@@ -315,6 +319,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 				BaseURL:           opts.baseURL,
 				APIKey:            opts.apiKey,
 				Protocol:          opts.protocol,
+				Version:           version,
 				ThinkingLevel:     thinking,
 				Tools:             env.Tools,
 				SysPrompt:         env.SysPrompt,

--- a/docs/issue#0467.html
+++ b/docs/issue#0467.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #467</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block; font-size: 0.6875rem; font-weight: 500;
+      padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/467">#467</a> &mdash; 启动横幅展示版本并高亮提示新版本 &mdash; 2026-08-01</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 横幅同步读本地缓存显示,异步只刷新缓存(不做活体重绘)</h3>
+      <p><strong>Ambiguity:</strong> US-004 要求"启动时检查最新 release,异步进行不阻塞"且"结果缓存,24h 最多联网一次",但未定义异步结果如何回填到已渲染的横幅。</p>
+      <p><strong>Choice:</strong> <code>renderBanner</code> 同步读取本地缓存文件(<code>CachedLatest</code>,非网络)决定是否显示升级提示;<code>StartBackgroundCheck</code> 在启动时 fire-and-forget 一个 goroutine,仅当缓存过期(&gt;24h)才联网并刷新缓存文件。新结果在<strong>下次</strong>启动显示。</p>
+      <p><strong>Rationale:</strong> Bubble Tea 横幅经 <code>addBanner</code> 一次性 seed 进 transcript,活体重绘需引入 tea.Msg 回路与横幅可变状态,复杂度高;"本地读显示 + 后台刷缓存"是 npm/brew 同款模式,零阻塞、零网络于热路径,完全满足验收条件。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> 版本由调用方(main)注入 Options.Version</h3>
+      <p><strong>Ambiguity:</strong> 横幅要显示"当前版本号",但 <code>main.version</code> 是 main 包私有变量,tui 包无法直接读。</p>
+      <p><strong>Choice:</strong> <code>tui.Options</code> 新增 <code>Version string</code> 字段,dispatch 传入包级 <code>version</code>。空值渲染为 <code>dev</code>。</p>
+      <p><strong>Rationale:</strong> 与 #465 <code>UpdateAvailable(current, latest)</code> 一致的"版本作入参"契约,避免 import 环。</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> 仅 TUI 横幅展示版本,行式 REPL 未加版本行</h3>
+      <p><strong>Spec said:</strong> US-004 明确锚定"交互式启动横幅(internal/cli/tui/banner.go 的信息面板)"。</p>
+      <p><strong>Implemented instead:</strong> 只改 TUI <code>banner.go</code>;<code>repl.Options</code> 未加 Version。</p>
+      <p><strong>Why:</strong> 验收条件与 PRD 都专指 tui/banner.go 信息面板,行式 REPL 无对应信息面板;不越界扩大改动范围。</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> cachePath 复刻 Home 逻辑 vs 依赖 pkgmgr.Home</h3>
+      <p><strong>Alternatives:</strong> (a) <code>selfupdate</code> import <code>pkgmgr</code> 复用 <code>Home()</code>;(b) 在 selfupdate 内复刻 8 行 PIGO_HOME/~.pigo 解析。</p>
+      <p><strong>Choice:</strong> 复刻。</p>
+      <p><strong>Rationale:</strong> 自更新是核心路径,不宜耦合到体量较大的包管理包;8 行 home 解析重复成本远低于引入 pkgmgr 依赖的耦合成本。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> review 修正:renderBanner 文档契约"无 I/O"已失真</h3>
+      <p><strong>Alternatives:</strong> (a) 把缓存读取上移出 renderBanner 以维持"无 I/O"契约;(b) 保留读取于横幅内,更新文档注释如实说明单次本地读。</p>
+      <p><strong>Choice:</strong> (b) 更新注释为"唯一 I/O 是一次廉价的本地缓存读取(非网络)"。</p>
+      <p><strong>Rationale:</strong> 升级提示与版本渲染同属横幅内聚职责,拆出去会把状态散到调用方;一次本地文件读在启动时可忽略,如实描述契约即可。</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 终端人工核验高亮配色</h3>
+      <p><strong>Assumption:</strong> 新版本号用 ANSI 214(橙)加粗、升级提示同色。单测已验证文本(版本行、<code>→ vX.Y.Z</code>、<code>运行 pigo update 升级</code>、dev 不提示、已最新不提示)。</p>
+      <p><strong>Verify:</strong> 验收条件含"终端交互式启动下人工核验横幅显示"——headless 环境无法真跑全屏 TUI,配色观感需在真实终端下由用户目视确认(有/无更新两态)。</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> 首次使用当次启动不显示提示</h3>
+      <p><strong>Assumption:</strong> 因"本地读显示 + 后台刷缓存",全新安装(无缓存)首次启动横幅不显示升级提示,后台刷完后于第二次启动才显示。</p>
+      <p><strong>Verify:</strong> 该延迟一轮的行为是否可接受;若要首启即提示,需改为活体重绘(tea.Msg 回填横幅),复杂度更高。</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/cli/tui/banner.go
+++ b/internal/cli/tui/banner.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+
+	"github.com/smallnest/pigo/internal/selfupdate"
 )
 
 // This file builds the startup splash shown at the top of the transcript: the
@@ -38,8 +40,9 @@ var logoColors = []string{
 }
 
 // renderBanner paints the logo gradient and joins it with a config panel showing
-// the session basics. It performs no I/O and never panics, so it is safe to build
-// eagerly at startup.
+// the session basics. Its only I/O is a single cheap read of the local
+// update-check cache (no network — CachedLatest); it never panics, so it is safe
+// to build eagerly at startup.
 func renderBanner(theme Theme, opts Options, cwd string) string {
 	var logo strings.Builder
 	for i, line := range logoLines {
@@ -55,11 +58,26 @@ func renderBanner(theme Theme, opts Options, cwd string) string {
 	value := lipgloss.NewStyle().Foreground(lipgloss.Color(colorUser)).Bold(true)
 
 	rows := [][2]string{
+		{"Version", firstNonEmpty(opts.Version, "dev")},
 		{"Model", firstNonEmpty(opts.Model, "—")},
 		{"Provider", firstNonEmpty(opts.ProviderName, "—")},
 		{"Protocol", firstNonEmpty(opts.Protocol, "—")},
 		{"Thinking", firstNonEmpty(string(opts.ThinkingLevel), "off")},
 		{"Directory", firstNonEmpty(cwd, "—")},
+	}
+
+	// When the cached latest-release check says a newer version exists, append a
+	// highlighted "→ vX.Y.Z" and an upgrade hint to the Version row. The check is
+	// read from the local cache only (no network here); a background refresh keeps
+	// it current for the next launch. dev/unparseable versions never trigger this.
+	upgradeHint := ""
+	if latest, _ := selfupdate.CachedLatest(); latest != "" {
+		if avail, comparable := selfupdate.UpdateAvailable(opts.Version, latest); comparable && avail {
+			newVer := lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true).Render(latest)
+			rows[0][1] = rows[0][1] + "  →  " + newVer
+			upgradeHint = label.Render(strings.Repeat(" ", 11)) +
+				lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render("运行 pigo update 升级")
+		}
 	}
 
 	var info strings.Builder
@@ -69,6 +87,9 @@ func renderBanner(theme Theme, opts Options, cwd string) string {
 			info.WriteByte('\n')
 		}
 		info.WriteString(label.Render(fmt.Sprintf("%-10s ", r[0])) + value.Render(r[1]))
+	}
+	if upgradeHint != "" {
+		info.WriteString("\n" + upgradeHint)
 	}
 
 	return lipgloss.JoinHorizontal(lipgloss.Center, logo.String(), "   ", info.String())

--- a/internal/cli/tui/banner_test.go
+++ b/internal/cli/tui/banner_test.go
@@ -1,0 +1,66 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeUpdateCache seeds the selfupdate cache under a temp PIGO_HOME so the
+// banner's cached-latest lookup is deterministic.
+func writeUpdateCache(t *testing.T, latest string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("PIGO_HOME", dir)
+	data, _ := json.Marshal(map[string]any{
+		"checked_at": time.Now(),
+		"latest":     latest,
+	})
+	if err := os.WriteFile(filepath.Join(dir, "update-check.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRenderBannerShowsVersion(t *testing.T) {
+	t.Setenv("PIGO_HOME", t.TempDir()) // empty cache: no upgrade hint
+	out := renderBanner(DefaultTheme(), Options{Version: "v0.3.1"}, "/tmp/proj")
+	if !strings.Contains(out, "Version") || !strings.Contains(out, "v0.3.1") {
+		t.Errorf("banner missing Version row: %q", out)
+	}
+	if strings.Contains(out, "运行 pigo update 升级") {
+		t.Error("banner should not show upgrade hint with empty cache")
+	}
+}
+
+func TestRenderBannerDevNoHint(t *testing.T) {
+	writeUpdateCache(t, "v9.9.9") // even with a newer tag cached...
+	out := renderBanner(DefaultTheme(), Options{Version: "dev"}, "/tmp/proj")
+	if !strings.Contains(out, "dev") {
+		t.Errorf("banner should show dev version: %q", out)
+	}
+	if strings.Contains(out, "运行 pigo update 升级") {
+		t.Error("dev build must not show an upgrade hint")
+	}
+}
+
+func TestRenderBannerUpgradeHint(t *testing.T) {
+	writeUpdateCache(t, "v0.4.0")
+	out := renderBanner(DefaultTheme(), Options{Version: "v0.3.1"}, "/tmp/proj")
+	if !strings.Contains(out, "v0.4.0") {
+		t.Errorf("banner should highlight newer version v0.4.0: %q", out)
+	}
+	if !strings.Contains(out, "运行 pigo update 升级") {
+		t.Errorf("banner should show upgrade hint: %q", out)
+	}
+}
+
+func TestRenderBannerUpToDate(t *testing.T) {
+	writeUpdateCache(t, "v0.3.1")
+	out := renderBanner(DefaultTheme(), Options{Version: "v0.3.1"}, "/tmp/proj")
+	if strings.Contains(out, "运行 pigo update 升级") {
+		t.Error("up-to-date build must not show an upgrade hint")
+	}
+}

--- a/internal/cli/tui/options.go
+++ b/internal/cli/tui/options.go
@@ -20,6 +20,9 @@ type Options struct {
 	BaseURL      string
 	APIKey       string
 	Protocol     string
+	// Version is the running build version (main.version), shown in the startup
+	// banner. Empty or "dev"/"unknown" renders as-is with no update hint.
+	Version string
 	// ThinkingLevel is the resolved reasoning-effort level (US-023): it seeds the
 	// live run config so every turn requests it, until a control command changes
 	// it.

--- a/internal/selfupdate/cache.go
+++ b/internal/selfupdate/cache.go
@@ -1,0 +1,102 @@
+// This file caches the latest-release check so pigo's startup banner can show
+// "update available" without a network call on every launch (US-004, FR-10).
+// The cache lives at $PIGO_HOME/update-check.json (or ~/.pigo/update-check.json)
+// and records the last check time plus the latest tag seen. CachedLatest reads
+// it synchronously (fast, local); StartBackgroundCheck refreshes it off the hot
+// path when older than the TTL, so a fresh result shows on the next launch. All
+// failures are silent: a missing or corrupt cache, an unresolvable home, or a
+// network error never surfaces an error or blocks startup.
+package selfupdate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// checkTTL is the minimum interval between networked latest-release checks.
+const checkTTL = 24 * time.Hour
+
+// cacheFileName is the on-disk cache under the pigo home directory.
+const cacheFileName = "update-check.json"
+
+// updateCache is the on-disk shape of the latest-release check cache.
+type updateCache struct {
+	CheckedAt time.Time `json:"checked_at"`
+	Latest    string    `json:"latest"`
+}
+
+// cachePath returns the cache file path, or "" when the home dir is unavailable.
+func cachePath() string {
+	if dir := os.Getenv("PIGO_HOME"); dir != "" {
+		return filepath.Join(dir, cacheFileName)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".pigo", cacheFileName)
+}
+
+// CachedLatest returns the latest tag recorded in the cache and whether the cache
+// is still fresh (younger than checkTTL). A missing, corrupt, or unreadable cache
+// yields ("", false). It never returns an error — the banner must not break on a
+// bad cache.
+func CachedLatest() (latest string, fresh bool) {
+	p := cachePath()
+	if p == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return "", false
+	}
+	var c updateCache
+	if err := json.Unmarshal(data, &c); err != nil {
+		return "", false
+	}
+	return c.Latest, time.Since(c.CheckedAt) < checkTTL
+}
+
+// StartBackgroundCheck refreshes the cache off the hot path when it is stale
+// (older than checkTTL). It returns immediately; the actual network check runs in
+// a goroutine so it never blocks banner rendering or first input. When current is
+// not a release version (dev/unknown) it does nothing — there is nothing to
+// compare against. All errors are swallowed: a failed check simply leaves the
+// cache untouched for next time.
+func StartBackgroundCheck(current string) {
+	if !IsReleaseVersion(current) {
+		return
+	}
+	if _, fresh := CachedLatest(); fresh {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		tag, err := LatestTag(ctx, &http.Client{Timeout: 10 * time.Second}, Repo)
+		if err != nil || tag == "" {
+			return
+		}
+		writeCache(tag)
+	}()
+}
+
+// writeCache persists the latest tag with the current time. Failures are silent.
+func writeCache(latest string) {
+	p := cachePath()
+	if p == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return
+	}
+	data, err := json.Marshal(updateCache{CheckedAt: time.Now(), Latest: latest})
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(p, data, 0o644)
+}

--- a/internal/selfupdate/cache_test.go
+++ b/internal/selfupdate/cache_test.go
@@ -1,0 +1,52 @@
+package selfupdate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCachedLatest(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PIGO_HOME", dir)
+
+	// No cache file yet → not fresh, empty latest.
+	if latest, fresh := CachedLatest(); latest != "" || fresh {
+		t.Errorf("empty cache = (%q,%v), want (\"\",false)", latest, fresh)
+	}
+
+	// Fresh cache → returns latest and fresh=true.
+	writeCache("v0.4.0")
+	if latest, fresh := CachedLatest(); latest != "v0.4.0" || !fresh {
+		t.Errorf("fresh cache = (%q,%v), want (v0.4.0,true)", latest, fresh)
+	}
+
+	// Stale cache (older than TTL) → latest kept, fresh=false.
+	stale, _ := json.Marshal(updateCache{CheckedAt: time.Now().Add(-25 * time.Hour), Latest: "v0.3.0"})
+	if err := os.WriteFile(filepath.Join(dir, cacheFileName), stale, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if latest, fresh := CachedLatest(); latest != "v0.3.0" || fresh {
+		t.Errorf("stale cache = (%q,%v), want (v0.3.0,false)", latest, fresh)
+	}
+
+	// Corrupt cache → silent ("", false), never an error.
+	if err := os.WriteFile(filepath.Join(dir, cacheFileName), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if latest, fresh := CachedLatest(); latest != "" || fresh {
+		t.Errorf("corrupt cache = (%q,%v), want (\"\",false)", latest, fresh)
+	}
+}
+
+func TestStartBackgroundCheckDevNoWrite(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PIGO_HOME", dir)
+	// dev is not a release version → must not touch the network or write a cache.
+	StartBackgroundCheck("dev")
+	if _, err := os.Stat(filepath.Join(dir, cacheFileName)); !os.IsNotExist(err) {
+		t.Errorf("dev build wrote a cache file; want none")
+	}
+}


### PR DESCRIPTION
## Summary
- 启动横幅信息面板新增 `Version` 行，展示当前版本号（空/dev 显示 `dev`）
- 新增 `internal/selfupdate/cache.go`：`CachedLatest`（同步读本地缓存，非网络）+ `StartBackgroundCheck`（后台 goroutine，24h TTL 才联网刷新缓存），失败静默
- 有新版时版本行高亮 `v0.3.1 → v0.4.0`（ANSI 214 橙加粗）并提示 `运行 pigo update 升级`；已最新/dev/无网络不提示
- `tui.Options` 新增 `Version` 字段，dispatch 注入 main.version

Closes #467

## Test plan
- [x] go build ./... / go vet ./...
- [x] go test ./internal/selfupdate/（缓存新鲜/过期/损坏/dev 不写）
- [x] go test ./internal/cli/tui/（版本行、升级提示、dev 不提示、已最新不提示）
- [ ] 终端交互式启动人工核验高亮配色（有/无更新两态）——headless 无法真跑全屏 TUI