### PR TITLE
feat(memory): path resolution + scope/type parsing (#474)

### DIFF
--- a/internal/memory/paths.go
+++ b/internal/memory/paths.go
@@ -1,0 +1,233 @@
+package memory
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Locator is the parsed identity of a memory file on disk: which scope it
+// belongs to, the scope id (project-id / session-id / slug; "" for global), the
+// semantic type, and the absolute path of the file itself.
+type Locator struct {
+	Scope   Scope
+	ScopeID string
+	Type    Type
+	Path    string
+}
+
+// knownTypes maps a layout <type> directory segment (or a frontmatter
+// metadata.type value) to its Type. Anything not present here resolves to
+// TypeFree.
+var knownTypes = map[string]Type{
+	string(TypeUser):       TypeUser,
+	string(TypeFeedback):   TypeFeedback,
+	string(TypeProject):    TypeProject,
+	string(TypeReference):  TypeReference,
+	string(TypeCheckpoint): TypeCheckpoint,
+	string(TypeProgress):   TypeProgress,
+	string(TypeNotes):      TypeNotes,
+	string(TypeFree):       TypeFree,
+}
+
+// scopeForMarker maps a top-level layout directory name to its Scope.
+var scopeForMarker = map[string]Scope{
+	"global":   ScopeGlobal,
+	"projects": ScopeProjects,
+	"sessions": ScopeSessions,
+}
+
+// typeFromDir maps a <type> directory segment to a Type, defaulting to TypeFree
+// for unknown segments.
+func typeFromDir(seg string) Type {
+	if t, ok := knownTypes[strings.ToLower(seg)]; ok {
+		return t
+	}
+	return TypeFree
+}
+
+// parsePath parses an absolute path in the mimo memory layout, relative to root,
+// into a Locator. Recognized shapes:
+//
+//	<root>/global/<type>/*.md               -> ScopeGlobal,   ScopeID="",        Type from <type>
+//	<root>/projects/<projectId>/<type>/*.md  -> ScopeProjects, ScopeID=projectId, Type from <type>
+//	<root>/sessions/<sessionId>/<type>/*.md  -> ScopeSessions, ScopeID=sessionId, Type from <type>
+//
+// A .md file directly under a scope dir (e.g. <root>/projects/<id>/MEMORY.md, or
+// <root>/global/MEMORY.md) has no <type> segment and resolves to TypeFree.
+// Unknown <type> segments also map to TypeFree. It returns (nil, false) for any
+// path outside root or outside the layout.
+func parsePath(root, absPath string) (*Locator, bool) {
+	rel, ok := relComponents(root, absPath)
+	if !ok || len(rel) == 0 {
+		return nil, false
+	}
+
+	scope, ok := scopeForMarker[rel[0]]
+	if !ok {
+		return nil, false
+	}
+
+	// rest is everything below the top-level scope marker.
+	rest := rel[1:]
+
+	var scopeID string
+	switch scope {
+	case ScopeGlobal:
+		// rest = [<type>/]<file>.md
+	case ScopeProjects, ScopeSessions:
+		// rest = <scopeId>/[<type>/]<file>.md
+		if len(rest) == 0 {
+			return nil, false
+		}
+		scopeID = rest[0]
+		rest = rest[1:]
+	default:
+		return nil, false
+	}
+
+	// A file component is mandatory and must be a Markdown file.
+	if len(rest) == 0 || !isMarkdown(rest[len(rest)-1]) {
+		return nil, false
+	}
+
+	typ := TypeFree
+	if len(rest) >= 2 {
+		// rest = <type>/.../<file>.md — the first segment names the type.
+		typ = typeFromDir(rest[0])
+	}
+
+	return &Locator{
+		Scope:   scope,
+		ScopeID: scopeID,
+		Type:    typ,
+		Path:    filepath.Clean(absPath),
+	}, true
+}
+
+// parseCcPath parses a Claude Code layout path relative to ccBase:
+//
+//	<ccBase>/<slug>/memory/**/*.md -> ScopeCC, ScopeID=<slug>, Type=TypeFree
+//
+// The real type is derived later from the file's YAML frontmatter via
+// parseCcFrontmatterType. It returns (nil, false) for paths outside the layout.
+func parseCcPath(ccBase, absPath string) (*Locator, bool) {
+	rel, ok := relComponents(ccBase, absPath)
+	if !ok {
+		return nil, false
+	}
+	// Need at least <slug>/memory/<file>.md.
+	if len(rel) < 3 || rel[1] != "memory" {
+		return nil, false
+	}
+	if !isMarkdown(rel[len(rel)-1]) {
+		return nil, false
+	}
+	return &Locator{
+		Scope:   ScopeCC,
+		ScopeID: rel[0],
+		Type:    TypeFree,
+		Path:    filepath.Clean(absPath),
+	}, true
+}
+
+// ccFrontmatter is the minimal shape read from a Claude Code memory file's
+// leading YAML frontmatter: either a nested metadata.type or a top-level type.
+type ccFrontmatter struct {
+	Type     string `yaml:"type"`
+	Metadata struct {
+		Type string `yaml:"type"`
+	} `yaml:"metadata"`
+}
+
+// parseCcFrontmatterType reads the semantic type from a leading YAML frontmatter
+// block (a "---" fence at the very start of body). It prefers metadata.type,
+// falling back to a top-level type. Absent, malformed, or unrecognized values
+// yield TypeFree.
+func parseCcFrontmatterType(body string) Type {
+	block, ok := frontmatterBlock(body)
+	if !ok {
+		return TypeFree
+	}
+	var fm ccFrontmatter
+	if err := yaml.Unmarshal([]byte(block), &fm); err != nil {
+		return TypeFree
+	}
+	candidate := fm.Metadata.Type
+	if candidate == "" {
+		candidate = fm.Type
+	}
+	if t, ok := knownTypes[strings.ToLower(strings.TrimSpace(candidate))]; ok {
+		return t
+	}
+	return TypeFree
+}
+
+// resolveProjectId derives a stable project id from an absolute repository path:
+// the first 12 hex characters of sha256(absRepoPath). It is deterministic and is
+// used as the scope_id for the projects scope.
+func resolveProjectId(absRepoPath string) string {
+	sum := sha256.Sum256([]byte(absRepoPath))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+// assertSafeComponent rejects a caller-supplied path component that would escape
+// the memory root: any ".." segment or a leading "/" (absolute path). Empty
+// components are also rejected. The write path uses this to sanitize
+// scope_id/type/filename before joining them under root.
+func assertSafeComponent(name string) error {
+	if name == "" {
+		return fmt.Errorf("memory: empty path component")
+	}
+	if strings.HasPrefix(name, "/") {
+		return fmt.Errorf("memory: unsafe path component %q: leading %q", name, "/")
+	}
+	for _, seg := range strings.Split(filepath.ToSlash(name), "/") {
+		if seg == ".." {
+			return fmt.Errorf("memory: unsafe path component %q: %q segment", name, "..")
+		}
+	}
+	return nil
+}
+
+// relComponents returns absPath expressed relative to base, split into
+// non-empty components. ok is false when absPath is not located under base.
+func relComponents(base, absPath string) (parts []string, ok bool) {
+	rel, err := filepath.Rel(filepath.Clean(base), filepath.Clean(absPath))
+	if err != nil {
+		return nil, false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." || rel == "" {
+		return nil, false
+	}
+	// Escaping base (e.g. "../foo") means the path is outside the layout.
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return nil, false
+	}
+	return strings.Split(rel, "/"), true
+}
+
+// isMarkdown reports whether name has a .md extension (case-insensitive).
+func isMarkdown(name string) bool {
+	return strings.EqualFold(filepath.Ext(name), ".md")
+}
+
+// frontmatterBlock returns the raw YAML between a leading "---" fence and the
+// next "---" line. ok is false when body has no opening fence at its very start.
+func frontmatterBlock(body string) (string, bool) {
+	rest := strings.ReplaceAll(body, "\r\n", "\n")
+	if !strings.HasPrefix(rest, "---\n") {
+		return "", false
+	}
+	rest = strings.TrimPrefix(rest, "---\n")
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return "", false
+	}
+	return rest[:end], true
+}

