### PR TITLE
feat(session): context inheritance plumbing (#483)

### DIFF
--- a/internal/session/inherit.go
+++ b/internal/session/inherit.go
@@ -1,0 +1,56 @@
+package session
+
+// Context inheritance plumbing for the "infinite context" feature (#483, built
+// on the header fields added by #480). A session created to *continue* another
+// session's collapsed context records two things on its header:
+//
+//   - ContextFrom: the source session id whose checkpoint holds the collapsed
+//     prefix (see runtime.LoadCheckpoint / CheckpointPath).
+//   - ContextWatermark: the message index up to which that prefix was collapsed;
+//     on resume/fork the runtime (#481) can load the source checkpoint and skip
+//     re-summarizing messages [0, ContextWatermark).
+//
+// This is deliberately side-effect-free header plumbing: it never touches the
+// memory dir or the runtime. It sits alongside ParentSession (which records
+// lineage) — inheritance additionally records *where the collapsed context came
+// from* so a forked/continued session need not re-summarize early context.
+
+// SetContextInheritance records on header that this session continues fromID's
+// collapsed context up to watermark. A non-positive watermark or an empty fromID
+// clears inheritance (both fields reset to their zero/omitempty state), so the
+// header round-trips as a session with no inherited checkpoint. This mirrors how
+// ParentSession is a plain header field set at creation time.
+func SetContextInheritance(header *SessionHeader, fromID string, watermark int) {
+	if header == nil {
+		return
+	}
+	if fromID == "" || watermark <= 0 {
+		header.ContextFrom = ""
+		header.ContextWatermark = 0
+		return
+	}
+	header.ContextFrom = fromID
+	header.ContextWatermark = watermark
+}
+
+// ContextInheritance reports the inherited-context source recorded on header:
+// the source session id, the watermark, and whether inheritance is set. It is
+// the read counterpart to SetContextInheritance — a convenience accessor the
+// runtime (#481) uses on resume/fork to decide whether to load the source
+// checkpoint. ok is true only when a non-empty source and a positive watermark
+// are both present, so a header with only one of the two (a malformed or
+// partially written record) reports ok=false rather than a half-configured
+// inheritance.
+func (h SessionHeader) ContextInheritance() (fromID string, watermark int, ok bool) {
+	if h.ContextFrom == "" || h.ContextWatermark <= 0 {
+		return "", 0, false
+	}
+	return h.ContextFrom, h.ContextWatermark, true
+}
+
+// HasContextInheritance reports whether header declares inherited collapsed
+// context. It is shorthand for the ok return of ContextInheritance.
+func (h SessionHeader) HasContextInheritance() bool {
+	_, _, ok := h.ContextInheritance()
+	return ok
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -734,3 +734,110 @@ func TestContextHeaderFieldsOmittedWhenZero(t *testing.T) {
 		t.Errorf("zero context fields must be omitted; header line = %s", headerLine)
 	}
 }
+
+// TestSetContextInheritanceRoundTrips verifies that a session created with
+// inheritance set via SetContextInheritance writes both fields and exposes them
+// (via the ContextInheritance accessor) when read back.
+func TestSetContextInheritanceRoundTrips(t *testing.T) {
+	s := newStore(t)
+	now := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	header := SessionHeader{ID: NewID(now), CreatedAt: now, UpdatedAt: now}
+	SetContextInheritance(&header, "src-sess-42", 12)
+
+	if err := s.Save(header, sampleMessages()); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, _, err := s.Load(header.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	fromID, watermark, ok := got.ContextInheritance()
+	if !ok {
+		t.Fatalf("ContextInheritance ok = false, want true")
+	}
+	if fromID != "src-sess-42" || watermark != 12 {
+		t.Errorf("ContextInheritance = (%q, %d), want (%q, 12)", fromID, watermark, "src-sess-42")
+	}
+	if !got.HasContextInheritance() {
+		t.Errorf("HasContextInheritance = false, want true")
+	}
+}
+
+// TestSetContextInheritanceClears verifies an empty source or non-positive
+// watermark clears both fields, so the header round-trips as a no-inheritance
+// session (omitempty keeps it byte-compatible with older files).
+func TestSetContextInheritanceClears(t *testing.T) {
+	cases := []struct {
+		name      string
+		fromID    string
+		watermark int
+	}{
+		{"empty source", "", 5},
+		{"zero watermark", "src", 0},
+		{"negative watermark", "src", -3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			header := SessionHeader{ID: "h", ContextFrom: "stale", ContextWatermark: 99}
+			SetContextInheritance(&header, tc.fromID, tc.watermark)
+			if header.ContextFrom != "" || header.ContextWatermark != 0 {
+				t.Errorf("expected cleared inheritance, got (%q, %d)", header.ContextFrom, header.ContextWatermark)
+			}
+			if header.HasContextInheritance() {
+				t.Errorf("HasContextInheritance = true after clear")
+			}
+		})
+	}
+}
+
+// TestContextInheritanceRejectsPartial verifies the accessor treats a header
+// with only one of the two fields as "no inheritance" (ok=false) rather than
+// reporting a half-configured record.
+func TestContextInheritanceRejectsPartial(t *testing.T) {
+	onlyFrom := SessionHeader{ContextFrom: "src"}
+	if _, _, ok := onlyFrom.ContextInheritance(); ok {
+		t.Errorf("ok = true for header with source but no watermark")
+	}
+	onlyWatermark := SessionHeader{ContextWatermark: 8}
+	if _, _, ok := onlyWatermark.ContextInheritance(); ok {
+		t.Errorf("ok = true for header with watermark but no source")
+	}
+}
+
+// TestLoadedSessionsWithoutInheritanceReadZero verifies backward compatibility:
+// v1/v2/v3 sessions written without the inheritance fields load with zero-value
+// ContextFrom/ContextWatermark and report HasContextInheritance()=false.
+func TestLoadedSessionsWithoutInheritanceReadZero(t *testing.T) {
+	s := newStore(t)
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	// v3 written through the normal path (no inheritance set).
+	v3 := SessionHeader{ID: "v3-noctx", CreatedAt: now, UpdatedAt: now}
+	if err := s.Save(v3, sampleMessages()); err != nil {
+		t.Fatalf("Save v3: %v", err)
+	}
+
+	// Hand-crafted v1 and v2 fixtures (bare message lines, no context fields).
+	msgLine := `{"role":"user","content":[{"type":"text","text":"hi"}]}`
+	if err := writeFile(filepath.Join(s.Dir(), FileName("v1-noctx")),
+		`{"version":1,"id":"v1-noctx","createdAt":"2026-01-02T03:04:05Z","updatedAt":"2026-01-02T03:04:05Z"}`+"\n"+msgLine+"\n"); err != nil {
+		t.Fatalf("write v1 fixture: %v", err)
+	}
+	if err := writeFile(filepath.Join(s.Dir(), FileName("v2-noctx")),
+		`{"version":2,"id":"v2-noctx","createdAt":"2026-01-02T03:04:05Z","updatedAt":"2026-01-02T03:04:05Z"}`+"\n"+msgLine+"\n"); err != nil {
+		t.Fatalf("write v2 fixture: %v", err)
+	}
+
+	for _, id := range []string{"v3-noctx", "v1-noctx", "v2-noctx"} {
+		got, _, err := s.Load(id)
+		if err != nil {
+			t.Fatalf("Load %s: %v", id, err)
+		}
+		if got.ContextFrom != "" || got.ContextWatermark != 0 {
+			t.Errorf("%s: expected zero inheritance, got (%q, %d)", id, got.ContextFrom, got.ContextWatermark)
+		}
+		if got.HasContextInheritance() {
+			t.Errorf("%s: HasContextInheritance = true, want false", id)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Helpers to set/read ContextFrom + ContextWatermark on a session header
- New session can declare it continues another session collapsed context
- Fields round-trip through write/read; v1/v2/v3 still load

Closes #483