### PR TITLE
feat(dream): LLM apply — real Consolidator (merge/prune) + writeback

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -440,7 +440,21 @@ func runDream(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		fmt.Fprintf(errOut, "pigo: dream: %v\n", err)
 		return 1
 	}
-	r := &dream.Runner{}
+	// The dream pass reuses the main-session model (SPEC Q3): resolve the same
+	// model/provider/api-key tuple cmd/pigo already overlaid from flags+config,
+	// and inject a real LLM-backed Consolidator so `pigo --dream` performs the
+	// semantic merge/prune step (not just the deterministic dedup/path-clean).
+	thinking, err := run.ResolveThinkingLevel(opts.thinkingLevel)
+	if err != nil {
+		fmt.Fprintf(errOut, "pigo: dream: %v\n", err)
+		return 1
+	}
+	cons, err := dream.NewLLMConsolidator(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.apiKey, thinking)
+	if err != nil {
+		fmt.Fprintf(errOut, "pigo: dream: %v\n", err)
+		return 1
+	}
+	r := &dream.Runner{Consolidator: cons}
 	report, err := r.Run(ctx, dream.RunOptions{
 		DryRun:     opts.dreamDryRun,
 		ProjectDir: projectDir,

--- a/internal/dream/apply.go
+++ b/internal/dream/apply.go
@@ -1,0 +1,247 @@
+package dream
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/provider"
+)
+
+// This file wires the llmConsolidator to a real provider (the main-session
+// model, SPEC Q3) and holds the MEMORY.md index cleanup the Runner runs after
+// writeback. The provider plumbing mirrors internal/cli/run.SetupEnv: resolve a
+// Provider for the model/base-url/protocol/provider tuple, resolve the API key
+// through a CredentialStore (--api-key override → env → config), and run a
+// single StreamCompletion, draining the event stream to the final text.
+
+// NewLLMConsolidator builds the production Consolidator backed by the given
+// model configuration — the same tuple cmd/pigo resolves for the main session
+// (CLI flags overlaid with config.toml). It resolves the Provider once so every
+// Consolidate call reuses it. A resolution failure (bad model / missing
+// provider) is returned so the caller can decide whether to fall back to the
+// no-op Consolidator or fail the run.
+func NewLLMConsolidator(model, baseURL, protocol, providerName, apiKey string, thinking agentcore.ThinkingLevel) (Consolidator, error) {
+	complete, err := newModelCompleter(model, baseURL, protocol, providerName, apiKey, thinking)
+	if err != nil {
+		return nil, err
+	}
+	return &llmConsolidator{complete: complete}, nil
+}
+
+// newModelCompleter resolves the provider and returns a completeFn that performs
+// one non-streaming-consuming completion: it sends the system+user prompt as a
+// single user turn (no tools — the dream agent only reasons and replies) and
+// returns the concatenated assistant text. A hard "cannot build the stream"
+// error is returned directly; a runtime failure rides the stream as a terminal
+// error event whose message we convert to an error (so the Runner marks the run
+// failed rather than silently deleting nothing, SPEC §5.5).
+func newModelCompleter(model, baseURL, protocol, providerName, apiKey string, thinking agentcore.ThinkingLevel) (completeFn, error) {
+	prov, resolvedName, err := provider.ResolveProvider(model, baseURL, protocol, providerName, os.Getenv)
+	if err != nil {
+		return nil, fmt.Errorf("dream: resolve provider: %w", err)
+	}
+	creds := provider.NewCredentialStore(nil)
+	creds.SetOverride(resolvedName, apiKey)
+
+	return func(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+		key := creds.GetAPIKey(ctx, resolvedName)
+		llm := provider.LlmContext{
+			SystemPrompt: systemPrompt,
+			Messages: agentcore.MessageList{
+				agentcore.UserMessage{
+					RoleField: agentcore.RoleUser,
+					Content:   agentcore.ContentList{agentcore.NewTextContent(userPrompt)},
+				},
+			},
+		}
+		stream, err := prov.StreamCompletion(ctx, provider.CompletionRequest{
+			Model:   model,
+			Context: llm,
+			Config:  provider.StreamConfig{APIKey: key, ThinkingLevel: thinking},
+		})
+		if err != nil {
+			return "", err
+		}
+		final, err := drainToMessage(ctx, stream)
+		if err != nil {
+			return "", err
+		}
+		if final.StopReason == agentcore.StopReasonError {
+			if final.ErrorMessage != "" {
+				return "", fmt.Errorf("model error: %s", final.ErrorMessage)
+			}
+			return "", fmt.Errorf("model returned an error response")
+		}
+		return agentcore.ContentToText(final.Content), nil
+	}, nil
+}
+
+// drainToMessage consumes the provider event stream to completion and returns
+// the terminal assistant message. It mirrors the loop's stream-drain contract:
+// the done/error event carries the final message; if the stream closes without
+// one, it falls back to the stream Result. Draining is required because the
+// producer blocks on the event channel until consumed.
+func drainToMessage(ctx context.Context, stream *provider.AssistantMessageEventStream) (agentcore.AssistantMessage, error) {
+	for ev := range stream.Events() {
+		switch e := ev.(type) {
+		case provider.StreamDoneEvent:
+			return e.Message, nil
+		case provider.StreamErrorEvent:
+			return e.Message, nil
+		}
+	}
+	final, err := stream.Result(ctx)
+	if err != nil {
+		return agentcore.AssistantMessage{}, err
+	}
+	return final, nil
+}
+
+// updateScopeIndexes rewrites each affected scope's MEMORY.md to drop any line
+// that references a now-deleted memory file, keeping the index consistent with
+// the entries on disk and free of dangling links (PRD US-003). It is safe to
+// call when no MEMORY.md exists (no-op) and when deleted is empty. Each rewrite
+// is atomic (temp+rename) and guarded by withinScope, so it cannot escape the
+// memory store.
+func updateScopeIndexes(memoryRoot, projectDir string, deleted map[string]struct{}) error {
+	if len(deleted) == 0 {
+		return nil
+	}
+	scopes := []string{filepath.Join(memoryRoot, "global")}
+	if projectDir != "" {
+		scopes = append(scopes, filepath.Join(memoryRoot, "projects", projectID(projectDir)))
+	}
+	for _, scope := range scopes {
+		index := filepath.Join(scope, "MEMORY.md")
+		if _, err := os.Stat(index); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if !withinScope(memoryRoot, projectDir, index) {
+			continue
+		}
+		tokens := indexRefTokens(memoryRoot, scope, deleted)
+		if len(tokens) == 0 {
+			continue
+		}
+		raw, err := os.ReadFile(index)
+		if err != nil {
+			return err
+		}
+		newBody, changed := stripDanglingIndexLines(string(raw), tokens)
+		if changed {
+			if err := atomicWrite(index, []byte(newBody)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// indexRefTokens is the set of substrings that identify a deleted file inside a
+// MEMORY.md index line: its absolute path, its path relative to the memory root
+// and to the scope root, and its bare basename. A line containing any of these
+// is treated as a link/reference to the removed entry. MEMORY.md itself is never
+// a token (it is never a consolidation deletion target).
+func indexRefTokens(memoryRoot, scope string, deleted map[string]struct{}) map[string]struct{} {
+	tokens := make(map[string]struct{})
+	for p := range deleted {
+		clean := filepath.Clean(p)
+		add := func(s string) {
+			if s != "" && s != "." {
+				tokens[filepath.ToSlash(s)] = struct{}{}
+			}
+		}
+		add(clean)
+		if rel, err := filepath.Rel(memoryRoot, clean); err == nil && !strings.HasPrefix(rel, "..") {
+			add(rel)
+		}
+		if rel, err := filepath.Rel(scope, clean); err == nil && !strings.HasPrefix(rel, "..") {
+			add(rel)
+		}
+		add(filepath.Base(clean))
+	}
+	return tokens
+}
+
+// stripDanglingIndexLines removes every line of body that references any of the
+// reference tokens, returning the rewritten body and whether anything changed.
+// It matches on the forward-slash form of each line so Windows-style separators
+// in the index still match the slash tokens. Matching is boundary-aware: a token
+// (e.g. the basename "b.md") only matches when it is not embedded inside a longer
+// filename token (so "club.md" or "b.mdx" is not mistaken for "b.md"), avoiding
+// dropping unrelated index lines.
+func stripDanglingIndexLines(body string, tokens map[string]struct{}) (string, bool) {
+	lines := strings.Split(body, "\n")
+	kept := make([]string, 0, len(lines))
+	changed := false
+	for _, line := range lines {
+		probe := filepath.ToSlash(line)
+		drop := false
+		for tok := range tokens {
+			if containsRefToken(probe, tok) {
+				drop = true
+				break
+			}
+		}
+		if drop {
+			changed = true
+			continue
+		}
+		kept = append(kept, line)
+	}
+	if !changed {
+		return body, false
+	}
+	return strings.Join(kept, "\n"), true
+}
+
+// containsRefToken reports whether tok occurs in line at a filename boundary:
+// the characters immediately before and after the match must not be filename
+// continuation characters ([A-Za-z0-9_-]). This lets "b.md" match "user/b.md",
+// "(b.md)" and "- b.md" while rejecting "club.md" and "b.mdx".
+func containsRefToken(line, tok string) bool {
+	if tok == "" {
+		return false
+	}
+	from := 0
+	for {
+		i := strings.Index(line[from:], tok)
+		if i < 0 {
+			return false
+		}
+		start := from + i
+		end := start + len(tok)
+		if !isFilenameChar(byteAt(line, start-1)) && !isFilenameChar(byteAt(line, end)) {
+			return true
+		}
+		from = start + 1
+	}
+}
+
+// byteAt returns line[i], or 0 when i is out of range (treated as a boundary).
+func byteAt(line string, i int) byte {
+	if i < 0 || i >= len(line) {
+		return 0
+	}
+	return line[i]
+}
+
+// isFilenameChar reports whether b can appear inside a bare filename token, used
+// to detect whether a reference-token match is embedded in a longer name.
+func isFilenameChar(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', b >= '0' && b <= '9':
+		return true
+	case b == '_' || b == '-':
+		return true
+	}
+	return false
+}
+

--- a/internal/dream/apply_test.go
+++ b/internal/dream/apply_test.go
@@ -1,0 +1,143 @@
+package dream
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/memory"
+)
+
+func TestUpdateScopeIndexesDropsDanglingLinks(t *testing.T) {
+	root := t.TempDir()
+	// A global MEMORY.md linking to two entries; b.md will be deleted.
+	writeMemFile(t, root, "global/user/a.md", "keep me")
+	b := writeMemFile(t, root, "global/user/b.md", "remove me")
+	idx := writeMemFile(t, root, "global/MEMORY.md",
+		"# Index\n- [a](user/a.md)\n- [b](user/b.md)\n- freeform note\n")
+
+	deleted := map[string]struct{}{filepath.Clean(b): {}}
+	if err := updateScopeIndexes(root, "", deleted); err != nil {
+		t.Fatalf("updateScopeIndexes: %v", err)
+	}
+	raw, err := os.ReadFile(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(raw)
+	if strings.Contains(got, "user/b.md") || strings.Contains(got, "b.md") {
+		t.Fatalf("dangling link to b.md not removed:\n%s", got)
+	}
+	if !strings.Contains(got, "user/a.md") {
+		t.Fatalf("live link to a.md wrongly removed:\n%s", got)
+	}
+	if !strings.Contains(got, "freeform note") {
+		t.Fatalf("unrelated line wrongly removed:\n%s", got)
+	}
+}
+
+// TestUpdateScopeIndexesBoundaryMatch: deleting b.md must not drop an index line
+// referencing a different entry whose name merely contains "b.md" as a
+// substring (e.g. club.md).
+func TestUpdateScopeIndexesBoundaryMatch(t *testing.T) {
+	root := t.TempDir()
+	writeMemFile(t, root, "global/user/club.md", "keep me")
+	b := writeMemFile(t, root, "global/user/b.md", "remove me")
+	idx := writeMemFile(t, root, "global/MEMORY.md",
+		"- [club](user/club.md)\n- [b](user/b.md)\n")
+
+	deleted := map[string]struct{}{filepath.Clean(b): {}}
+	if err := updateScopeIndexes(root, "", deleted); err != nil {
+		t.Fatalf("updateScopeIndexes: %v", err)
+	}
+	got, _ := os.ReadFile(idx)
+	if !strings.Contains(string(got), "user/club.md") {
+		t.Fatalf("club.md link wrongly removed by substring match:\n%s", got)
+	}
+	if strings.Contains(string(got), "user/b.md") {
+		t.Fatalf("b.md link not removed:\n%s", got)
+	}
+}
+
+func TestUpdateScopeIndexesNoIndexIsNoOp(t *testing.T) {
+	root := t.TempDir()
+	writeMemFile(t, root, "global/user/a.md", "x")
+	deleted := map[string]struct{}{filepath.Join(root, "global", "user", "a.md"): {}}
+	if err := updateScopeIndexes(root, "", deleted); err != nil {
+		t.Fatalf("updateScopeIndexes with no MEMORY.md should be a no-op, got %v", err)
+	}
+}
+
+// TestRunEndToEndWithMerge exercises the full non-dry-run write path with a stub
+// Consolidator that merges b.md into a.md and prunes c.md: files converge on
+// disk, the MEMORY.md index loses its dangling links, Reconcile runs, the Report
+// counters are correct, and a full-text search no longer hits the merged-away
+// fragment (US-003 / US-006 / US-009).
+func TestRunEndToEndWithMerge(t *testing.T) {
+	root := t.TempDir()
+	a := writeMemFile(t, root, "global/user/a.md", "shared topic original a")
+	b := writeMemFile(t, root, "global/user/b.md", "shared topic zebrafragment only in b")
+	c := writeMemFile(t, root, "global/user/c.md", "outdated standalone note")
+	idx := writeMemFile(t, root, "global/MEMORY.md",
+		"# Index\n- [a](user/a.md)\n- [b](user/b.md)\n- [c](user/c.md)\n")
+
+	stub := &stubConsolidator{result: ConsolidateResult{
+		MergedBodies: map[string]string{a: "shared topic merged and current"},
+		Deletions:    []string{b, c},
+		Merged:       1,
+		Pruned:       1,
+		Notes:        []string{"pruned c: outdated"},
+	}}
+	r := &Runner{MemoryRoot: root, Consolidator: stub}
+	rep, err := r.Run(context.Background(), RunOptions{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !stub.called {
+		t.Fatal("Consolidator not called")
+	}
+	if rep.Merged != 1 || rep.Pruned != 1 {
+		t.Fatalf("counters wrong: %+v", rep)
+	}
+	// a.md rewritten, b.md + c.md gone.
+	if got, _ := os.ReadFile(a); string(got) != "shared topic merged and current" {
+		t.Fatalf("a.md not rewritten: %q", got)
+	}
+	if _, err := os.Stat(b); !os.IsNotExist(err) {
+		t.Fatal("b.md should be deleted")
+	}
+	if _, err := os.Stat(c); !os.IsNotExist(err) {
+		t.Fatal("c.md should be deleted")
+	}
+	// MEMORY.md no longer links to the removed entries.
+	rawIdx, _ := os.ReadFile(idx)
+	if strings.Contains(string(rawIdx), "b.md") || strings.Contains(string(rawIdx), "c.md") {
+		t.Fatalf("MEMORY.md retains dangling links:\n%s", rawIdx)
+	}
+	if !strings.Contains(string(rawIdx), "a.md") {
+		t.Fatalf("MEMORY.md lost the live a.md link:\n%s", rawIdx)
+	}
+	// Reconcile ran and indexed the surviving files.
+	if rep.Reconciled.Indexed == 0 {
+		t.Fatalf("Reconcile did not index: %+v", rep.Reconciled)
+	}
+	if rep.FilesAfter != 2 { // a.md + MEMORY.md
+		t.Fatalf("FilesAfter = %d, want 2", rep.FilesAfter)
+	}
+
+	// The merged-away fragment must no longer be searchable.
+	store, err := memory.Open(filepath.Join(root, "index.db"), root, "")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+	hits, err := store.Search("zebrafragment", memory.SearchOptions{ReconcileFirst: true})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("merged-away fragment still searchable: %+v", hits)
+	}
+}

--- a/internal/dream/consolidator.go
+++ b/internal/dream/consolidator.go
@@ -1,0 +1,359 @@
+package dream
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// This file implements the real, LLM-backed Consolidator (SPEC §5.1 step 5,
+// §5.1.1). It turns the deterministic Plan into a prompt for the main-session
+// model, asks it to confirm semantic merges and conservative prunes, and parses
+// the strict-JSON response back into a ConsolidateResult the Runner applies.
+//
+// The deterministic half (exact dedup, dead-path cleanup, MEMORY.md rewrite,
+// Reconcile, counters) stays in the Runner; this file is purely the semantic
+// LLM step. It never touches disk — it only produces decisions the Runner
+// path-guards and applies.
+
+// completeFn performs a single LLM completion: given the system and user
+// prompts it returns the model's text response, or an error for a hard
+// transport/provider failure. The provider-backed implementation lives in
+// apply.go (newModelCompleter); tests inject a canned function so no live model
+// is ever called.
+type completeFn func(ctx context.Context, systemPrompt, userPrompt string) (string, error)
+
+// defaultBodyBudget caps how many bytes of each entry body are shown to the
+// model, bounding prompt size on large memory libraries (SPEC §8.2 token
+// budget). Bodies longer than this are truncated with a marker so the model
+// still sees the leading, usually most salient, content.
+const defaultBodyBudget = 6000
+
+// llmConsolidator is the production Consolidator: it drives the main-session
+// model through complete and parses the response. bodyBudget (0 → default)
+// bounds per-entry body size in the prompt.
+type llmConsolidator struct {
+	complete   completeFn
+	bodyBudget int
+}
+
+// Consolidate builds the prompt from the plan, runs one model completion, and
+// parses the response into merge/prune decisions. A hard model/transport error
+// is returned (the Runner maps it to a failed run, SPEC §5.5). A well-formed
+// call whose text cannot be parsed is NOT an error: it yields an empty result
+// with an explanatory note, so an unparseable response conservatively KEEPs
+// everything (PRD FR-14) and the deterministic pass still applies.
+func (c *llmConsolidator) Consolidate(ctx context.Context, in ConsolidateInput) (ConsolidateResult, error) {
+	if c.complete == nil {
+		return ConsolidateResult{}, fmt.Errorf("dream: llmConsolidator has no completion function")
+	}
+	eligible := eligibleFiles(in.Plan)
+	if len(eligible) == 0 {
+		// Nothing the model could act on (empty library, or only MEMORY.md /
+		// duplicates). Skip the call entirely.
+		return ConsolidateResult{}, nil
+	}
+	budget := c.bodyBudget
+	if budget <= 0 {
+		budget = defaultBodyBudget
+	}
+	prompt := buildConsolidatePrompt(in, eligible, budget)
+
+	raw, err := c.complete(ctx, dreamSystemPrompt, prompt)
+	if err != nil {
+		return ConsolidateResult{}, fmt.Errorf("dream: model completion: %w", err)
+	}
+
+	allowed := make(map[string]struct{}, len(eligible))
+	for _, f := range eligible {
+		allowed[filepath.Clean(f.Path)] = struct{}{}
+	}
+	return parseConsolidateResponse(raw, allowed), nil
+}
+
+// eligibleFiles is the subset of plan files the model may act on: it excludes
+// MEMORY.md index files (they are indexes, not entries — #521 NEW_WORK: we
+// special-case MEMORY.md out of merge/prune so the index is never folded into an
+// entry) and the redundant members of an exact-dedupe group (g.Paths[1:], which
+// the deterministic pass removes anyway — offering them would let the model
+// merge into a path about to be deleted). The representative g.Paths[0] stays.
+func eligibleFiles(plan Plan) []MemoryFile {
+	drop := make(map[string]struct{})
+	for _, g := range plan.DedupeGroups {
+		for _, p := range g.Paths[1:] {
+			drop[filepath.Clean(p)] = struct{}{}
+		}
+	}
+	var out []MemoryFile
+	for _, f := range plan.Files {
+		if isMemoryIndex(f.Path) {
+			continue
+		}
+		if _, dup := drop[filepath.Clean(f.Path)]; dup {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// isMemoryIndex reports whether path is a scope MEMORY.md index file, which the
+// consolidation step must never merge, rewrite, or prune.
+func isMemoryIndex(path string) bool {
+	return strings.EqualFold(filepath.Base(path), "MEMORY.md")
+}
+
+// buildConsolidatePrompt renders the user prompt: the scope, the eligible
+// entries (path + scope/type + body, truncated to budget), and the deterministic
+// hints (near-dup candidate pairs, dead local-path references). It only lists
+// paths that are eligible, so the model is naturally steered away from MEMORY.md
+// and duplicate paths.
+func buildConsolidatePrompt(in ConsolidateInput, eligible []MemoryFile, budget int) string {
+	var b strings.Builder
+	b.WriteString("# Memory consolidation request\n\n")
+	b.WriteString("Memory root: ")
+	b.WriteString(in.MemoryRoot)
+	b.WriteByte('\n')
+	if in.ProjectDir != "" {
+		b.WriteString("Active project scope: ")
+		b.WriteString(in.ProjectDir)
+		b.WriteByte('\n')
+	} else {
+		b.WriteString("Scope: global only\n")
+	}
+	b.WriteString(fmt.Sprintf("\n## Entries (%d)\n\n", len(eligible)))
+	for i, f := range eligible {
+		typ := f.Type
+		if typ == "" {
+			typ = "(root)"
+		}
+		b.WriteString(fmt.Sprintf("### [%d] %s\n", i+1, f.Path))
+		b.WriteString(fmt.Sprintf("scope=%s type=%s bytes=%d\n\n", f.Scope, typ, f.Size))
+		b.WriteString("```\n")
+		b.WriteString(truncateBody(f.Body, budget))
+		b.WriteString("\n```\n\n")
+	}
+
+	if pairs := eligiblePairs(in.Plan, eligible); len(pairs) > 0 {
+		b.WriteString("## Near-duplicate candidate pairs (merge only if truly overlapping)\n\n")
+		for _, p := range pairs {
+			b.WriteString(fmt.Sprintf("- %s  <->  %s  (similarity %.2f)\n", p.A, p.B, p.Similarity))
+		}
+		b.WriteByte('\n')
+	}
+
+	if refs := eligibleInvalidRefs(in.Plan, eligible); len(refs) > 0 {
+		b.WriteString("## Entries referencing local files that no longer exist\n")
+		b.WriteString("(the dead reference text is cleaned automatically; only PRUNE an entry if losing that reference leaves it meaningless)\n\n")
+		for _, r := range refs {
+			b.WriteString(fmt.Sprintf("- %s references missing %s\n", r.File, r.Ref))
+		}
+		b.WriteByte('\n')
+	}
+
+	b.WriteString("Return the JSON object described in your instructions. When in doubt, KEEP.\n")
+	return b.String()
+}
+
+// truncateBody trims body to at most budget bytes on a rune boundary, appending
+// a marker when truncation occurred so the model knows content was elided.
+func truncateBody(body string, budget int) string {
+	if budget <= 0 || len(body) <= budget {
+		return body
+	}
+	cut := budget
+	for cut > 0 && !isRuneStart(body[cut]) {
+		cut--
+	}
+	return body[:cut] + "\n…[truncated]"
+}
+
+// isRuneStart reports whether b is not a UTF-8 continuation byte, so a truncation
+// cut there does not split a multi-byte rune.
+func isRuneStart(b byte) bool { return b&0xC0 != 0x80 }
+
+// eligiblePairs filters the plan's near-dup pairs to those whose BOTH members
+// are eligible (both are still offered to the model), so we never point the
+// model at a MEMORY.md or a to-be-deduped duplicate.
+func eligiblePairs(plan Plan, eligible []MemoryFile) []NearDupPair {
+	ok := make(map[string]struct{}, len(eligible))
+	for _, f := range eligible {
+		ok[filepath.Clean(f.Path)] = struct{}{}
+	}
+	var out []NearDupPair
+	for _, p := range plan.NearDupPairs {
+		_, a := ok[filepath.Clean(p.A)]
+		_, b := ok[filepath.Clean(p.B)]
+		if a && b {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// eligibleInvalidRefs filters dead-path references to those on eligible files.
+func eligibleInvalidRefs(plan Plan, eligible []MemoryFile) []InvalidPathRef {
+	ok := make(map[string]struct{}, len(eligible))
+	for _, f := range eligible {
+		ok[filepath.Clean(f.Path)] = struct{}{}
+	}
+	var out []InvalidPathRef
+	for _, r := range plan.InvalidPathRefs {
+		if _, found := ok[filepath.Clean(r.File)]; found {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// modelDecision mirrors the strict JSON output schema the dream prompt requires.
+type modelDecision struct {
+	Merges []struct {
+		Keep   string   `json:"keep"`
+		Body   string   `json:"body"`
+		Remove []string `json:"remove"`
+	} `json:"merges"`
+	Prunes []struct {
+		Path   string `json:"path"`
+		Reason string `json:"reason"`
+	} `json:"prunes"`
+	Notes []string `json:"notes"`
+}
+
+// parseConsolidateResponse turns the model's text into a ConsolidateResult,
+// validating every path against allowed (the eligible input paths). It is
+// conservative by construction: any decision that references an unknown path, a
+// MEMORY.md index, an empty merged body, or an empty prune reason is dropped
+// rather than obeyed, and an unparseable response yields an empty result with a
+// note (PRD FR-14 — default to KEEP on uncertainty). It never returns an error;
+// callers treat a hard model failure separately.
+func parseConsolidateResponse(raw string, allowed map[string]struct{}) ConsolidateResult {
+	body := extractJSONObject(raw)
+	if body == "" {
+		return ConsolidateResult{Notes: []string{"dream: model response contained no JSON object; kept all entries"}}
+	}
+	var dec modelDecision
+	if err := json.Unmarshal([]byte(body), &dec); err != nil {
+		return ConsolidateResult{Notes: []string{"dream: model response was not valid JSON; kept all entries"}}
+	}
+
+	var res ConsolidateResult
+	res.MergedBodies = make(map[string]string)
+	delSet := make(map[string]struct{})
+
+	valid := func(p string) (string, bool) {
+		clean := filepath.Clean(strings.TrimSpace(p))
+		if clean == "" || clean == "." {
+			return "", false
+		}
+		if isMemoryIndex(clean) {
+			return "", false
+		}
+		if _, ok := allowed[clean]; !ok {
+			return "", false
+		}
+		return clean, true
+	}
+
+	for _, m := range dec.Merges {
+		keep, ok := valid(m.Keep)
+		if !ok || strings.TrimSpace(m.Body) == "" {
+			// Unknown/invalid target or an empty rewrite: skip, keep everything.
+			continue
+		}
+		removed := 0
+		for _, r := range m.Remove {
+			rp, ok := valid(r)
+			if !ok || rp == keep {
+				continue
+			}
+			if _, dup := delSet[rp]; dup {
+				continue
+			}
+			delSet[rp] = struct{}{}
+			removed++
+		}
+		if removed == 0 {
+			// A merge that removes nothing is a no-op rewrite; ignore it to avoid
+			// gratuitously touching a file the model merely echoed back.
+			continue
+		}
+		res.MergedBodies[keep] = m.Body
+		res.Merged += removed
+	}
+
+	for _, p := range dec.Prunes {
+		pp, ok := valid(p.Path)
+		if !ok || strings.TrimSpace(p.Reason) == "" {
+			// No path or no stated reason → conservative KEEP.
+			continue
+		}
+		if _, dup := delSet[pp]; dup {
+			continue
+		}
+		// Never prune an entry we are simultaneously keeping as a merge target.
+		if _, kept := res.MergedBodies[pp]; kept {
+			continue
+		}
+		delSet[pp] = struct{}{}
+		res.Pruned++
+		res.Notes = append(res.Notes, fmt.Sprintf("pruned %s: %s", pp, strings.TrimSpace(p.Reason)))
+	}
+
+	if len(res.MergedBodies) == 0 {
+		res.MergedBodies = nil
+	}
+	for p := range delSet {
+		res.Deletions = append(res.Deletions, p)
+	}
+	sort.Strings(res.Deletions)
+
+	for _, n := range dec.Notes {
+		if s := strings.TrimSpace(n); s != "" {
+			res.Notes = append(res.Notes, s)
+		}
+	}
+	return res
+}
+
+// extractJSONObject returns the outermost {...} span of s, tolerating models
+// that wrap the object in prose or Markdown code fences. It returns "" when no
+// balanced object is found.
+func extractJSONObject(s string) string {
+	start := strings.IndexByte(s, '{')
+	if start < 0 {
+		return ""
+	}
+	depth := 0
+	inStr := false
+	esc := false
+	for i := start; i < len(s); i++ {
+		ch := s[i]
+		if inStr {
+			switch {
+			case esc:
+				esc = false
+			case ch == '\\':
+				esc = true
+			case ch == '"':
+				inStr = false
+			}
+			continue
+		}
+		switch ch {
+		case '"':
+			inStr = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return s[start : i+1]
+			}
+		}
+	}
+	return ""
+}

--- a/internal/dream/consolidator_test.go
+++ b/internal/dream/consolidator_test.go
@@ -1,0 +1,195 @@
+package dream
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// canned builds an allowed-set + Plan pair for parser tests from a list of
+// absolute paths.
+func allowedSet(paths ...string) map[string]struct{} {
+	m := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		m[filepath.Clean(p)] = struct{}{}
+	}
+	return m
+}
+
+func TestBuildConsolidatePromptListsEntriesAndHints(t *testing.T) {
+	root := "/mem"
+	a := "/mem/global/user/a.md"
+	b := "/mem/global/user/b.md"
+	idx := "/mem/global/MEMORY.md"
+	plan := Plan{
+		Files: []MemoryFile{
+			{Path: a, Scope: "global", Type: "user", Size: 5, Body: "alpha body"},
+			{Path: b, Scope: "global", Type: "user", Size: 5, Body: "beta body"},
+			{Path: idx, Scope: "global", Type: "", Size: 3, Body: "- [a](user/a.md)"},
+		},
+		NearDupPairs:    []NearDupPair{{A: a, B: b, Similarity: 0.82}},
+		InvalidPathRefs: []InvalidPathRef{{File: a, Ref: "./gone.go"}},
+	}
+	eligible := eligibleFiles(plan)
+	if len(eligible) != 2 {
+		t.Fatalf("eligibleFiles = %d, want 2 (MEMORY.md excluded)", len(eligible))
+	}
+	prompt := buildConsolidatePrompt(ConsolidateInput{Plan: plan, MemoryRoot: root, ProjectDir: ""}, eligible, defaultBodyBudget)
+
+	for _, want := range []string{a, b, "alpha body", "beta body", "similarity 0.82", "./gone.go", "global only"} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q\n---\n%s", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "MEMORY.md") {
+		t.Errorf("prompt must not offer the MEMORY.md index as an entry:\n%s", prompt)
+	}
+}
+
+func TestTruncateBody(t *testing.T) {
+	if got := truncateBody("short", 100); got != "short" {
+		t.Fatalf("no truncation expected, got %q", got)
+	}
+	long := strings.Repeat("x", 50)
+	got := truncateBody(long, 10)
+	if !strings.HasPrefix(got, strings.Repeat("x", 10)) || !strings.Contains(got, "truncated") {
+		t.Fatalf("truncateBody = %q", got)
+	}
+}
+
+func TestParseConsolidateResponseMergeAndPrune(t *testing.T) {
+	a := "/mem/global/user/a.md"
+	b := "/mem/global/user/b.md"
+	c := "/mem/global/user/c.md"
+	allowed := allowedSet(a, b, c)
+
+	raw := "here you go:\n```json\n" + `{
+	  "merges": [{"keep": "` + a + `", "body": "merged body", "remove": ["` + b + `"]}],
+	  "prunes": [{"path": "` + c + `", "reason": "superseded by newer note"}],
+	  "notes": ["did the thing"]
+	}` + "\n```\n"
+
+	res := parseConsolidateResponse(raw, allowed)
+	if res.Merged != 1 {
+		t.Errorf("Merged = %d, want 1", res.Merged)
+	}
+	if res.Pruned != 1 {
+		t.Errorf("Pruned = %d, want 1", res.Pruned)
+	}
+	if got := res.MergedBodies[a]; got != "merged body" {
+		t.Errorf("MergedBodies[a] = %q", got)
+	}
+	wantDel := map[string]bool{b: true, c: true}
+	if len(res.Deletions) != 2 {
+		t.Fatalf("Deletions = %v, want b and c", res.Deletions)
+	}
+	for _, d := range res.Deletions {
+		if !wantDel[d] {
+			t.Errorf("unexpected deletion %q", d)
+		}
+	}
+	joined := strings.Join(res.Notes, "|")
+	if !strings.Contains(joined, "superseded by newer note") || !strings.Contains(joined, "did the thing") {
+		t.Errorf("notes missing content: %v", res.Notes)
+	}
+}
+
+func TestParseConsolidateResponseRejectsUnknownAndUnsafePaths(t *testing.T) {
+	a := "/mem/global/user/a.md"
+	allowed := allowedSet(a)
+	raw := `{
+	  "merges": [{"keep": "/etc/passwd", "body": "x", "remove": ["` + a + `"]}],
+	  "prunes": [{"path": "/mem/global/MEMORY.md", "reason": "index"}]
+	}`
+	res := parseConsolidateResponse(raw, allowed)
+	if res.Merged != 0 || res.Pruned != 0 || len(res.Deletions) != 0 {
+		t.Fatalf("unsafe/unknown paths must be ignored, got %+v", res)
+	}
+}
+
+func TestParseConsolidateResponseConservativeOnEmptyReasonAndBadJSON(t *testing.T) {
+	a := "/mem/global/user/a.md"
+	allowed := allowedSet(a)
+
+	// Empty prune reason → KEEP.
+	res := parseConsolidateResponse(`{"prunes":[{"path":"`+a+`","reason":""}]}`, allowed)
+	if res.Pruned != 0 || len(res.Deletions) != 0 {
+		t.Fatalf("empty reason must KEEP, got %+v", res)
+	}
+
+	// Unparseable → empty result with a note, never a deletion.
+	res = parseConsolidateResponse("the model rambled with no json", allowed)
+	if res.Merged != 0 || res.Pruned != 0 || len(res.Deletions) != 0 {
+		t.Fatalf("bad JSON must KEEP everything, got %+v", res)
+	}
+	if len(res.Notes) == 0 {
+		t.Fatal("expected an explanatory note on unparseable response")
+	}
+}
+
+func TestParseConsolidateResponseNoOpMergeIgnored(t *testing.T) {
+	a := "/mem/global/user/a.md"
+	allowed := allowedSet(a)
+	// A merge that removes nothing must not touch the file.
+	res := parseConsolidateResponse(`{"merges":[{"keep":"`+a+`","body":"rewritten","remove":[]}]}`, allowed)
+	if len(res.MergedBodies) != 0 || res.Merged != 0 {
+		t.Fatalf("no-op merge must be ignored, got %+v", res)
+	}
+}
+
+func TestLLMConsolidatorUsesCompleter(t *testing.T) {
+	root := "/mem"
+	a := "/mem/global/user/a.md"
+	b := "/mem/global/user/b.md"
+	plan := Plan{Files: []MemoryFile{
+		{Path: a, Scope: "global", Type: "user", Body: "one"},
+		{Path: b, Scope: "global", Type: "user", Body: "two"},
+	}}
+
+	var gotSystem, gotUser string
+	c := &llmConsolidator{complete: func(_ context.Context, sys, user string) (string, error) {
+		gotSystem, gotUser = sys, user
+		return `{"merges":[{"keep":"` + a + `","body":"merged","remove":["` + b + `"]}]}`, nil
+	}}
+	res, err := c.Consolidate(context.Background(), ConsolidateInput{Plan: plan, MemoryRoot: root})
+	if err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+	if gotSystem != dreamSystemPrompt {
+		t.Error("system prompt not passed through")
+	}
+	if !strings.Contains(gotUser, a) {
+		t.Error("user prompt missing entry path")
+	}
+	if res.Merged != 1 || res.MergedBodies[a] != "merged" {
+		t.Fatalf("merge not applied: %+v", res)
+	}
+}
+
+func TestLLMConsolidatorPropagatesHardError(t *testing.T) {
+	plan := Plan{Files: []MemoryFile{{Path: "/mem/global/user/a.md", Scope: "global", Type: "user", Body: "x"}}}
+	c := &llmConsolidator{complete: func(context.Context, string, string) (string, error) {
+		return "", errors.New("upstream 500")
+	}}
+	if _, err := c.Consolidate(context.Background(), ConsolidateInput{Plan: plan, MemoryRoot: "/mem"}); err == nil {
+		t.Fatal("expected hard completion error to propagate")
+	}
+}
+
+func TestLLMConsolidatorSkipsWhenNoEligibleFiles(t *testing.T) {
+	called := false
+	c := &llmConsolidator{complete: func(context.Context, string, string) (string, error) {
+		called = true
+		return "{}", nil
+	}}
+	// Only a MEMORY.md index → nothing eligible → no model call.
+	plan := Plan{Files: []MemoryFile{{Path: "/mem/global/MEMORY.md", Scope: "global", Body: "idx"}}}
+	if _, err := c.Consolidate(context.Background(), ConsolidateInput{Plan: plan, MemoryRoot: "/mem"}); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+	if called {
+		t.Fatal("model should not be called when no eligible files exist")
+	}
+}

--- a/internal/dream/prompt.go
+++ b/internal/dream/prompt.go
@@ -1,0 +1,49 @@
+package dream
+
+// This file holds the dream consolidation Agent's system prompt (SPEC §2.2) and
+// the strict JSON output schema the model must follow. The prompt scopes the
+// task to the LLM half of the mixed division of labor (SPEC §5.1.1): confirm
+// semantic merges of near-duplicate entries, and prune only clearly outdated or
+// contradicted entries — always conservatively (PRD FR-14: when uncertain,
+// KEEP). It never invents facts and only ever names paths that were provided in
+// the input, so the deterministic scope guard in the Runner cannot be tricked
+// into writing outside the memory store.
+
+// dreamSystemPrompt is the fixed system instruction for the dream consolidation
+// pass. It is deliberately narrow: the Go side already handles exact dedup, path
+// validation, near-dup candidate pairing, MEMORY.md rewrite, and index rebuild;
+// the model only decides the semantic merges and prunes.
+const dreamSystemPrompt = `You are the memory-consolidation agent for pigo ("dream"). You run periodically over a developer's persistent memory library and produce a compact, non-redundant, current set of memory entries.
+
+Each memory entry is a Markdown file. You are given the current entries (with their absolute file paths and bodies), plus deterministic hints: candidate near-duplicate pairs and references to local files that no longer exist. Exact byte-duplicates and dead-path cleanup are already handled mechanically — you do NOT need to act on those.
+
+Your job, and ONLY your job:
+1. MERGE semantically-overlapping entries. When two or more entries cover the same fact/topic, combine them into a single entry that keeps the most recent and most informative content. Rewrite that surviving entry's full body to be self-contained and concise; the other entries are removed.
+2. PRUNE entries that are clearly outdated or directly contradicted by a newer entry.
+
+Hard rules:
+- BE CONSERVATIVE. If you are unsure whether two entries truly overlap, do NOT merge them. If you are unsure whether an entry is outdated or contradicted, KEEP it. Losing a real memory is far worse than leaving a small redundancy.
+- NEVER invent facts. A merged body may only restate information already present in the entries you are combining. Do not add, infer, or embellish.
+- Only ever reference file paths that appear verbatim in the input. Never emit a path that was not given to you.
+- Never merge into, prune, or otherwise target a MEMORY.md index file. Those are indexes, not entries.
+- Preserve any Markdown frontmatter (the leading '---' block with name/description/metadata) on a surviving/merged entry, updating it only to reflect the merged content.
+- Do NOT create new entries. Distillation of new facts is handled by a separate step.
+
+Output format:
+- Respond with a SINGLE JSON object and nothing else. No prose, no Markdown code fences.
+- Schema:
+  {
+    "merges": [
+      {
+        "keep": "<absolute path of the entry to keep and rewrite>",
+        "body": "<the full rewritten body for the kept entry>",
+        "remove": ["<absolute path merged away>", ...]
+      }
+    ],
+    "prunes": [
+      { "path": "<absolute path to remove>", "reason": "<why it is outdated or contradicted>" }
+    ],
+    "notes": ["<short human-readable summary of a decision>", ...]
+  }
+- Every "keep"/"remove"/"path" MUST be one of the input paths. "remove" must not contain the "keep" path.
+- If there is nothing to merge or prune, return {"merges": [], "prunes": [], "notes": []}. Returning an empty result is the correct, safe answer when in doubt.`

--- a/internal/dream/runner.go
+++ b/internal/dream/runner.go
@@ -201,6 +201,18 @@ func (r *Runner) Run(ctx context.Context, opts RunOptions) (Report, error) {
 		return Report{}, fmt.Errorf("dream: apply consolidation: %w", err)
 	}
 
+	// Keep each affected scope's MEMORY.md index consistent with the entries on
+	// disk: drop any link to a file removed by dedupe or by the Consolidator so
+	// no dangling references survive (PRD US-003). The full removed set is the
+	// deterministic dedupe deletions plus the Consolidator's own deletions
+	// (merged-away + pruned entries).
+	for _, p := range cres.Deletions {
+		deleted[filepath.Clean(p)] = struct{}{}
+	}
+	if err := updateScopeIndexes(memoryRoot, opts.ProjectDir, deleted); err != nil {
+		return Report{}, fmt.Errorf("dream: update scope index: %w", err)
+	}
+
 	res, err := store.Reconcile()
 	if err != nil {
 		return Report{}, fmt.Errorf("dream: reconcile: %w", err)


### PR DESCRIPTION
## Summary
- Add `llmConsolidator`: builds a prompt from the deterministic `Plan` and drives the main-session model once, parsing a strict-JSON response into merge/prune decisions (SPEC §5.1/§5.1.1).
- New `prompt.go` (dedicated dream system prompt + JSON schema), `consolidator.go` (eligible-file selection, prompt builder, tolerant parser), `apply.go` (provider-backed single completion reusing the resolved main-session model per SPEC Q3, plus MEMORY.md dangling-link cleanup).
- Wire the real Consolidator into `pigo --dream` (`cmd/pigo`); the no-op stays the default when none is injected.
- Runner updates each affected scope's MEMORY.md after writeback (US-003), then Reconcile runs as before.
- Conservative pruning (FR-14): unknown/unsafe paths, empty bodies/reasons, and unparseable responses all default to KEEP.

## Design notes
- MEMORY.md index files are excluded from merge/prune candidates (never folded into an entry); exact-dedup duplicates are excluded from LLM candidates since the deterministic pass removes them.
- Distillation (NewEntries) is intentionally out of scope here — left to #524.

Closes #523

## Test plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./internal/dream/... ./cmd/...` green
- [x] Unit tests: prompt builder, JSON parser (merge/prune, unsafe-path rejection, conservative fallback), MEMORY.md boundary-aware link cleanup
- [x] Integration test: Runner end-to-end with a stub Consolidator — files converge, MEMORY.md loses dangling links, Reconcile runs, counters correct, merged-away fragment no longer searchable
- [x] No live LLM used in tests