### PR TITLE
feat(dream): dream.lock single-instance mutex

### DIFF
--- a/internal/dream/lock.go
+++ b/internal/dream/lock.go
@@ -1,0 +1,147 @@
+package dream
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ErrLocked is returned by AcquireLock when a live (non-stale) lock is already
+// held by another process. Callers detect it (via errors.Is) to exit "skipped"
+// rather than treating it as a real failure. It is deliberately distinct from
+// the I/O errors AcquireLock may also return.
+var ErrLocked = errors.New("dream: consolidation already running")
+
+// DefaultStaleAfter is how long after a lock's started_at the lock is considered
+// abandoned (e.g. the holder crashed) and may be taken over. See spec §5.4.
+var DefaultStaleAfter = 30 * time.Minute
+
+// lockInfo is the JSON body persisted in the lock file.
+type lockInfo struct {
+	PID       int       `json:"pid"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+// Lock represents an acquired dream single-instance lock backed by the file
+// <memoryRoot>/global/dream/dream.lock. It guarantees at most one consolidation
+// runs at a time across processes, with crash-safe stale takeover.
+type Lock struct {
+	path     string
+	released bool
+}
+
+// lockPath is the lock file location under the memory root. It is a separate
+// file from state.json and never touches it.
+func lockPath(memoryRoot string) string {
+	return filepath.Join(memoryRoot, "global", "dream", "dream.lock")
+}
+
+// AcquireLock attempts to acquire the dream single-instance lock under
+// memoryRoot. On success it returns a *Lock the caller must Release (typically
+// via defer). If a live lock is already held it returns ErrLocked. If the
+// existing lock is stale (its started_at is older than now-DefaultStaleAfter) or
+// malformed/unparseable, it is treated as abandoned and taken over. Any other
+// error (permissions, unexpected I/O) is returned as-is so the caller can
+// distinguish it from the ErrLocked "skipped" case.
+func AcquireLock(memoryRoot string) (*Lock, error) {
+	dir := filepath.Join(memoryRoot, "global", "dream")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	path := lockPath(memoryRoot)
+
+	// First attempt: atomic exclusive create.
+	l, err := createLock(path)
+	if err == nil {
+		return l, nil
+	}
+	if !os.IsExist(err) {
+		// Real I/O error (permissions, etc.), not a contention signal.
+		return nil, err
+	}
+
+	// A lock file already exists. Decide whether it is stale and takeable.
+	if !staleLock(path, time.Now()) {
+		return nil, ErrLocked
+	}
+
+	// Stale (or malformed) lock: take it over. Removing then re-creating with
+	// O_EXCL keeps the create atomic. A racing process that recreates the file
+	// between our Remove and create will cause our create to fail with EEXIST;
+	// we surface that as ErrLocked (the other process won the race).
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	l, err = createLock(path)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil, ErrLocked
+		}
+		return nil, err
+	}
+	return l, nil
+}
+
+// createLock atomically creates the lock file with O_EXCL and writes the current
+// pid + start time as JSON. On EEXIST it returns an error for which os.IsExist
+// is true.
+func createLock(path string) (*Lock, error) {
+	f, err := os.OpenFile(path, os.O_EXCL|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	data, err := json.Marshal(lockInfo{PID: os.Getpid(), StartedAt: time.Now().UTC()})
+	if err != nil {
+		f.Close()
+		os.Remove(path)
+		return nil, err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(path)
+		return nil, err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(path)
+		return nil, err
+	}
+	return &Lock{path: path}, nil
+}
+
+// staleLock reports whether the lock file at path is stale (takeable) as of now.
+// A lock is stale when its started_at is older than now-DefaultStaleAfter. A
+// missing, unreadable, or malformed/unparseable lock file is also treated as
+// stale so a corrupt lock never wedges dream permanently.
+func staleLock(path string, now time.Time) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Missing or unreadable: treat as takeable.
+		return true
+	}
+	var info lockInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		// Malformed lock body: treat as stale.
+		return true
+	}
+	if info.StartedAt.IsZero() {
+		// No usable timestamp: treat as stale.
+		return true
+	}
+	return now.Sub(info.StartedAt) > DefaultStaleAfter
+}
+
+// Release removes the lock file. It is safe to call in a defer and safe to
+// double-call: a second call (or a call after the file was already removed) is a
+// no-op and never panics. A missing file is not an error.
+func (l *Lock) Release() error {
+	if l == nil || l.released {
+		return nil
+	}
+	l.released = true
+	if err := os.Remove(l.path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/dream/lock_test.go
+++ b/internal/dream/lock_test.go
@@ -1,0 +1,191 @@
+package dream
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeLock writes a lock file with the given pid and started_at directly, for
+// tests that need to simulate a pre-existing (possibly stale) lock.
+func writeLock(t *testing.T, root string, pid int, startedAt time.Time) string {
+	t.Helper()
+	dir := filepath.Join(root, "global", "dream")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "dream.lock")
+	data, err := json.Marshal(lockInfo{PID: pid, StartedAt: startedAt})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestAcquireLockMutualExclusion(t *testing.T) {
+	root := t.TempDir()
+	l1, err := AcquireLock(root)
+	if err != nil {
+		t.Fatalf("first AcquireLock: %v", err)
+	}
+	defer l1.Release()
+
+	// A second acquire while the first is live must fail with ErrLocked.
+	l2, err := AcquireLock(root)
+	if !errors.Is(err, ErrLocked) {
+		t.Fatalf("second AcquireLock err = %v, want ErrLocked", err)
+	}
+	if l2 != nil {
+		t.Errorf("second AcquireLock returned non-nil Lock alongside error")
+	}
+}
+
+func TestAcquireLockCreatesFileWithBody(t *testing.T) {
+	root := t.TempDir()
+	l, err := AcquireLock(root)
+	if err != nil {
+		t.Fatalf("AcquireLock: %v", err)
+	}
+	defer l.Release()
+
+	path := filepath.Join(root, "global", "dream", "dream.lock")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read lock file: %v", err)
+	}
+	var info lockInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		t.Fatalf("lock body not valid JSON: %v", err)
+	}
+	if info.PID != os.Getpid() {
+		t.Errorf("lock pid = %d, want %d", info.PID, os.Getpid())
+	}
+	if info.StartedAt.IsZero() {
+		t.Errorf("lock started_at is zero, want current time")
+	}
+}
+
+func TestAcquireLockDoesNotTouchState(t *testing.T) {
+	root := t.TempDir()
+	l, err := AcquireLock(root)
+	if err != nil {
+		t.Fatalf("AcquireLock: %v", err)
+	}
+	defer l.Release()
+	if _, err := os.Stat(filepath.Join(root, "global", "dream", "state.json")); !os.IsNotExist(err) {
+		t.Errorf("AcquireLock created/left state.json (err=%v); lock must be a separate file", err)
+	}
+}
+
+func TestAcquireLockStaleTakeover(t *testing.T) {
+	root := t.TempDir()
+	// Existing lock older than staleAfter → takeable.
+	writeLock(t, root, 99999, time.Now().Add(-DefaultStaleAfter-time.Minute))
+
+	l, err := AcquireLock(root)
+	if err != nil {
+		t.Fatalf("AcquireLock over stale lock err = %v, want takeover success", err)
+	}
+	defer l.Release()
+
+	// The lock body should now reflect our pid.
+	data, err := os.ReadFile(filepath.Join(root, "global", "dream", "dream.lock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var info lockInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		t.Fatal(err)
+	}
+	if info.PID != os.Getpid() {
+		t.Errorf("after takeover pid = %d, want %d (our pid)", info.PID, os.Getpid())
+	}
+}
+
+func TestAcquireLockFreshLockNotTakeable(t *testing.T) {
+	root := t.TempDir()
+	// A recently-started lock is live, not stale.
+	writeLock(t, root, 99999, time.Now().Add(-time.Minute))
+
+	if _, err := AcquireLock(root); !errors.Is(err, ErrLocked) {
+		t.Fatalf("AcquireLock over fresh lock err = %v, want ErrLocked", err)
+	}
+}
+
+func TestAcquireLockMalformedTakeover(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "global", "dream")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "dream.lock"), []byte("{garbage not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := AcquireLock(root)
+	if err != nil {
+		t.Fatalf("AcquireLock over malformed lock err = %v, want takeover success", err)
+	}
+	defer l.Release()
+}
+
+func TestReleaseAndReacquire(t *testing.T) {
+	root := t.TempDir()
+	l1, err := AcquireLock(root)
+	if err != nil {
+		t.Fatalf("first AcquireLock: %v", err)
+	}
+	if err := l1.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	// File must be gone after release.
+	if _, err := os.Stat(filepath.Join(root, "global", "dream", "dream.lock")); !os.IsNotExist(err) {
+		t.Errorf("lock file still present after Release (err=%v)", err)
+	}
+	// Re-acquire must succeed now that the lock is free.
+	l2, err := AcquireLock(root)
+	if err != nil {
+		t.Fatalf("re-acquire after release: %v", err)
+	}
+	defer l2.Release()
+}
+
+func TestReleaseDoubleCallSafe(t *testing.T) {
+	root := t.TempDir()
+	l, err := AcquireLock(root)
+	if err != nil {
+		t.Fatalf("AcquireLock: %v", err)
+	}
+	if err := l.Release(); err != nil {
+		t.Fatalf("first Release: %v", err)
+	}
+	// Second Release (and even after the file is gone) must not panic or error.
+	if err := l.Release(); err != nil {
+		t.Errorf("second Release err = %v, want nil", err)
+	}
+}
+
+func TestReleaseNilSafe(t *testing.T) {
+	var l *Lock
+	if err := l.Release(); err != nil {
+		t.Errorf("nil Lock Release err = %v, want nil", err)
+	}
+}
+
+func TestStaleLockBoundary(t *testing.T) {
+	root := t.TempDir()
+	path := writeLock(t, root, 1, time.Unix(0, 0).UTC())
+	now := time.Unix(0, 0).UTC()
+	if staleLock(path, now.Add(DefaultStaleAfter-time.Second)) {
+		t.Errorf("lock within staleAfter reported stale")
+	}
+	if !staleLock(path, now.Add(DefaultStaleAfter+time.Second)) {
+		t.Errorf("lock past staleAfter reported not stale")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/dream/lock.go`: `AcquireLock(memoryRoot)` over `<memoryRoot>/global/dream/dream.lock` using `O_EXCL|O_CREATE|O_WRONLY` (atomic exclusive create), body JSON `{pid, started_at}`.
- Live lock held -> sentinel `ErrLocked` so callers exit "skipped", distinct from real I/O errors.
- Crash-safe stale takeover: locks with `started_at` older than `now-DefaultStaleAfter` (default 30min) and malformed/unparseable locks are taken over atomically.
- `Release()` removes the lockfile; defer-safe, double-call safe, nil-safe. Separate file from state.json.

Closes #520

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/dream/...`
- [x] `go test ./internal/dream/...` (O_EXCL mutual exclusion, stale takeover, malformed takeover, release + re-acquire, boundary)