--- a/internal/memory/paths_test.go
+++ b/internal/memory/paths_test.go
@@ -1,0 +1,203 @@
+package memory
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestParsePathScopesAndTypes(t *testing.T) {
+	root := "/mem/root"
+
+	cases := []struct {
+		name    string
+		path    string
+		scope   Scope
+		scopeID string
+		typ     Type
+	}{
+		{
+			name:  "global with type dir",
+			path:  filepath.Join(root, "global", "user", "profile.md"),
+			scope: ScopeGlobal, scopeID: "", typ: TypeUser,
+		},
+		{
+			name:  "global unknown type dir -> free",
+			path:  filepath.Join(root, "global", "whatever", "x.md"),
+			scope: ScopeGlobal, scopeID: "", typ: TypeFree,
+		},
+		{
+			name:  "global file directly under scope -> free",
+			path:  filepath.Join(root, "global", "MEMORY.md"),
+			scope: ScopeGlobal, scopeID: "", typ: TypeFree,
+		},
+		{
+			name:  "projects with type dir",
+			path:  filepath.Join(root, "projects", "abc123", "checkpoint", "c1.md"),
+			scope: ScopeProjects, scopeID: "abc123", typ: TypeCheckpoint,
+		},
+		{
+			name:  "projects file directly under id -> free",
+			path:  filepath.Join(root, "projects", "abc123", "MEMORY.md"),
+			scope: ScopeProjects, scopeID: "abc123", typ: TypeFree,
+		},
+		{
+			name:  "sessions with type dir",
+			path:  filepath.Join(root, "sessions", "sess-1", "notes", "n.md"),
+			scope: ScopeSessions, scopeID: "sess-1", typ: TypeNotes,
+		},
+		{
+			name:  "sessions progress type",
+			path:  filepath.Join(root, "sessions", "sess-1", "progress", "p.md"),
+			scope: ScopeSessions, scopeID: "sess-1", typ: TypeProgress,
+		},
+		{
+			name:  "nested file under type dir keeps type",
+			path:  filepath.Join(root, "projects", "abc123", "reference", "sub", "r.md"),
+			scope: ScopeProjects, scopeID: "abc123", typ: TypeReference,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			loc, ok := parsePath(root, tc.path)
+			if !ok {
+				t.Fatalf("parsePath(%q) returned ok=false", tc.path)
+			}
+			if loc.Scope != tc.scope {
+				t.Errorf("scope = %q, want %q", loc.Scope, tc.scope)
+			}
+			if loc.ScopeID != tc.scopeID {
+				t.Errorf("scopeID = %q, want %q", loc.ScopeID, tc.scopeID)
+			}
+			if loc.Type != tc.typ {
+				t.Errorf("type = %q, want %q", loc.Type, tc.typ)
+			}
+			if loc.Path != filepath.Clean(tc.path) {
+				t.Errorf("path = %q, want %q", loc.Path, filepath.Clean(tc.path))
+			}
+		})
+	}
+}
+
+func TestParsePathOutsideLayout(t *testing.T) {
+	root := "/mem/root"
+	bad := []string{
+		"/other/place/x.md",                         // outside root
+		filepath.Join(root, "unknownscope", "x.md"), // not a layout scope
+		filepath.Join(root, "global"),               // no file component
+		filepath.Join(root, "projects", "abc123"),   // scope id dir, no file
+		filepath.Join(root, "global", "user", "x.txt"), // not markdown
+	}
+	for _, p := range bad {
+		if loc, ok := parsePath(root, p); ok {
+			t.Errorf("parsePath(%q) = %+v, ok=true; want ok=false", p, loc)
+		}
+	}
+}
+
+func TestParseCcPath(t *testing.T) {
+	base := "/home/u/.claude/projects"
+
+	loc, ok := parseCcPath(base, filepath.Join(base, "my-slug", "memory", "some", "note.md"))
+	if !ok {
+		t.Fatalf("parseCcPath returned ok=false")
+	}
+	if loc.Scope != ScopeCC {
+		t.Errorf("scope = %q, want %q", loc.Scope, ScopeCC)
+	}
+	if loc.ScopeID != "my-slug" {
+		t.Errorf("scopeID = %q, want %q", loc.ScopeID, "my-slug")
+	}
+	if loc.Type != TypeFree {
+		t.Errorf("type = %q, want %q", loc.Type, TypeFree)
+	}
+
+	bad := []string{
+		filepath.Join(base, "my-slug", "note.md"),            // no memory segment
+		filepath.Join(base, "my-slug", "notmemory", "n.md"),  // wrong segment
+		filepath.Join(base, "my-slug", "memory", "note.txt"), // not markdown
+		"/elsewhere/x/memory/n.md",                           // outside base
+	}
+	for _, p := range bad {
+		if loc, ok := parseCcPath(base, p); ok {
+			t.Errorf("parseCcPath(%q) = %+v, ok=true; want ok=false", p, loc)
+		}
+	}
+}
+
+func TestParseCcFrontmatterType(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want Type
+	}{
+		{
+			name: "nested metadata.type present",
+			body: "---\nmetadata:\n  type: reference\n  other: x\n---\nbody here\n",
+			want: TypeReference,
+		},
+		{
+			name: "top-level type present",
+			body: "---\ntype: feedback\n---\nbody\n",
+			want: TypeFeedback,
+		},
+		{
+			name: "metadata.type wins over top-level",
+			body: "---\ntype: free\nmetadata:\n  type: project\n---\n",
+			want: TypeProject,
+		},
+		{
+			name: "absent frontmatter",
+			body: "no frontmatter here\n",
+			want: TypeFree,
+		},
+		{
+			name: "empty frontmatter",
+			body: "---\n---\nbody\n",
+			want: TypeFree,
+		},
+		{
+			name: "unknown type value",
+			body: "---\nmetadata:\n  type: bogus\n---\n",
+			want: TypeFree,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseCcFrontmatterType(tc.body); got != tc.want {
+				t.Errorf("parseCcFrontmatterType = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveProjectId(t *testing.T) {
+	const p = "/Users/dev/repo"
+	a := resolveProjectId(p)
+	b := resolveProjectId(p)
+	if a != b {
+		t.Errorf("resolveProjectId not stable: %q != %q", a, b)
+	}
+	if len(a) != 12 {
+		t.Errorf("resolveProjectId length = %d, want 12", len(a))
+	}
+	if resolveProjectId("/Users/dev/other") == a {
+		t.Errorf("resolveProjectId collided for distinct paths")
+	}
+}
+
+func TestAssertSafeComponent(t *testing.T) {
+	ok := []string{"user", "abc123", "sub/dir/file.md", "checkpoint"}
+	for _, s := range ok {
+		if err := assertSafeComponent(s); err != nil {
+			t.Errorf("assertSafeComponent(%q) = %v, want nil", s, err)
+		}
+	}
+
+	bad := []string{"", "..", "../etc", "a/../b", "/etc/passwd", "sub/../../x"}
+	for _, s := range bad {
+		if err := assertSafeComponent(s); err == nil {
+			t.Errorf("assertSafeComponent(%q) = nil, want error", s)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- parsePath/parseCcPath resolve scope/scope_id/type from disk layout
- parseCcFrontmatterType reads metadata.type from YAML frontmatter
- resolveProjectId = sha256(path)[:12]; assertSafeComponent guards traversal

Closes #474