### PR TITLE
feat(dream): --dream subprocess entry + Runner skeleton + dry-run

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -33,6 +34,7 @@ import (
 	"github.com/smallnest/pigo/internal/cli/run"
 	"github.com/smallnest/pigo/internal/cli/tui"
 	"github.com/smallnest/pigo/internal/cli/ui"
+	"github.com/smallnest/pigo/internal/dream"
 	"github.com/smallnest/pigo/internal/selfupdate"
 )
 
@@ -94,6 +96,15 @@ type cliOptions struct {
 	// #135): pigo reads JSON-RPC sub-agent run requests from stdin and writes
 	// results to stdout. Internal, used by SubAgentTool's process mode.
 	subagentRPC bool
+	// dream, when set, runs the process-isolated memory-consolidation pass and
+	// exits: pigo enumerates + consolidates the global/project memory scope, emits
+	// a single-line Report JSON on stdout, and exits 0/1. Internal, spawned by the
+	// dream scheduler (and usable headlessly by scripts). See internal/dream and
+	// SPEC §4.1/§4.2.
+	dream bool
+	// dreamDryRun pairs with --dream: analyze and report without writing files or
+	// updating dream state (the lock is still taken). SPEC §5.5 dry-run row.
+	dreamDryRun bool
 	// thinkingLevel, when non-empty, is the --thinking-level flag: the reasoning
 	// effort for requests (off|minimal|low|medium|high|xhigh). It is the highest-
 	// precedence layer in resolveThinkingLevel, overriding PIGO_THINKING_LEVEL, the
@@ -159,6 +170,8 @@ func main() {
 	flag.StringArrayVar(&opts.promptTemplates, "prompt-template", nil, "load a prompt template from a file or directory (non-recursive); repeatable (mirrors pi --prompt-template)")
 	flag.StringVar(&opts.thinkingLevel, "thinking-level", "", "reasoning effort: off|minimal|low|medium|high|xhigh (overrides PIGO_THINKING_LEVEL and config; default medium)")
 	flag.BoolVar(&opts.subagentRPC, "subagent-rpc", false, "internal: run as a process-isolated sub-agent JSON-RPC server over stdio (US-019)")
+	flag.BoolVar(&opts.dream, "dream", false, "internal: run a memory-consolidation pass over the global/project memory scope, emit a Report JSON on stdout, and exit (SPEC §4.1)")
+	flag.BoolVar(&opts.dreamDryRun, "dream-dry-run", false, "internal: with --dream, analyze and report without writing files or updating dream state (SPEC §5.5)")
 	flag.BoolVar(&opts.noTUI, "no-tui", false, "use the line-based REPL instead of the full-screen TUI")
 	flag.StringVarP(&opts.cwd, "cwd", "C", "", "run as if pigo was started in this directory (matches the Claude Agent SDK's cwd; like git -C): tool file access, trust, hooks, and project config all resolve against it")
 	flag.BoolVarP(&opts.showVersion, "version", "v", false, "print version information and exit")
@@ -269,6 +282,16 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 	// sub-agents and shares nothing with the interactive/headless paths.
 	if opts.subagentRPC {
 		return headless.RunSubAgentRPC(ctx, os.Stdin, out, errOut)
+	}
+
+	// --dream is the subprocess consolidation mode (SPEC §4.1/§4.2): run one
+	// memory-consolidation pass to completion, emit a single-line Report JSON on
+	// stdout (progress/logs go to stderr), and exit 0 on success / 1 on failure.
+	// It runs before any interactive/headless session assembly and honors -C/--cwd
+	// for the project scope (applied above via os.Chdir). It shares nothing with
+	// the REPL/headless paths.
+	if opts.dream {
+		return runDream(ctx, opts, out, errOut)
 	}
 
 	// --list-sessions is a standalone action: print and exit.
@@ -402,6 +425,37 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		ThinkingLevel: opts.thinkingLevel,
 		ResumeID:      resumeID,
 	}, out, errOut)
