### PR TITLE
feat(agenttool): memory_search tool (#477)

### DIFF
--- a/internal/agenttool/memory_tool.go
+++ b/internal/agenttool/memory_tool.go
@@ -1,0 +1,170 @@
+// This file implements the memory_search AgentTool (issue #477): a read-only
+// tool that queries the persistent memory library (internal/memory) by relevance
+// using its BM25 full-text index and returns ranked snippets to the model.
+//
+// Writes are intentionally NOT a separate tool here. Per the SPEC (§4.1/§4.2),
+// memory writes reuse the existing Write/Edit file tools, constrained to the
+// memory root and carrying the canonical frontmatter (name/description/
+// metadata.type). Traversal protection for those writes lives in the memory
+// package (memory.assertSafeComponent) and the write-path plumbing; a dedicated
+// memory_write tool would duplicate that. After an off-tool write, the next
+// memory_search picks it up automatically because Execute searches with
+// ReconcileFirst=true (lazy reconcile).
+package agenttool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/memory"
+)
+
+// memorySearchDefaultLimit is the result cap used when the caller omits limit or
+// passes a non-positive value; memorySearchMaxLimit is the hard upper bound.
+const (
+	memorySearchDefaultLimit = 10
+	memorySearchMaxLimit     = 50
+)
+
+// MemorySearchTool searches the persistent memory library by relevance. Store is
+// exported so the loop-integration node (#481) can construct the tool with a
+// live *memory.Store, mirroring how TodoTool exposes its Store.
+type MemorySearchTool struct {
+	// Store is the persistent memory store. When nil, Execute degrades to a
+	// friendly no-op result rather than erroring, so a session without memory
+	// configured still runs.
+	Store *memory.Store
+}
+
+// memorySearchArgs is the decoded argument shape for memory_search.
+type memorySearchArgs struct {
+	Query string `json:"query"`
+	Scope string `json:"scope"`
+	Type  string `json:"type"`
+	Limit int    `json:"limit"`
+}
+
+// Name implements AgentTool.
+func (t *MemorySearchTool) Name() string { return "memory_search" }
+
+// Description implements AgentTool.
+func (t *MemorySearchTool) Description() string {
+	return "Search the persistent memory library by relevance (BM25 full-text) " +
+		"and return ranked snippets from previously saved notes, checkpoints, and " +
+		"references. Use it to recall context from earlier sessions before " +
+		"answering or acting. Optional filters: scope (global|projects|sessions|cc), " +
+		"type (user|feedback|project|reference|checkpoint|progress|notes|free), and " +
+		"limit (default 10, max 50). Results are ordered most-relevant first."
+}
+
+// Schema implements AgentTool.
+func (t *MemorySearchTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "query": {"type": "string", "description": "Free-text query; tokenized and matched against memory bodies (BM25)."},
+    "scope": {"type": "string", "description": "Optional scope filter: global, projects, sessions, or cc."},
+    "type":  {"type": "string", "description": "Optional type filter: user, feedback, project, reference, checkpoint, progress, notes, or free."},
+    "limit": {"type": "integer", "description": "Max results to return (default 10, capped at 50)."}
+  },
+  "required": ["query"],
+  "additionalProperties": false
+}`)
+}
+
+// ExecutionMode implements AgentTool. memory_search is read-only, so it runs in
+// the default parallel mode.
+func (t *MemorySearchTool) ExecutionMode() agentcore.ToolExecutionMode {
+	return agentcore.ToolExecutionParallel
+}
+
+// Execute implements AgentTool. It decodes the args, runs a lazily-reconciled
+// BM25 search, and formats the ranked hits as text (one line each:
+// "[type/scope] path (score) — snippet") with the structured []SearchResult in
+// Details. A nil Store or empty query degrades to a friendly no-op result rather
+// than a Go error so the loop keeps running.
+func (t *MemorySearchTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+	a, bad := decodeArgs[memorySearchArgs](args, "memory_search")
+	if bad != nil {
+		return *bad, nil
+	}
+
+	query := strings.TrimSpace(a.Query)
+	if t.Store == nil {
+		return agentcore.AgentToolResult{
+			Content: agentcore.ContentList{agentcore.NewTextContent(
+				"memory_search: no memory store configured; nothing to search.")},
+		}, nil
+	}
+	if query == "" {
+		return agentcore.AgentToolResult{
+			Content: agentcore.ContentList{agentcore.NewTextContent(
+				"memory_search: empty query; provide a search string.")},
+		}, nil
+	}
+
+	limit := a.Limit
+	if limit <= 0 {
+		limit = memorySearchDefaultLimit
+	}
+	if limit > memorySearchMaxLimit {
+		limit = memorySearchMaxLimit
+	}
+
+	results, err := t.Store.Search(query, memory.SearchOptions{
+		Scope:          strings.TrimSpace(a.Scope),
+		Type:           strings.TrimSpace(a.Type),
+		Limit:          limit,
+		ReconcileFirst: true, // lazy reconcile so off-tool writes are indexed
+		// ScoreFloor left at its zero value → package default (0.15).
+	})
+	if err != nil {
+		return errorResult(fmt.Sprintf("memory_search: %v", err)), nil
+	}
+
+	if len(results) == 0 {
+		return agentcore.AgentToolResult{
+			Content: agentcore.ContentList{agentcore.NewTextContent(
+				fmt.Sprintf("memory_search: no results for %q.", query))},
+			Details: results,
+		}, nil
+	}
+
+	return agentcore.AgentToolResult{
+		Content: agentcore.ContentList{agentcore.NewTextContent(formatMemoryResults(query, results))},
+		Details: results,
+	}, nil
+}
+
+// formatMemoryResults renders ranked hits as a header line plus one line per
+// result: "[type/scope] path (score) — snippet". Snippets are whitespace-
+// collapsed so a multi-line body stays on a single row.
+func formatMemoryResults(query string, results []memory.SearchResult) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "memory_search: %d result(s) for %q, most relevant first:", len(results), query)
+	for _, r := range results {
+		typ := string(r.Type)
+		if typ == "" {
+			typ = "free"
+		}
+		scope := string(r.Scope)
+		if r.ScopeID != "" {
+			scope = scope + "/" + r.ScopeID
+		}
+		line := fmt.Sprintf("\n[%s/%s] %s (%.3f)", typ, scope, r.Path, r.Score)
+		if snip := collapseWhitespace(r.Snippet); snip != "" {
+			line += " — " + snip
+		}
+		b.WriteString(line)
+	}
+	return b.String()
+}
+
+// collapseWhitespace folds any run of whitespace (including newlines) into a
+// single space and trims the ends, keeping a snippet to one line.
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/internal/agenttool/memory_tool_test.go
+++ b/internal/agenttool/memory_tool_test.go
@@ -1,0 +1,179 @@
+package agenttool
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/memory"
+)
+
+// newMemoryStoreWithCorpus opens a *memory.Store over a temp DB + temp mimo root
+// and writes a couple of .md files under the layout. It does NOT reconcile — the
+// tool's ReconcileFirst=true is expected to index them lazily on first search.
+func newMemoryStoreWithCorpus(t *testing.T) *memory.Store {
+	t.Helper()
+	base := t.TempDir()
+	root := filepath.Join(base, "mimo")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	writeMemFile(t, root, "permission deadlock encountered during checkpoint save then retry succeeded",
+		"projects", "proj1", "notes", "rare.md")
+	writeMemFile(t, root, "unrelated grocery shopping list",
+		"global", "user", "u1.md")
+
+	dbPath := filepath.Join(base, "sub", "memory.db")
+	st, err := memory.Open(dbPath, root, "")
+	if err != nil {
+		t.Fatalf("memory.Open: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return st
+}
+
+func writeMemFile(t *testing.T, root, body string, segs ...string) string {
+	t.Helper()
+	full := filepath.Join(append([]string{root}, segs...)...)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir for %q: %v", full, err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %q: %v", full, err)
+	}
+	return filepath.Clean(full)
+}
+
+func runMemorySearch(t *testing.T, tool *MemorySearchTool, args map[string]any) (string, any) {
+	t.Helper()
+	raw, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	res, err := tool.Execute(context.Background(), "call-1", raw, nil)
+	if err != nil {
+		t.Fatalf("Execute returned Go error: %v", err)
+	}
+	return contentText(res.Content), res.Details
+}
+
+// contentText concatenates the text of every TextContent block in a result.
+func contentText(content agentcore.ContentList) string {
+	var b strings.Builder
+	for _, c := range content {
+		if tc, ok := c.(agentcore.TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}
+
+func TestMemorySearchToolInterface(t *testing.T) {
+	tool := &MemorySearchTool{}
+	if tool.Name() != "memory_search" {
+		t.Fatalf("Name = %q, want memory_search", tool.Name())
+	}
+	if tool.Description() == "" {
+		t.Fatal("Description must not be empty")
+	}
+	// Schema must be valid JSON declaring query as required.
+	var schema struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(tool.Schema(), &schema); err != nil {
+		t.Fatalf("Schema is not valid JSON: %v", err)
+	}
+	if len(schema.Required) != 1 || schema.Required[0] != "query" {
+		t.Fatalf("Schema required = %v, want [query]", schema.Required)
+	}
+}
+
+func TestMemorySearchFindsSnippet(t *testing.T) {
+	tool := &MemorySearchTool{Store: newMemoryStoreWithCorpus(t)}
+
+	text, details := runMemorySearch(t, tool, map[string]any{"query": "permission deadlock"})
+
+	if !strings.Contains(text, "rare.md") {
+		t.Fatalf("expected result text to reference rare.md, got:\n%s", text)
+	}
+	if !strings.Contains(strings.ToLower(text), "permission") {
+		t.Fatalf("expected snippet to mention 'permission', got:\n%s", text)
+	}
+
+	// Details must carry the structured results (lazy reconcile indexed the file).
+	results, ok := details.([]memory.SearchResult)
+	if !ok {
+		t.Fatalf("Details type = %T, want []memory.SearchResult", details)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least one structured result")
+	}
+	found := false
+	for _, r := range results {
+		if strings.HasSuffix(r.Path, filepath.Join("notes", "rare.md")) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected rare.md among structured results, got %+v", results)
+	}
+}
+
+func TestMemorySearchScopeAndTypeFilter(t *testing.T) {
+	tool := &MemorySearchTool{Store: newMemoryStoreWithCorpus(t)}
+
+	// Filter to the global/user doc; the projects/notes doc must be excluded even
+	// though it also matches the shared word.
+	text, _ := runMemorySearch(t, tool, map[string]any{
+		"query": "grocery permission",
+		"scope": "global",
+		"type":  "user",
+	})
+	if strings.Contains(text, "rare.md") {
+		t.Fatalf("scope/type filter should exclude rare.md, got:\n%s", text)
+	}
+	if !strings.Contains(text, "u1.md") {
+		t.Fatalf("expected u1.md to match global/user filter, got:\n%s", text)
+	}
+}
+
+func TestMemorySearchNoResults(t *testing.T) {
+	tool := &MemorySearchTool{Store: newMemoryStoreWithCorpus(t)}
+	text, _ := runMemorySearch(t, tool, map[string]any{"query": "zzzznonexistenttoken"})
+	if !strings.Contains(text, "no results") {
+		t.Fatalf("expected a clear empty message, got:\n%s", text)
+	}
+}
+
+func TestMemorySearchEmptyQueryNoOp(t *testing.T) {
+	tool := &MemorySearchTool{Store: newMemoryStoreWithCorpus(t)}
+	text, _ := runMemorySearch(t, tool, map[string]any{"query": "   "})
+	if !strings.Contains(text, "empty query") {
+		t.Fatalf("expected empty-query no-op message, got:\n%s", text)
+	}
+}
+
+func TestMemorySearchNilStoreNoOp(t *testing.T) {
+	tool := &MemorySearchTool{} // Store nil
+	text, _ := runMemorySearch(t, tool, map[string]any{"query": "anything"})
+	if !strings.Contains(text, "no memory store") {
+		t.Fatalf("expected nil-store no-op message, got:\n%s", text)
+	}
+}
+
+func TestMemorySearchInvalidArgs(t *testing.T) {
+	tool := &MemorySearchTool{Store: newMemoryStoreWithCorpus(t)}
+	res, err := tool.Execute(context.Background(), "call-1", json.RawMessage(`{"query": 123}`), nil)
+	if err != nil {
+		t.Fatalf("Execute returned Go error: %v", err)
+	}
+	var text strings.Builder
+	text.WriteString(contentText(res.Content))
+	if !strings.Contains(text.String(), "invalid arguments") {
+		t.Fatalf("expected invalid-arguments error result, got:\n%s", text.String())
+	}
+}


### PR DESCRIPTION
## Summary
- memory_search AgentTool: BM25 search over persistent memory, scope/type/limit args, lazy reconcile
- Results as text + structured Details; nil-store/empty-query no-op

Closes #477