### PR TITLE
feat(dream): deterministic consolidation plan + Report (#521)

### DIFF
--- a/internal/dream/plan.go
+++ b/internal/dream/plan.go
@@ -1,0 +1,359 @@
+package dream
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// NearDupThreshold is the normalized-token Jaccard similarity at or above which
+// two memory files are emitted as a near-duplicate candidate pair for the later
+// LLM merge-decision step (spec §5.1.1). It is deliberately conservative: this
+// node only PAIRS candidates, it never merges, so a false-positive pair costs
+// only one extra LLM comparison while a missed pair silently loses a merge
+// opportunity.
+const NearDupThreshold = 0.7
+
+// MemoryFile is one enumerated memory file under the global or the active
+// project scope, with the derived metadata the deterministic plan needs. Body
+// is retained so the near-duplicate pairing can tokenize it without a second
+// read.
+type MemoryFile struct {
+	Path        string // absolute path on disk
+	Scope       string // "global" | "projects"
+	Type        string // layout <type> segment ("" for a file directly under the scope root)
+	Size        int64  // byte size of the file content
+	ContentHash string // sha256 hex of the raw file content
+	Body        string // full file content (used for path extraction + tokenization)
+}
+
+// DedupeGroup is a set of two or more files whose content is byte-identical
+// (same ContentHash). The apply node keeps one representative and removes the
+// rest; Deduped in the Report counts len(Paths)-1 per group.
+type DedupeGroup struct {
+	Hash  string   `json:"hash"`
+	Paths []string `json:"paths"`
+}
+
+// InvalidPathRef is a local filesystem path mentioned in a memory file's body
+// that no longer exists on disk. External references (URLs, mailto:, etc.) are
+// never recorded here (spec §5.2 / PRD US-004).
+type InvalidPathRef struct {
+	File string `json:"file"` // memory file containing the reference
+	Ref  string `json:"ref"`  // the original (unresolved) reference text
+}
+
+// NearDupPair is a candidate pair of files whose token-set similarity is at or
+// above NearDupThreshold but whose content is not byte-identical. It is a
+// suggestion for the LLM to decide whether an actual merge is warranted; this
+// node performs no merge.
+type NearDupPair struct {
+	A          string  `json:"a"`
+	B          string  `json:"b"`
+	Similarity float64 `json:"similarity"`
+}
+
+// Plan is the plain-data output of the deterministic half of a /dream run. It
+// carries no behavior and makes no LLM calls; the later apply node consumes it
+// to drive merges/prunes and to compute the final Report counters.
+type Plan struct {
+	Files           []MemoryFile     `json:"files"`
+	DedupeGroups    []DedupeGroup    `json:"dedupe_groups"`
+	InvalidPathRefs []InvalidPathRef `json:"invalid_path_refs"`
+	NearDupPairs    []NearDupPair    `json:"near_dup_pairs"`
+	BytesBefore     int64            `json:"bytes_before"`
+	FilesBefore     int              `json:"files_before"`
+}
+
+// BuildPlan enumerates the consolidation-eligible memory files (global scope +
+// the given project's scope) under memoryRoot and computes the deterministic
+// consolidation plan: exact-dedup groups, invalid local path references, and
+// near-duplicate candidate pairs. It excludes the sessions scope entirely and
+// any file whose layout type is "checkpoint" (session-transient state, not
+// long-term memory — spec §1.3 / §5.1.1).
+//
+// projectDir is the working directory of the active project; its stable project
+// id (matching internal/memory's resolveProjectId) selects the projects
+// sub-scope. An empty projectDir restricts the plan to the global scope. A
+// missing memoryRoot or scope directory is not an error — it yields an empty
+// plan, mirroring memory.Reconcile's tolerance of an absent root.
+func BuildPlan(memoryRoot, projectDir string) (Plan, error) {
+	var plan Plan
+
+	globalRoot := filepath.Join(memoryRoot, "global")
+	globalFiles, err := enumerateScope(globalRoot, "global")
+	if err != nil {
+		return Plan{}, err
+	}
+	files := globalFiles
+
+	if projectDir != "" {
+		projectRoot := filepath.Join(memoryRoot, "projects", projectID(projectDir))
+		projFiles, err := enumerateScope(projectRoot, "projects")
+		if err != nil {
+			return Plan{}, err
+		}
+		files = append(files, projFiles...)
+	}
+
+	plan.Files = files
+	plan.FilesBefore = len(files)
+	for _, f := range files {
+		plan.BytesBefore += f.Size
+	}
+
+	plan.DedupeGroups = dedupeGroups(files)
+	plan.InvalidPathRefs = invalidPathRefs(files, projectDir)
+	plan.NearDupPairs = nearDupPairs(files)
+
+	return plan, nil
+}
+
+// enumerateScope walks scopeRoot for *.md files, deriving each file's layout
+// type from its first path segment relative to scopeRoot. Files under a
+// "checkpoint" type directory are skipped. A missing scopeRoot yields no files
+// and no error.
+func enumerateScope(scopeRoot, scope string) ([]MemoryFile, error) {
+	var out []MemoryFile
+	err := filepath.WalkDir(scopeRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() || !strings.EqualFold(filepath.Ext(d.Name()), ".md") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(scopeRoot, path)
+		if relErr != nil {
+			return nil
+		}
+		segs := strings.Split(filepath.ToSlash(rel), "/")
+		typ := ""
+		if len(segs) >= 2 {
+			typ = strings.ToLower(segs[0])
+		}
+		if typ == "checkpoint" {
+			return nil
+		}
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			if os.IsNotExist(readErr) {
+				return nil
+			}
+			return readErr
+		}
+		sum := sha256.Sum256(raw)
+		out = append(out, MemoryFile{
+			Path:        filepath.Clean(path),
+			Scope:       scope,
+			Type:        typ,
+			Size:        int64(len(raw)),
+			ContentHash: hex.EncodeToString(sum[:]),
+			Body:        string(raw),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Deterministic order regardless of directory iteration order.
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out, nil
+}
+
+// dedupeGroups groups files by identical content hash, returning only groups
+// with two or more members (a file with a unique hash is not a duplicate). The
+// result is stable: groups are ordered by hash, paths within a group by path.
+func dedupeGroups(files []MemoryFile) []DedupeGroup {
+	byHash := make(map[string][]string)
+	for _, f := range files {
+		byHash[f.ContentHash] = append(byHash[f.ContentHash], f.Path)
+	}
+	var groups []DedupeGroup
+	for hash, paths := range byHash {
+		if len(paths) < 2 {
+			continue
+		}
+		sort.Strings(paths)
+		groups = append(groups, DedupeGroup{Hash: hash, Paths: paths})
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].Hash < groups[j].Hash })
+	return groups
+}
+
+// invalidPathRefs scans each file's body for local filesystem path references
+// and records the ones that no longer exist. Relative references are resolved
+// against projectDir; "~/" against the user home dir. URLs and other external
+// references are never considered (see extractLocalPathRefs).
+func invalidPathRefs(files []MemoryFile, projectDir string) []InvalidPathRef {
+	var out []InvalidPathRef
+	for _, f := range files {
+		seen := make(map[string]struct{})
+		for _, ref := range extractLocalPathRefs(f.Body) {
+			if _, dup := seen[ref]; dup {
+				continue
+			}
+			seen[ref] = struct{}{}
+			// A bare relative reference is only meaningful against a project
+			// base. Without one (global-only plan) skip it rather than
+			// resolving against an arbitrary cwd and flagging spuriously.
+			isRelative := !filepath.IsAbs(ref) && !strings.HasPrefix(ref, "~/")
+			if isRelative && projectDir == "" {
+				continue
+			}
+			resolved := resolveRef(ref, projectDir)
+			if _, err := os.Stat(resolved); err != nil && os.IsNotExist(err) {
+				out = append(out, InvalidPathRef{File: f.Path, Ref: ref})
+			}
+		}
+	}
+	return out
+}
+
+// nearDupPairs emits candidate pairs whose normalized-token Jaccard similarity
+// is at or above NearDupThreshold. Pairs of byte-identical files are skipped:
+// those are exact duplicates handled by dedupeGroups, not near-duplicates.
+func nearDupPairs(files []MemoryFile) []NearDupPair {
+	tokens := make([]map[string]struct{}, len(files))
+	for i, f := range files {
+		tokens[i] = tokenize(f.Body)
+	}
+	var out []NearDupPair
+	for i := 0; i < len(files); i++ {
+		for j := i + 1; j < len(files); j++ {
+			if files[i].ContentHash == files[j].ContentHash {
+				continue
+			}
+			sim := jaccard(tokens[i], tokens[j])
+			if sim >= NearDupThreshold {
+				out = append(out, NearDupPair{A: files[i].Path, B: files[j].Path, Similarity: sim})
+			}
+		}
+	}
+	return out
+}
+
+// projectID derives the stable projects-scope id from a project directory,
+// mirroring internal/memory.resolveProjectId: the first 12 hex chars of
+// sha256(absPath). The path is made absolute first so relative and absolute
+// forms of the same directory map to the same id.
+func projectID(projectDir string) string {
+	abs, err := filepath.Abs(projectDir)
+	if err != nil {
+		abs = projectDir
+	}
+	sum := sha256.Sum256([]byte(abs))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+// extractLocalPathRefs returns the local filesystem path references found in
+// body. It splits on whitespace and common Markdown/code delimiters (so
+// `path`, [text](path) and bare tokens are all captured), then keeps only
+// tokens that look like a local path while rejecting URLs and other external
+// references.
+func extractLocalPathRefs(body string) []string {
+	fields := strings.FieldsFunc(body, func(r rune) bool {
+		switch r {
+		case ' ', '\t', '\n', '\r', '`', '(', ')', '[', ']', '{', '}', '"', '\'', '<', '>', ',', ';', '|':
+			return true
+		}
+		return false
+	})
+	var out []string
+	for _, tok := range fields {
+		// Trim trailing sentence punctuation that commonly abuts a path.
+		tok = strings.TrimRight(tok, ".:!?")
+		if isLocalPathRef(tok) {
+			out = append(out, tok)
+		}
+	}
+	return out
+}
+
+// isLocalPathRef reports whether tok looks like a local filesystem path rather
+// than a URL or other external reference. It accepts absolute ("/..."),
+// explicitly relative ("./", "../") and home-relative ("~/") tokens outright;
+// a bare relative token (no leading marker) must contain a separator AND a file
+// extension in its last segment, so ordinary prose like "TCP/IP", "read/write"
+// or "and/or" is not mistaken for a path. URL-schemed tokens are rejected.
+func isLocalPathRef(tok string) bool {
+	if tok == "" {
+		return false
+	}
+	if strings.Contains(tok, "://") {
+		return false
+	}
+	lower := strings.ToLower(tok)
+	for _, scheme := range []string{"http:", "https:", "ftp:", "ftps:", "file:", "mailto:", "ssh:", "git:", "www."} {
+		if strings.HasPrefix(lower, scheme) {
+			return false
+		}
+	}
+	switch {
+	case strings.HasPrefix(tok, "/"),
+		strings.HasPrefix(tok, "./"),
+		strings.HasPrefix(tok, "../"),
+		strings.HasPrefix(tok, "~/"):
+		return true
+	}
+	// A bare relative token needs both a separator and an extension on its last
+	// segment to be treated as a path (avoids flagging prose like "TCP/IP").
+	if !strings.Contains(tok, "/") {
+		return false
+	}
+	last := tok[strings.LastIndex(tok, "/")+1:]
+	return strings.Contains(last, ".") && !strings.HasSuffix(last, ".")
+}
+
+// resolveRef turns a reference into an absolute path for existence checking:
+// "~/" expands to the user home dir, absolute paths pass through, and relative
+// paths resolve against projectDir (or the current dir when projectDir is "").
+func resolveRef(ref, projectDir string) string {
+	if strings.HasPrefix(ref, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, ref[2:])
+		}
+	}
+	if filepath.IsAbs(ref) {
+		return filepath.Clean(ref)
+	}
+	return filepath.Join(projectDir, ref)
+}
+
+// tokenize lowercases body and splits it into the set of alphanumeric tokens
+// used for near-duplicate similarity. Punctuation and Markdown syntax are
+// discarded so formatting differences do not affect the score.
+func tokenize(body string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, tok := range strings.FieldsFunc(strings.ToLower(body), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+	}) {
+		set[tok] = struct{}{}
+	}
+	return set
+}
+
+// jaccard returns |a∩b| / |a∪b|. Two empty sets are dissimilar (0) rather than
+// identical, so blank files are never paired as near-duplicates.
+func jaccard(a, b map[string]struct{}) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	inter := 0
+	for t := range a {
+		if _, ok := b[t]; ok {
+			inter++
+		}
+	}
+	union := len(a) + len(b) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}

