### PR TITLE
feat(runtime): context rebuild + /rebuild command (#482)

### DIFF
--- a/internal/cli/repl/repl.go
+++ b/internal/cli/repl/repl.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -336,6 +337,25 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 			// is rewritten linearly (Save) and the branch-tracking state is reset to
 			// the new flattened leaf.
 			runManualCompact(out, deps)
+			deps.header.UpdatedAt = time.Now().UTC()
+			if err := deps.store.Save(deps.header, deps.agentCtx.Messages); err != nil {
+				fmt.Fprintf(out, "pigo: session save failed: %v\n", err)
+			}
+			deps.persisted = len(deps.agentCtx.Messages)
+			deps.curLeaf = ""
+			if _, entries, err := deps.store.LoadEntries(deps.header.ID); err == nil && len(entries) > 0 {
+				deps.curLeaf = entries[len(entries)-1].ID
+			}
+			continue
+		}
+		if line == "/rebuild" {
+			// /rebuild is intercepted here for the same reason as /compact: it
+			// reconstructs the whole message list (checkpoint summary + retained
+			// tail) and mutates the shared context, which a slash Action closure
+			// cannot do. It reloads a persisted checkpoint when present, else falls
+			// back to lossy compaction. Like /compact, the session is rewritten
+			// linearly (Save) and the branch cursor reset to the new flattened leaf.
+			runManualRebuild(out, deps)
 			deps.header.UpdatedAt = time.Now().UTC()
 			if err := deps.store.Save(deps.header, deps.agentCtx.Messages); err != nil {
 				fmt.Fprintf(out, "pigo: session save failed: %v\n", err)
@@ -955,6 +975,57 @@ func runManualCompact(out io.Writer, deps replDeps) {
 	summarized := len(msgs) - (len(rebuilt) - 1)
 	fmt.Fprintf(out, "compacted: %d → %d tokens, summarized %d messages, kept %d\n",
 		before, after, summarized, len(rebuilt)-1)
+}
+
+// runManualRebuild reconstructs the shared context on an explicit /rebuild
+// request. It reloads the session's persisted checkpoint (from #480) and inserts
+// the compression boundary at its watermark — collapsing the pre-watermark
+// prefix into the checkpoint summary and preserving the recent tail verbatim. If
+// no checkpoint exists it falls back to the same lossy compaction /compact runs.
+// It prints the before/after token counts; a failure is reported but non-fatal
+// (the original context is kept unchanged).
+func runManualRebuild(out io.Writer, deps replDeps) {
+	msgs := deps.agentCtx.Messages
+	before := compaction.EstimateContextTokens(msgs).Tokens
+
+	// Build a RunConfig matching a normal turn so the no-checkpoint fallback can
+	// summarize against the live provider/model (RebuildFromCheckpoint reuses the
+	// loop's compaction path). The checkpoint path itself is pure/local.
+	cfg := runtime.RunConfig{
+		LoopConfig: runtime.LoopConfig{
+			Model:         deps.live.Model,
+			Provider:      deps.live.ProviderName,
+			ThinkingLevel: deps.live.ThinkingLevel,
+			Stream:        provider.StreamFnFromProvider(deps.live.Provider),
+			ContextWindow: deps.live.ContextWindow,
+			Compaction:    compaction.DefaultCompactionSettings,
+		},
+	}
+	if deps.creds != nil {
+		cfg.GetAPIKey = deps.creds.GetAPIKey
+	}
+
+	// The checkpoint lives at <memoryRoot>/sessions/<id>/checkpoint.md; the session
+	// store is rooted at <memoryRoot>/sessions, so the memory root is its parent.
+	memoryRoot := filepath.Dir(deps.store.Dir())
+
+	fmt.Fprintln(out, ui.Colorize(ui.Enabled(), ui.Dim, "Preparing conversation context…"))
+	res, err := runtime.RebuildFromCheckpoint(context.Background(), msgs, deps.header.ID, memoryRoot, &cfg, nil)
+	if err != nil {
+		fmt.Fprintf(out, "rebuild failed: %v (context left unchanged)\n", err)
+		return
+	}
+	if res.NoOp {
+		fmt.Fprintf(out, "nothing to rebuild (%d tokens, %d messages)\n", before, len(msgs))
+		return
+	}
+	deps.agentCtx.Messages = res.Messages
+	source := "checkpoint"
+	if !res.FromCheckpoint {
+		source = "compaction (no checkpoint)"
+	}
+	fmt.Fprintf(out, "rebuilt from %s: %d → %d tokens, collapsed %d messages, kept %d\n",
+		source, res.TokensBefore, res.TokensAfter, res.SummarizedCount, res.KeptCount)
 }
 
 // replayTranscript prints a resumed session's prior messages to out so the user

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -426,6 +426,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.transcript.addSystem("(context compacted)")
 		return m, m.pumpNext()
 
+	case rebuildDoneMsg:
+		// A manual /rebuild finished: clear the pinned "Preparing conversation
+		// context…" spinner (no run is pumping, so stop it and drop out of the
+		// running state) and report the outcome. rebuild() already applied the
+		// rebuilt messages and set session.compacted on success.
+		m.spinner.unpin()
+		m.spinner.stop()
+		m.running = false
+		if msg.err != nil {
+			m.transcript.addSystem("rebuild failed: " + msg.err.Error() + " (context left unchanged)")
+		} else {
+			m.transcript.addSystem(msg.summary)
+		}
+		m.relayout()
+		return m, nil
+
 	case runEndMsg:
 		m.running = false
 		m.runCh = nil
@@ -714,6 +730,27 @@ func (m Model) runSlash(line string) (tea.Model, tea.Cmd) {
 	if line == "/exit" || line == "/quit" {
 		m.quitting = true
 		return m, tea.Quit
+	}
+	// /rebuild is intercepted before registry resolution (like /exit): it
+	// reconstructs the shared context from a persisted checkpoint (or falls back
+	// to compaction) and replaces the message list in place — work a slash Action
+	// closure cannot do. It reuses the compacting-indicator: the spinner is armed
+	// and pinned to "Preparing conversation context…" while the rebuild runs off
+	// the tea loop, and rebuildDoneMsg clears it and reports the result.
+	if line == "/rebuild" {
+		m.transcript.addUser(line)
+		m.input.Clear()
+		m.menu.close()
+		if m.session == nil {
+			m.transcript.addSystem("(rebuild unavailable: no active session)")
+			m.relayout()
+			return m, nil
+		}
+		m.spinner.begin(time.Now(), m.thinkingLabel())
+		m.spinner.pin("Preparing conversation context")
+		m.running = true
+		m.relayout()
+		return m, tea.Batch(m.session.rebuildCmd(), m.tickSpinner())
 	}
 	m.transcript.addUser(line)
 	m.input.Clear()

--- a/internal/cli/tui/session.go
+++ b/internal/cli/tui/session.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -247,7 +248,55 @@ func (s *runSession) buildConfig() runtime.RunConfig {
 	return cfg
 }
 
-// startRun is the real binding for Model.startRunFn: it appends the submitted
+// rebuildDoneMsg reports the outcome of a manual /rebuild to the model: summary
+// is the status line to show in the transcript, err is set when the rebuild
+// failed (the context is then left unchanged).
+type rebuildDoneMsg struct {
+	summary string
+	err     error
+}
+
+// rebuildCmd runs a context rebuild off the tea loop (the no-checkpoint fallback
+// makes a summarization LLM call, so it must not block the UI goroutine) and
+// yields a rebuildDoneMsg the model folds into the transcript. It mirrors the
+// REPL's runManualRebuild.
+func (s *runSession) rebuildCmd() tea.Cmd {
+	return func() tea.Msg {
+		summary, err := s.rebuild()
+		return rebuildDoneMsg{summary: summary, err: err}
+	}
+}
+
+// rebuild reconstructs the shared context from the session's persisted checkpoint
+// (collapsing the pre-watermark prefix to the checkpoint summary and preserving
+// the recent tail verbatim), falling back to lossy compaction when no checkpoint
+// exists. It replaces agentCtx.Messages in place on success and flags compacted
+// so persist() re-saves the flattened context linearly (as after a /compact).
+func (s *runSession) rebuild() (string, error) {
+	msgs := s.agentCtx.Messages
+	before := compaction.EstimateContextTokens(msgs).Tokens
+	// The checkpoint lives under <memoryRoot>/sessions/<id>/; the store is rooted
+	// at <memoryRoot>/sessions, so the memory root is its parent.
+	memoryRoot := filepath.Dir(s.store.Dir())
+	cfg := s.buildConfig()
+	res, err := runtime.RebuildFromCheckpoint(context.Background(), msgs, s.header.ID, memoryRoot, &cfg, nil)
+	if err != nil {
+		return "", err
+	}
+	if res.NoOp {
+		return fmt.Sprintf("nothing to rebuild (%d tokens, %d messages)", before, len(msgs)), nil
+	}
+	s.agentCtx.Messages = res.Messages
+	s.compacted = true
+	source := "checkpoint"
+	if !res.FromCheckpoint {
+		source = "compaction (no checkpoint)"
+	}
+	return fmt.Sprintf("context rebuilt from %s: %d → %d tokens, collapsed %d messages, kept %d",
+		source, res.TokensBefore, res.TokensAfter, res.SummarizedCount, res.KeptCount), nil
+}
+
+
 // prompt to the growing context as a user message, then hands the context and a
 // freshly-built config to the event bridge (bridge.startRun → runtime.StartRun +
 // DrainStream on a goroutine), returning the bridge channel and the first

--- a/internal/runtime/rebuild.go
+++ b/internal/runtime/rebuild.go
@@ -1,0 +1,165 @@
+// Context rebuild for the "infinite context" feature (#482). Where auto-
+// compaction (loop.go) collapses history *lossily* on the fly, a rebuild
+// reconstructs the working context deterministically from a persisted
+// checkpoint: everything before the checkpoint watermark is replaced by the
+// distilled checkpoint summary, and everything at/after the watermark is kept
+// verbatim. This is what the /rebuild command (REPL + TUI) invokes, and what
+// the run loop (#481) will call on resume to reload a collapsed prefix instead
+// of replaying the whole transcript.
+//
+// When no checkpoint exists yet there is nothing to reload, so a rebuild falls
+// back to the ordinary lossy compaction path (the same compaction.Compact flow
+// runCompaction drives) so /rebuild still shrinks an overgrown context.
+//
+// This file is deliberately side-effect free with respect to the loop: it never
+// mutates the caller's AgentContext. It returns the rebuilt MessageList (plus a
+// RebuildResult describing what happened and an equivalent CompactionEvent) so
+// the CLI handlers — and, later, #481 — decide when and how to apply it.
+package runtime
+
+import (
+	"context"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/compaction"
+)
+
+// RebuildResult describes the outcome of a context rebuild. Messages is the
+// rebuilt list ready to replace the live context; the remaining fields mirror
+// CompactionEvent so a front-end can report the same before/after summary as a
+// compaction.
+type RebuildResult struct {
+	// Messages is the rebuilt context: a single summary/checkpoint message
+	// followed by the retained recent tail. When NoOp is true it is the original
+	// list, unchanged.
+	Messages agentcore.MessageList
+	// FromCheckpoint is true when the boundary came from a persisted checkpoint;
+	// false when the no-checkpoint fallback ran a lossy compaction.
+	FromCheckpoint bool
+	// Watermark is the boundary index used: the checkpoint watermark, or the
+	// compaction cut point in the fallback path.
+	Watermark int
+	// SummarizedCount is how many leading messages were collapsed into the summary.
+	SummarizedCount int
+	// KeptCount is how many recent messages were preserved verbatim.
+	KeptCount int
+	// TokensBefore / TokensAfter are the estimated context tokens before and after
+	// the rebuild (equal when NoOp).
+	TokensBefore int
+	TokensAfter  int
+	// NoOp is true when nothing changed: no checkpoint existed and there was
+	// nothing to compact (an empty summarization range).
+	NoOp bool
+}
+
+// Event renders the rebuild as a CompactionEvent so consumers that already
+// handle compaction reporting (the REPL/TUI event surfaces) can present a
+// rebuild with the same shape. Reason is "rebuild".
+func (r *RebuildResult) Event() agentcore.CompactionEvent {
+	return agentcore.CompactionEvent{
+		Reason:          "rebuild",
+		TokensBefore:    r.TokensBefore,
+		TokensAfter:     r.TokensAfter,
+		SummarizedCount: r.SummarizedCount,
+		KeptCount:       r.KeptCount,
+	}
+}
+
+// RebuildFromCheckpoint reconstructs the working context for sessionID.
+//
+// If a checkpoint exists under memoryRoot, the compression boundary is inserted
+// at checkpoint.Watermark: messages before the watermark collapse to the
+// checkpoint summary (rendered as a single compaction message), and messages
+// at/after the watermark are preserved verbatim. The watermark is clamped to
+// [0, len(msgs)] so a stale checkpoint recorded against a longer history (or one
+// that has since been re-compacted) never slices out of range.
+//
+// If no checkpoint exists, it falls back to the lossy compaction path — the same
+// compaction.Compact flow the loop's auto-compaction uses (runCompaction) — so
+// /rebuild still shrinks the context. When there is nothing to compact the
+// original list is returned with NoOp set.
+//
+// It performs no mutation of the caller's context and no checkpoint writes; the
+// returned RebuildResult carries the rebuilt list for the caller to apply. When
+// waitForCheckpoint is non-nil it is invoked before reading, so a caller that
+// has an in-flight checkpoint write can block until it lands (kept as a callback
+// so this stays decoupled from the loop's write path).
+func RebuildFromCheckpoint(
+	ctx context.Context,
+	msgs agentcore.MessageList,
+	sessionID, memoryRoot string,
+	cfg *RunConfig,
+	waitForCheckpoint func(),
+) (*RebuildResult, error) {
+	if waitForCheckpoint != nil {
+		waitForCheckpoint()
+	}
+	now := nowMillis()
+	tokensBefore := compaction.EstimateContextTokens(msgs).Tokens
+
+	cp, ok, err := LoadCheckpoint(sessionID, memoryRoot)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return rebuildFromLoadedCheckpoint(msgs, cp, tokensBefore, now), nil
+	}
+
+	// No checkpoint: fall back to the ordinary lossy compaction path.
+	res, err := runCompaction(ctx, msgs, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		// Nothing to summarize (no valid cut point / empty range): leave as-is.
+		return &RebuildResult{
+			Messages:     msgs,
+			TokensBefore: tokensBefore,
+			TokensAfter:  tokensBefore,
+			KeptCount:    len(msgs),
+			NoOp:         true,
+		}, nil
+	}
+	rebuilt := res.RebuildContext(msgs, now)
+	kept := len(rebuilt) - 1
+	return &RebuildResult{
+		Messages:        rebuilt,
+		FromCheckpoint:  false,
+		Watermark:       res.FirstKeptIndex,
+		SummarizedCount: len(msgs) - kept,
+		KeptCount:       kept,
+		TokensBefore:    tokensBefore,
+		TokensAfter:     compaction.EstimateContextTokens(rebuilt).Tokens,
+	}, nil
+}
+
+// rebuildFromLoadedCheckpoint builds the rebuilt context from a loaded
+// checkpoint: the pre-watermark prefix collapses to a single compaction message
+// carrying cp.Summary, and the tail from the (clamped) watermark on is preserved
+// verbatim. It reuses compaction.CompactionResult.RebuildContext so the summary
+// message is shaped exactly like a compaction checkpoint.
+func rebuildFromLoadedCheckpoint(msgs agentcore.MessageList, cp *Checkpoint, tokensBefore int, now int64) *RebuildResult {
+	w := cp.Watermark
+	if w < 0 {
+		w = 0
+	}
+	if w > len(msgs) {
+		w = len(msgs)
+	}
+	res := &compaction.CompactionResult{
+		Summary:        cp.Summary,
+		FirstKeptIndex: w,
+		TokensBefore:   tokensBefore,
+	}
+	rebuilt := res.RebuildContext(msgs, now)
+	kept := len(rebuilt) - 1
+	return &RebuildResult{
+		Messages:        rebuilt,
+		FromCheckpoint:  true,
+		Watermark:       w,
+		SummarizedCount: w,
+		KeptCount:       kept,
+		TokensBefore:    tokensBefore,
+		TokensAfter:     compaction.EstimateContextTokens(rebuilt).Tokens,
+	}
+}

--- a/internal/runtime/rebuild_test.go
+++ b/internal/runtime/rebuild_test.go
@@ -1,0 +1,194 @@
+package runtime
+
+// Tests for context rebuild (#482): with a checkpoint present, RebuildFromCheckpoint
+// inserts the compression boundary at the watermark — collapsing the pre-watermark
+// prefix into the checkpoint summary and preserving the recent tail verbatim; with
+// no checkpoint it falls back to the lossy compaction path (compaction.Compact).
+// Filesystem access uses t.TempDir(), matching checkpoint_test.go; the summary
+// model is the shared summaryStream fake from compaction_test.go.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/compaction"
+)
+
+// textUser builds a user message carrying body, used to seed a rebuildable history.
+func textUser(body string) agentcore.UserMessage {
+	return agentcore.UserMessage{
+		RoleField: agentcore.RoleUser,
+		Content:   agentcore.ContentList{agentcore.NewTextContent(body)},
+	}
+}
+
+func TestRebuildFromCheckpoint_InsertsBoundary(t *testing.T) {
+	root := t.TempDir()
+	const sessionID = "sess-rebuild"
+
+	// A 6-message history; the checkpoint collapses the first 4 into a summary and
+	// keeps messages [4:] verbatim.
+	msgs := agentcore.MessageList{
+		textUser("m0"), textUser("m1"), textUser("m2"),
+		textUser("m3"), textUser("keep-A"), textUser("keep-B"),
+	}
+	cp := Checkpoint{
+		Watermark:       4,
+		Summary:         "## Goal\ndistilled prefix",
+		CreatedAt:       time.Now().UTC(),
+		CoveredMessages: 4,
+	}
+	if err := WriteCheckpoint(sessionID, root, cp); err != nil {
+		t.Fatalf("WriteCheckpoint: %v", err)
+	}
+
+	// No summarization stream is needed: the checkpoint path is pure and local.
+	cfg := newRunCfg(nil)
+	res, err := RebuildFromCheckpoint(context.Background(), msgs, sessionID, root, &cfg, nil)
+	if err != nil {
+		t.Fatalf("RebuildFromCheckpoint: %v", err)
+	}
+	if !res.FromCheckpoint {
+		t.Fatalf("expected FromCheckpoint=true")
+	}
+	if res.NoOp {
+		t.Fatalf("expected a real rebuild, got NoOp")
+	}
+	if res.Watermark != 4 || res.SummarizedCount != 4 {
+		t.Fatalf("watermark/summarized: got %d/%d, want 4/4", res.Watermark, res.SummarizedCount)
+	}
+	// Rebuilt list = 1 compaction message + the retained tail (2 messages).
+	if len(res.Messages) != 3 {
+		t.Fatalf("rebuilt length: got %d, want 3: %+v", len(res.Messages), res.Messages)
+	}
+	if res.KeptCount != 2 {
+		t.Fatalf("kept: got %d, want 2", res.KeptCount)
+	}
+	// The prefix must collapse into a single compaction message carrying the summary.
+	head, ok := res.Messages[0].(agentcore.CompactionMessage)
+	if !ok {
+		t.Fatalf("message[0] should be a compaction checkpoint, got %T", res.Messages[0])
+	}
+	if !strings.Contains(head.Summary, "distilled prefix") {
+		t.Fatalf("summary not carried through: %q", head.Summary)
+	}
+	// The recent tail is preserved verbatim, in order.
+	for i, want := range []string{"keep-A", "keep-B"} {
+		um, ok := res.Messages[i+1].(agentcore.UserMessage)
+		if !ok {
+			t.Fatalf("message[%d] should be preserved user message, got %T", i+1, res.Messages[i+1])
+		}
+		if got := agentcore.ContentToText(um.Content); got != want {
+			t.Fatalf("tail[%d]: got %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestRebuildFromCheckpoint_ClampsStaleWatermark(t *testing.T) {
+	root := t.TempDir()
+	const sessionID = "sess-stale"
+
+	msgs := agentcore.MessageList{textUser("a"), textUser("b")}
+	// Watermark past the end (history was re-compacted since the checkpoint).
+	cp := Checkpoint{Watermark: 99, Summary: "old summary", CreatedAt: time.Now().UTC()}
+	if err := WriteCheckpoint(sessionID, root, cp); err != nil {
+		t.Fatalf("WriteCheckpoint: %v", err)
+	}
+
+	cfg := newRunCfg(nil)
+	res, err := RebuildFromCheckpoint(context.Background(), msgs, sessionID, root, &cfg, nil)
+	if err != nil {
+		t.Fatalf("RebuildFromCheckpoint: %v", err)
+	}
+	// Clamped to len(msgs)=2: everything collapses, no verbatim tail, only the head.
+	if res.Watermark != 2 || res.KeptCount != 0 {
+		t.Fatalf("clamp: watermark=%d kept=%d, want 2/0", res.Watermark, res.KeptCount)
+	}
+	if len(res.Messages) != 1 {
+		t.Fatalf("rebuilt length: got %d, want 1 (summary only)", len(res.Messages))
+	}
+}
+
+func TestRebuildFromCheckpoint_WaitCallbackInvoked(t *testing.T) {
+	root := t.TempDir()
+	const sessionID = "sess-wait"
+	cp := Checkpoint{Watermark: 0, Summary: "s", CreatedAt: time.Now().UTC()}
+	if err := WriteCheckpoint(sessionID, root, cp); err != nil {
+		t.Fatalf("WriteCheckpoint: %v", err)
+	}
+
+	waited := false
+	cfg := newRunCfg(nil)
+	_, err := RebuildFromCheckpoint(context.Background(), agentcore.MessageList{textUser("x")}, sessionID, root, &cfg, func() { waited = true })
+	if err != nil {
+		t.Fatalf("RebuildFromCheckpoint: %v", err)
+	}
+	if !waited {
+		t.Fatalf("waitForCheckpoint callback was not invoked before reading")
+	}
+}
+
+func TestRebuildFromCheckpoint_FallsBackToCompaction(t *testing.T) {
+	root := t.TempDir() // empty: no checkpoint on disk
+	const sessionID = "sess-nocp"
+
+	// Seed a long history so FindCutPoint leaves a summarizable prefix.
+	msgs := bigUserMessages(12, 800)
+
+	cfg := newRunCfg(scriptedStream(nil))
+	cfg.SummaryStream = summaryStream("## Goal\nfallback compaction summary")
+	cfg.ContextWindow = 2000
+	cfg.Compaction = compaction.CompactionSettings{Enabled: true, ReserveTokens: 500, KeepRecentTokens: 100}
+
+	res, err := RebuildFromCheckpoint(context.Background(), msgs, sessionID, root, &cfg, nil)
+	if err != nil {
+		t.Fatalf("RebuildFromCheckpoint: %v", err)
+	}
+	if res.FromCheckpoint {
+		t.Fatalf("expected fallback (FromCheckpoint=false) when no checkpoint exists")
+	}
+	if res.NoOp {
+		t.Fatalf("expected a real compaction fallback, got NoOp")
+	}
+	if res.SummarizedCount <= 0 {
+		t.Fatalf("expected some messages summarized, got %d", res.SummarizedCount)
+	}
+	if res.TokensAfter >= res.TokensBefore {
+		t.Fatalf("fallback should reduce tokens: before=%d after=%d", res.TokensBefore, res.TokensAfter)
+	}
+	// The rebuilt context begins with a compaction checkpoint holding the summary.
+	head, ok := res.Messages[0].(agentcore.CompactionMessage)
+	if !ok {
+		t.Fatalf("message[0] should be a compaction checkpoint, got %T", res.Messages[0])
+	}
+	if !strings.Contains(head.Summary, "fallback compaction summary") {
+		t.Fatalf("fallback summary not carried through: %q", head.Summary)
+	}
+}
+
+func TestRebuildFromCheckpoint_FallbackNoOpWhenNothingToCompact(t *testing.T) {
+	root := t.TempDir() // no checkpoint
+	const sessionID = "sess-empty"
+
+	// A single short message: no valid cut point leaves a summarization range, so
+	// Compact returns (nil, nil) and the rebuild is a no-op.
+	msgs := agentcore.MessageList{textUser("only")}
+	cfg := newRunCfg(scriptedStream(nil))
+	cfg.SummaryStream = summaryStream("unused")
+	cfg.ContextWindow = 2000
+	cfg.Compaction = compaction.CompactionSettings{Enabled: true, ReserveTokens: 500, KeepRecentTokens: 100}
+
+	res, err := RebuildFromCheckpoint(context.Background(), msgs, sessionID, root, &cfg, nil)
+	if err != nil {
+		t.Fatalf("RebuildFromCheckpoint: %v", err)
+	}
+	if !res.NoOp {
+		t.Fatalf("expected NoOp when there is nothing to compact")
+	}
+	if len(res.Messages) != 1 || res.TokensAfter != res.TokensBefore {
+		t.Fatalf("no-op should return the original context unchanged: %+v", res)
+	}
+}


### PR DESCRIPTION
## Summary
- RebuildFromCheckpoint: collapse pre-watermark to checkpoint summary, preserve recent verbatim
- Falls back to existing compaction when no checkpoint
- /rebuild in REPL + TUI with Preparing conversation context progress pin

Closes #482