### PR TITLE
Wire persistent memory + checkpoint recall into loop

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -307,13 +307,16 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			fmt.Fprintln(errOut, "pigo: no prompt (use -p \"...\" or positional args)")
 			return 2
 		}
-		env, err := run.SetupEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.apiKey, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt)
+		env, err := run.SetupEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.apiKey, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt, opts.memory.Memory.Enabled)
 		if err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 1
 		}
 		if env.Plugins != nil {
 			defer env.Plugins.Close()
+		}
+		if env.Memory != nil {
+			defer env.Memory.Close()
 		}
 		thinking, err := run.ResolveThinkingLevel(opts.thinkingLevel)
 		if err != nil {
@@ -379,13 +382,16 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		return 2
 	}
 
-	env, err := run.SetupEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.apiKey, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt)
+	env, err := run.SetupEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.apiKey, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt, opts.memory.Memory.Enabled)
 	if err != nil {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
 		return 1
 	}
 	if env.Plugins != nil {
 		defer env.Plugins.Close()
+	}
+	if env.Memory != nil {
+		defer env.Memory.Close()
 	}
 	return headless.Run(ctx, headless.RunParams{
 		Mode:          mode,

--- a/cmd/pigo/main_test.go
+++ b/cmd/pigo/main_test.go
@@ -128,7 +128,7 @@ func TestCwdChdirRootsEnv(t *testing.T) {
 		t.Fatalf("EvalSymlinks: %v", err)
 	}
 
-	env, err := run.SetupEnv("openrouter/free", "", "", "", "", true /*noTools*/, true /*noSkills*/, "", nil)
+	env, err := run.SetupEnv("openrouter/free", "", "", "", "", true /*noTools*/, true /*noSkills*/, "", nil, false /*memEnabled*/)
 	if err != nil {
 		t.Fatalf("SetupEnv: %v", err)
 	}

--- a/internal/cli/headless/headless.go
+++ b/internal/cli/headless/headless.go
@@ -85,6 +85,9 @@ func Run(ctx context.Context, p RunParams, out, errOut io.Writer) int {
 	creds.SetOverride(env.ProviderName, p.APIKey)
 	runCfg := run.NewConfig(p.Model, env.ProviderName, thinking, env.Provider, creds, run.ToolRegistry(env.Tools), run.TodoReminders(env.Tools))
 	runCfg.SessionID = hs.header.ID
+	// Route auto-compaction checkpoints to the shared memory root so a rebuild can
+	// recover the pre-watermark prefix (no-op when memory is disabled → empty root).
+	runCfg.MemoryRoot = run.MemoryRootFromTools(env.Tools)
 
 	// Wire hooks uniformly with every other driver (#425): resolve the trust-gated
 	// hook set, install the tool-execution + Stop seams, dispatch SessionStart, and

--- a/internal/cli/repl/interactive.go
+++ b/internal/cli/repl/interactive.go
@@ -212,6 +212,7 @@ func Run(opts Options) error {
 		confirmMu: &sync.Mutex{},
 		curLeaf:   curLeaf,
 		persisted: len(history),
+		memoryRoot: run.MemoryRootFromTools(opts.Tools),
 		notifier:  plugin.NewEventNotifier(opts.Plugins, os.Stderr),
 		goal:      agenttool.NewGoalState(),
 		telemetry: cli.NewTelemetryHolder(),

--- a/internal/cli/repl/repl.go
+++ b/internal/cli/repl/repl.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -140,6 +139,11 @@ type replDeps struct {
 	// command toggles its secondary writer. When no remote session is active it
 	// forwards only to the terminal.
 	tee *teeWriter
+
+	// memoryRoot is the persistent-memory Store root (empty when memory is
+	// disabled). streamRun routes auto-compaction checkpoints here and /rebuild
+	// recovers from <memoryRoot>/sessions/<id>/, the canonical checkpoint location.
+	memoryRoot string
 }
 
 // replScanBufInit is the initial size of the shared input reader. A REPL user
@@ -540,6 +544,8 @@ func streamRun(ctx context.Context, out io.Writer, deps replDeps, prompt string)
 			},
 		},
 		Reminders: deps.reminders,
+		SessionID: deps.header.ID,
+		MemoryRoot: deps.memoryRoot,
 	}
 	// Per-turn wiring of the tool-execution + Stop seams (PreToolUse/PostToolUse/
 	// Stop) onto this turn's freshly-built cfg; a nil dispatcher is a no-op so the
@@ -1005,9 +1011,10 @@ func runManualRebuild(out io.Writer, deps replDeps) {
 		cfg.GetAPIKey = deps.creds.GetAPIKey
 	}
 
-	// The checkpoint lives at <memoryRoot>/sessions/<id>/checkpoint.md; the session
-	// store is rooted at <memoryRoot>/sessions, so the memory root is its parent.
-	memoryRoot := filepath.Dir(deps.store.Dir())
+	// Checkpoints live at <memoryRoot>/sessions/<id>/checkpoint.md; recover from
+	// the same root streamRun writes to. Empty when memory is disabled — then
+	// RebuildFromCheckpoint falls back to lossy compaction.
+	memoryRoot := deps.memoryRoot
 
 	fmt.Fprintln(out, ui.Colorize(ui.Enabled(), ui.Dim, "Preparing conversation context…"))
 	res, err := runtime.RebuildFromCheckpoint(context.Background(), msgs, deps.header.ID, memoryRoot, &cfg, nil)

--- a/internal/cli/run/memory_wiring_test.go
+++ b/internal/cli/run/memory_wiring_test.go
@@ -1,0 +1,87 @@
+package run
+
+// Tests for the persistent-memory loop wiring (#481): OpenMemoryStore's
+// enabled/disabled contract, MemoryRootFromTools resolving through the opened
+// store, and TodoReminders registering the memory reminder provider alongside
+// the todo one.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/agenttool"
+	"github.com/smallnest/pigo/internal/memory"
+)
+
+// TestOpenMemoryStoreDisabled verifies memory.enabled=false yields (nil, nil):
+// a disabled store is not an error, so the caller degrades to file-based
+// auto-memory without logging a failure.
+func TestOpenMemoryStoreDisabled(t *testing.T) {
+	store, err := OpenMemoryStore(false)
+	if err != nil {
+		t.Fatalf("OpenMemoryStore(false) err = %v, want nil", err)
+	}
+	if store != nil {
+		t.Fatalf("OpenMemoryStore(false) store = %v, want nil", store)
+	}
+}
+
+// TestMemoryDirHonorsPIGOHome verifies MemoryDir roots the store at
+// $PIGO_HOME/memory when the override is set.
+func TestMemoryDirHonorsPIGOHome(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PIGO_HOME", dir)
+	if got, want := MemoryDir(), filepath.Join(dir, "memory"); got != want {
+		t.Errorf("MemoryDir() = %q, want %q", got, want)
+	}
+}
+
+// TestMemoryRootFromToolsPresent verifies the root is resolved through the
+// memory_search tool's Store.Root() when one is wired into the tool set.
+func TestMemoryRootFromToolsPresent(t *testing.T) {
+	root := t.TempDir()
+	store, err := memory.Open(filepath.Join(root, "index.db"), root, "")
+	if err != nil {
+		t.Fatalf("memory.Open: %v", err)
+	}
+	defer store.Close()
+
+	tools := []agentcore.AgentTool{&agenttool.MemorySearchTool{Store: store}}
+	if got := MemoryRootFromTools(tools); got != root {
+		t.Errorf("MemoryRootFromTools = %q, want %q", got, root)
+	}
+}
+
+// TestMemoryRootFromToolsAbsent verifies the root is "" when no memory_search
+// tool (or a store-less one) is present.
+func TestMemoryRootFromToolsAbsent(t *testing.T) {
+	if got := MemoryRootFromTools(nil); got != "" {
+		t.Errorf("MemoryRootFromTools(nil) = %q, want empty", got)
+	}
+	tools := []agentcore.AgentTool{&agenttool.MemorySearchTool{Store: nil}}
+	if got := MemoryRootFromTools(tools); got != "" {
+		t.Errorf("MemoryRootFromTools(store-less) = %q, want empty", got)
+	}
+}
+
+// TestTodoRemindersRegistersMemoryProvider verifies TodoReminders builds a
+// non-empty registry from a memory_search tool alone, and stays nil when no
+// provider-bearing tool is present.
+func TestTodoRemindersRegistersMemoryProvider(t *testing.T) {
+	root := t.TempDir()
+	store, err := memory.Open(filepath.Join(root, "index.db"), root, "")
+	if err != nil {
+		t.Fatalf("memory.Open: %v", err)
+	}
+	defer store.Close()
+
+	reg := TodoReminders([]agentcore.AgentTool{&agenttool.MemorySearchTool{Store: store}})
+	if reg == nil || reg.Empty() {
+		t.Fatal("TodoReminders with a memory_search tool should yield a non-empty registry")
+	}
+
+	if reg := TodoReminders(nil); reg != nil {
+		t.Errorf("TodoReminders(nil) = %v, want nil", reg)
+	}
+}

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smallnest/pigo/internal/agenttool"
 	"github.com/smallnest/pigo/internal/builtinskills"
 	"github.com/smallnest/pigo/internal/hooks"