+}
+
+// runDream executes the subprocess memory-consolidation pass (SPEC §4.1/§4.2).
+// It runs dream.Runner to completion, marshals the resulting Report as a single
+// line of JSON on stdout (the parent/scheduler parses this), and returns the
+// process exit code: 0 on success (including a "skipped" run when another dream
+// holds the lock) or 1 on failure. Progress and diagnostics go to errOut. The
+// project scope comes from the working directory, which -C/--cwd already applied
+// via os.Chdir before dispatch, so an empty ProjectDir here resolves to cwd.
+func runDream(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
+	projectDir, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(errOut, "pigo: dream: %v\n", err)
+		return 1
+	}
+	r := &dream.Runner{}
+	report, err := r.Run(ctx, dream.RunOptions{
+		DryRun:     opts.dreamDryRun,
+		ProjectDir: projectDir,
+	})
+	if err != nil {
+		fmt.Fprintf(errOut, "pigo: dream: %v\n", err)
+		return 1
+	}
+	// Single-line JSON on stdout is the stdout contract (SPEC §4.2). Encoder
+	// writes a trailing newline, keeping the report one line.
+	if err := json.NewEncoder(out).Encode(report); err != nil {
+		fmt.Fprintf(errOut, "pigo: dream: encode report: %v\n", err)
+		return 1
+	}
+	return 0
 }
 
 // shouldUseTUI is the pure entry-gating predicate for the no-prompt path