--- a/internal/dream/plan_test.go
+++ b/internal/dream/plan_test.go
@@ -1,0 +1,216 @@
+package dream
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeMemFile writes body to <root>/<rel> creating parent dirs, returning the
+// absolute path.
+func writeMemFile(t *testing.T, root, rel, body string) string {
+	t.Helper()
+	p := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Clean(p)
+}
+
+func TestBuildPlanEnumeratesGlobalAndProjectExcludingSessionsAndCheckpoint(t *testing.T) {
+	root := t.TempDir()
+	projectDir := t.TempDir()
+	pid := projectID(projectDir)
+
+	gUser := writeMemFile(t, root, "global/user/prefs.md", "global user prefs\n")
+	pProj := writeMemFile(t, root, filepath.Join("projects", pid, "project", "arch.md"), "project architecture notes\n")
+	// Must be excluded:
+	writeMemFile(t, root, "sessions/sess1/notes/x.md", "session scoped note\n")
+	writeMemFile(t, root, "global/checkpoint/cp.md", "checkpoint transient\n")
+	writeMemFile(t, root, filepath.Join("projects", pid, "checkpoint", "cp.md"), "project checkpoint\n")
+
+	plan, err := BuildPlan(root, projectDir)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, f := range plan.Files {
+		got[f.Path] = true
+	}
+	if !got[gUser] {
+		t.Errorf("global user file not enumerated")
+	}
+	if !got[pProj] {
+		t.Errorf("project file not enumerated")
+	}
+	if plan.FilesBefore != 2 {
+		t.Errorf("FilesBefore = %d, want 2 (sessions + checkpoint excluded); files=%v", plan.FilesBefore, plan.Files)
+	}
+	if plan.BytesBefore == 0 {
+		t.Errorf("BytesBefore = 0, want >0")
+	}
+}
+
+func TestBuildPlanEmptyRoot(t *testing.T) {
+	plan, err := BuildPlan(filepath.Join(t.TempDir(), "does-not-exist"), "")
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if plan.FilesBefore != 0 || len(plan.Files) != 0 {
+		t.Errorf("empty root should yield empty plan, got %+v", plan)
+	}
+}
+
+func TestExactDedupGrouping(t *testing.T) {
+	root := t.TempDir()
+	same := "identical memory body\nline two\n"
+	a := writeMemFile(t, root, "global/user/a.md", same)
+	b := writeMemFile(t, root, "global/reference/b.md", same)
+	writeMemFile(t, root, "global/notes/c.md", "a totally different unique body\n")
+
+	plan, err := BuildPlan(root, "")
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if len(plan.DedupeGroups) != 1 {
+		t.Fatalf("DedupeGroups = %d, want 1: %+v", len(plan.DedupeGroups), plan.DedupeGroups)
+	}
+	g := plan.DedupeGroups[0]
+	if len(g.Paths) != 2 {
+		t.Fatalf("group paths = %v, want [a b]", g.Paths)
+	}
+	want := map[string]bool{a: true, b: true}
+	for _, p := range g.Paths {
+		if !want[p] {
+			t.Errorf("unexpected path in dedupe group: %q", p)
+		}
+	}
+}
+
+func TestPathValidation(t *testing.T) {
+	root := t.TempDir()
+	projectDir := t.TempDir()
+
+	// A real file the memory references (relative to projectDir).
+	existingRel := "src/main.go"
+	writeMemFile(t, projectDir, existingRel, "package main\n") // reuse helper; writes under projectDir
+
+	body := "See `src/main.go` for the entrypoint.\n" +
+		"Old helper lived at `src/gone/removed.go` but was deleted.\n" +
+		"Reference: https://example.com/docs and [site](https://pkg.go.dev/net/http).\n" +
+		"Email me at mailto:dev@example.com.\n"
+	writeMemFile(t, root, "global/project/notes.md", body)
+
+	plan, err := BuildPlan(root, projectDir)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+
+	var flagged []string
+	for _, r := range plan.InvalidPathRefs {
+		flagged = append(flagged, r.Ref)
+	}
+
+	// Missing local path must be flagged.
+	if !containsRef(flagged, "src/gone/removed.go") {
+		t.Errorf("missing path src/gone/removed.go not flagged; flagged=%v", flagged)
+	}
+	// Existing local path must NOT be flagged.
+	if containsRef(flagged, "src/main.go") {
+		t.Errorf("existing path src/main.go wrongly flagged; flagged=%v", flagged)
+	}
+	// URLs / external refs must NEVER be flagged.
+	for _, r := range flagged {
+		if wantsURLReject(r) {
+			t.Errorf("external reference wrongly flagged as invalid local path: %q", r)
+		}
+	}
+}
+
+func containsRef(refs []string, want string) bool {
+	for _, r := range refs {
+		if r == want {
+			return true
+		}
+	}
+	return false
+}
+
+func wantsURLReject(r string) bool {
+	for _, bad := range []string{"http", "https", "mailto", "example.com", "pkg.go.dev"} {
+		if strings.HasPrefix(r, bad) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPathValidationIgnoresProseSlashes(t *testing.T) {
+	root := t.TempDir()
+	projectDir := t.TempDir()
+	// Prose tokens with slashes but no file extension must not be flagged as
+	// missing local paths.
+	body := "We support TCP/IP and read/write access; input/output is N/A here.\n"
+	writeMemFile(t, root, "global/notes/prose.md", body)
+
+	plan, err := BuildPlan(root, projectDir)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if len(plan.InvalidPathRefs) != 0 {
+		t.Errorf("prose slashes wrongly flagged as paths: %+v", plan.InvalidPathRefs)
+	}
+}
+
+func TestNearDupPairingThreshold(t *testing.T) {
+	root := t.TempDir()
+	// Two highly-overlapping (but not identical) bodies -> should pair.
+	writeMemFile(t, root, "global/user/a.md",
+		"the quick brown fox jumps over the lazy dog near the river bank today\n")
+	writeMemFile(t, root, "global/user/b.md",
+		"the quick brown fox jumps over the lazy dog near the river bank tomorrow\n")
+	// A dissimilar body -> should not pair with the others.
+	writeMemFile(t, root, "global/notes/c.md",
+		"completely unrelated content about database indexing and query planning\n")
+
+	plan, err := BuildPlan(root, "")
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if len(plan.NearDupPairs) != 1 {
+		t.Fatalf("NearDupPairs = %d, want exactly 1: %+v", len(plan.NearDupPairs), plan.NearDupPairs)
+	}
+	p := plan.NearDupPairs[0]
+	if p.Similarity < NearDupThreshold {
+		t.Errorf("paired similarity %v below threshold %v", p.Similarity, NearDupThreshold)
+	}
+	// The dissimilar file must not appear in any pair.
+	for _, pr := range plan.NearDupPairs {
+		if filepath.Base(pr.A) == "c.md" || filepath.Base(pr.B) == "c.md" {
+			t.Errorf("dissimilar file c.md wrongly paired: %+v", pr)
+		}
+	}
+}
+
+func TestNearDupSkipsExactDuplicates(t *testing.T) {
+	root := t.TempDir()
+	same := "one two three four five six seven eight nine ten\n"
+	writeMemFile(t, root, "global/user/a.md", same)
+	writeMemFile(t, root, "global/user/b.md", same)
+
+	plan, err := BuildPlan(root, "")
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	if len(plan.NearDupPairs) != 0 {
+		t.Errorf("exact duplicates should be handled by dedupe, not near-dup pairs: %+v", plan.NearDupPairs)
+	}
+	if len(plan.DedupeGroups) != 1 {
+		t.Errorf("DedupeGroups = %d, want 1", len(plan.DedupeGroups))
+	}
+}

--- a/internal/dream/report.go
+++ b/internal/dream/report.go
@@ -1,0 +1,28 @@
+package dream
+
+// Report is the structured change summary produced by a /dream consolidation
+// run. It is persisted inside State.LastReport (state.go) and emitted as a
+// single line of JSON on the child process stdout (spec §4.2). Every count is a
+// deterministic tally the runner fills in after the plan (Go-deterministic) and
+// apply (LLM) phases; the zero value is a valid "nothing changed" report.
+//
+// The JSON tags match spec §3.2 exactly so the parent process (and any
+// scripted/headless caller) can decode the stdout contract without a shared Go
+// type.
+type Report struct {
+	Merged       int      `json:"merged"`        // entries merged away by the LLM apply step
+	Deduped      int      `json:"deduped"`       // exact (content-hash) duplicates removed
+	PathsCleaned int      `json:"paths_cleaned"` // stale local path references cleaned
+	Pruned       int      `json:"pruned"`        // stale/contradictory entries pruned
+	Distilled    int      `json:"distilled"`     // new memories distilled from session JSONL
+	BytesBefore  int64    `json:"bytes_before"`
+	BytesAfter   int64    `json:"bytes_after"`
+	FilesBefore  int      `json:"files_before"`
+	FilesAfter   int      `json:"files_after"`
+	DryRun       bool     `json:"dry_run"`
+	Notes        []string `json:"notes,omitempty"` // human-readable reasons (prune causes, etc.)
+	Reconciled   struct {
+		Indexed int `json:"indexed"`
+		Pruned  int `json:"pruned"`
+	} `json:"reconciled"`
+}

--- a/internal/dream/report_test.go
+++ b/internal/dream/report_test.go
@@ -1,0 +1,66 @@
+package dream
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestReportJSONTags(t *testing.T) {
+	r := Report{
+		Merged:       1,
+		Deduped:      2,
+		PathsCleaned: 3,
+		Pruned:       4,
+		Distilled:    5,
+		BytesBefore:  100,
+		BytesAfter:   80,
+		FilesBefore:  10,
+		FilesAfter:   9,
+		DryRun:       true,
+		Notes:        []string{"pruned stale entry"},
+	}
+	r.Reconciled.Indexed = 6
+	r.Reconciled.Pruned = 7
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{
+		"merged", "deduped", "paths_cleaned", "pruned", "distilled",
+		"bytes_before", "bytes_after", "files_before", "files_after",
+		"dry_run", "notes", "reconciled",
+	} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("missing JSON key %q in %s", key, data)
+		}
+	}
+	rec, ok := m["reconciled"].(map[string]any)
+	if !ok {
+		t.Fatalf("reconciled not an object: %v", m["reconciled"])
+	}
+	if _, ok := rec["indexed"]; !ok {
+		t.Errorf("reconciled.indexed missing: %v", rec)
+	}
+	if _, ok := rec["pruned"]; !ok {
+		t.Errorf("reconciled.pruned missing: %v", rec)
+	}
+}
+
+func TestReportZeroValueOmitsNotes(t *testing.T) {
+	data, err := json.Marshal(Report{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := m["notes"]; ok {
+		t.Errorf("empty notes should be omitted, got %s", data)
+	}
+}

--- a/internal/dream/state.go
+++ b/internal/dream/state.go
@@ -14,12 +14,8 @@ type State struct {
 	LastRunAt  time.Time `json:"last_run_at"`
 	LastStatus string    `json:"last_status"` // "ok" | "failed" | "skipped"
 	// LastReport holds the structured change report from the last run. It is
-	// kept as json.RawMessage here so this foundation layer stays decoupled
-	// from the Report struct, which is defined by a later node
-	// (report.go). The raw bytes round-trip losslessly; the later node can
-	// decode them into a typed Report or migrate this field.
-	// TODO(#521): replace json.RawMessage with *Report once report.go lands.
-	LastReport json.RawMessage `json:"last_report,omitempty"`
+	// nil until dream has completed at least one non-dry-run pass.
+	LastReport *Report `json:"last_report,omitempty"`
 }
 
 // statePath is the state file location under the memory root.

--- a/internal/dream/state_test.go
+++ b/internal/dream/state_test.go
@@ -1,17 +1,15 @@
 package dream
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 	"time"
 )
 
 func TestStateRoundTrip(t *testing.T) {
 	root := t.TempDir()
-	report := json.RawMessage(`{"merged":3,"deduped":1}`)
+	report := &Report{Merged: 3, Deduped: 1, DryRun: false}
 	want := State{
 		LastRunAt:  time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC),
 		LastStatus: "ok",
@@ -30,17 +28,11 @@ func TestStateRoundTrip(t *testing.T) {
 	if got.LastStatus != want.LastStatus {
 		t.Errorf("LastStatus = %q, want %q", got.LastStatus, want.LastStatus)
 	}
-	// LastReport round-trips as raw JSON; compare semantically since
-	// re-marshaling may reformat whitespace.
-	var gotObj, wantObj map[string]any
-	if err := json.Unmarshal(got.LastReport, &gotObj); err != nil {
-		t.Fatalf("unmarshal got.LastReport: %v", err)
+	if got.LastReport == nil {
+		t.Fatalf("LastReport = nil, want %+v", want.LastReport)
 	}
-	if err := json.Unmarshal(want.LastReport, &wantObj); err != nil {
-		t.Fatalf("unmarshal want.LastReport: %v", err)
-	}
-	if !reflect.DeepEqual(gotObj, wantObj) {
-		t.Errorf("LastReport = %v, want %v", gotObj, wantObj)
+	if got.LastReport.Merged != report.Merged || got.LastReport.Deduped != report.Deduped {
+		t.Errorf("LastReport = %+v, want %+v", got.LastReport, report)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `report.go`: `Report` struct with spec §3.2 JSON tags and consolidation counters (merged/deduped/paths_cleaned/pruned/distilled, byte/file counts, reconciled sub-struct).
- Add `plan.go`: `BuildPlan(memoryRoot, projectDir)` — enumerates global + project-scope `*.md` (excludes sessions + checkpoint), computes `BytesBefore`/`FilesBefore`, exact-dedup groups (content hash), invalid local path references (URLs and prose slashes ignored), and near-duplicate candidate pairs via normalized token Jaccard (`NearDupThreshold`). Plain-data `Plan`, no LLM calls.
- Migrate `State.LastReport` from `json.RawMessage` to `*Report` (removes `TODO(#521)`).

Closes #521

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/dream/...` green (exact-dedup grouping, path validation existing/missing/URL/prose, near-dup threshold pairing + exact-dup skip, Report JSON tags)