### PR TITLE
feat(memory): BM25 full-text search (#476)

### DIFF
--- a/internal/memory/ftsquery.go
+++ b/internal/memory/ftsquery.go
@@ -1,0 +1,62 @@
+package memory
+
+import "regexp"
+
+// ftsTokenRe matches contiguous runs of Unicode letters (incl. CJK), numbers,
+// and underscore. Everything else — whitespace, punctuation, FTS5 operator
+// characters — is treated as a separator. \p{L} deliberately includes CJK
+// letters so queries like "配置文件" tokenize into a single searchable run.
+var ftsTokenRe = regexp.MustCompile(`[\p{L}\p{N}_]+`)
+
+// buildFtsQuery builds an FTS5 MATCH expression from a free-form user query.
+//
+// FTS5's MATCH grammar has its own operators and special characters
+// (`"`, `(`, `)`, `*`, `:`, `^`, `-`, `.`, `{`, `}`). Passing a raw user string
+// containing any of these crashes the parser. We tokenize on non-word runs,
+// wrap each token in phrase quotes (which turn it into a literal-word search
+// that ignores FTS5 special chars), and OR-join.
+//
+// OR (not AND): AND-join requires EVERY query word to appear in a document, so
+// a single descriptive word the user added that is absent from the stored text
+// zeroes the whole query even when most tokens match. OR lets BM25 rank by how
+// many / how rare the matched tokens are; the caller applies a relative score
+// floor to drop common-word-only noise (see Store.Search).
+//
+// Returns "" when no usable tokens are extracted. Callers treat that as "empty
+// query, no results" and send no SQL.
+func buildFtsQuery(raw string) string {
+	matches := ftsTokenRe.FindAllString(raw, -1)
+	if len(matches) == 0 {
+		return ""
+	}
+
+	quoted := make([]string, 0, len(matches))
+	for _, tok := range matches {
+		// Strip any embedded double quotes, then wrap the token as a phrase.
+		stripped := removeQuotes(tok)
+		if stripped == "" {
+			continue
+		}
+		quoted = append(quoted, `"`+stripped+`"`)
+	}
+	if len(quoted) == 0 {
+		return ""
+	}
+
+	out := quoted[0]
+	for _, q := range quoted[1:] {
+		out += " OR " + q
+	}
+	return out
+}
+
+// removeQuotes strips every double-quote character from s.
+func removeQuotes(s string) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r != '"' {
+			out = append(out, r)
+		}
+	}
+	return string(out)
+}

--- a/internal/memory/ftsquery_test.go
+++ b/internal/memory/ftsquery_test.go
@@ -1,0 +1,55 @@
+package memory
+
+import "testing"
+
+func TestBuildFtsQueryMultiWordOrJoin(t *testing.T) {
+	got := buildFtsQuery("permission deadlock retry")
+	want := `"permission" OR "deadlock" OR "retry"`
+	if got != want {
+		t.Fatalf("buildFtsQuery multi-word: got %q want %q", got, want)
+	}
+}
+
+func TestBuildFtsQuerySingleToken(t *testing.T) {
+	if got := buildFtsQuery("checkpoint"); got != `"checkpoint"` {
+		t.Fatalf("buildFtsQuery single: got %q", got)
+	}
+}
+
+func TestBuildFtsQueryCJKTokensKept(t *testing.T) {
+	// CJK letters are \p{L} and must survive tokenization. Whitespace splits
+	// them into separate tokens; punctuation is a separator.
+	got := buildFtsQuery("配置文件 端口")
+	want := `"配置文件" OR "端口"`
+	if got != want {
+		t.Fatalf("buildFtsQuery CJK: got %q want %q", got, want)
+	}
+}
+
+func TestBuildFtsQueryPunctuationStripped(t *testing.T) {
+	// FTS5 special chars and punctuation become separators; underscores and
+	// digits are word characters.
+	got := buildFtsQuery(`port: 5433 (postgres-db)  foo_bar`)
+	want := `"port" OR "5433" OR "postgres" OR "db" OR "foo_bar"`
+	if got != want {
+		t.Fatalf("buildFtsQuery punctuation: got %q want %q", got, want)
+	}
+}
+
+func TestBuildFtsQueryStripsEmbeddedQuotes(t *testing.T) {
+	// A token can only contain word chars, so a raw double-quote is a
+	// separator; but guard the strip explicitly.
+	got := buildFtsQuery(`say "hello"`)
+	want := `"say" OR "hello"`
+	if got != want {
+		t.Fatalf("buildFtsQuery quotes: got %q want %q", got, want)
+	}
+}
+
+func TestBuildFtsQueryEmptyAndWhitespace(t *testing.T) {
+	for _, in := range []string{"", "   ", "\t\n", "!!! ??? ... ---", "()[]{}"} {
+		if got := buildFtsQuery(in); got != "" {
+			t.Fatalf("buildFtsQuery(%q): got %q want empty", in, got)
+		}
+	}
+}