--- a/internal/dream/runner.go
+++ b/internal/dream/runner.go
@@ -1,0 +1,477 @@
+package dream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/smallnest/pigo/internal/memory"
+)
+
+// Consolidator is the LLM-driven apply step, injected so the deterministic
+// Runner skeleton can run end-to-end without an LLM. It receives the plain-data
+// plan (dedupe groups + invalid-path refs + near-dup candidate pairs) and
+// returns the semantic decisions: which merged bodies to rewrite, which entries
+// to delete (merged-away / pruned), and which new entries to distill.
+//
+// #523 will implement a real Consolidator backed by the main-session model and
+// the dream system prompt (SPEC §5.1 step 5, §5.1.1). Until then the Runner uses
+// nopConsolidator, so the deterministic half (exact dedup + path clean +
+// Reconcile) is fully exercised and testable in isolation.
+type Consolidator interface {
+	Consolidate(ctx context.Context, in ConsolidateInput) (ConsolidateResult, error)
+}
+
+// ConsolidateInput is the plain-data view handed to the Consolidator. It carries
+// the deterministic Plan (which already embeds the dedupe groups, invalid-path
+// refs and near-dup pairs) plus the resolved roots so the implementation can
+// compute in-scope write targets. It intentionally carries no behavior and no
+// live handles (no *memory.Store, no *sql.DB) so it stays trivially serializable
+// if #523 chooses to marshal it across a subprocess/RPC boundary.
+type ConsolidateInput struct {
+	Plan       Plan   `json:"plan"`
+	MemoryRoot string `json:"memory_root"`
+	ProjectDir string `json:"project_dir"`
+}
+
+// NewEntry is a distilled memory file the Consolidator wants created. Path must
+// resolve within the memory root's global/project scope; the Runner rejects any
+// out-of-scope target before writing (SPEC §5.2 / §7.1).
+type NewEntry struct {
+	Path string `json:"path"`
+	Body string `json:"body"`
+}
+
+// ConsolidateResult is the Consolidator's decision set. All paths are absolute
+// and must lie within the memory root scope. Merged/Pruned/Distilled are the
+// report counters the Runner surfaces verbatim; the deterministic Deduped and
+// PathsCleaned counters are computed by the Runner itself, not here.
+type ConsolidateResult struct {
+	// MergedBodies maps an existing memory file path to its rewritten (merged /
+	// compacted) body. The Runner overwrites each file in place.
+	MergedBodies map[string]string `json:"merged_bodies,omitempty"`
+	// Deletions are memory files to remove (entries merged away or pruned as
+	// stale/contradictory).
+	Deletions []string `json:"deletions,omitempty"`
+	// NewEntries are freshly distilled memory files to create.
+	NewEntries []NewEntry `json:"new_entries,omitempty"`
+
+	Merged    int      `json:"merged"`
+	Pruned    int      `json:"pruned"`
+	Distilled int      `json:"distilled"`
+	Notes     []string `json:"notes,omitempty"`
+}
+
+// nopConsolidator is the default no-op Consolidator used when none is injected.
+// It makes no decisions, so a Runner with it performs only the deterministic
+// dedup + path-clean + Reconcile pass — enough for the skeleton to run
+// end-to-end and be unit-tested without an LLM.
+type nopConsolidator struct{}
+
+func (nopConsolidator) Consolidate(context.Context, ConsolidateInput) (ConsolidateResult, error) {
+	return ConsolidateResult{}, nil
+}
+
+// Runner is the subprocess-side consolidation entry point (SPEC §2.2 / §5.1). It
+// runs the deterministic plan, delegates semantic merge/prune/distill to an
+// injected Consolidator, applies the results within the memory-root scope, and
+// rebuilds the FTS index via memory.Reconcile. The zero value is usable: an
+// empty MemoryRoot is resolved from the environment and a nil Consolidator falls
+// back to nopConsolidator.
+type Runner struct {
+	// Consolidator is the injected LLM apply step; nil selects nopConsolidator.
+	Consolidator Consolidator
+	// MemoryRoot overrides the environment-resolved memory root. Empty means
+	// resolve via ResolveMemoryRoot (PIGO_HOME / ~/.pigo). Tests set it to a temp
+	// dir; production leaves it empty.
+	MemoryRoot string
+}
+
+// RunOptions are the per-invocation parameters mirroring the CLI flags. ProjectDir
+// selects the projects sub-scope (empty → global-only); DryRun analyzes without
+// writing files or updating state (but still takes the lock — SPEC §5.5).
+type RunOptions struct {
+	DryRun     bool
+	ProjectDir string
+}
+
+// Run executes one consolidation pass and returns the change Report. The flow is
+// the deterministic algorithm of SPEC §5.1:
+//
+//	open store → resolve memoryRoot → acquire lock (ErrLocked → skipped, no error)
+//	→ BuildPlan → Consolidate → if !DryRun: apply dedup + path-clean + consolidation
+//	→ Reconcile → recount → SaveState(ok); if DryRun: counts only, no writes/state.
+//
+// A held lock is not a failure: Run returns a zero-count Report and a nil error
+// so the caller exits 0 ("skipped"). Genuine errors (I/O, plan, apply) are
+// returned for the caller to map to exit 1 / status "failed".
+func (r *Runner) Run(ctx context.Context, opts RunOptions) (Report, error) {
+	memoryRoot := r.MemoryRoot
+	if memoryRoot == "" {
+		memoryRoot = ResolveMemoryRoot()
+	}
+	if memoryRoot == "" {
+		return Report{}, fmt.Errorf("dream: cannot resolve memory root")
+	}
+
+	lock, err := AcquireLock(memoryRoot)
+	if err != nil {
+		if isLocked(err) {
+			// Another dream is running: skip silently. Zero-count report, no error
+			// → caller exits 0, leaves last_status unchanged (SPEC §5.5 / §6.1). We
+			// have opened nothing and created no files, honoring the skip contract.
+			return Report{DryRun: opts.DryRun}, nil
+		}
+		return Report{}, fmt.Errorf("dream: acquire lock: %w", err)
+	}
+	defer lock.Release()
+
+	plan, err := BuildPlan(memoryRoot, opts.ProjectDir)
+	if err != nil {
+		return Report{}, fmt.Errorf("dream: build plan: %w", err)
+	}
+
+	rep := Report{
+		DryRun:      opts.DryRun,
+		BytesBefore: plan.BytesBefore,
+		FilesBefore: plan.FilesBefore,
+	}
+
+	cons := r.Consolidator
+	if cons == nil {
+		cons = nopConsolidator{}
+	}
+	cres, err := cons.Consolidate(ctx, ConsolidateInput{
+		Plan:       plan,
+		MemoryRoot: memoryRoot,
+		ProjectDir: opts.ProjectDir,
+	})
+	if err != nil {
+		// The runner surfaces the error; the parent/scheduler (node #8) maps a
+		// non-zero exit to state.LastStatus="failed" (SPEC §4.2/§6.1). The runner
+		// itself only ever persists "ok", so it never opens/creates the store on a
+		// failing or dry-run path.
+		return Report{}, fmt.Errorf("dream: consolidate: %w", err)
+	}
+
+	// Surface the Consolidator's semantic counters verbatim (SPEC §5.1.1: merge /
+	// prune / distill are LLM decisions).
+	rep.Merged = cres.Merged
+	rep.Pruned = cres.Pruned
+	rep.Distilled = cres.Distilled
+	rep.Notes = append(rep.Notes, cres.Notes...)
+
+	if opts.DryRun {
+		// Predict the deterministic counters without touching disk or state, and
+		// without opening the store (which would create index.db). The after-sizes
+		// stay zero: nothing was written, so there is no post-state to measure
+		// (SPEC §5.5 dry-run row).
+		rep.Deduped = plannedDedupeCount(plan)
+		rep.PathsCleaned = plannedPathCleanCount(plan)
+		return rep, nil
+	}
+
+	// --- write path (non dry-run) -------------------------------------------
+	//
+	// Open the store only here: a dry-run or a lock skip must not create index.db
+	// (SPEC §5.5). The store is needed solely for the post-write Reconcile.
+	store, err := memory.Open(filepath.Join(memoryRoot, "index.db"), memoryRoot, "")
+	if err != nil {
+		return Report{}, fmt.Errorf("dream: open memory store: %w", err)
+	}
+	defer store.Close()
+
+	deleted, deduped, err := applyDedupe(memoryRoot, opts.ProjectDir, plan)
+	if err != nil {
+		return Report{}, fmt.Errorf("dream: apply dedupe: %w", err)
+	}
+	rep.Deduped = deduped
+
+	cleaned, err := applyPathClean(memoryRoot, opts.ProjectDir, plan, deleted)
+	if err != nil {
+		return Report{}, fmt.Errorf("dream: apply path-clean: %w", err)
+	}
+	rep.PathsCleaned = cleaned
+
+	if err := applyConsolidation(memoryRoot, opts.ProjectDir, cres, deleted); err != nil {
+		return Report{}, fmt.Errorf("dream: apply consolidation: %w", err)
+	}
+
+	res, err := store.Reconcile()
+	if err != nil {
+		return Report{}, fmt.Errorf("dream: reconcile: %w", err)
+	}
+	rep.Reconciled.Indexed = res.Indexed
+	rep.Reconciled.Pruned = res.Pruned
+
+	// Recompute post-state sizes by re-enumerating the same scopes.
+	after, err := BuildPlan(memoryRoot, opts.ProjectDir)
+	if err != nil {
+		return Report{}, fmt.Errorf("dream: recount: %w", err)
+	}
+	rep.BytesAfter = after.BytesBefore
+	rep.FilesAfter = after.FilesBefore
+
+	repCopy := rep
+	if err := SaveState(memoryRoot, State{
+		LastRunAt:  time.Now().UTC(),
+		LastStatus: "ok",
+		LastReport: &repCopy,
+	}); err != nil {
+		return Report{}, fmt.Errorf("dream: save state: %w", err)
+	}
+
+	return rep, nil
+}
+
+// isLocked reports whether err is the ErrLocked contention signal. Kept as a
+// helper so the skipped-vs-failed branch reads clearly.
+func isLocked(err error) bool {
+	return errors.Is(err, ErrLocked)
+}
+
+// ResolveMemoryRoot returns the persistent memory root directory the same way
+// the CLI does (internal/cli/run.MemoryDir): $PIGO_HOME/memory, else
+// ~/.pigo/memory. It is duplicated here rather than imported to keep the dream
+// package free of a dependency on the CLI assembly layer (and any import cycle
+// through it). Returns "" when neither PIGO_HOME nor the home dir is resolvable.
+func ResolveMemoryRoot() string {
+	dir := os.Getenv("PIGO_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		dir = filepath.Join(home, ".pigo")
+	}
+	return filepath.Join(dir, "memory")
+}
+
+// withinScope reports whether target is a write target permitted by this run's
+// consolidation scope: it must live under <memoryRoot>/global or, when a
+// projectDir is set, under that project's own <memoryRoot>/projects/<id>
+// directory. Anything else — the sessions scope, an UNRELATED project's
+// directory, or a path outside memoryRoot (e.g. user source) — is rejected. This
+// is the SPEC §5.2 / §7.1 path-boundary guard that keeps an LLM-produced path
+// from escaping the memory store or clobbering other projects' memories, and it
+// mirrors BuildPlan, which only enumerates global + the active project.
+//
+// The check is symlink-aware: both the scope base and the target's longest
+// existing ancestor are passed through filepath.EvalSymlinks before comparison,
+// so a symlink planted inside an allowed scope cannot redirect a write/delete
+// outside the allowed directory. A prefix match is done on path boundaries (not
+// raw string prefixes) so "<root>/globalX" does not pass as "<root>/global".
+func withinScope(memoryRoot, projectDir, target string) bool {
+	if memoryRoot == "" || target == "" {
+		return false
+	}
+	absRoot, err := filepath.Abs(memoryRoot)
+	if err != nil {
+		return false
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return false
+	}
+	resolvedTarget := resolveExisting(filepath.Clean(absTarget))
+
+	bases := []string{filepath.Join(absRoot, "global")}
+	if projectDir != "" {
+		bases = append(bases, filepath.Join(absRoot, "projects", projectID(projectDir)))
+	}
+	for _, base := range bases {
+		base = resolveExisting(base)
+		if resolvedTarget == base {
+			return true
+		}
+		if strings.HasPrefix(resolvedTarget, base+string(os.PathSeparator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveExisting returns path with symlinks resolved as far as the filesystem
+// allows: it walks up to the longest existing ancestor, resolves that with
+// filepath.EvalSymlinks, then rejoins the not-yet-existing tail. This lets the
+// scope guard defeat symlink redirection (an existing symlink component is
+// dereferenced to its real location) while still handling brand-new target
+// paths whose leaf files do not exist yet. On any resolution error it falls back
+// to the cleaned input so the guard fails closed via the lexical comparison.
+func resolveExisting(path string) string {
+	path = filepath.Clean(path)
+	tail := ""
+	cur := path
+	for {
+		if resolved, err := filepath.EvalSymlinks(cur); err == nil {
+			if tail == "" {
+				return resolved
+			}
+			return filepath.Join(resolved, tail)
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Reached the root without finding an existing component.
+			return path
+		}
+		tail = filepath.Join(filepath.Base(cur), tail)
+		cur = parent
+	}
+}
+
+// plannedDedupeCount is the number of files a dedupe pass would remove: one per
+// duplicate beyond the representative in each group (SPEC report.Deduped).
+func plannedDedupeCount(plan Plan) int {
+	n := 0
+	for _, g := range plan.DedupeGroups {
+		if len(g.Paths) > 1 {
+			n += len(g.Paths) - 1
+		}
+	}
+	return n
+}
+
+// plannedPathCleanCount is the number of distinct invalid local path references
+// a path-clean pass would strip (SPEC report.PathsCleaned).
+func plannedPathCleanCount(plan Plan) int {
+	return len(plan.InvalidPathRefs)
+}
+
+// applyDedupe removes exact-duplicate memory files, keeping the first path in
+// each group (paths are pre-sorted by BuildPlan) and deleting the rest. Every
+// deletion target is guarded by withinScope. It returns the set of deleted paths
+// (so later passes skip them) and the Deduped count.
+func applyDedupe(memoryRoot, projectDir string, plan Plan) (map[string]struct{}, int, error) {
+	deleted := make(map[string]struct{})
+	count := 0
+	for _, g := range plan.DedupeGroups {
+		if len(g.Paths) < 2 {
+			continue
+		}
+		// Keep g.Paths[0] as the representative; remove the duplicates.
+		for _, p := range g.Paths[1:] {
+			if !withinScope(memoryRoot, projectDir, p) {
+				return nil, 0, fmt.Errorf("refusing out-of-scope dedupe target %q", p)
+			}
+			if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+				return nil, 0, err
+			}
+			deleted[filepath.Clean(p)] = struct{}{}
+			count++
+		}
+	}
+	return deleted, count, nil
+}
+
+// applyPathClean strips invalid local path references from the bodies of the
+// files that still exist (skipping any removed by dedupe). Each distinct
+// (file, ref) is removed by deleting the exact reference substring and is
+// counted once. This is the deterministic half of FR-11; the Consolidator may
+// later decide whole-entry pruning for refs that leave an entry meaningless.
+// Every rewrite target is guarded by withinScope.
+func applyPathClean(memoryRoot, projectDir string, plan Plan, deleted map[string]struct{}) (int, error) {
+	// Group refs by file so each file is read/written at most once.
+	byFile := make(map[string][]string)
+	for _, r := range plan.InvalidPathRefs {
+		clean := filepath.Clean(r.File)
+		if _, gone := deleted[clean]; gone {
+			continue
+		}
+		byFile[clean] = append(byFile[clean], r.Ref)
+	}
+
+	count := 0
+	for file, refs := range byFile {
+		if !withinScope(memoryRoot, projectDir, file) {
+			return 0, fmt.Errorf("refusing out-of-scope path-clean target %q", file)
+		}
+		raw, err := os.ReadFile(file)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return 0, err
+		}
+		body := string(raw)
+		for _, ref := range refs {
+			if strings.Contains(body, ref) {
+				body = strings.ReplaceAll(body, ref, "")
+				count++
+			}
+		}
+		if body != string(raw) {
+			if err := atomicWrite(file, []byte(body)); err != nil {
+				return 0, err
+			}
+		}
+	}
+	return count, nil
+}
+
+// applyConsolidation writes the Consolidator's decisions: rewritten merged
+// bodies, new distilled entries, and deletions. Every write/delete target is
+// guarded by withinScope so an LLM cannot escape the memory store (SPEC §5.2 /
+// §7.1). Deletions already performed by dedupe are skipped.
+func applyConsolidation(memoryRoot, projectDir string, cres ConsolidateResult, deleted map[string]struct{}) error {
+	for path, body := range cres.MergedBodies {
+		if !withinScope(memoryRoot, projectDir, path) {
+			return fmt.Errorf("refusing out-of-scope merged-body target %q", path)
+		}
+		if err := atomicWrite(path, []byte(body)); err != nil {
+			return err
+		}
+	}
+	for _, e := range cres.NewEntries {
+		if !withinScope(memoryRoot, projectDir, e.Path) {
+			return fmt.Errorf("refusing out-of-scope new-entry target %q", e.Path)
+		}
+		if err := atomicWrite(e.Path, []byte(e.Body)); err != nil {
+			return err
+		}
+	}
+	for _, path := range cres.Deletions {
+		if _, gone := deleted[filepath.Clean(path)]; gone {
+			continue
+		}
+		if !withinScope(memoryRoot, projectDir, path) {
+			return fmt.Errorf("refusing out-of-scope deletion target %q", path)
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// atomicWrite writes data to path via a temp file + rename in the same directory
+// so a crash mid-write cannot leave a truncated memory file (SPEC §6.3). The
+// parent directory is created lazily.
+func atomicWrite(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".dream-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return nil
+}

--- a/internal/dream/runner_test.go
+++ b/internal/dream/runner_test.go
@@ -1,0 +1,303 @@
+package dream
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// stubConsolidator returns a fixed result and records that it was called.
+type stubConsolidator struct {
+	result ConsolidateResult
+	called bool
+}
+
+func (s *stubConsolidator) Consolidate(context.Context, ConsolidateInput) (ConsolidateResult, error) {
+	s.called = true
+	return s.result, nil
+}
+
+// TestRunEmptyMemoryDir: an empty memory dir yields an all-zero Report with
+// status ok (no error). Reconcile tolerates the missing scopes.
+func TestRunEmptyMemoryDir(t *testing.T) {
+	root := t.TempDir()
+	r := &Runner{MemoryRoot: root}
+	rep, err := r.Run(context.Background(), RunOptions{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rep.FilesBefore != 0 || rep.BytesBefore != 0 || rep.FilesAfter != 0 || rep.BytesAfter != 0 {
+		t.Fatalf("expected all-zero report, got %+v", rep)
+	}
+	if rep.Deduped != 0 || rep.Merged != 0 || rep.Pruned != 0 || rep.PathsCleaned != 0 {
+		t.Fatalf("expected zero counters, got %+v", rep)
+	}
+	// State should be written with status ok for a non-dry-run.
+	st, err := LoadState(root)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if st.LastStatus != "ok" {
+		t.Fatalf("LastStatus = %q, want ok", st.LastStatus)
+	}
+}
+
+// TestRunDryRunWritesNothing: dry-run computes counts, writes no files, does not
+// update state, but still acquires + releases the lock.
+func TestRunDryRunWritesNothing(t *testing.T) {
+	root := t.TempDir()
+	// Two byte-identical files → one dedupe candidate.
+	a := writeMemFile(t, root, "global/user/a.md", "same content")
+	b := writeMemFile(t, root, "global/user/b.md", "same content")
+
+	r := &Runner{MemoryRoot: root}
+	rep, err := r.Run(context.Background(), RunOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !rep.DryRun {
+		t.Fatal("Report.DryRun = false, want true")
+	}
+	if rep.Deduped != 1 {
+		t.Fatalf("Deduped = %d, want 1 (predicted)", rep.Deduped)
+	}
+	// Both files must still exist — dry-run writes nothing.
+	if _, err := os.Stat(a); err != nil {
+		t.Fatalf("file a removed in dry-run: %v", err)
+	}
+	if _, err := os.Stat(b); err != nil {
+		t.Fatalf("file b removed in dry-run: %v", err)
+	}
+	// State must NOT be updated (never-run remains).
+	st, err := LoadState(root)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if !st.LastRunAt.IsZero() || st.LastStatus != "" {
+		t.Fatalf("dry-run updated state: %+v", st)
+	}
+	// Lock must have been released (a fresh acquire succeeds).
+	lk, err := AcquireLock(root)
+	if err != nil {
+		t.Fatalf("lock not released after dry-run: %v", err)
+	}
+	lk.Release()
+}
+
+// TestRunLockedSkips: when a live lock is already held, Run returns a zero-count
+// report and NO error (exit-0 "skipped" semantics), and does not touch state.
+func TestRunLockedSkips(t *testing.T) {
+	root := t.TempDir()
+	writeMemFile(t, root, "global/user/a.md", "content")
+
+	held, err := AcquireLock(root)
+	if err != nil {
+		t.Fatalf("pre-acquire lock: %v", err)
+	}
+	defer held.Release()
+
+	r := &Runner{MemoryRoot: root}
+	rep, err := r.Run(context.Background(), RunOptions{})
+	if err != nil {
+		t.Fatalf("Run under held lock should not error, got %v", err)
+	}
+	if rep.FilesBefore != 0 || rep.Deduped != 0 {
+		t.Fatalf("skipped run should have zero report, got %+v", rep)
+	}
+	// State untouched (never ran).
+	st, _ := LoadState(root)
+	if !st.LastRunAt.IsZero() || st.LastStatus != "" {
+		t.Fatalf("skipped run touched state: %+v", st)
+	}
+}
+
+// TestRunAppliesDedupe: a non-dry-run removes exact duplicates, updates state,
+// and reflects counts in the Report.
+func TestRunAppliesDedupe(t *testing.T) {
+	root := t.TempDir()
+	a := writeMemFile(t, root, "global/user/a.md", "same content")
+	b := writeMemFile(t, root, "global/user/b.md", "same content")
+
+	r := &Runner{MemoryRoot: root}
+	rep, err := r.Run(context.Background(), RunOptions{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rep.Deduped != 1 {
+		t.Fatalf("Deduped = %d, want 1", rep.Deduped)
+	}
+	// Exactly one of the two duplicates must survive (the sorted-first: a.md).
+	_, errA := os.Stat(a)
+	_, errB := os.Stat(b)
+	if errA != nil {
+		t.Fatalf("representative a.md removed: %v", errA)
+	}
+	if errB == nil {
+		t.Fatal("duplicate b.md should have been removed")
+	}
+	if rep.FilesAfter != 1 {
+		t.Fatalf("FilesAfter = %d, want 1", rep.FilesAfter)
+	}
+	st, _ := LoadState(root)
+	if st.LastStatus != "ok" || st.LastReport == nil {
+		t.Fatalf("state not updated: %+v", st)
+	}
+}
+
+// TestWithinScope: the path-boundary guard accepts in-scope targets and rejects
+// everything outside <memoryRoot>/global and the active project's directory.
+func TestWithinScope(t *testing.T) {
+	root := t.TempDir()
+	projectDir := t.TempDir()
+	pid := projectID(projectDir)
+	otherPID := "0123456789ab" // a different, unrelated project id
+	cases := []struct {
+		name    string
+		project string
+		target  string
+		want    bool
+	}{
+		{"global file", projectDir, filepath.Join(root, "global", "user", "x.md"), true},
+		{"active project file", projectDir, filepath.Join(root, "projects", pid, "notes", "y.md"), true},
+		{"global root itself", projectDir, filepath.Join(root, "global"), true},
+		{"unrelated project rejected", projectDir, filepath.Join(root, "projects", otherPID, "z.md"), false},
+		{"any project rejected when global-only", "", filepath.Join(root, "projects", pid, "y.md"), false},
+		{"global still ok when global-only", "", filepath.Join(root, "global", "x.md"), true},
+		{"sessions scope rejected", projectDir, filepath.Join(root, "sessions", "s1", "checkpoint.md"), false},
+		{"outside root rejected", projectDir, filepath.Join(root, "..", "evil.md"), false},
+		{"sibling prefix not confused", projectDir, filepath.Join(root, "globalX", "z.md"), false},
+		{"absolute escape rejected", projectDir, "/etc/passwd", false},
+		{"empty target rejected", projectDir, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := withinScope(root, tc.project, tc.target); got != tc.want {
+				t.Fatalf("withinScope(%q, %q, %q) = %v, want %v", root, tc.project, tc.target, got, tc.want)
+			}
+		})
+	}
+	if withinScope("", projectDir, filepath.Join(root, "global", "x.md")) {
+		t.Fatal("empty memoryRoot must reject")
+	}
+}
+
+// TestWithinScopeSymlinkEscape: a symlink planted inside an allowed scope must
+// not let a target escape memoryRoot. The guard resolves symlinks on existing
+// ancestors before the containment check (SPEC §7.1 defense-in-depth).
+func TestWithinScopeSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir() // a directory fully outside memoryRoot
+
+	globalDir := filepath.Join(root, "global")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatalf("mkdir global: %v", err)
+	}
+	// <root>/global/escape -> <outside>
+	link := filepath.Join(globalDir, "escape")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	// Lexically this looks in-scope (<root>/global/escape/evil.md) but resolves
+	// to <outside>/evil.md, which must be rejected.
+	target := filepath.Join(link, "evil.md")
+	if withinScope(root, "", target) {
+		t.Fatalf("symlink escape target accepted: %q", target)
+	}
+}
+
+// TestRunPathClean: a memory file referencing a non-existent local path has that
+// reference stripped and counted.
+func TestRunPathClean(t *testing.T) {
+	root := t.TempDir()
+	proj := t.TempDir()
+	missing := filepath.Join(proj, "does", "not", "exist.go")
+	body := "See `" + missing + "` for details."
+	f := writeMemFile(t, root, "global/reference/r.md", body)
+
+	r := &Runner{MemoryRoot: root}
+	rep, err := r.Run(context.Background(), RunOptions{ProjectDir: proj})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rep.PathsCleaned != 1 {
+		t.Fatalf("PathsCleaned = %d, want 1", rep.PathsCleaned)
+	}
+	raw, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatalf("read cleaned file: %v", err)
+	}
+	if got := string(raw); got == body {
+		t.Fatalf("body unchanged after path-clean: %q", got)
+	}
+}
+
+// TestRunConsolidatorApplied: an injected Consolidator's new-entry write and
+// counters flow through, and the write lands within scope.
+func TestRunConsolidatorApplied(t *testing.T) {
+	root := t.TempDir()
+	writeMemFile(t, root, "global/user/a.md", "hello")
+
+	newPath := filepath.Join(root, "global", "user", "distilled.md")
+	stub := &stubConsolidator{result: ConsolidateResult{
+		NewEntries: []NewEntry{{Path: newPath, Body: "distilled fact"}},
+		Distilled:  1,
+		Merged:     2,
+		Pruned:     3,
+		Notes:      []string{"note"},
+	}}
+	r := &Runner{MemoryRoot: root, Consolidator: stub}
+	rep, err := r.Run(context.Background(), RunOptions{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !stub.called {
+		t.Fatal("Consolidator was not called")
+	}
+	if rep.Distilled != 1 || rep.Merged != 2 || rep.Pruned != 3 {
+		t.Fatalf("counters not surfaced: %+v", rep)
+	}
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("new entry not written: %v", err)
+	}
+}
+
+// TestApplyConsolidationRejectsOutOfScope: a Consolidator that tries to write
+// outside the memory root is rejected by the guard.
+func TestApplyConsolidationRejectsOutOfScope(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "escape.md")
+	cres := ConsolidateResult{
+		NewEntries: []NewEntry{{Path: outside, Body: "x"}},
+	}
+	if err := applyConsolidation(root, "", cres, nil); err == nil {
+		t.Fatal("expected out-of-scope write to be rejected")
+	}
+	if _, err := os.Stat(outside); err == nil {
+		t.Fatal("out-of-scope file must not be created")
+	}
+}
+
+// TestRunDryRunLeavesStaleLockTakeable is a small guard that dry-run's lock is
+// released promptly (no leftover live lock).
+func TestRunDryRunLockReleased(t *testing.T) {
+	root := t.TempDir()
+	r := &Runner{MemoryRoot: root}
+	if _, err := r.Run(context.Background(), RunOptions{DryRun: true}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Fresh acquire must succeed immediately (lock released, not merely stale).
+	// Force a long stale window so a leftover *live* lock would block acquisition,
+	// proving Run released it rather than leaving it to be reclaimed as stale.
+	// Restore the package default afterward so this does not leak into other tests.
+	orig := DefaultStaleAfter
+	DefaultStaleAfter = time.Hour
+	defer func() { DefaultStaleAfter = orig }()
+	lk, err := AcquireLock(root)
+	if err != nil {
+		t.Fatalf("lock not released: %v", err)
+	}
+	lk.Release()
+}


### PR DESCRIPTION
## Summary
- Register internal `--dream` / `--dream-dry-run` flags in `cmd/pigo/main.go` (sibling to `--subagent-rpc`); dispatch to `dream.Runner` before session assembly, emit single-line Report JSON on stdout, logs on stderr, exit 0 (success/skipped) / 1 (failure). Honors `-C`/`--cwd` for the project scope.
- Add `internal/dream/runner.go`: `Runner` + `RunOptions{DryRun,ProjectDir}` + `Run()` implementing SPEC 5.1 (open store -> memoryRoot -> AcquireLock (ErrLocked -> skipped/nil) -> BuildPlan -> Consolidate -> apply dedup/path-clean + Reconcile + SaveState). `Consolidator` interface with plain-data input/result and `nopConsolidator` default so the deterministic skeleton runs end-to-end. Symlink-aware `withinScope` path-boundary guard.
- Add `internal/dream/runner_test.go`: table tests for dry-run (no writes/state, lock taken+released), locked->skipped, path guard rejects out-of-root, empty dir -> all-zero Report.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/dream/... ./cmd/...`

Closes #522