### PR TITLE
feat(runtime): checkpoint persistence + watermark (#480)

### DIFF
--- a/internal/runtime/checkpoint.go
+++ b/internal/runtime/checkpoint.go
@@ -1,0 +1,193 @@
+// Checkpoint persistence for the "infinite context" feature (#480). A checkpoint
+// is a distilled summary of a conversation *prefix* — everything up to a
+// watermark message index — persisted as a Markdown memory file so a later run
+// can reload the collapsed context instead of replaying (and re-tokenizing) the
+// whole transcript.
+//
+// The file lives at <memoryRoot>/sessions/<sessionID>/checkpoint.md and carries
+// the repo's standard YAML frontmatter (name/description/metadata.type) with the
+// checkpoint bookkeeping (watermark, createdAt, covered message count) under
+// metadata; the Summary is the Markdown body. This mirrors the memory-file
+// convention (see internal/memory, TypeCheckpoint = "checkpoint") so the memory
+// indexer can pick these files up unchanged.
+//
+// This node provides only the persistence primitives plus the summarize→
+// Checkpoint bridge. Wiring into the run loop (#481) is deliberately out of
+// scope: a checkpoint write failure is returned to the caller, which is expected
+// to log-and-continue rather than abort the turn.
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"gopkg.in/yaml.v3"
+)
+
+// Checkpoint is a distilled summary of the conversation up to (and including)
+// Watermark. It is the in-memory form written to / read from checkpoint.md.
+type Checkpoint struct {
+	// Watermark is the message index the checkpoint summarizes up to: messages
+	// [0, Watermark) are collapsed into Summary. A resumed run replays only the
+	// tail after Watermark, prepending Summary as the collapsed context.
+	Watermark int
+	// Summary is the distilled context (the Markdown body of checkpoint.md),
+	// produced by the summarization LLM call (see compaction.GenerateSummary).
+	Summary string
+	// CreatedAt is when the checkpoint was distilled (RFC 3339, UTC).
+	CreatedAt time.Time
+	// CoveredMessages is how many messages the summary actually folded in. It
+	// usually equals Watermark for a linear prefix but is recorded separately so
+	// a caller that checkpoints a non-contiguous slice still keeps an honest count.
+	CoveredMessages int
+}
+
+// SummarizeFunc distills a slice of conversation messages into a single summary
+// string. It is the seam that lets BuildCheckpoint reuse compaction.GenerateSummary
+// without this package depending on the provider stack: the caller supplies a
+// closure over GenerateSummary (binding ctx/stream/model/cfg), and BuildCheckpoint
+// invokes it. A summarization error is propagated, never swallowed.
+type SummarizeFunc func(ctx context.Context, msgs []agentcore.Message) (string, error)
+
+// checkpointFrontmatter is the YAML head of checkpoint.md. It matches the repo's
+// name/description/metadata convention (mirrors SkillFrontmatter and the memory
+// file layout) so the file is a well-formed memory document.
+type checkpointFrontmatter struct {
+	Name        string             `yaml:"name"`
+	Description string             `yaml:"description"`
+	Metadata    checkpointMetadata `yaml:"metadata"`
+}
+
+// checkpointMetadata carries the checkpoint bookkeeping under metadata. Type is
+// fixed to "checkpoint" (memory.TypeCheckpoint) so the memory indexer classifies
+// it correctly.
+type checkpointMetadata struct {
+	Type            string    `yaml:"type"`
+	Watermark       int       `yaml:"watermark"`
+	CreatedAt       time.Time `yaml:"createdAt"`
+	CoveredMessages int       `yaml:"coveredMessages"`
+}
+
+// checkpointType is the metadata.type value for a checkpoint memory file. It is
+// duplicated here (rather than importing internal/memory) to keep this package's
+// dependency surface minimal; the two must stay in sync.
+const checkpointType = "checkpoint"
+
+// CheckpointPath returns the on-disk path of a session's checkpoint file:
+// <memoryRoot>/sessions/<sessionID>/checkpoint.md.
+func CheckpointPath(sessionID, memoryRoot string) string {
+	return filepath.Join(memoryRoot, "sessions", sessionID, "checkpoint.md")
+}
+
+// BuildCheckpoint distills msgs into a Checkpoint by invoking summarize, tagging
+// the result with watermark and now (coerced to UTC). It performs no I/O — the
+// caller persists the result with WriteCheckpoint — so the (potentially slow,
+// potentially failing) summarization call stays off the write path. A nil
+// summarize or a summarization error is returned as an error.
+func BuildCheckpoint(ctx context.Context, msgs []agentcore.Message, watermark int, now time.Time, summarize SummarizeFunc) (Checkpoint, error) {
+	if summarize == nil {
+		return Checkpoint{}, fmt.Errorf("runtime: BuildCheckpoint: nil summarize func")
+	}
+	summary, err := summarize(ctx, msgs)
+	if err != nil {
+		return Checkpoint{}, fmt.Errorf("runtime: distill checkpoint: %w", err)
+	}
+	return Checkpoint{
+		Watermark:       watermark,
+		Summary:         summary,
+		CreatedAt:       now.UTC(),
+		CoveredMessages: len(msgs),
+	}, nil
+}
+
+// WriteCheckpoint persists cp as <memoryRoot>/sessions/<sessionID>/checkpoint.md,
+// creating parent directories (0o755). It writes to a temp file and atomically
+// renames it into place so a concurrent reader never sees a half-written file.
+// The write is intended to be non-fatal to callers: on error the on-disk file is
+// left untouched and the error is returned for the caller to log-and-continue.
+func WriteCheckpoint(sessionID, memoryRoot string, cp Checkpoint) error {
+	if sessionID == "" {
+		return fmt.Errorf("runtime: WriteCheckpoint: empty sessionID")
+	}
+	path := CheckpointPath(sessionID, memoryRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("runtime: create checkpoint dir: %w", err)
+	}
+
+	doc, err := renderCheckpoint(cp)
+	if err != nil {
+		return err
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, doc, 0o644); err != nil {
+		return fmt.Errorf("runtime: write checkpoint temp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("runtime: commit checkpoint: %w", err)
+	}
+	return nil
+}
+
+// renderCheckpoint serializes cp into the checkpoint.md byte form: a "---"-fenced
+// YAML frontmatter block followed by the Summary as the Markdown body.
+func renderCheckpoint(cp Checkpoint) ([]byte, error) {
+	fm := checkpointFrontmatter{
+		Name:        "checkpoint",
+		Description: fmt.Sprintf("Conversation checkpoint at watermark %d (%d messages).", cp.Watermark, cp.CoveredMessages),
+		Metadata: checkpointMetadata{
+			Type:            checkpointType,
+			Watermark:       cp.Watermark,
+			CreatedAt:       cp.CreatedAt.UTC(),
+			CoveredMessages: cp.CoveredMessages,
+		},
+	}
+	fmBytes, err := yaml.Marshal(fm)
+	if err != nil {
+		return nil, fmt.Errorf("runtime: encode checkpoint frontmatter: %w", err)
+	}
+	var b bytes.Buffer
+	b.WriteString("---\n")
+	b.Write(fmBytes)
+	b.WriteString("---\n\n")
+	b.WriteString(cp.Summary)
+	return b.Bytes(), nil
+}
+
+// LoadCheckpoint reads and parses the checkpoint for sessionID under memoryRoot.
+// It returns (nil, false, nil) when the file does not exist — a missing
+// checkpoint is a normal "no collapsed context yet" state, not an error. A
+// present-but-malformed file yields a non-nil error.
+func LoadCheckpoint(sessionID, memoryRoot string) (*Checkpoint, bool, error) {
+	path := CheckpointPath(sessionID, memoryRoot)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("runtime: read checkpoint: %w", err)
+	}
+
+	fmBytes, body, err := splitFrontmatter(content)
+	if err != nil {
+		return nil, false, fmt.Errorf("runtime: parse checkpoint %s: %w", path, err)
+	}
+	var fm checkpointFrontmatter
+	if err := yaml.Unmarshal(fmBytes, &fm); err != nil {
+		return nil, false, fmt.Errorf("runtime: decode checkpoint frontmatter %s: %w", path, err)
+	}
+
+	cp := &Checkpoint{
+		Watermark:       fm.Metadata.Watermark,
+		Summary:         string(bytes.TrimLeft(body, "\r\n")),
+		CreatedAt:       fm.Metadata.CreatedAt.UTC(),
+		CoveredMessages: fm.Metadata.CoveredMessages,
+	}
+	return cp, true, nil
+}