--- a/internal/memory/search.go
+++ b/internal/memory/search.go
@@ -1,0 +1,173 @@
+package memory
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// SearchResult is a single ranked hit from Store.Search. Score is normalized so
+// that higher = better (the raw FTS5 bm25 value, where lower is better, is
+// negated).
+type SearchResult struct {
+	Path    string
+	Snippet string
+	Score   float64
+	Scope   Scope
+	ScopeID string
+	Type    Type
+}
+
+// SearchOptions tunes a Store.Search call. All fields are optional; the zero
+// value performs an unfiltered search with default limit and score floor.
+type SearchOptions struct {
+	// Scope, ScopeID and Type, when non-empty, restrict results to rows whose
+	// corresponding memory_index column matches exactly.
+	Scope   string
+	ScopeID string
+	Type    string
+	// Limit caps the number of returned results; <=0 means the default of 10.
+	Limit int
+	// ReconcileFirst runs a lazy Store.Reconcile before searching so that
+	// off-tool writes are picked up. Its counts are ignored; hard errors
+	// propagate.
+	ReconcileFirst bool
+	// ScoreFloor is the relative floor ratio: trailing rows scoring below
+	// topScore*ScoreFloor are dropped. <=0 keeps all matches when 0, but the
+	// default of 0.15 is used when the field is left at its zero value; pass a
+	// negative value to explicitly disable the floor.
+	ScoreFloor float64
+}
+
+// defaultSearchLimit is the result count used when SearchOptions.Limit <= 0.
+const defaultSearchLimit = 10
+
+// maxFetchLimit caps the over-fetch used to feed the relative score floor.
+const maxFetchLimit = 50
+
+// defaultScoreFloor is the relative floor applied when SearchOptions.ScoreFloor
+// is left at its zero value.
+const defaultScoreFloor = 0.15
+
+// Search runs a BM25 full-text query over the indexed memory bodies.
+//
+// The free-form query is tokenized and OR-joined by buildFtsQuery; an empty
+// token set returns (nil, nil) without touching SQL. Results are ranked by
+// BM25 (converted to higher = better), over-fetched 3x (capped at 50) so a
+// relative score floor can trim common-word-only noise, then sliced to the
+// requested limit. Optional scope/scope_id/type filters restrict the corpus.
+func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error) {
+	if opts.ReconcileFirst {
+		if _, err := s.Reconcile(); err != nil {
+			return nil, fmt.Errorf("memory: reconcile before search: %w", err)
+		}
+	}
+
+	match := buildFtsQuery(query)
+	if match == "" {
+		// No usable tokens: treat as empty query with no results, send no SQL.
+		return nil, nil
+	}
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = defaultSearchLimit
+	}
+	fetchLimit := limit * 3
+	if fetchLimit > maxFetchLimit {
+		fetchLimit = maxFetchLimit
+	}
+
+	// The FTS5 table `memory_fts` is external-content over `memory_index`, so
+	// filter columns (scope/scope_id/type) and the display path live on
+	// memory_index and the join is memory_index.id = memory_fts.rowid. snippet()
+	// and bm25() operate on the FTS table; body is FTS column 0.
+	var sb strings.Builder
+	sb.WriteString(`
+SELECT mi.path, mi.scope, mi.scope_id, mi.type,
+       snippet(memory_fts, 0, '<<', '>>', '...', 32) AS snippet,
+       bm25(memory_fts) AS score
+FROM memory_fts
+JOIN memory_index mi ON mi.id = memory_fts.rowid
+WHERE memory_fts MATCH ?`)
+
+	// MATCH parameter is always first; filter params follow in order.
+	args := []any{match}
+	if opts.Scope != "" {
+		sb.WriteString(" AND mi.scope = ?")
+		args = append(args, opts.Scope)
+	}
+	if opts.ScopeID != "" {
+		sb.WriteString(" AND mi.scope_id = ?")
+		args = append(args, opts.ScopeID)
+	}
+	if opts.Type != "" {
+		sb.WriteString(" AND mi.type = ?")
+		args = append(args, opts.Type)
+	}
+	// bm25(): lower = better, so ascending order puts the best hit first.
+	sb.WriteString(" ORDER BY score ASC LIMIT ?")
+	args = append(args, fetchLimit)
+
+	rows, err := s.db.Query(sb.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("memory: search query: %w", err)
+	}
+	defer rows.Close()
+
+	var results []SearchResult
+	for rows.Next() {
+		var (
+			path, scope, scopeID, typ string
+			snippet                   sql.NullString
+			bm25                      float64
+		)
+		if err := rows.Scan(&path, &scope, &scopeID, &typ, &snippet, &bm25); err != nil {
+			return nil, fmt.Errorf("memory: scan search row: %w", err)
+		}
+		results = append(results, SearchResult{
+			Path:    path,
+			Snippet: snippet.String,
+			Score:   -bm25, // convert to higher = better
+			Scope:   Scope(scope),
+			ScopeID: scopeID,
+			Type:    Type(typ),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("memory: iterate search rows: %w", err)
+	}
+	if len(results) == 0 {
+		return nil, nil
+	}
+
+	// Relative score floor. BM25 magnitudes are corpus-size dependent (in a
+	// tiny corpus every score collapses toward 0 due to low IDF), so an
+	// absolute floor would wrongly wipe real hits. We keep results scoring at
+	// least topScore*floor. The #1 result is ALWAYS kept — a match is a match
+	// even when BM25 can't discriminate. Default 0.15; a negative floor
+	// disables the trimming entirely.
+	floor := opts.ScoreFloor
+	if floor == 0 {
+		floor = defaultScoreFloor
+	}
+
+	// Rows come back ORDER BY score ASC (best first after negation), so
+	// results[0] is the top hit.
+	if floor > 0 {
+		topScore := results[0].Score
+		cutoff := topScore * floor
+		kept := results[:1]
+		for _, r := range results[1:] {
+			if r.Score >= cutoff {
+				kept = append(kept, r)
+			}
+		}
+		results = kept
+	}
+
+	if len(results) > limit {
+		results = results[:limit]
+	}
+	return results, nil
+}

--- a/internal/memory/search_test.go
+++ b/internal/memory/search_test.go
@@ -1,0 +1,152 @@
+package memory
+
+import "testing"
+
+// seedSearchCorpus writes a small memory corpus and indexes it. "checkpoint" is
+// deliberately a common word (appears in many docs) while "permission" and
+// "deadlock" are rare, so BM25 + the relative floor can be exercised.
+func seedSearchCorpus(t *testing.T, st *Store, root string) map[string]string {
+	t.Helper()
+	paths := map[string]string{}
+	paths["rare"] = writeFile(t, root,
+		"permission deadlock encountered during checkpoint save then retry succeeded",
+		"projects", "proj1", "notes", "rare.md")
+	paths["c1"] = writeFile(t, root, "checkpoint state alpha", "global", "checkpoint", "c1.md")
+	paths["c2"] = writeFile(t, root, "checkpoint state beta", "global", "checkpoint", "c2.md")
+	paths["c3"] = writeFile(t, root, "checkpoint state gamma", "global", "checkpoint", "c3.md")
+	paths["c4"] = writeFile(t, root, "checkpoint state delta", "global", "checkpoint", "c4.md")
+	paths["user"] = writeFile(t, root, "unrelated grocery shopping list", "global", "user", "u1.md")
+	if _, err := st.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	return paths
+}
+
+func resultPaths(rs []SearchResult) map[string]bool {
+	m := make(map[string]bool, len(rs))
+	for _, r := range rs {
+		m[r.Path] = true
+	}
+	return m
+}
+
+func TestSearchMultiWordOrRecall(t *testing.T) {
+	st, root, _ := openTempWithRoots(t)
+	p := seedSearchCorpus(t, st, root)
+
+	// OR recall: a query spanning a rare word (in one doc) and the common word
+	// (in several) should surface docs matching either. Disable the floor so we
+	// verify raw OR recall independent of trimming.
+	res, err := st.Search("permission checkpoint", SearchOptions{ScoreFloor: -1})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	got := resultPaths(res)
+	if !got[p["rare"]] {
+		t.Fatalf("expected rare doc in recall results, got %v", got)
+	}
+	if !got[p["c1"]] {
+		t.Fatalf("expected a checkpoint doc in recall results, got %v", got)
+	}
+}
+
+func TestSearchScoreFloorDropsCommonWordOnly(t *testing.T) {
+	st, root, _ := openTempWithRoots(t)
+	p := seedSearchCorpus(t, st, root)
+
+	// The rare doc matches permission+deadlock+checkpoint; the c* docs match
+	// only the common "checkpoint". With the default floor the multi-rare doc
+	// ranks top and the common-word-only docs are trimmed.
+	res, err := st.Search("permission deadlock checkpoint", SearchOptions{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res) == 0 {
+		t.Fatal("expected at least the top result")
+	}
+	if res[0].Path != p["rare"] {
+		t.Fatalf("expected rare doc ranked top, got %q", res[0].Path)
+	}
+	// Higher = better after negation: the top score should be positive-most.
+	for _, r := range res[1:] {
+		if r.Score > res[0].Score {
+			t.Fatalf("result %q outscored the top hit", r.Path)
+		}
+	}
+	got := resultPaths(res)
+	for _, key := range []string{"c1", "c2", "c3", "c4"} {
+		if got[p[key]] {
+			t.Fatalf("common-word-only doc %s should have been dropped by floor, got %v", key, got)
+		}
+	}
+}
+
+func TestSearchScopeAndTypeFilters(t *testing.T) {
+	st, root, _ := openTempWithRoots(t)
+	p := seedSearchCorpus(t, st, root)
+
+	// scope filter: only the projects doc should match under scope=projects.
+	res, err := st.Search("checkpoint permission", SearchOptions{Scope: "projects", ScoreFloor: -1})
+	if err != nil {
+		t.Fatalf("Search scope: %v", err)
+	}
+	got := resultPaths(res)
+	if !got[p["rare"]] || len(got) != 1 {
+		t.Fatalf("scope=projects should return only the rare doc, got %v", got)
+	}
+
+	// type filter: only global/checkpoint docs, none of the projects/user docs.
+	res, err = st.Search("checkpoint permission", SearchOptions{Type: string(TypeCheckpoint), ScoreFloor: -1})
+	if err != nil {
+		t.Fatalf("Search type: %v", err)
+	}
+	got = resultPaths(res)
+	if got[p["rare"]] || got[p["user"]] {
+		t.Fatalf("type=checkpoint should exclude non-checkpoint docs, got %v", got)
+	}
+	if !got[p["c1"]] {
+		t.Fatalf("type=checkpoint should include checkpoint docs, got %v", got)
+	}
+}
+
+func TestSearchEmptyQueryReturnsNil(t *testing.T) {
+	st, root, _ := openTempWithRoots(t)
+	seedSearchCorpus(t, st, root)
+
+	for _, q := range []string{"", "   ", "!!! ??? ---"} {
+		res, err := st.Search(q, SearchOptions{})
+		if err != nil {
+			t.Fatalf("Search(%q): unexpected error %v", q, err)
+		}
+		if res != nil {
+			t.Fatalf("Search(%q): expected nil results, got %v", q, res)
+		}
+	}
+}
+
+func TestSearchReconcileFirst(t *testing.T) {
+	st, root, _ := openTempWithRoots(t)
+	// Write a file but do NOT reconcile manually; ReconcileFirst should index it.
+	writeFile(t, root, "lazy reconciled permission deadlock content", "global", "notes", "lazy.md")
+
+	res, err := st.Search("permission deadlock", SearchOptions{ReconcileFirst: true})
+	if err != nil {
+		t.Fatalf("Search ReconcileFirst: %v", err)
+	}
+	if len(res) == 0 {
+		t.Fatal("ReconcileFirst should have indexed and matched the lazy doc")
+	}
+}
+
+func TestSearchLimit(t *testing.T) {
+	st, root, _ := openTempWithRoots(t)
+	seedSearchCorpus(t, st, root)
+
+	res, err := st.Search("checkpoint", SearchOptions{Limit: 2, ScoreFloor: -1})
+	if err != nil {
+		t.Fatalf("Search limit: %v", err)
+	}
+	if len(res) > 2 {
+		t.Fatalf("limit=2 should cap results, got %d", len(res))
+	}
+}


### PR DESCRIPTION
## Summary
- buildFtsQuery: Unicode/CJK tokenize, OR-joined phrase query, empty-safe
- Store.Search: BM25 rank, over-fetch 3x cap 50, relative score floor (default 0.15), scope/scope_id/type filters, optional lazy reconcile

Closes #476