### PR TITLE
feat(dream): [dream] config table + state + due-check

### DIFF
--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -50,6 +50,22 @@ type FileConfig struct {
 	Memory     MemoryConfig     `toml:"memory"`
 	Checkpoint CheckpointConfig `toml:"checkpoint"`
 	Compaction CompactionConfig `toml:"compaction"`
+	// Dream is the [dream] TOML table for the /dream memory-consolidation
+	// feature. Pure config plumbing here; defaults/normalization live in
+	// internal/dream (Config). See tasks/spec-dream-memory-consolidation.md
+	// §3.3.
+	Dream DreamConfig `toml:"dream"`
+}
+
+// DreamConfig is the [dream] TOML table for /dream memory consolidation.
+// Enabled is a pointer so an absent key (nil) is distinguishable from an
+// explicit false: nil is treated as true, only enabled = false disables
+// auto-trigger. IntervalDays and RecentSessions use zero as "apply default"
+// (7 and 20 respectively); normalization lives in dream.Config.
+type DreamConfig struct {
+	Enabled        *bool `toml:"enabled"`
+	IntervalDays   int   `toml:"interval_days"`
+	RecentSessions int   `toml:"recent_sessions"`
 }
 
 // FileConfigPath returns the path to the user config file:

--- a/internal/cli/config/config_test.go
+++ b/internal/cli/config/config_test.go
@@ -132,3 +132,45 @@ func TestGenericBaseURLEnvVar(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadFileConfig_DreamTable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := `
+[dream]
+enabled = false
+interval_days = 14
+recent_sessions = 50
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+	if cfg.Dream.Enabled == nil || *cfg.Dream.Enabled {
+		t.Errorf("Dream.Enabled = %v, want explicit false", cfg.Dream.Enabled)
+	}
+	if cfg.Dream.IntervalDays != 14 {
+		t.Errorf("Dream.IntervalDays = %d, want 14", cfg.Dream.IntervalDays)
+	}
+	if cfg.Dream.RecentSessions != 50 {
+		t.Errorf("Dream.RecentSessions = %d, want 50", cfg.Dream.RecentSessions)
+	}
+}
+
+func TestLoadFileConfig_DreamTableAbsent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("model = \"foo\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadFileConfig(path)
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+	// Absent [dream] table: Enabled pointer nil (→ default true downstream),
+	// ints zero (→ defaults downstream). Parsing must not error.
+	if cfg.Dream.Enabled != nil || cfg.Dream.IntervalDays != 0 || cfg.Dream.RecentSessions != 0 {
+		t.Errorf("absent dream table = %+v, want zero-value", cfg.Dream)
+	}
+}

--- a/internal/dream/config.go
+++ b/internal/dream/config.go
@@ -1,0 +1,48 @@
+// Package dream implements the /dream memory-consolidation feature's foundation
+// layer: the resolved [dream] configuration, on-disk run state, and the
+// deterministic due-check that decides whether an auto-trigger is warranted.
+// This layer has no LLM dependency; the runner, scheduler, lock, and plan/apply
+// logic live in later nodes. See tasks/spec-dream-memory-consolidation.md
+// §3.2/§3.3/§5.1/§5.4.
+package dream
+
+// Built-in defaults for the [dream] table, exposed so config normalization and
+// tests share one source of truth.
+const (
+	DefaultEnabled        = true
+	DefaultIntervalDays   = 7
+	DefaultRecentSessions = 20
+)
+
+// Config is the resolved [dream] configuration with defaults applied. It is the
+// shape the scheduler and runner consume, distinct from the raw
+// config.DreamConfig (which uses *bool / zero to distinguish "unset").
+type Config struct {
+	Enabled        bool
+	IntervalDays   int
+	RecentSessions int
+}
+
+// NewConfig normalizes a raw [dream] table into a Config, applying defaults: a
+// nil enabled pointer means true (only an explicit false disables); a
+// non-positive interval_days falls back to 7; a non-positive recent_sessions
+// falls back to 20. A missing [dream] table is representable as the zero
+// arguments (nil, 0, 0) and yields all defaults, so parsing never errors on an
+// absent table.
+func NewConfig(enabled *bool, intervalDays, recentSessions int) Config {
+	c := Config{
+		Enabled:        DefaultEnabled,
+		IntervalDays:   intervalDays,
+		RecentSessions: recentSessions,
+	}
+	if enabled != nil {
+		c.Enabled = *enabled
+	}
+	if c.IntervalDays <= 0 {
+		c.IntervalDays = DefaultIntervalDays
+	}
+	if c.RecentSessions <= 0 {
+		c.RecentSessions = DefaultRecentSessions
+	}
+	return c
+}

--- a/internal/dream/config_test.go
+++ b/internal/dream/config_test.go
@@ -1,0 +1,61 @@
+package dream
+
+import "testing"
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestNewConfigDefaults(t *testing.T) {
+	// Missing [dream] table: nil enabled, zero ints → all defaults.
+	c := NewConfig(nil, 0, 0)
+	if !c.Enabled {
+		t.Errorf("Enabled = false, want true (nil → true)")
+	}
+	if c.IntervalDays != DefaultIntervalDays {
+		t.Errorf("IntervalDays = %d, want %d", c.IntervalDays, DefaultIntervalDays)
+	}
+	if c.RecentSessions != DefaultRecentSessions {
+		t.Errorf("RecentSessions = %d, want %d", c.RecentSessions, DefaultRecentSessions)
+	}
+}
+
+func TestNewConfigEnabledSemantics(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled *bool
+		want    bool
+	}{
+		{"nil treated as true", nil, true},
+		{"explicit true", boolPtr(true), true},
+		{"explicit false", boolPtr(false), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewConfig(tt.enabled, 0, 0).Enabled; got != tt.want {
+				t.Errorf("Enabled = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewConfigNonPositiveFallback(t *testing.T) {
+	tests := []struct {
+		name                   string
+		interval, recent       int
+		wantInterval, wantRcnt int
+	}{
+		{"zero falls back", 0, 0, DefaultIntervalDays, DefaultRecentSessions},
+		{"negative falls back", -3, -1, DefaultIntervalDays, DefaultRecentSessions},
+		{"positive preserved", 14, 50, 14, 50},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewConfig(nil, tt.interval, tt.recent)
+			if c.IntervalDays != tt.wantInterval {
+				t.Errorf("IntervalDays = %d, want %d", c.IntervalDays, tt.wantInterval)
+			}
+			if c.RecentSessions != tt.wantRcnt {
+				t.Errorf("RecentSessions = %d, want %d", c.RecentSessions, tt.wantRcnt)
+			}
+		})
+	}
+}

--- a/internal/dream/state.go
+++ b/internal/dream/state.go
@@ -1,0 +1,103 @@
+package dream
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// State is the persisted /dream run state, stored as JSON at
+// <memoryRoot>/global/dream/state.json. A zero-value State (LastRunAt zero,
+// empty status, nil report) means dream has never run.
+type State struct {
+	LastRunAt  time.Time `json:"last_run_at"`
+	LastStatus string    `json:"last_status"` // "ok" | "failed" | "skipped"
+	// LastReport holds the structured change report from the last run. It is
+	// kept as json.RawMessage here so this foundation layer stays decoupled
+	// from the Report struct, which is defined by a later node
+	// (report.go). The raw bytes round-trip losslessly; the later node can
+	// decode them into a typed Report or migrate this field.
+	// TODO(#521): replace json.RawMessage with *Report once report.go lands.
+	LastReport json.RawMessage `json:"last_report,omitempty"`
+}
+
+// statePath is the state file location under the memory root.
+func statePath(memoryRoot string) string {
+	return filepath.Join(memoryRoot, "global", "dream", "state.json")
+}
+
+// LoadState reads the dream state from <memoryRoot>/global/dream/state.json. A
+// missing file returns a zero-value State (never run) with no error. Corrupt or
+// unreadable JSON is tolerated the same way: the caller gets a zero-value State
+// and no error, so a damaged state file degrades to "never run" rather than
+// breaking dream entirely.
+func LoadState(memoryRoot string) (State, error) {
+	data, err := os.ReadFile(statePath(memoryRoot))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return State{}, nil
+		}
+		// Unreadable (permissions, transient IO): treat as never-run rather
+		// than surfacing an error that would block dream.
+		return State{}, nil
+	}
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		// Corrupt JSON: degrade to never-run.
+		return State{}, nil
+	}
+	return s, nil
+}
+
+// SaveState writes the dream state to <memoryRoot>/global/dream/state.json,
+// creating the parent directory lazily. The file is written atomically via a
+// temp file + rename so a crash mid-write cannot leave a truncated state.json.
+func SaveState(memoryRoot string, s State) error {
+	dir := filepath.Join(memoryRoot, "global", "dream")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := statePath(memoryRoot)
+	tmp, err := os.CreateTemp(dir, "state-*.json.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return nil
+}
+
+// Due reports whether an auto-triggered consolidation is warranted at now given
+// cfg. It returns true only when dream is enabled and the configured interval
+// has elapsed since the last run. Two cases deliberately return false:
+//   - cfg.Enabled is false: auto-trigger is disabled entirely (US-001).
+//   - a zero LastRunAt (dream has never run): the first-ever run is NOT
+//     auto-triggered — the user is prompted to run /dream manually instead — to
+//     avoid a cold-start token cost for new users. See spec §11.1.
+func (s State) Due(cfg Config, now time.Time) bool {
+	if !cfg.Enabled {
+		return false
+	}
+	if s.LastRunAt.IsZero() {
+		return false
+	}
+	interval := time.Duration(cfg.IntervalDays) * 24 * time.Hour
+	return now.Sub(s.LastRunAt) >= interval
+}

--- a/internal/dream/state_test.go
+++ b/internal/dream/state_test.go
@@ -1,0 +1,108 @@
+package dream
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestStateRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	report := json.RawMessage(`{"merged":3,"deduped":1}`)
+	want := State{
+		LastRunAt:  time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC),
+		LastStatus: "ok",
+		LastReport: report,
+	}
+	if err := SaveState(root, want); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	got, err := LoadState(root)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if !got.LastRunAt.Equal(want.LastRunAt) {
+		t.Errorf("LastRunAt = %v, want %v", got.LastRunAt, want.LastRunAt)
+	}
+	if got.LastStatus != want.LastStatus {
+		t.Errorf("LastStatus = %q, want %q", got.LastStatus, want.LastStatus)
+	}
+	// LastReport round-trips as raw JSON; compare semantically since
+	// re-marshaling may reformat whitespace.
+	var gotObj, wantObj map[string]any
+	if err := json.Unmarshal(got.LastReport, &gotObj); err != nil {
+		t.Fatalf("unmarshal got.LastReport: %v", err)
+	}
+	if err := json.Unmarshal(want.LastReport, &wantObj); err != nil {
+		t.Fatalf("unmarshal want.LastReport: %v", err)
+	}
+	if !reflect.DeepEqual(gotObj, wantObj) {
+		t.Errorf("LastReport = %v, want %v", gotObj, wantObj)
+	}
+}
+
+func TestSaveStateCreatesDir(t *testing.T) {
+	root := t.TempDir()
+	if err := SaveState(root, State{LastStatus: "ok"}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "global", "dream", "state.json")); err != nil {
+		t.Errorf("state.json not created: %v", err)
+	}
+}
+
+func TestLoadStateMissingIsZero(t *testing.T) {
+	got, err := LoadState(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if !got.LastRunAt.IsZero() || got.LastStatus != "" || got.LastReport != nil {
+		t.Errorf("missing state = %+v, want zero-value", got)
+	}
+}
+
+func TestLoadStateCorruptTolerated(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "global", "dream")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadState(root)
+	if err != nil {
+		t.Fatalf("LoadState returned error on corrupt JSON, want tolerated: %v", err)
+	}
+	if !got.LastRunAt.IsZero() {
+		t.Errorf("corrupt state = %+v, want zero-value (never run)", got)
+	}
+}
+
+func TestDue(t *testing.T) {
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	cfg := Config{Enabled: true, IntervalDays: 7, RecentSessions: 20}
+	tests := []struct {
+		name string
+		cfg  Config
+		last time.Time
+		want bool
+	}{
+		{"due: interval elapsed", cfg, now.Add(-8 * 24 * time.Hour), true},
+		{"due: exactly at interval", cfg, now.Add(-7 * 24 * time.Hour), true},
+		{"not due: within interval", cfg, now.Add(-3 * 24 * time.Hour), false},
+		{"zero LastRunAt never due", cfg, time.Time{}, false},
+		{"disabled never due", Config{Enabled: false, IntervalDays: 7}, now.Add(-30 * 24 * time.Hour), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := State{LastRunAt: tt.last}
+			if got := s.Due(tt.cfg, now); got != tt.want {
+				t.Errorf("Due = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/dream` foundation layer (no LLM dependency): `Config` with defaults + normalizer, `State` JSON persistence at `<memoryRoot>/global/dream/state.json`, and a deterministic `Due(cfg, now)` due-check.
- `[dream]` TOML table on `FileConfig` (`DreamConfig` with `*bool enabled`, `interval_days`, `recent_sessions`).
- `Due` returns false for a zero `LastRunAt` so the first-ever run is not auto-triggered (spec §11.1) and false when disabled.
- Missing/corrupt state JSON tolerated as never-run; atomic temp+rename write with lazy `MkdirAll`.
- `LastReport` kept as `json.RawMessage` to decouple from the `Report` struct defined by a later node.

Closes #519

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/dream/... ./internal/cli/config/...`
- [x] config parse + defaults + `*bool` (nil/true/false) semantics
- [x] state round-trip + zero-value + corrupt-JSON tolerance
- [x] `Due` boundaries (due / not-due / zero-LastRunAt→false / disabled)