### PR TITLE
feat(cli): /memory command + memstatus report

### DIFF
--- a/internal/cli/memstatus/memstatus.go
+++ b/internal/cli/memstatus/memstatus.go
@@ -1,0 +1,195 @@
+// This file implements the /memory slash command (US-011, FR-20, #484) that
+// prints a colored report describing the persistent memory store and the
+// infinite-context state: entry counts by scope, the current context window and
+// auto-compaction trigger point, current context usage, and checkpoint status.
+//
+// Unlike /status (which reads everything through cli.Host), /memory takes its
+// inputs explicitly so both the REPL and the TUI can call it with the live
+// memory store, which the Host contract does not expose.
+package memstatus
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/cli/ui"
+	"github.com/smallnest/pigo/internal/compaction"
+	"github.com/smallnest/pigo/internal/memory"
+	"github.com/smallnest/pigo/internal/runtime"
+)
+
+// scopeOrder is the display order for memory scopes. Scopes not listed here are
+// appended afterwards in lexical order.
+var scopeOrder = []memory.Scope{
+	memory.ScopeGlobal,
+	memory.ScopeProjects,
+	memory.ScopeSessions,
+	memory.ScopeCC,
+}
+
+// RunMemory prints a colored multi-section report about persistent memory and
+// infinite context to out. store may be nil (persistent memory disabled), in
+// which case the memory-store section reports that state and the checkpoint /
+// context sections still render from msgs and the checkpoint file.
+func RunMemory(out io.Writer, store *memory.Store, memoryRoot, sessionID string, msgs agentcore.MessageList, contextWindow int) {
+	color := ui.Enabled()
+
+	fmt.Fprintln(out)
+	printStoreSection(out, color, store, memoryRoot)
+	fmt.Fprintln(out)
+	printContextSection(out, color, msgs, contextWindow)
+	fmt.Fprintln(out)
+	printCheckpointSection(out, color, memoryRoot, sessionID)
+}
+
+// printStoreSection prints the persistent memory store section: whether memory
+// is enabled, the root directory, and entry counts per scope. It reconciles the
+// on-disk files into the index first so the counts are fresh.
+func printStoreSection(out io.Writer, color bool, store *memory.Store, memoryRoot string) {
+	fmt.Fprintf(out, "%s\n", ui.Colorize(color, ui.Bold, "persistent memory:"))
+	if store == nil {
+		fmt.Fprintf(out, "  %s %s\n",
+			ui.Colorize(color, ui.Dim, "status:"),
+			ui.Colorize(color, ui.Yellow, "disabled"))
+		return
+	}
+	fmt.Fprintf(out, "  %s %s\n",
+		ui.Colorize(color, ui.Dim, "status:"),
+		ui.Colorize(color, ui.Green, "enabled"))
+	if memoryRoot != "" {
+		fmt.Fprintf(out, "  %s %s\n", ui.Colorize(color, ui.Dim, "root:"), memoryRoot)
+	}
+
+	if _, err := store.Reconcile(); err != nil {
+		fmt.Fprintf(out, "  %s %s\n",
+			ui.Colorize(color, ui.Dim, "entries:"),
+			ui.Colorize(color, ui.Red, fmt.Sprintf("reconcile failed: %v", err)))
+		return
+	}
+	counts, err := store.CountByScope()
+	if err != nil {
+		fmt.Fprintf(out, "  %s %s\n",
+			ui.Colorize(color, ui.Dim, "entries:"),
+			ui.Colorize(color, ui.Red, fmt.Sprintf("count failed: %v", err)))
+		return
+	}
+
+	total := 0
+	for _, n := range counts {
+		total += n
+	}
+	fmt.Fprintf(out, "  %s %d\n", ui.Colorize(color, ui.Dim, "entries:"), total)
+	for _, scope := range orderedScopes(counts) {
+		fmt.Fprintf(out, "    %s %d\n",
+			ui.Colorize(color, ui.Dim, string(scope)+":"), counts[scope])
+	}
+}
+
+// orderedScopes returns the scopes present in counts, listing the well-known
+// scopes first (scopeOrder) and any others afterwards in lexical order.
+func orderedScopes(counts map[memory.Scope]int) []memory.Scope {
+	seen := make(map[memory.Scope]bool, len(counts))
+	var out []memory.Scope
+	for _, s := range scopeOrder {
+		if _, ok := counts[s]; ok {
+			out = append(out, s)
+			seen[s] = true
+		}
+	}
+	var extra []memory.Scope
+	for s := range counts {
+		if !seen[s] {
+			extra = append(extra, s)
+		}
+	}
+	sort.Slice(extra, func(i, j int) bool { return extra[i] < extra[j] })
+	return append(out, extra...)
+}
+
+// printContextSection prints the current context usage and the auto-compaction
+// trigger point (window minus reserve), mirroring /status's context block so
+// /memory is self-contained for infinite-context inspection.
+func printContextSection(out io.Writer, color bool, msgs agentcore.MessageList, contextWindow int) {
+	tokens := compaction.EstimateContextTokens(msgs).Tokens
+
+	fmt.Fprintf(out, "%s\n", ui.Colorize(color, ui.Bold, "context:"))
+	if contextWindow > 0 {
+		fmt.Fprintf(out, "  %s %d / %d tokens\n",
+			ui.Colorize(color, ui.Dim, "current:"), tokens, contextWindow)
+		util := int(float64(tokens) / float64(contextWindow) * 100)
+		utilColor := ui.Green
+		if util >= 90 {
+			utilColor = ui.Red
+		} else if util >= 70 {
+			utilColor = ui.Yellow
+		}
+		fmt.Fprintf(out, "  %s %s\n",
+			ui.Colorize(color, ui.Dim, "utilization:"),
+			ui.Colorize(color, utilColor, fmt.Sprintf("%d%%", util)))
+
+		reserve := compaction.DefaultCompactionSettings.ReserveTokens
+		threshold := contextWindow - reserve
+		remaining := threshold - tokens
+		if remaining < 0 {
+			fmt.Fprintf(out, "  %s %s (window: %d, reserve: %d)\n",
+				ui.Colorize(color, ui.Dim, "compaction trigger:"),
+				ui.Colorize(color, ui.Red, fmt.Sprintf("%d tokens over trigger (%d)", -remaining, threshold)),
+				contextWindow, reserve)
+		} else {
+			fmt.Fprintf(out, "  %s %s (window: %d, reserve: %d)\n",
+				ui.Colorize(color, ui.Dim, "compaction trigger:"),
+				ui.Colorize(color, ui.Green, fmt.Sprintf("%d tokens until trigger (%d)", remaining, threshold)),
+				contextWindow, reserve)
+		}
+	} else {
+		fmt.Fprintf(out, "  %s %d tokens\n", ui.Colorize(color, ui.Dim, "current:"), tokens)
+		fmt.Fprintf(out, "  %s %s\n",
+			ui.Colorize(color, ui.Dim, "compaction trigger:"),
+			ui.Colorize(color, ui.Yellow, "auto-compaction disabled (unknown window)"))
+	}
+}
+
+// printCheckpointSection prints the infinite-context checkpoint status for the
+// session: whether a checkpoint.md exists and, if so, its watermark, covered
+// message count, and creation time.
+func printCheckpointSection(out io.Writer, color bool, memoryRoot, sessionID string) {
+	fmt.Fprintf(out, "%s\n", ui.Colorize(color, ui.Bold, "checkpoint:"))
+	if memoryRoot == "" || sessionID == "" {
+		fmt.Fprintf(out, "  %s %s\n",
+			ui.Colorize(color, ui.Dim, "status:"),
+			ui.Colorize(color, ui.Yellow, "unavailable (no memory root or session id)"))
+		return
+	}
+	cp, ok, err := runtime.LoadCheckpoint(sessionID, memoryRoot)
+	if err != nil {
+		fmt.Fprintf(out, "  %s %s\n",
+			ui.Colorize(color, ui.Dim, "status:"),
+			ui.Colorize(color, ui.Red, fmt.Sprintf("load failed: %v", err)))
+		return
+	}
+	if !ok {
+		fmt.Fprintf(out, "  %s %s\n",
+			ui.Colorize(color, ui.Dim, "status:"),
+			ui.Colorize(color, ui.Dim, "none yet"))
+		fmt.Fprintf(out, "  %s %s\n",
+			ui.Colorize(color, ui.Dim, "path:"),
+			runtime.CheckpointPath(sessionID, memoryRoot))
+		return
+	}
+	fmt.Fprintf(out, "  %s %s\n",
+		ui.Colorize(color, ui.Dim, "status:"),
+		ui.Colorize(color, ui.Green, "present"))
+	fmt.Fprintf(out, "  %s %d\n", ui.Colorize(color, ui.Dim, "watermark:"), cp.Watermark)
+	fmt.Fprintf(out, "  %s %d\n", ui.Colorize(color, ui.Dim, "covered messages:"), cp.CoveredMessages)
+	if !cp.CreatedAt.IsZero() {
+		fmt.Fprintf(out, "  %s %s\n",
+			ui.Colorize(color, ui.Dim, "created:"),
+			cp.CreatedAt.Format("2006-01-02 15:04:05 MST"))
+	}
+	fmt.Fprintf(out, "  %s %s\n",
+		ui.Colorize(color, ui.Dim, "path:"),
+		runtime.CheckpointPath(sessionID, memoryRoot))
+}
+

