### PR TITLE
config: nested [memory]/[checkpoint] tables + compaction.max_context

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -114,6 +114,12 @@ type cliOptions struct {
 	// given directory. This is what makes pigo usable as an SDK backend that can
 	// be pointed at an arbitrary project root.
 	cwd string
+	// memory holds the resolved [memory]/[checkpoint]/[compaction] config tables
+	// (defaults applied, string forms parsed). These have no CLI flags — the
+	// config file is their only source — so applyFileConfig always populates this
+	// (defaults when the tables are absent) for downstream memory/checkpoint/
+	// compaction wiring to consume. See config.MemorySettings.
+	memory config.MemorySettings
 }
 
 func main() {
@@ -247,6 +253,10 @@ func applyFileConfig(opts *cliOptions, cfg config.FileConfig, changed func(strin
 	if len(cfg.Prompts) > 0 {
 		opts.configPrompts = cfg.Prompts
 	}
+	// The [memory]/[checkpoint]/[compaction] tables have no CLI flags, so they
+	// are resolved (with defaults) and overlaid unconditionally — an absent set
+	// of tables yields the default-safe MemorySettings.
+	opts.memory = cfg.ResolveMemorySettings()
 }
 
 // dispatch runs the resolved command and returns a process exit code, writing

--- a/cmd/pigo/main_test.go
+++ b/cmd/pigo/main_test.go
@@ -255,3 +255,39 @@ func TestApplyFileConfigPrompts(t *testing.T) {
 		t.Errorf("opts.configPrompts = %v, want [./my-prompts /abs/x.md]", opts.configPrompts)
 	}
 }
+
+// applyFileConfig always resolves the [memory]/[checkpoint]/[compaction] tables
+// into opts.memory, applying defaults when they are absent.
+func TestApplyFileConfig_MemoryDefaults(t *testing.T) {
+	var opts cliOptions
+	applyFileConfig(&opts, config.FileConfig{}, changedSet())
+	if !opts.memory.Memory.Enabled || !opts.memory.Memory.ReconcileOnSearch {
+		t.Errorf("memory defaults not applied: %+v", opts.memory.Memory)
+	}
+	if opts.memory.Memory.SearchScoreFloor != 0.15 {
+		t.Errorf("search_score_floor default = %v, want 0.15", opts.memory.Memory.SearchScoreFloor)
+	}
+	if len(opts.memory.CheckpointThresholds) != 3 {
+		t.Errorf("checkpoint thresholds default = %v, want 3 entries", opts.memory.CheckpointThresholds)
+	}
+	if opts.memory.MaxContext.IsSet() {
+		t.Errorf("max_context should be unset by default")
+	}
+}
+
+// A configured [memory]/[compaction] set overlays into opts.memory.
+func TestApplyFileConfig_MemoryOverride(t *testing.T) {
+	var opts cliOptions
+	enabled := false
+	cfg := config.FileConfig{
+		Memory:     config.MemoryConfig{Enabled: &enabled},
+		Compaction: config.CompactionConfig{MaxContext: "50%"},
+	}
+	applyFileConfig(&opts, cfg, changedSet())
+	if opts.memory.Memory.Enabled {
+		t.Errorf("memory.enabled=false should overlay, got true")
+	}
+	if got := opts.memory.MaxContext.Resolve(200000); got != 100000 {
+		t.Errorf("max_context 50%% of 200000 = %d, want 100000", got)
+	}
+}

--- a/config.toml.example
+++ b/config.toml.example
@@ -43,3 +43,30 @@ no_skills = false
 
 # Internal: run as a process-isolated sub-agent JSON-RPC server over stdio (US-019).
 # subagent_rpc = false
+
+# --- Persistent memory + infinite context (nested tables) ---
+
+# [memory] controls the persistent memory system. All keys are optional and
+# default to the values shown; set memory.enabled = false to fully disable it.
+# [memory]
+# enabled = true              # master switch for the memory system
+# reconcile_on_search = true  # lazily re-index memory files before each search
+# search_score_floor = 0.15   # drop search hits below this relevance score (0..1)
+# cc_index = false            # also index the Claude Code memory directory (read-only)
+
+# [checkpoint] controls infinite-context checkpointing.
+# [checkpoint]
+# thresholds = ["40%", "60%", "80%"]  # context-window fill levels that trigger compaction
+# reserved = 4096                     # optional: tokens to reserve (int) or a percentage ("10%")
+
+# [checkpoint.push_caps] caps per-section injection token budgets.
+# [checkpoint.push_caps]
+# memory = 800
+# recall = 1200
+
+# [compaction] tunes auto-compaction.
+# [compaction]
+# max_context accepts a token count (300000), a K/M suffix ("300K", "1M"), or a
+# percentage of the provider window ("50%"). It only lowers the trigger point and
+# is always clamped by the provider limit.
+# max_context = "300K"

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -42,6 +42,14 @@ type FileConfig struct {
 	// Prompts is the config.toml `prompts` array: paths (files or dirs) to load
 	// prompt templates from at the settings tier (mirrors pi's settings prompts).
 	Prompts []string `toml:"prompts"`
+	// Memory, Checkpoint, and Compaction are nested TOML tables for the
+	// persistent-memory / infinite-context feature. They are pure config
+	// plumbing here; defaults/parsing live in memory.go (Resolve* helpers) and
+	// the overlay into runtime options lives in cmd/pigo. See
+	// tasks/spec-persistent-memory-infinite-context.md §3/§4/§5.2.
+	Memory     MemoryConfig     `toml:"memory"`
+	Checkpoint CheckpointConfig `toml:"checkpoint"`
+	Compaction CompactionConfig `toml:"compaction"`
 }
 
 // FileConfigPath returns the path to the user config file:

--- a/internal/cli/config/memory.go
+++ b/internal/cli/config/memory.go
@@ -1,0 +1,265 @@
+// Memory/checkpoint/compaction config: the nested TOML tables [memory],
+// [checkpoint], and compaction.max_context (spec-persistent-memory-infinite-
+// context §3/§4/§5.2). This file is pure config plumbing — parse, defaults, and
+// resolve helpers only. The actual memory Store, checkpoint persistence, and
+// compaction trigger live in later layers (internal/memory, internal/runtime,
+// internal/compaction) and consume the resolved values overlaid in cmd/pigo.
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Built-in defaults for the [memory] table. Exposed so overlay and tests share
+// one source of truth (mirrors the flat-config defaults documented in main.go).
+const (
+	DefaultMemoryEnabled           = true
+	DefaultMemoryReconcileOnSearch = true
+	DefaultMemorySearchScoreFloor  = 0.15
+	DefaultMemoryCCIndex           = false
+)
+
+// DefaultCheckpointThresholds is the built-in compaction trigger ladder as
+// percentage strings; ResolveThresholds parses them into fractions in (0,1].
+func DefaultCheckpointThresholds() []string {
+	return []string{"40%", "60%", "80%"}
+}
+
+// MemoryConfig is the [memory] TOML table. Bool fields whose default is true
+// (Enabled, ReconcileOnSearch) and the float ScoreFloor use pointers so an
+// absent key is distinguishable from an explicit false/0 — nil means "apply the
+// default", which is what makes memory.enabled=false representable and
+// default-safe. CCIndex defaults to false, so a plain bool suffices.
+type MemoryConfig struct {
+	Enabled           *bool    `toml:"enabled"`
+	ReconcileOnSearch *bool    `toml:"reconcile_on_search"`
+	SearchScoreFloor  *float64 `toml:"search_score_floor"`
+	CCIndex           bool     `toml:"cc_index"`
+}
+
+// ResolvedMemory is MemoryConfig with defaults applied and the score floor
+// clamped to [0,1]. It is the shape downstream memory wiring consumes.
+type ResolvedMemory struct {
+	Enabled           bool
+	ReconcileOnSearch bool
+	SearchScoreFloor  float64
+	CCIndex           bool
+}
+
+// Resolve applies the [memory] defaults: absent keys fall back to
+// true/true/0.15/false; an explicit search_score_floor outside [0,1] is clamped
+// into range.
+func (m MemoryConfig) Resolve() ResolvedMemory {
+	r := ResolvedMemory{
+		Enabled:           DefaultMemoryEnabled,
+		ReconcileOnSearch: DefaultMemoryReconcileOnSearch,
+		SearchScoreFloor:  DefaultMemorySearchScoreFloor,
+		CCIndex:           m.CCIndex,
+	}
+	if m.Enabled != nil {
+		r.Enabled = *m.Enabled
+	}
+	if m.ReconcileOnSearch != nil {
+		r.ReconcileOnSearch = *m.ReconcileOnSearch
+	}
+	if m.SearchScoreFloor != nil {
+		f := *m.SearchScoreFloor
+		switch {
+		case f < 0:
+			f = 0
+		case f > 1:
+			f = 1
+		}
+		r.SearchScoreFloor = f
+	}
+	return r
+}
+
+// IntOrString accepts either a TOML integer or string for the optional
+// [checkpoint].reserved key (e.g. reserved = 4096 or reserved = "10%"). Set
+// reports whether the key was present; IsInt selects the populated field.
+type IntOrString struct {
+	Set   bool
+	IsInt bool
+	Int   int
+	Str   string
+}
+
+// UnmarshalTOML implements toml.Unmarshaler so a bare int or a quoted string
+// both decode without failing the whole file.
+func (v *IntOrString) UnmarshalTOML(data any) error {
+	v.Set = true
+	switch t := data.(type) {
+	case int64:
+		v.IsInt, v.Int = true, int(t)
+	case int:
+		v.IsInt, v.Int = true, t
+	case float64:
+		v.IsInt, v.Int = true, int(t)
+	case string:
+		v.Str = t
+	default:
+		return fmt.Errorf("reserved: unsupported type %T (want int or string)", data)
+	}
+	return nil
+}
+
+// CheckpointConfig is the [checkpoint] TOML table. push_caps is a nested table
+// of per-section token caps (e.g. [checkpoint.push_caps] with memory = 800,
+// recall = 1200), modeled as a map.
+type CheckpointConfig struct {
+	Thresholds []string       `toml:"thresholds"`
+	Reserved   IntOrString    `toml:"reserved"`
+	PushCaps   map[string]int `toml:"push_caps"`
+}
+
+// ResolveThresholds parses the configured threshold percentage strings into
+// fractions in (0,1], skipping out-of-range/unparseable entries. An empty list
+// — or one where every entry is invalid — falls back to the built-in defaults.
+func (c CheckpointConfig) ResolveThresholds() []float64 {
+	src := c.Thresholds
+	if len(src) == 0 {
+		src = DefaultCheckpointThresholds()
+	}
+	out := parseThresholds(src)
+	if len(out) == 0 {
+		out = parseThresholds(DefaultCheckpointThresholds())
+	}
+	return out
+}
+
+func parseThresholds(ss []string) []float64 {
+	var out []float64
+	for _, s := range ss {
+		if f, ok := ParseThresholdFraction(s); ok {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// ParseThresholdFraction parses a percentage string like "80%" into a fraction
+// in (0,1]. Values outside that range (<=0, >100%) or lacking a % suffix are
+// rejected with ok=false so callers fall back to a default.
+func ParseThresholdFraction(s string) (float64, bool) {
+	s = strings.TrimSpace(s)
+	if !strings.HasSuffix(s, "%") {
+		return 0, false
+	}
+	n, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimSuffix(s, "%")), 64)
+	if err != nil {
+		return 0, false
+	}
+	f := n / 100
+	if f <= 0 || f > 1 {
+		return 0, false
+	}
+	return f, true
+}
+
+// CompactionConfig is the [compaction] TOML table. Only max_context is wired
+// here; it lowers the auto-compaction trigger point and is always clamped by
+// the provider window by the consumer.
+type CompactionConfig struct {
+	MaxContext string `toml:"max_context"`
+}
+
+// ResolveMaxContext parses the max_context string form. An empty value yields
+// an unset MaxContext (no error).
+func (c CompactionConfig) ResolveMaxContext() (MaxContext, error) {
+	return ParseMaxContext(c.MaxContext)
+}
+
+// MaxContext is a parsed compaction.max_context value: either an absolute token
+// count or a fraction of the provider window. The zero value is "unset" and
+// Resolve returns 0. Resolve is a pure function; the provider-limit clamp is
+// applied by the consumer.
+type MaxContext struct {
+	set      bool
+	fraction float64 // >0 for a "N%" form
+	tokens   int     // absolute token count when fraction == 0
+}
+
+// IsSet reports whether max_context was configured.
+func (m MaxContext) IsSet() bool { return m.set }
+
+// Resolve returns the token budget for the given provider window: window*
+// fraction (rounded) for a percentage form, or the absolute token count
+// otherwise. An unset value returns 0. This is intentionally unclamped — the
+// consumer applies the provider-limit clamp.
+func (m MaxContext) Resolve(window int) int {
+	if !m.set {
+		return 0
+	}
+	if m.fraction > 0 {
+		return int(float64(window)*m.fraction + 0.5)
+	}
+	return m.tokens
+}
+
+// ParseMaxContext parses the accepted max_context forms: a plain token count
+// ("300000"), a K/M-suffixed count ("300K", "1M", case-insensitive, fractions
+// allowed like "1.5M"), or a percentage of the provider window ("50%"). An
+// empty string is unset (no error); other malformed or non-positive values are
+// errors.
+func ParseMaxContext(s string) (MaxContext, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return MaxContext{}, nil
+	}
+	if strings.HasSuffix(s, "%") {
+		n, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimSuffix(s, "%")), 64)
+		if err != nil {
+			return MaxContext{}, fmt.Errorf("max_context: invalid percent %q: %w", s, err)
+		}
+		f := n / 100
+		if f <= 0 || f > 1 {
+			return MaxContext{}, fmt.Errorf("max_context: percent out of range %q (want (0%%,100%%])", s)
+		}
+		return MaxContext{set: true, fraction: f}, nil
+	}
+	mult := 1.0
+	body := s
+	switch last := s[len(s)-1]; last {
+	case 'k', 'K':
+		mult, body = 1_000, s[:len(s)-1]
+	case 'm', 'M':
+		mult, body = 1_000_000, s[:len(s)-1]
+	}
+	n, err := strconv.ParseFloat(strings.TrimSpace(body), 64)
+	if err != nil {
+		return MaxContext{}, fmt.Errorf("max_context: invalid token count %q: %w", s, err)
+	}
+	if n <= 0 {
+		return MaxContext{}, fmt.Errorf("max_context: must be positive %q", s)
+	}
+	return MaxContext{set: true, tokens: int(n*mult + 0.5)}, nil
+}
+
+// MemorySettings bundles the resolved [memory]/[checkpoint]/[compaction] config
+// for overlay into runtime options: defaults applied, string forms pre-parsed.
+// It is produced by FileConfig.ResolveMemorySettings and is always well-formed
+// (an invalid max_context is treated as unset rather than failing the overlay).
+type MemorySettings struct {
+	Memory               ResolvedMemory
+	CheckpointThresholds []float64
+	CheckpointReserved   IntOrString
+	CheckpointPushCaps   map[string]int
+	MaxContext           MaxContext
+}
+
+// ResolveMemorySettings resolves the three nested tables into MemorySettings,
+// applying defaults. It never fails: an unparseable compaction.max_context is
+// dropped to unset so a single bad key cannot break config overlay.
+func (c FileConfig) ResolveMemorySettings() MemorySettings {
+	mc, _ := c.Compaction.ResolveMaxContext()
+	return MemorySettings{
+		Memory:               c.Memory.Resolve(),
+		CheckpointThresholds: c.Checkpoint.ResolveThresholds(),
+		CheckpointReserved:   c.Checkpoint.Reserved,
+		CheckpointPushCaps:   c.Checkpoint.PushCaps,
+		MaxContext:           mc,
+	}
+}

