### PR TITLE
feat(memory): reconcile lazy sync + fingerprints (#475)

### DIFF
--- a/internal/memory/reconcile.go
+++ b/internal/memory/reconcile.go
@@ -1,0 +1,235 @@
+package memory
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Result reports what a Reconcile pass changed: Indexed counts rows inserted or
+// updated (new or changed files), Pruned counts rows deleted because their file
+// no longer exists on disk.
+type Result struct {
+	Indexed int
+	Pruned  int
+}
+
+// walkMemoryDir recursively collects every *.md file under root. A missing root
+// (ENOENT) yields an empty slice and no error, so reconcile is safe to run
+// before the memory directory has been created.
+func walkMemoryDir(root string) ([]string, error) {
+	var out []string
+	var recurse func(dir string) error
+	recurse = func(dir string) error {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		for _, entry := range entries {
+			full := filepath.Join(dir, entry.Name())
+			if entry.IsDir() {
+				if err := recurse(full); err != nil {
+					return err
+				}
+			} else if entry.Type().IsRegular() && isMarkdown(entry.Name()) {
+				out = append(out, full)
+			}
+		}
+		return nil
+	}
+	if err := recurse(root); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// walkCcRoot collects every <base>/<slug>/memory/**/*.md file. A missing base
+// (ENOENT) yields an empty slice; slugs without a memory subdirectory are
+// silently skipped.
+func walkCcRoot(base string) ([]string, error) {
+	slugs, err := os.ReadDir(base)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []string
+	for _, entry := range slugs {
+		if !entry.IsDir() {
+			continue
+		}
+		memoryDir := filepath.Join(base, entry.Name(), "memory")
+		info, err := os.Stat(memoryDir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		files, err := walkMemoryDir(memoryDir)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, files...)
+	}
+	return out, nil
+}
+
+// Reconcile performs a lazy sync between the memory files on disk and the
+// memory_index table. It walks both the mimo root and (when configured) the cc
+// base, prunes rows whose file no longer exists, and indexes new or changed
+// files. Unchanged files are skipped via a size-mtime fingerprint. The FTS
+// index is kept consistent by the memory_ai/ad/au triggers, so only
+// memory_index is touched here.
+func (s *Store) Reconcile() (Result, error) {
+	var res Result
+
+	// Collect disk paths from BOTH roots BEFORE pruning. Pruning per-root would
+	// wrongly wipe the other root's rows, because each walk's set is missing the
+	// other root's paths.
+	mimoFiles, err := walkMemoryDir(s.root)
+	if err != nil {
+		return res, fmt.Errorf("memory: walk mimo root %q: %w", s.root, err)
+	}
+	var ccFiles []string
+	if s.ccBase != "" {
+		ccFiles, err = walkCcRoot(s.ccBase)
+		if err != nil {
+			return res, fmt.Errorf("memory: walk cc base %q: %w", s.ccBase, err)
+		}
+	}
+
+	diskPaths := make(map[string]struct{}, len(mimoFiles)+len(ccFiles))
+	for _, p := range mimoFiles {
+		diskPaths[filepath.Clean(p)] = struct{}{}
+	}
+	for _, p := range ccFiles {
+		diskPaths[filepath.Clean(p)] = struct{}{}
+	}
+
+	// Load existing {path -> fingerprint} from memory_index.
+	existing, err := s.loadFingerprints()
+	if err != nil {
+		return res, err
+	}
+
+	// PRUNE: delete rows whose path is no longer on disk.
+	for p := range existing {
+		if _, ok := diskPaths[p]; ok {
+			continue
+		}
+		if _, err := s.db.Exec(`DELETE FROM memory_index WHERE path = ?`, p); err != nil {
+			return res, fmt.Errorf("memory: prune %q: %w", p, err)
+		}
+		res.Pruned++
+	}
+
+	// INDEX: mimo files use parsePath and keep loc.Type.
+	for _, p := range mimoFiles {
+		loc, ok := parsePath(s.root, p)
+		if !ok {
+			continue
+		}
+		updated, err := s.indexFile(loc, loc.Type, false, existing[filepath.Clean(p)])
+		if err != nil {
+			return res, err
+		}
+		if updated {
+			res.Indexed++
+		}
+	}
+
+	// INDEX: cc files use parseCcPath; final type is derived from frontmatter.
+	for _, p := range ccFiles {
+		loc, ok := parseCcPath(s.ccBase, p)
+		if !ok {
+			continue
+		}
+		updated, err := s.indexFile(loc, loc.Type, true, existing[filepath.Clean(p)])
+		if err != nil {
+			return res, err
+		}
+		if updated {
+			res.Indexed++
+		}
+	}
+
+	return res, nil
+}
+
+// loadFingerprints returns the current {path -> fingerprint} map from
+// memory_index.
+func (s *Store) loadFingerprints() (map[string]string, error) {
+	rows, err := s.db.Query(`SELECT path, fingerprint FROM memory_index`)
+	if err != nil {
+		return nil, fmt.Errorf("memory: load fingerprints: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]string)
+	for rows.Next() {
+		var path, fp string
+		if err := rows.Scan(&path, &fp); err != nil {
+			return nil, fmt.Errorf("memory: scan fingerprint: %w", err)
+		}
+		out[path] = fp
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("memory: iterate fingerprints: %w", err)
+	}
+	return out, nil
+}
+
+// indexFile stats loc.Path, computes its size-mtime fingerprint, and upserts the
+// row when the fingerprint differs from oldFingerprint. It returns true when a
+// row was inserted or updated. A file that vanished between the walk and the
+// stat (ENOENT) is silently skipped. For cc files (isCc) the semantic type is
+// derived from the file's YAML frontmatter, falling back to defaultType.
+func (s *Store) indexFile(loc *Locator, defaultType Type, isCc bool, oldFingerprint string) (bool, error) {
+	info, err := os.Stat(loc.Path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("memory: stat %q: %w", loc.Path, err)
+	}
+
+	fingerprint := fmt.Sprintf("%d-%d", info.Size(), info.ModTime().UnixNano())
+	if oldFingerprint == fingerprint {
+		return false, nil // hit: unchanged file
+	}
+
+	raw, err := os.ReadFile(loc.Path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("memory: read %q: %w", loc.Path, err)
+	}
+	body := string(raw)
+
+	finalType := defaultType
+	if isCc {
+		finalType = parseCcFrontmatterType(body)
+	}
+
+	now := time.Now().UnixNano()
+	const upsert = `
+INSERT INTO memory_index (path, scope, scope_id, type, body, fingerprint, last_indexed_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(path) DO UPDATE SET
+  scope = excluded.scope,
+  scope_id = excluded.scope_id,
+  type = excluded.type,
+  body = excluded.body,
+  fingerprint = excluded.fingerprint,
+  last_indexed_at = excluded.last_indexed_at`
+	if _, err := s.db.Exec(upsert,
+		loc.Path, string(loc.Scope), loc.ScopeID, string(finalType), body, fingerprint, now,
+	); err != nil {
+		return false, fmt.Errorf("memory: upsert %q: %w", loc.Path, err)
+	}
+	return true, nil
+}

--- a/internal/memory/reconcile_test.go
+++ b/internal/memory/reconcile_test.go
@@ -1,0 +1,256 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// openTempWithRoots opens a Store backed by a temp-file DB with explicit mimo
+// root and cc base directories (both created on disk).
+func openTempWithRoots(t *testing.T) (st *Store, root, ccBase string) {
+	t.Helper()
+	base := t.TempDir()
+	root = filepath.Join(base, "mimo")
+	ccBase = filepath.Join(base, "cc")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	if err := os.MkdirAll(ccBase, 0o755); err != nil {
+		t.Fatalf("mkdir ccBase: %v", err)
+	}
+	dbPath := filepath.Join(base, "sub", "memory.db")
+	st, err := Open(dbPath, root, ccBase)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return st, root, ccBase
+}
+
+// writeFile writes body to a mimo path built from segments under root, creating
+// parent directories. It returns the absolute path (cleaned).
+func writeFile(t *testing.T, base string, body string, segs ...string) string {
+	t.Helper()
+	full := filepath.Join(append([]string{base}, segs...)...)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir for %q: %v", full, err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %q: %v", full, err)
+	}
+	return filepath.Clean(full)
+}
+
+// rowFor returns (scope, scopeId, type, fingerprint, body, found) for a path.
+func rowFor(t *testing.T, st *Store, path string) (scope, scopeID, typ, fp, body string, found bool) {
+	t.Helper()
+	err := st.DB().QueryRow(
+		`SELECT scope, scope_id, type, fingerprint, body FROM memory_index WHERE path = ?`, path,
+	).Scan(&scope, &scopeID, &typ, &fp, &body)
+	if err != nil {
+		return "", "", "", "", "", false
+	}
+	return scope, scopeID, typ, fp, body, true
+}
+
+func countRows(t *testing.T, st *Store) int {
+	t.Helper()
+	var n int
+	if err := st.DB().QueryRow(`SELECT count(*) FROM memory_index`).Scan(&n); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	return n
+}
+
+// TestReconcileNewFileIndexed indexes a fresh mimo file and records its locator.
+func TestReconcileNewFileIndexed(t *testing.T) {
+	st, root, _ := openTempWithRoots(t)
+
+	p := writeFile(t, root, "hello world", "global", "reference", "note.md")
+
+	res, err := st.Reconcile()
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.Indexed != 1 || res.Pruned != 0 {
+		t.Fatalf("Reconcile result = %+v, want {Indexed:1 Pruned:0}", res)
+	}
+
+	scope, scopeID, typ, fp, body, found := rowFor(t, st, p)
+	if !found {
+		t.Fatalf("row for %q not found", p)
+	}
+	if scope != string(ScopeGlobal) || scopeID != "" || typ != string(TypeReference) {
+		t.Fatalf("row = scope=%q scope_id=%q type=%q, want global/''/reference", scope, scopeID, typ)
+	}
+	if body != "hello world" {
+		t.Fatalf("body = %q, want %q", body, "hello world")
+	}
+	if fp == "" {
+		t.Fatalf("fingerprint empty")
+	}
+}
+
+// TestReconcileUnchangedFileHit re-runs reconcile with no changes and expects a
+// fingerprint hit (no re-index).
+func TestReconcileUnchangedFileHit(t *testing.T) {
+	st, root, _ := openTempWithRoots(t)
+	writeFile(t, root, "stable content", "global", "notes", "a.md")
+
+	if res, err := st.Reconcile(); err != nil || res.Indexed != 1 {
+		t.Fatalf("first Reconcile = %+v, err=%v, want Indexed:1", res, err)
+	}
+	res, err := st.Reconcile()
+	if err != nil {
+		t.Fatalf("second Reconcile: %v", err)
+	}
+	if res.Indexed != 0 || res.Pruned != 0 {
+		t.Fatalf("second Reconcile = %+v, want {Indexed:0 Pruned:0} (fingerprint hit)", res)
+	}
+}
+
+// TestReconcileChangedFileReindexed bumps a file's size and mtime and expects a
+// re-index.
+func TestReconcileChangedFileReindexed(t *testing.T) {
+	st, root, _ := openTempWithRoots(t)
+	p := writeFile(t, root, "v1", "global", "notes", "a.md")
+
+	if _, err := st.Reconcile(); err != nil {
+		t.Fatalf("first Reconcile: %v", err)
+	}
+	_, _, _, fp1, _, _ := rowFor(t, st, p)
+
+	// Rewrite with different size and force a later mtime to guarantee the
+	// fingerprint changes regardless of filesystem timestamp resolution.
+	if err := os.WriteFile(p, []byte("v2 longer body"), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(p, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	res, err := st.Reconcile()
+	if err != nil {
+		t.Fatalf("second Reconcile: %v", err)
+	}
+	if res.Indexed != 1 || res.Pruned != 0 {
+		t.Fatalf("second Reconcile = %+v, want {Indexed:1 Pruned:0}", res)
+	}
+	_, _, _, fp2, body, _ := rowFor(t, st, p)
+	if fp1 == fp2 {
+		t.Fatalf("fingerprint unchanged after edit: %q", fp2)
+	}
+	if body != "v2 longer body" {
+		t.Fatalf("body = %q, want re-indexed content", body)
+	}
+}
+
+// TestReconcileDeletedFilePruned removes a file and expects its row pruned.
+func TestReconcileDeletedFilePruned(t *testing.T) {
+	st, root, _ := openTempWithRoots(t)
+	p := writeFile(t, root, "temp", "global", "notes", "gone.md")
+
+	if _, err := st.Reconcile(); err != nil {
+		t.Fatalf("first Reconcile: %v", err)
+	}
+	if countRows(t, st) != 1 {
+		t.Fatalf("want 1 row after index")
+	}
+
+	if err := os.Remove(p); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	res, err := st.Reconcile()
+	if err != nil {
+		t.Fatalf("second Reconcile: %v", err)
+	}
+	if res.Indexed != 0 || res.Pruned != 1 {
+		t.Fatalf("second Reconcile = %+v, want {Indexed:0 Pruned:1}", res)
+	}
+	if _, _, _, _, _, found := rowFor(t, st, p); found {
+		t.Fatalf("row for deleted file still present")
+	}
+}
+
+// TestReconcileCcFrontmatterType indexes a cc-root file and derives its type
+// from YAML frontmatter.
+func TestReconcileCcFrontmatterType(t *testing.T) {
+	st, _, ccBase := openTempWithRoots(t)
+
+	const body = "---\nmetadata:\n  type: checkpoint\n---\ncc body text"
+	// <ccBase>/<slug>/memory/**/*.md
+	p := writeFile(t, ccBase, body, "my-project", "memory", "sub", "cp.md")
+
+	res, err := st.Reconcile()
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.Indexed != 1 || res.Pruned != 0 {
+		t.Fatalf("Reconcile = %+v, want {Indexed:1 Pruned:0}", res)
+	}
+	scope, scopeID, typ, _, _, found := rowFor(t, st, p)
+	if !found {
+		t.Fatalf("cc row not found")
+	}
+	if scope != string(ScopeCC) || scopeID != "my-project" || typ != string(TypeCheckpoint) {
+		t.Fatalf("cc row = scope=%q scope_id=%q type=%q, want cc/my-project/checkpoint", scope, scopeID, typ)
+	}
+}
+
+// TestReconcileBothRootsNoCrossPrune verifies that indexing both roots does not
+// prune the other root's rows (the reconcile.ts correctness note).
+func TestReconcileBothRootsNoCrossPrune(t *testing.T) {
+	st, root, ccBase := openTempWithRoots(t)
+
+	mimoP := writeFile(t, root, "mimo body", "projects", "proj1", "project", "m.md")
+	ccP := writeFile(t, ccBase, "cc body", "slug1", "memory", "c.md")
+
+	res, err := st.Reconcile()
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.Indexed != 2 || res.Pruned != 0 {
+		t.Fatalf("Reconcile = %+v, want {Indexed:2 Pruned:0}", res)
+	}
+	if _, _, _, _, _, ok := rowFor(t, st, mimoP); !ok {
+		t.Fatalf("mimo row missing")
+	}
+	if _, _, _, _, _, ok := rowFor(t, st, ccP); !ok {
+		t.Fatalf("cc row missing")
+	}
+
+	// A second no-op reconcile must not prune either row.
+	res, err = st.Reconcile()
+	if err != nil {
+		t.Fatalf("second Reconcile: %v", err)
+	}
+	if res.Pruned != 0 {
+		t.Fatalf("second Reconcile pruned %d, want 0", res.Pruned)
+	}
+	if countRows(t, st) != 2 {
+		t.Fatalf("row count = %d, want 2", countRows(t, st))
+	}
+}
+
+// TestReconcileMissingRoots verifies reconcile is a no-op when roots do not
+// exist yet (ENOENT tolerated).
+func TestReconcileMissingRoots(t *testing.T) {
+	base := t.TempDir()
+	dbPath := filepath.Join(base, "memory.db")
+	st, err := Open(dbPath, filepath.Join(base, "nope"), filepath.Join(base, "nocc"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+
+	res, err := st.Reconcile()
+	if err != nil {
+		t.Fatalf("Reconcile on missing roots: %v", err)
+	}
+	if res.Indexed != 0 || res.Pruned != 0 {
+		t.Fatalf("Reconcile = %+v, want zero", res)
+	}
+}


### PR DESCRIPTION
## Summary
- Store.Reconcile walks mimo+cc roots, indexes new/changed, prunes deleted
- size-mtime fingerprint skips unchanged files
- FTS kept in sync via existing triggers

Closes #475