--- a/internal/cli/memstatus/memstatus_test.go
+++ b/internal/cli/memstatus/memstatus_test.go
@@ -1,0 +1,53 @@
+package memstatus
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/memory"
+)
+
+// TestRunMemoryDisabled renders the disabled state when the store is nil and
+// still prints the context and checkpoint sections.
+func TestRunMemoryDisabled(t *testing.T) {
+	var buf bytes.Buffer
+	RunMemory(&buf, nil, "", "", nil, 0)
+	out := buf.String()
+	for _, want := range []string{"persistent memory:", "disabled", "context:", "checkpoint:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunMemoryEnabledCounts reconciles a store with entries and asserts the
+// report shows enabled status and per-scope counts.
+func TestRunMemoryEnabledCounts(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "mem")
+	if err := os.MkdirAll(filepath.Join(root, "global", "reference"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "global", "reference", "a.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	st, err := memory.Open(filepath.Join(base, "index.db"), root, "")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer st.Close()
+
+	var buf bytes.Buffer
+	msgs := agentcore.MessageList{agentcore.UserMessage{Content: agentcore.ContentList{agentcore.NewTextContent("hi")}}}
+	RunMemory(&buf, st, root, "sess-1", msgs, 200000)
+	out := buf.String()
+	for _, want := range []string{"enabled", "entries:", "global:", "context:", "checkpoint:", "none yet"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/cli/repl/interactive.go
+++ b/internal/cli/repl/interactive.go
@@ -213,6 +213,7 @@ func Run(opts Options) error {
 		curLeaf:   curLeaf,
 		persisted: len(history),
 		memoryRoot: run.MemoryRootFromTools(opts.Tools),
+		memstore:   run.MemoryStoreFromTools(opts.Tools),
 		notifier:  plugin.NewEventNotifier(opts.Plugins, os.Stderr),
 		goal:      agenttool.NewGoalState(),
 		telemetry: cli.NewTelemetryHolder(),

--- a/internal/cli/repl/repl.go
+++ b/internal/cli/repl/repl.go
@@ -29,12 +29,14 @@ import (
 	"github.com/smallnest/pigo/internal/cli"
 	"github.com/smallnest/pigo/internal/cli/btw"
 	"github.com/smallnest/pigo/internal/cli/goal"
+	"github.com/smallnest/pigo/internal/cli/memstatus"
 	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/status"
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/clipboard"
 	"github.com/smallnest/pigo/internal/compaction"
 	"github.com/smallnest/pigo/internal/hooks"
+	"github.com/smallnest/pigo/internal/memory"
 	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
@@ -144,6 +146,9 @@ type replDeps struct {
 	// disabled). streamRun routes auto-compaction checkpoints here and /rebuild
 	// recovers from <memoryRoot>/sessions/<id>/, the canonical checkpoint location.
 	memoryRoot string
+	// memstore is the live persistent-memory Store (nil when memory is disabled).
+	// It lets /memory inspect entry counts without re-opening the database.
+	memstore *memory.Store
 }
 
 // replScanBufInit is the initial size of the shared input reader. A REPL user
@@ -423,6 +428,15 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 			// closure cannot see. The exact-or-space-prefix guard keeps "/statusfoo"
 			// from being mistaken for "/status".
 			status.RunStatus(out, &deps)
+			continue
+		}
+		if line == "/memory" || strings.HasPrefix(line, "/memory ") {
+			// /memory prints the persistent-memory + infinite-context report.
+			// Like /status it needs live state (the memory store, memory root,
+			// session id, and messages) that a string→string Action closure
+			// cannot reach, so it is intercepted here.
+			memstatus.RunMemory(out, deps.memstore, deps.memoryRoot, deps.header.ID,
+				deps.agentCtx.Messages, deps.live.ContextWindow)
 			continue
 		}
 		if line == "/goal" || strings.HasPrefix(line, "/goal ") {

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -307,6 +307,19 @@ func MemoryRootFromTools(tools []agentcore.AgentTool) string {
 	return ""
 }
 
+// MemoryStoreFromTools returns the persistent memory Store backing the run's
+// memory_search tool, or nil when persistent memory is not wired into this tool
+// set. It lets status commands (/memory) inspect the live store without
+// re-opening the database.
+func MemoryStoreFromTools(tools []agentcore.AgentTool) *memory.Store {
+	for _, t := range tools {
+		if mt, ok := t.(*agenttool.MemorySearchTool); ok && mt.Store != nil {
+			return mt.Store
+		}
+	}
+	return nil
+}
+
 // MemoryDir returns the persistent memory root directory: $PIGO_HOME/memory, or
 // ~/.pigo/memory by default (a single global store so cross-project "global"
 // memories are searchable, mirroring the session store's ~/.pigo base). It

--- a/internal/cli/tui/model.go
+++ b/internal/cli/tui/model.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"regexp"
@@ -13,6 +14,8 @@ import (
 
 	"github.com/smallnest/pigo/internal/agentcore"
 	"github.com/smallnest/pigo/internal/cli"
+	"github.com/smallnest/pigo/internal/cli/memstatus"
+	"github.com/smallnest/pigo/internal/memory"
 	"github.com/smallnest/pigo/internal/runtime"
 )
 
@@ -730,6 +733,30 @@ func (m Model) runSlash(line string) (tea.Model, tea.Cmd) {
 	if line == "/exit" || line == "/quit" {
 		m.quitting = true
 		return m, tea.Quit
+	}
+	// /memory is intercepted before registry resolution (like /rebuild): it
+	// prints the persistent-memory + infinite-context report, reading the live
+	// memory store, memory root, session id, and messages that a slash Action
+	// closure (string→string) cannot reach.
+	if line == "/memory" || strings.HasPrefix(line, "/memory ") {
+		m.transcript.addUser(line)
+		m.input.Clear()
+		m.menu.close()
+		var buf bytes.Buffer
+		var store *memory.Store
+		var memoryRoot, sessionID string
+		var msgs agentcore.MessageList
+		window := m.live.ContextWindow
+		if m.session != nil {
+			store = m.session.memstore
+			memoryRoot = m.session.memoryRoot
+			sessionID = m.session.header.ID
+			msgs = m.session.agentCtx.Messages
+		}
+		memstatus.RunMemory(&buf, store, memoryRoot, sessionID, msgs, window)
+		m.transcript.addSystem(strings.TrimRight(buf.String(), "\n"))
+		m.relayout()
+		return m, nil
 	}
 	// /rebuild is intercepted before registry resolution (like /exit): it
 	// reconstructs the shared context from a persisted checkpoint (or falls back

--- a/internal/cli/tui/session.go
+++ b/internal/cli/tui/session.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smallnest/pigo/internal/cli/ui"
 	"github.com/smallnest/pigo/internal/compaction"
 	"github.com/smallnest/pigo/internal/hooks"
+	"github.com/smallnest/pigo/internal/memory"
 	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
@@ -53,6 +54,9 @@ type runSession struct {
 	// disabled). It routes auto-compaction checkpoints and /rebuild recovery to
 	// <memoryRoot>/sessions/<id>/, the canonical checkpoint location.
 	memoryRoot string
+	// memstore is the live persistent-memory Store (nil when memory is disabled).
+	// It lets /memory inspect entry counts without re-opening the database.
+	memstore *memory.Store
 
 	// dispatcher is the session's hook dispatcher, nil when no hooks are
 	// configured (FR-18). hookDeps carries the session id / project dir stamped
@@ -163,6 +167,7 @@ func newRunSessionWithStore(store *session.Store, opts Options) (*runSession, []
 		curLeaf:   curLeaf,
 		persisted: len(history),
 		memoryRoot: run.MemoryRootFromTools(opts.Tools),
+		memstore:   run.MemoryStoreFromTools(opts.Tools),
 	}
 	// Wire hooks uniformly with every other driver (#425): resolve the trust-gated
 	// hook set, build the dispatcher, dispatch SessionStart once, and compose the

--- a/internal/memory/count_test.go
+++ b/internal/memory/count_test.go
@@ -1,0 +1,57 @@
+package memory
+
+import (
+	"testing"
+)
+
+// TestCountByScopeEmpty returns an empty map for a fresh store with no entries.
+func TestCountByScopeEmpty(t *testing.T) {
+	st := openTemp(t)
+	counts, err := st.CountByScope()
+	if err != nil {
+		t.Fatalf("CountByScope: %v", err)
+	}
+	if len(counts) != 0 {
+		t.Fatalf("counts = %v, want empty", counts)
+	}
+}
+
+// TestCountByScopeGroups reconciles files across scopes and asserts the counts
+// are grouped per scope.
+func TestCountByScopeGroups(t *testing.T) {
+	st, root, _ := openTempWithRoots(t)
+
+	writeFile(t, root, "g1", "global", "reference", "a.md")
+	writeFile(t, root, "g2", "global", "notes", "b.md")
+	writeFile(t, root, "p1", "projects", "proj1", "project", "m.md")
+
+	if _, err := st.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	counts, err := st.CountByScope()
+	if err != nil {
+		t.Fatalf("CountByScope: %v", err)
+	}
+	if counts[ScopeGlobal] != 2 {
+		t.Fatalf("global count = %d, want 2 (counts=%v)", counts[ScopeGlobal], counts)
+	}
+	if counts[ScopeProjects] != 1 {
+		t.Fatalf("projects count = %d, want 1 (counts=%v)", counts[ScopeProjects], counts)
+	}
+	if _, ok := counts[ScopeSessions]; ok {
+		t.Fatalf("sessions should be absent, got %d", counts[ScopeSessions])
+	}
+}
+
+// TestCountByScopeNilStore is safe on a nil store and yields an empty map.
+func TestCountByScopeNilStore(t *testing.T) {
+	var st *Store
+	counts, err := st.CountByScope()
+	if err != nil {
+		t.Fatalf("CountByScope on nil: %v", err)
+	}
+	if len(counts) != 0 {
+		t.Fatalf("counts = %v, want empty", counts)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -100,6 +100,34 @@ func (s *Store) Root() string {
 	return s.root
 }
 
+// CountByScope returns the number of indexed memory entries grouped by scope.
+// Scopes with no entries are omitted from the map. It reflects the current
+// contents of memory_index; callers that want fresh counts should Reconcile
+// first. A nil store or nil db yields an empty map.
+func (s *Store) CountByScope() (map[Scope]int, error) {
+	out := make(map[Scope]int)
+	if s == nil || s.db == nil {
+		return out, nil
+	}
+	rows, err := s.db.Query(`SELECT scope, COUNT(*) FROM memory_index GROUP BY scope`)
+	if err != nil {
+		return nil, fmt.Errorf("memory: count by scope: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var scope string
+		var n int
+		if err := rows.Scan(&scope, &n); err != nil {
+			return nil, fmt.Errorf("memory: scan scope count: %w", err)
+		}
+		out[Scope(scope)] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("memory: iterate scope counts: %w", err)
+	}
+	return out, nil
+}
+
 // Close closes the underlying database connection.
 func (s *Store) Close() error {
 	if s == nil || s.db == nil {


### PR DESCRIPTION
## Summary
- Add `/memory` slash command in both REPL and TUI: prints persistent-memory entry counts by scope, current context usage, the auto-compaction trigger point, and checkpoint status.
- New `internal/cli/memstatus` package with an explicit-param `RunMemory` shared by both drivers (the `cli.Host` contract does not expose the memory store).
- Add `memory.Store.CountByScope()` and `run.MemoryStoreFromTools()`; store the live `*memory.Store` in `replDeps` and `runSession`.

Closes #484

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` all green
- [x] New tests: `memory.CountByScope` (empty/grouped/nil) and `memstatus.RunMemory` (disabled/enabled)