--- a/internal/cli/config/memory_test.go
+++ b/internal/cli/config/memory_test.go
@@ -1,0 +1,234 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// boolPtr / floatPtr are test helpers for the pointer-valued MemoryConfig fields.
+func boolPtr(b bool) *bool        { return &b }
+func floatPtr(f float64) *float64 { return &f }
+
+func TestMemoryConfig_ResolveDefaults(t *testing.T) {
+	got := MemoryConfig{}.Resolve()
+	want := ResolvedMemory{
+		Enabled:           true,
+		ReconcileOnSearch: true,
+		SearchScoreFloor:  0.15,
+		CCIndex:           false,
+	}
+	if got != want {
+		t.Fatalf("Resolve() defaults = %+v, want %+v", got, want)
+	}
+}
+
+func TestMemoryConfig_ResolveOverrides(t *testing.T) {
+	got := MemoryConfig{
+		Enabled:           boolPtr(false),
+		ReconcileOnSearch: boolPtr(false),
+		SearchScoreFloor:  floatPtr(0.5),
+		CCIndex:           true,
+	}.Resolve()
+	want := ResolvedMemory{
+		Enabled:           false,
+		ReconcileOnSearch: false,
+		SearchScoreFloor:  0.5,
+		CCIndex:           true,
+	}
+	if got != want {
+		t.Fatalf("Resolve() overrides = %+v, want %+v", got, want)
+	}
+}
+
+// memory.enabled=false must be representable and distinct from "absent".
+func TestMemoryConfig_EnabledFalseRepresentable(t *testing.T) {
+	if r := (MemoryConfig{Enabled: boolPtr(false)}).Resolve(); r.Enabled {
+		t.Fatal("explicit enabled=false should resolve to false")
+	}
+	if r := (MemoryConfig{}).Resolve(); !r.Enabled {
+		t.Fatal("absent enabled should default to true")
+	}
+}
+
+func TestMemoryConfig_ScoreFloorClamp(t *testing.T) {
+	if r := (MemoryConfig{SearchScoreFloor: floatPtr(-1)}).Resolve(); r.SearchScoreFloor != 0 {
+		t.Errorf("negative score floor should clamp to 0, got %v", r.SearchScoreFloor)
+	}
+	if r := (MemoryConfig{SearchScoreFloor: floatPtr(2)}).Resolve(); r.SearchScoreFloor != 1 {
+		t.Errorf("score floor >1 should clamp to 1, got %v", r.SearchScoreFloor)
+	}
+}
+
+func TestParseThresholdFraction(t *testing.T) {
+	cases := []struct {
+		in   string
+		want float64
+		ok   bool
+	}{
+		{"40%", 0.40, true},
+		{"60%", 0.60, true},
+		{"80%", 0.80, true},
+		{"100%", 1.0, true},
+		{" 75% ", 0.75, true},
+		{"0%", 0, false},   // out of range (must be >0)
+		{"120%", 0, false}, // out of range (>100%)
+		{"-10%", 0, false},
+		{"80", 0, false},  // missing %
+		{"abc%", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := ParseThresholdFraction(c.in)
+		if ok != c.ok || (ok && got != c.want) {
+			t.Errorf("ParseThresholdFraction(%q) = (%v,%v), want (%v,%v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestCheckpointConfig_ResolveThresholds(t *testing.T) {
+	// Absent → defaults 40/60/80%.
+	if got := (CheckpointConfig{}).ResolveThresholds(); !reflect.DeepEqual(got, []float64{0.40, 0.60, 0.80}) {
+		t.Errorf("default thresholds = %v, want [0.4 0.6 0.8]", got)
+	}
+	// Explicit override.
+	if got := (CheckpointConfig{Thresholds: []string{"50%", "90%"}}).ResolveThresholds(); !reflect.DeepEqual(got, []float64{0.50, 0.90}) {
+		t.Errorf("override thresholds = %v, want [0.5 0.9]", got)
+	}
+	// Out-of-range entries skipped, valid kept.
+	if got := (CheckpointConfig{Thresholds: []string{"120%", "70%"}}).ResolveThresholds(); !reflect.DeepEqual(got, []float64{0.70}) {
+		t.Errorf("mixed thresholds = %v, want [0.7]", got)
+	}
+	// All invalid → fall back to defaults.
+	if got := (CheckpointConfig{Thresholds: []string{"nope", "0%"}}).ResolveThresholds(); !reflect.DeepEqual(got, []float64{0.40, 0.60, 0.80}) {
+		t.Errorf("all-invalid thresholds = %v, want defaults", got)
+	}
+}
+
+func TestParseMaxContext(t *testing.T) {
+	cases := []struct {
+		in     string
+		set    bool
+		window int
+		want   int
+	}{
+		{"", false, 200000, 0},
+		{"300000", true, 200000, 300000},
+		{"300K", true, 200000, 300000},
+		{"1M", true, 200000, 1000000},
+		{"1m", true, 200000, 1000000},
+		{"1.5M", true, 200000, 1500000},
+		{"50%", true, 200000, 100000},
+		{"25%", true, 400000, 100000},
+	}
+	for _, c := range cases {
+		mc, err := ParseMaxContext(c.in)
+		if err != nil {
+			t.Errorf("ParseMaxContext(%q) unexpected error: %v", c.in, err)
+			continue
+		}
+		if mc.IsSet() != c.set {
+			t.Errorf("ParseMaxContext(%q).IsSet() = %v, want %v", c.in, mc.IsSet(), c.set)
+		}
+		if got := mc.Resolve(c.window); got != c.want {
+			t.Errorf("ParseMaxContext(%q).Resolve(%d) = %d, want %d", c.in, c.window, got, c.want)
+		}
+	}
+}
+
+func TestParseMaxContext_Invalid(t *testing.T) {
+	for _, in := range []string{"0%", "150%", "-100%", "abc", "0", "-5", "12x"} {
+		if _, err := ParseMaxContext(in); err == nil {
+			t.Errorf("ParseMaxContext(%q) should error", in)
+		}
+	}
+}
+
+func TestLoadFileConfig_MemoryTables(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := `
+[memory]
+enabled = false
+reconcile_on_search = false
+search_score_floor = 0.3
+cc_index = true
+
+[checkpoint]
+thresholds = ["50%", "70%"]
+reserved = 4096
+
+[checkpoint.push_caps]
+memory = 800
+recall = 1200
+
+[compaction]
+max_context = "300K"
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+
+	mem := cfg.Memory.Resolve()
+	if mem.Enabled || mem.ReconcileOnSearch || !mem.CCIndex || mem.SearchScoreFloor != 0.3 {
+		t.Errorf("memory resolved = %+v", mem)
+	}
+	if got := cfg.Checkpoint.ResolveThresholds(); !reflect.DeepEqual(got, []float64{0.50, 0.70}) {
+		t.Errorf("thresholds = %v, want [0.5 0.7]", got)
+	}
+	if !cfg.Checkpoint.Reserved.Set || !cfg.Checkpoint.Reserved.IsInt || cfg.Checkpoint.Reserved.Int != 4096 {
+		t.Errorf("reserved = %+v, want int 4096", cfg.Checkpoint.Reserved)
+	}
+	if cfg.Checkpoint.PushCaps["memory"] != 800 || cfg.Checkpoint.PushCaps["recall"] != 1200 {
+		t.Errorf("push_caps = %v", cfg.Checkpoint.PushCaps)
+	}
+	mc, err := cfg.Compaction.ResolveMaxContext()
+	if err != nil {
+		t.Fatalf("ResolveMaxContext: %v", err)
+	}
+	if got := mc.Resolve(200000); got != 300000 {
+		t.Errorf("max_context resolve = %d, want 300000", got)
+	}
+}
+
+func TestLoadFileConfig_ReservedString(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[checkpoint]\nreserved = \"10%\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+	if !cfg.Checkpoint.Reserved.Set || cfg.Checkpoint.Reserved.IsInt || cfg.Checkpoint.Reserved.Str != "10%" {
+		t.Errorf("reserved = %+v, want string 10%%", cfg.Checkpoint.Reserved)
+	}
+}
+
+// Absent tables → default-safe resolved settings.
+func TestResolveMemorySettings_Defaults(t *testing.T) {
+	ms := FileConfig{}.ResolveMemorySettings()
+	if !ms.Memory.Enabled || !ms.Memory.ReconcileOnSearch || ms.Memory.SearchScoreFloor != 0.15 || ms.Memory.CCIndex {
+		t.Errorf("default memory = %+v", ms.Memory)
+	}
+	if !reflect.DeepEqual(ms.CheckpointThresholds, []float64{0.40, 0.60, 0.80}) {
+		t.Errorf("default thresholds = %v", ms.CheckpointThresholds)
+	}
+	if ms.MaxContext.IsSet() {
+		t.Errorf("default max_context should be unset")
+	}
+	if ms.CheckpointReserved.Set {
+		t.Errorf("default reserved should be unset")
+	}
+}
+
+// An invalid max_context must not fail the overlay — it drops to unset.
+func TestResolveMemorySettings_InvalidMaxContextIgnored(t *testing.T) {
+	ms := FileConfig{Compaction: CompactionConfig{MaxContext: "garbage"}}.ResolveMemorySettings()
+	if ms.MaxContext.IsSet() {
+		t.Errorf("invalid max_context should resolve to unset, got set")
+	}
+}


### PR DESCRIPTION
## Summary
- Add nested TOML tables `[memory]` (enabled/reconcile_on_search/search_score_floor/cc_index) and `[checkpoint]` (thresholds, reserved, push_caps) to `FileConfig`, plus `compaction.max_context`.
- Pointer fields make absent keys default-safe (true/true/0.15/false) and `memory.enabled=false` representable; `IntOrString` accepts `reserved` as int or string.
- Parse helpers: threshold `%` strings -> (0,1] (out-of-range ignored, fallback to defaults); `max_context` accepts int / "300K" / "1M" / "50%" with a pure `Resolve(window)` helper.
- `cmd/pigo` overlays the resolved settings into `cliOptions` following the existing `applyFileConfig` pattern (infallible: bad `max_context` drops to unset).
- Config plumbing only — the memory Store / checkpoint logic land in later nodes. Documented the new tables in `config.toml.example`.

Closes #479

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` green
- [x] Unit tests: defaults when keys absent, explicit overrides, `memory.enabled=false`, threshold + max_context parsing incl. out-of-range fallback, reserved int/string, push_caps map