+	"github.com/smallnest/pigo/internal/memory"
 	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
@@ -42,6 +43,15 @@ type Env struct {
 	// Plugins holds any loaded external plugins so the caller can Close them when
 	// the run ends. It is nil when no plugins were discovered.
 	Plugins *plugin.Manager
+
+	// Memory is the persistent memory store opened once for the run (issue #481),
+	// or nil when persistent memory is disabled (memory.enabled=false), tools are
+	// disabled (--no-tools), or the store could not be opened (a non-fatal
+	// failure). When non-nil the caller MUST Close it when the run ends. The store
+	// is also handed to the memory_search tool (in Tools) and, through it, the
+	// per-turn memory reminder provider, so this field exists mainly so the owner
+	// can close the DB — downstream wiring reaches the store via the tool.
+	Memory *memory.Store
 }
 
 // SetupEnv resolves the provider for model/baseURL, builds the tool set rooted
@@ -54,7 +64,7 @@ type Env struct {
 // config.toml) used as the override for sub-agent credential resolution so
 // dispatched task children authenticate the same way the parent does. It
 // returns an error rather than exiting so the caller owns exit-code mapping.
-func SetupEnv(model, baseURL, protocol, providerName, apiKey string, noTools, noSkills bool, systemPrompt string, appendSystemPrompt []string) (Env, error) {
+func SetupEnv(model, baseURL, protocol, providerName, apiKey string, noTools, noSkills bool, systemPrompt string, appendSystemPrompt []string, memEnabled bool) (Env, error) {
 	cwd, _ := os.Getwd()
 	prov, resolvedName, err := provider.ResolveProvider(model, baseURL, protocol, providerName, os.Getenv)
 	if err != nil {
@@ -65,6 +75,20 @@ func SetupEnv(model, baseURL, protocol, providerName, apiKey string, noTools, no
 		return Env{}, err
 	}
 	tools := BuiltinTools(cwd, noTools)
+	// Open the persistent memory store once (issue #481) and expose it as the
+	// memory_search tool so the agent can recall earlier context. Memory is a
+	// tool, so it is skipped under --no-tools; memory.enabled=false disables it
+	// too. Opening is non-fatal: a failure logs and leaves memory off, matching
+	// the "fall back to file-based auto-memory" contract.
+	var memStore *memory.Store
+	if !noTools {
+		if store, err := OpenMemoryStore(memEnabled); err != nil {
+			fmt.Fprintf(os.Stderr, "pigo: memory disabled: %v\n", err)
+		} else if store != nil {
+			memStore = store
+			tools = append(tools, &agenttool.MemorySearchTool{Store: store})
+		}
+	}
 	// Wire the generic task tool (US-002, #454) unless tools are disabled. It
 	// dispatches general-purpose sub-agents that reuse the resolved provider
 	// stream/model. Each spawn gets a fresh child RunConfig whose registry is the
@@ -132,6 +156,7 @@ func SetupEnv(model, baseURL, protocol, providerName, apiKey string, noTools, no
 		SysPrompt:    sysPrompt,
 		Skills:       skills,
 		Plugins:      mgr,
+		Memory:       memStore,
 	}, nil
 }
 
@@ -243,15 +268,77 @@ func ToolRegistry(tools []agentcore.AgentTool) *agenttool.ToolRegistry {
 // TodoReminders builds the per-turn system-reminder registry for a tool set
 // (US-002): it locates the stateful TodoTool and registers a TodoReminderProvider
 // over its shared store, so the model is reminded of unfinished tasks each turn.
-// Returns nil when no todo tool is present (e.g. --no-tools), leaving injection
-// disabled.
+// It also registers a MemoryReminderProvider over the memory_search tool's store
+// (issue #481) when present, so relevant persisted memory is recalled each turn
+// (this is the recall channel used after auto-compaction/rebuild). Returns nil
+// when neither provider applies (e.g. --no-tools), leaving injection disabled.
 func TodoReminders(tools []agentcore.AgentTool) *runtime.ReminderRegistry {
+	var providers []runtime.ReminderProvider
 	for _, t := range tools {
-		if tt, ok := t.(*agenttool.TodoTool); ok && tt.Store != nil {
-			return runtime.NewReminderRegistry(&runtime.TodoReminderProvider{Store: tt.Store})
+		switch tool := t.(type) {
+		case *agenttool.TodoTool:
+			if tool.Store != nil {
+				providers = append(providers, &runtime.TodoReminderProvider{Store: tool.Store})
+			}
+		case *agenttool.MemorySearchTool:
+			if tool.Store != nil {
+				providers = append(providers, &runtime.MemoryReminderProvider{Store: tool.Store})
+			}
 		}
 	}
-	return nil
+	if len(providers) == 0 {
+		return nil
+	}
+	return runtime.NewReminderRegistry(providers...)
+}
+
+// MemoryRootFromTools returns the persistent memory root the run's memory_search
+// tool is backed by (its Store.Root()), or "" when persistent memory is not wired
+// into this tool set (memory.enabled=false, --no-tools, or the store failed to
+// open). It is the canonical source of the memory root for checkpoint persistence
+// and context rebuild (<root>/sessions/<id>/checkpoint.md): callers resolve the
+// root through the opened store rather than re-deriving it from the session store.
+func MemoryRootFromTools(tools []agentcore.AgentTool) string {
+	for _, t := range tools {
+		if mt, ok := t.(*agenttool.MemorySearchTool); ok && mt.Store != nil {
+			return mt.Store.Root()
+		}
+	}
+	return ""
+}
+
+// MemoryDir returns the persistent memory root directory: $PIGO_HOME/memory, or
+// ~/.pigo/memory by default (a single global store so cross-project "global"
+// memories are searchable, mirroring the session store's ~/.pigo base). It
+// returns "" when the home directory cannot be resolved and no override is set.
+func MemoryDir() string {
+	dir := os.Getenv("PIGO_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		dir = filepath.Join(home, ".pigo")
+	}
+	return filepath.Join(dir, "memory")
+}
+
+// OpenMemoryStore opens the persistent memory store under MemoryDir() (index DB
+// at <root>/index.db). It returns (nil, nil) — not an error — when persistent
+// memory is disabled (memEnabled=false) or the home dir is unresolvable, so the
+// caller degrades to file-based auto-memory without treating the off state as a
+// failure. A genuine open failure is returned as an error for the caller to log
+// non-fatally.
+func OpenMemoryStore(memEnabled bool) (*memory.Store, error) {
+	if !memEnabled {
+		return nil, nil
+	}
+	root := MemoryDir()
+	if root == "" {
+		return nil, nil
+	}
+	dbPath := filepath.Join(root, "index.db")
+	return memory.Open(dbPath, root, "")
 }
 
 // SkillsDir returns the directory skills are loaded from. It defaults to

--- a/internal/cli/tui/session.go
+++ b/internal/cli/tui/session.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -49,6 +48,11 @@ type runSession struct {
 	reg       *agenttool.ToolRegistry
 	reminders *runtime.ReminderRegistry
 	creds     *provider.CredentialStore
+
+	// memoryRoot is the persistent-memory Store root (empty when memory is
+	// disabled). It routes auto-compaction checkpoints and /rebuild recovery to
+	// <memoryRoot>/sessions/<id>/, the canonical checkpoint location.
+	memoryRoot string
 
 	// dispatcher is the session's hook dispatcher, nil when no hooks are
 	// configured (FR-18). hookDeps carries the session id / project dir stamped
@@ -158,6 +162,7 @@ func newRunSessionWithStore(store *session.Store, opts Options) (*runSession, []
 		creds:     creds,
 		curLeaf:   curLeaf,
 		persisted: len(history),
+		memoryRoot: run.MemoryRootFromTools(opts.Tools),
 	}
 	// Wire hooks uniformly with every other driver (#425): resolve the trust-gated
 	// hook set, build the dispatcher, dispatch SessionStart once, and compose the
@@ -239,6 +244,8 @@ func (s *runSession) buildConfig() runtime.RunConfig {
 			},
 		},
 		Reminders: s.reminders,
+		SessionID: s.header.ID,
+		MemoryRoot: s.memoryRoot,
 	}
 	// Per-turn wiring of the tool-execution + Stop seams; nil dispatcher is a
 	// no-op so the hot path pays nothing when no hooks are configured (FR-18).
@@ -275,9 +282,10 @@ func (s *runSession) rebuildCmd() tea.Cmd {
 func (s *runSession) rebuild() (string, error) {
 	msgs := s.agentCtx.Messages
 	before := compaction.EstimateContextTokens(msgs).Tokens
-	// The checkpoint lives under <memoryRoot>/sessions/<id>/; the store is rooted
-	// at <memoryRoot>/sessions, so the memory root is its parent.
-	memoryRoot := filepath.Dir(s.store.Dir())
+	// Checkpoints live under <memoryRoot>/sessions/<id>/; recover from the same
+	// root the loop writes to. Empty when memory is disabled — RebuildFromCheckpoint
+	// then falls back to lossy compaction.
+	memoryRoot := s.memoryRoot
 	cfg := s.buildConfig()
 	res, err := runtime.RebuildFromCheckpoint(context.Background(), msgs, s.header.ID, memoryRoot, &cfg, nil)
 	if err != nil {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -87,6 +87,19 @@ func (s *Store) DB() *sql.DB {
 	return s.db
 }
 
+// Root returns the memory root directory the store was opened with (the magic
+// layout root holding global/projects/sessions). It is the canonical source for
+// the memory root used by checkpoint persistence and context rebuild
+// (<root>/sessions/<id>/checkpoint.md); callers must resolve the memory root
+// through this accessor rather than re-deriving it from another store's dir. It
+// is "" for a nil store.
+func (s *Store) Root() string {
+	if s == nil {
+		return ""
+	}
+	return s.root
+}
+
 // Close closes the underlying database connection.
 func (s *Store) Close() error {
 	if s == nil || s.db == nil {

--- a/internal/runtime/loop.go
+++ b/internal/runtime/loop.go
@@ -21,6 +21,8 @@ package runtime
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/smallnest/pigo/internal/agentcore"
@@ -98,8 +100,18 @@ type RunConfig struct {
 
 	// SessionID, when set, is carried in the run's agent_start event so a
 	// stream-json consumer sees the backing session id in the first event and can
-	// resume the run later (mirrors pi/Claude Code).
+	// resume the run later (mirrors pi/Claude Code). It is also the session key
+	// under which auto-compaction checkpoints are persisted (see MemoryRoot).
 	SessionID string
+
+	// MemoryRoot, when non-empty (together with SessionID), enables checkpoint
+	// persistence for the "infinite context" feature (#480/#481): after a
+	// successful auto-compaction the collapsed prefix's summary is written as a
+	// checkpoint under <MemoryRoot>/sessions/<SessionID>/checkpoint.md so a later
+	// run can reload it instead of replaying the whole transcript. It is left ""
+	// when persistent memory is disabled (memory.enabled=false), which fully
+	// disables checkpoint writing. A checkpoint write failure is non-fatal.
+	MemoryRoot string
 }
 
 // LoopEventStream is the stream returned by the loop entry points: it carries
@@ -350,6 +362,11 @@ func maybeAutoCompact(ctx context.Context, agentCtx *agentcore.AgentContext, cfg
 		// Nothing to summarize (cut point left no prefix); leave context as-is.
 		return
 	}
+	// Persist a checkpoint of the collapsed prefix before rewriting the context so
+	// a later run can reload it (infinite context, #480/#481). It reuses the
+	// summary compaction just produced — no extra LLM call — and is best-effort:
+	// a write failure is logged and the run continues on the compacted context.
+	writeCompactionCheckpoint(ctx, agentCtx.Messages, res, cfg)
 	now := nowMillis()
 	rebuilt := res.RebuildContext(agentCtx.Messages, now)
 	summarized := len(agentCtx.Messages) - (len(rebuilt) - 1)
@@ -387,6 +404,42 @@ func runCompaction(ctx context.Context, msgs agentcore.MessageList, cfg *RunConf
 	}
 	scfg := provider.StreamConfig{APIKey: key, ThinkingLevel: cfg.ThinkingLevel}
 	return compaction.Compact(ctx, stream, model, msgs, cfg.Compaction, -1, nil, "", scfg)
+}
+
+// writeCompactionCheckpoint persists the just-produced compaction summary as a
+// session checkpoint so a later run can reload the collapsed prefix instead of
+// replaying it (#480/#481). It is a no-op unless checkpoint persistence is wired
+// (MemoryRoot and SessionID both set) — which is how memory.enabled=false keeps
+// the whole subsystem inert. It reuses res.Summary (no extra summarization call)
+// via BuildCheckpoint, tagging the checkpoint with the compaction cut point as
+// its watermark. All failures are non-fatal: they are logged to stderr and the
+// run continues on the compacted context (WriteCheckpoint's log-and-continue
+// contract).
+func writeCompactionCheckpoint(ctx context.Context, msgs agentcore.MessageList, res *compaction.CompactionResult, cfg *RunConfig) {
+	if cfg.MemoryRoot == "" || cfg.SessionID == "" || res == nil {
+		return
+	}
+	watermark := res.FirstKeptIndex
+	if watermark < 0 {
+		watermark = 0
+	}
+	if watermark > len(msgs) {
+		watermark = len(msgs)
+	}
+	// summarize returns the summary the compaction already computed, so
+	// BuildCheckpoint records an honest CoveredMessages count without a second
+	// LLM round-trip.
+	summarize := func(context.Context, []agentcore.Message) (string, error) {
+		return res.Summary, nil
+	}
+	cp, err := BuildCheckpoint(ctx, msgs[:watermark], watermark, time.Now(), summarize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pigo: checkpoint: build for session %s: %v\n", cfg.SessionID, err)
+		return
+	}
+	if err := WriteCheckpoint(cfg.SessionID, cfg.MemoryRoot, cp); err != nil {
+		fmt.Fprintf(os.Stderr, "pigo: checkpoint: write for session %s: %v\n", cfg.SessionID, err)
+	}
 }
 
 // applyTurnUpdate applies a non-nil TurnUpdate to the mutable loop state: any


### PR DESCRIPTION
## Summary
- Open the persistent memory store when `memory.enabled` and tools are on; register the `memory_search` tool + its reminder provider (`OpenMemoryStore`, `TodoReminders`).
- Add canonical root helpers (`MemoryDir`, `MemoryRootFromTools`) so the memory root is resolved through the opened store, not re-derived from the session store.
- All three drivers (REPL, TUI, headless) now set `RunConfig.SessionID` + `MemoryRoot`, so `writeCompactionCheckpoint` fires and `/rebuild` recovers the pre-watermark prefix from `<memoryRoot>/sessions/<id>/checkpoint.md`.
- Store lifecycle: `main.go` passes `memEnabled` to `SetupEnv` and closes `env.Memory` on exit.

Closes #481

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (green; added `internal/cli/run/memory_wiring_test.go` covering disabled-store contract, root resolution present/absent, and reminder registration)