--- a/internal/runtime/checkpoint_test.go
+++ b/internal/runtime/checkpoint_test.go
@@ -1,0 +1,138 @@
+package runtime
+
+// Tests for checkpoint persistence (#480): the write→load round-trip, the
+// missing-file sentinel, and the summarize→Checkpoint bridge. They drive the
+// real filesystem via t.TempDir(), matching the session/memory test style.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// TestCheckpointRoundTrip is the core acceptance check: a written checkpoint
+// loads back with watermark, summary, createdAt, and covered count preserved.
+func TestCheckpointRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	created := time.Date(2026, 8, 1, 9, 30, 0, 0, time.UTC)
+	cp := Checkpoint{
+		Watermark:       42,
+		Summary:         "The user asked to refactor foo().\nWe extracted a helper and added tests.",
+		CreatedAt:       created,
+		CoveredMessages: 42,
+	}
+	if err := WriteCheckpoint("sess-abc", root, cp); err != nil {
+		t.Fatalf("WriteCheckpoint: %v", err)
+	}
+
+	got, ok, err := LoadCheckpoint("sess-abc", root)
+	if err != nil {
+		t.Fatalf("LoadCheckpoint: %v", err)
+	}
+	if !ok {
+		t.Fatal("LoadCheckpoint: found = false, want true")
+	}
+	if got.Watermark != cp.Watermark {
+		t.Errorf("Watermark = %d, want %d", got.Watermark, cp.Watermark)
+	}
+	if got.CoveredMessages != cp.CoveredMessages {
+		t.Errorf("CoveredMessages = %d, want %d", got.CoveredMessages, cp.CoveredMessages)
+	}
+	if got.Summary != cp.Summary {
+		t.Errorf("Summary = %q, want %q", got.Summary, cp.Summary)
+	}
+	if !got.CreatedAt.Equal(cp.CreatedAt) {
+		t.Errorf("CreatedAt = %v, want %v", got.CreatedAt, cp.CreatedAt)
+	}
+}
+
+// TestCheckpointFileLayoutAndFrontmatter verifies the file lands at the expected
+// path and carries the repo's name/description/metadata.type=checkpoint convention.
+func TestCheckpointFileLayoutAndFrontmatter(t *testing.T) {
+	root := t.TempDir()
+	cp := Checkpoint{Watermark: 3, Summary: "body text", CreatedAt: time.Now().UTC(), CoveredMessages: 3}
+	if err := WriteCheckpoint("s1", root, cp); err != nil {
+		t.Fatalf("WriteCheckpoint: %v", err)
+	}
+	want := filepath.Join(root, "sessions", "s1", "checkpoint.md")
+	if want != CheckpointPath("s1", root) {
+		t.Fatalf("CheckpointPath = %q, want %q", CheckpointPath("s1", root), want)
+	}
+	content, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("read checkpoint file: %v", err)
+	}
+	fm, _, err := splitFrontmatter(content)
+	if err != nil {
+		t.Fatalf("splitFrontmatter: %v", err)
+	}
+	s := string(fm)
+	for _, needle := range []string{"name: checkpoint", "type: checkpoint", "watermark: 3"} {
+		if !strings.Contains(s, needle) {
+			t.Errorf("frontmatter missing %q; got:\n%s", needle, s)
+		}
+	}
+}
+
+// TestLoadCheckpointMissing verifies a missing checkpoint is the (nil,false,nil)
+// sentinel, not an error — callers treat "no checkpoint yet" as normal.
+func TestLoadCheckpointMissing(t *testing.T) {
+	root := t.TempDir()
+	cp, ok, err := LoadCheckpoint("nope", root)
+	if err != nil {
+		t.Fatalf("LoadCheckpoint on missing file: err = %v, want nil", err)
+	}
+	if ok {
+		t.Error("found = true, want false")
+	}
+	if cp != nil {
+		t.Errorf("checkpoint = %+v, want nil", cp)
+	}
+}
+
+// TestBuildCheckpoint verifies the summarize bridge tags the result with the
+// watermark, covered count, and a UTC createdAt.
+func TestBuildCheckpoint(t *testing.T) {
+	msgs := []agentcore.Message{
+		agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent("hi")}},
+		agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant, Content: agentcore.ContentList{agentcore.NewTextContent("hello")}},
+	}
+	now := time.Date(2026, 8, 1, 10, 0, 0, 0, time.FixedZone("x", 3600))
+	summarize := func(ctx context.Context, m []agentcore.Message) (string, error) {
+		if len(m) != len(msgs) {
+			t.Errorf("summarize got %d msgs, want %d", len(m), len(msgs))
+		}
+		return "distilled", nil
+	}
+	cp, err := BuildCheckpoint(context.Background(), msgs, 2, now, summarize)
+	if err != nil {
+		t.Fatalf("BuildCheckpoint: %v", err)
+	}
+	if cp.Summary != "distilled" {
+		t.Errorf("Summary = %q, want %q", cp.Summary, "distilled")
+	}
+	if cp.Watermark != 2 || cp.CoveredMessages != 2 {
+		t.Errorf("Watermark/Covered = %d/%d, want 2/2", cp.Watermark, cp.CoveredMessages)
+	}
+	if cp.CreatedAt.Location() != time.UTC {
+		t.Errorf("CreatedAt not UTC: %v", cp.CreatedAt)
+	}
+}
+
+// TestBuildCheckpointPropagatesError verifies a summarization failure surfaces
+// as an error rather than a partial checkpoint (write path never runs).
+func TestBuildCheckpointPropagatesError(t *testing.T) {
+	boom := errors.New("summarize failed")
+	_, err := BuildCheckpoint(context.Background(), nil, 0, time.Now(), func(context.Context, []agentcore.Message) (string, error) {
+		return "", boom
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want wrapping %v", err, boom)
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -75,6 +75,15 @@ type SessionHeader struct {
 	// (US-006, #122). Empty for a session created from scratch. It records
 	// lineage only; a fork is otherwise a fully independent session file.
 	ParentSession string `json:"parentSession,omitempty"`
+	// ContextFrom is the id of the session this one inherited its collapsed
+	// context from (#480, "infinite context"). Empty when the session started
+	// with no inherited checkpoint. Optional and additive: older schemas (v1/v2/v3)
+	// omit it and still load.
+	ContextFrom string `json:"contextFrom,omitempty"`
+	// ContextWatermark is the message index up to which context was collapsed
+	// into an inherited checkpoint (#480). Messages before this index live in the
+	// checkpoint summary rather than the replayed transcript. Optional/additive.
+	ContextWatermark int `json:"contextWatermark,omitempty"`
 }
 
 // Entry wraps one persisted message with the tree metadata introduced in schema

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -686,3 +686,51 @@ func TestSaveLoadCompactionEntry(t *testing.T) {
 		t.Fatalf("compaction fields: %+v", cm)
 	}
 }
+
+// TestContextHeaderFieldsRoundTrip verifies the additive "infinite context"
+// header fields (#480) — ContextFrom/ContextWatermark — survive a Save→Load
+// round-trip through the real session file path.
+func TestContextHeaderFieldsRoundTrip(t *testing.T) {
+	s := newStore(t)
+	now := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	header := SessionHeader{
+		ID:               NewID(now),
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		ContextFrom:      "parent-sess-123",
+		ContextWatermark: 37,
+	}
+	if err := s.Save(header, sampleMessages()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, _, err := s.Load(header.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.ContextFrom != "parent-sess-123" {
+		t.Errorf("ContextFrom = %q, want %q", got.ContextFrom, "parent-sess-123")
+	}
+	if got.ContextWatermark != 37 {
+		t.Errorf("ContextWatermark = %d, want 37", got.ContextWatermark)
+	}
+}
+
+// TestContextHeaderFieldsOmittedWhenZero verifies the fields are omitempty: a
+// header without them serializes without the keys, keeping v1/v2/v3 files
+// byte-compatible for the common no-inherited-context case.
+func TestContextHeaderFieldsOmittedWhenZero(t *testing.T) {
+	s := newStore(t)
+	now := time.Now().UTC()
+	header := SessionHeader{ID: "no-ctx", CreatedAt: now, UpdatedAt: now}
+	if err := s.Save(header, sampleMessages()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(s.Dir(), FileName("no-ctx")))
+	if err != nil {
+		t.Fatalf("read session file: %v", err)
+	}
+	headerLine := strings.SplitN(string(raw), "\n", 2)[0]
+	if strings.Contains(headerLine, "contextFrom") || strings.Contains(headerLine, "contextWatermark") {
+		t.Errorf("zero context fields must be omitted; header line = %s", headerLine)
+	}
+}


### PR DESCRIPTION
## Summary
- Checkpoint struct + WriteCheckpoint/LoadCheckpoint (sessions/<id>/checkpoint.md, frontmatter type=checkpoint)
- SessionHeader gains optional contextFrom/contextWatermark (additive, v3-compatible)
- Reuses compaction.GenerateSummary via a SummarizeFunc seam; write failure is non-fatal

Closes #480