### PR TITLE
feat(repl): /dream manual command + report rendering

### DIFF
--- a/internal/cli/prompts/registry.go
+++ b/internal/cli/prompts/registry.go
@@ -317,6 +317,7 @@ func RegisterLiveCommands(reg *runtime.SlashRegistry, live *cli.LiveConfig) {
 		{"status", "show session status: runtime config, context, telemetry, credentials, environment"},
 		{"goal", "run autonomously toward a goal: /goal [--tokens N] <objective> | pause | resume | clear"},
 		{"btw", "ask a quick side question without touching the main conversation: /btw <question> (bare /btw reopens the last one)"},
+		{"dream", "consolidate memory now (dedupe, merge, prune, distill); /dream --dry-run previews without writing"},
 		{"remote-control", "mirror this session to a phone/browser on your LAN: /remote-control [stop|status]"},
 	} {
 		reg.AddBuiltin(runtime.SlashCommand{

--- a/internal/cli/repl/dream_repl.go
+++ b/internal/cli/repl/dream_repl.go
@@ -1,0 +1,240 @@
+// This file implements the manual `/dream` REPL command (SPEC §4.1, US-007):
+// it spawns the process-isolated memory-consolidation subprocess
+// (`pigo --dream [--dream-dry-run] -C <projectDir>`), captures the single-line
+// Report JSON the child writes to stdout (SPEC §4.2), and renders it as a
+// full-table change report. `--dry-run` runs the same analysis without writing
+// (the subprocess enforces that; the command only reflects report.DryRun).
+//
+// The report renderers (RenderReportTable / RenderReportLine) live here rather
+// than in internal/dream/report.go so the presentation layer stays in the CLI
+// package and to keep dream internals conflict-free. RenderReportLine is
+// exported because the startup background trigger (#526) reuses it for its
+// one-line summary.
+package repl
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/smallnest/pigo/internal/cli/ui"
+	"github.com/smallnest/pigo/internal/dream"
+)
+
+// dreamSubprocessResult is the parsed outcome of one spawn: the decoded Report
+// plus whatever the child wrote to stderr (surfaced in error messages so a
+// failing run is diagnosable). It is returned by the spawn seam so the
+// parse-and-render path can be unit-tested against canned JSON without spawning
+// a real LLM-backed dream.
+type dreamSubprocessResult struct {
+	report dream.Report
+	stderr string
+}
+
+// spawnDream is the seam that launches the dream subprocess and decodes its
+// stdout Report. It is a package var so tests can substitute a canned stdout
+// (avoiding a real LLM-backed run — see acceptance criteria). The production
+// implementation is spawnDreamSubprocess.
+var spawnDream = spawnDreamSubprocess
+
+// spawnDreamSubprocess runs `pigo --dream [--dream-dry-run] -C <projectDir>` to
+// completion, capturing stdout (the single-line Report JSON, SPEC §4.2) and
+// stderr (progress/diagnostics). A non-zero exit or unparseable stdout is
+// returned as an error carrying the stderr tail so the caller can print a clear
+// failure (SPEC §6.1). It never mutates the REPL's own state.
+func spawnDreamSubprocess(ctx context.Context, projectDir string, dryRun bool) (dreamSubprocessResult, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return dreamSubprocessResult{}, fmt.Errorf("resolve pigo executable: %w", err)
+	}
+	args := []string{"--dream"}
+	if dryRun {
+		args = append(args, "--dream-dry-run")
+	}
+	if projectDir != "" {
+		args = append(args, "-C", projectDir)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, exe, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	errTail := strings.TrimSpace(stderr.String())
+	if runErr != nil {
+		// Exit 1 (or a kill/timeout) → failed (SPEC §6.1). Surface the stderr
+		// tail so the user sees why.
+		if errTail != "" {
+			return dreamSubprocessResult{stderr: errTail}, fmt.Errorf("%w: %s", runErr, errTail)
+		}
+		return dreamSubprocessResult{}, runErr
+	}
+	var report dream.Report
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &report); err != nil {
+		// Unparseable stdout is treated as failed (SPEC §6.1).
+		return dreamSubprocessResult{stderr: errTail}, fmt.Errorf("parse report: %w", err)
+	}
+	return dreamSubprocessResult{report: report, stderr: errTail}, nil
+}
+
+// runDream handles an intercepted `/dream` (or `/dream --dry-run`) line: it
+// checks for a live lock (so a background dream already running yields the
+// "已有 dream 在运行" notice rather than a confusing empty report), spawns the
+// consolidation subprocess with a progress indication, and renders the returned
+// Report as a full table. A failed or unparseable run prints a clear error and
+// returns to the prompt without crashing the REPL (SPEC §6.1).
+func runDream(out io.Writer, deps replDeps, line string) {
+	dryRun := dreamHasDryRun(line)
+
+	// Pre-spawn lock check: if a background (or other) dream already holds a live
+	// lock, the subprocess would just skip and emit an all-zero report,
+	// indistinguishable from "nothing changed". Detect it here so the manual
+	// command can tell the user (SPEC §6.1 locked row: "已有 dream 在运行").
+	if dreamLockHeld(deps.memoryRoot) {
+		fmt.Fprintln(out, ui.Colorize(ui.Enabled(), ui.Yellow, "已有 dream 在运行 (a dream consolidation is already running)"))
+		return
+	}
+
+	progress := "Dreaming… (consolidating memory)"
+	if dryRun {
+		progress = "Dreaming… (dry-run, analyzing memory — nothing will be written)"
+	}
+	fmt.Fprintln(out, ui.Colorize(ui.Enabled(), ui.Dim, progress))
+
+	// Bound the subprocess so a hung LLM-backed run cannot wedge the REPL
+	// indefinitely (SPEC §6.3/§11.2: parent context timeout, default 10min). On
+	// timeout CommandContext kills the child and spawnDream surfaces a failed run.
+	ctx, cancel := context.WithTimeout(context.Background(), dreamRunTimeout)
+	defer cancel()
+	res, err := spawnDream(ctx, deps.cwd, dryRun)
+	if err != nil {
+		fmt.Fprintf(out, "%s %v\n", ui.Colorize(ui.Enabled(), ui.Red, "dream failed:"), err)
+		return
+	}
+	RenderReportTable(out, res.report)
+}
+
+// dreamRunTimeout bounds a manual /dream subprocess (SPEC §6.3 default 10min).
+var dreamRunTimeout = 10 * time.Minute
+
+// dreamHasDryRun reports whether the /dream command line carries the --dry-run
+// flag. It accepts "--dry-run" as a standalone token so "/dream --dry-run" and
+// "/dream  --dry-run" both match, while a bare "/dream" does not.
+func dreamHasDryRun(line string) bool {
+	for _, f := range strings.Fields(line) {
+		if f == "--dry-run" {
+			return true
+		}
+	}
+	return false
+}
+
+// dreamLockPayload mirrors the on-disk dream.lock body (SPEC §3.1:
+// {"pid":..,"started_at":..}). It is decoded read-only in the parent to detect
+// a running dream; the authoritative lock logic lives in internal/dream/lock.go.
+type dreamLockPayload struct {
+	StartedAt time.Time `json:"started_at"`
+}
+
+// dreamLockHeld reports whether a live (non-stale) dream lock exists under
+// memoryRoot. A missing root/lock or a stale lock (older than
+// dream.DefaultStaleAfter, matching the runner's takeover rule) reads as not
+// held. Read-only: it never creates, removes, or takes over the lock — that is
+// the subprocess Runner's job.
+func dreamLockHeld(memoryRoot string) bool {
+	if memoryRoot == "" {
+		return false
+	}
+	path := filepath.Join(memoryRoot, "global", "dream", "dream.lock")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var info dreamLockPayload
+	if err := json.Unmarshal(data, &info); err != nil {
+		// Malformed lock body: the runner treats it as stale/takeable, so it is
+		// not a live lock from the user's perspective.
+		return false
+	}
+	if info.StartedAt.IsZero() {
+		return false
+	}
+	return time.Since(info.StartedAt) <= dream.DefaultStaleAfter
+}
+
+// RenderReportTable writes the full change report (SPEC §2.2/§6.1 manual row):
+// one aligned row per counter, byte/file before→after, and any Notes. A dry-run
+// report is clearly labeled DRY-RUN and states that nothing was written.
+func RenderReportTable(out io.Writer, r dream.Report) {
+	enabled := ui.Enabled()
+	if r.DryRun {
+		fmt.Fprintln(out, ui.Colorize(enabled, ui.Bold, "dream report [DRY-RUN — nothing written]"))
+	} else {
+		fmt.Fprintln(out, ui.Colorize(enabled, ui.Bold, "dream report"))
+	}
+	rows := []struct {
+		label string
+		value string
+	}{
+		{"merged", fmt.Sprintf("%d", r.Merged)},
+		{"deduped", fmt.Sprintf("%d", r.Deduped)},
+		{"paths-cleaned", fmt.Sprintf("%d", r.PathsCleaned)},
+		{"pruned", fmt.Sprintf("%d", r.Pruned)},
+		{"distilled", fmt.Sprintf("%d", r.Distilled)},
+		{"bytes", fmt.Sprintf("%s → %s", formatBytes(r.BytesBefore), formatBytes(r.BytesAfter))},
+		{"files", fmt.Sprintf("%d → %d", r.FilesBefore, r.FilesAfter)},
+		{"reconciled", fmt.Sprintf("indexed %d, pruned %d", r.Reconciled.Indexed, r.Reconciled.Pruned)},
+	}
+	width := 0
+	for _, row := range rows {
+		if len(row.label) > width {
+			width = len(row.label)
+		}
+	}
+	for _, row := range rows {
+		label := ui.Colorize(enabled, ui.Dim, fmt.Sprintf("  %-*s", width, row.label))
+		fmt.Fprintf(out, "%s  %s\n", label, row.value)
+	}
+	if len(r.Notes) > 0 {
+		fmt.Fprintln(out, ui.Colorize(enabled, ui.Dim, "  notes:"))
+		for _, n := range r.Notes {
+			fmt.Fprintf(out, "    - %s\n", n)
+		}
+	}
+}
+
+// RenderReportLine renders a compact one-line summary of a dream Report. It is
+// exported so the startup background trigger (#526) can reuse it for its
+// non-intrusive one-line notice (SPEC §6.1 background row). A dry-run report is
+// prefixed [DRY-RUN].
+func RenderReportLine(r dream.Report) string {
+	prefix := "dream:"
+	if r.DryRun {
+		prefix = "dream [DRY-RUN]:"
+	}
+	return fmt.Sprintf("%s merged %d, deduped %d, paths-cleaned %d, pruned %d, distilled %d, %s→%s, %d→%d files",
+		prefix, r.Merged, r.Deduped, r.PathsCleaned, r.Pruned, r.Distilled,
+		formatBytes(r.BytesBefore), formatBytes(r.BytesAfter), r.FilesBefore, r.FilesAfter)
+}
+
+// formatBytes renders a byte count as a compact human-readable string (B/KB/MB).
+// It uses 1024-based units and one decimal place above 1KB, matching the terse
+// style of the rest of the REPL status output.
+func formatBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%dB", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f%cB", float64(n)/float64(div), "KMGT"[exp])
+}

--- a/internal/cli/repl/dream_repl_test.go
+++ b/internal/cli/repl/dream_repl_test.go
@@ -1,0 +1,255 @@
+package repl
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/dream"
+)
+
+// sampleReport is a non-trivial Report used across the renderer tests: every
+// counter is distinct so a mis-wired field is caught, and Notes/Reconciled are
+// populated so their rendering is exercised too.
+func sampleReport() dream.Report {
+	r := dream.Report{
+		Merged:       2,
+		Deduped:      1,
+		PathsCleaned: 3,
+		Pruned:       4,
+		Distilled:    5,
+		BytesBefore:  4096,
+		BytesAfter:   2048,
+		FilesBefore:  9,
+		FilesAfter:   7,
+		Notes:        []string{"pruned stale entry X", "no new sessions"},
+	}
+	r.Reconciled.Indexed = 6
+	r.Reconciled.Pruned = 1
+	return r
+}
+
+func TestRenderReportTable(t *testing.T) {
+	var buf bytes.Buffer
+	RenderReportTable(&buf, sampleReport())
+	got := buf.String()
+
+	// Key counts must appear (label + value).
+	for _, want := range []string{
+		"dream report",
+		"merged", "deduped", "paths-cleaned", "pruned", "distilled",
+		"4.0KB → 2.0KB", // bytes before→after
+		"9 → 7",         // files before→after
+		"indexed 6, pruned 1",
+		"pruned stale entry X",
+		"no new sessions",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("full table missing %q\n---\n%s", want, got)
+		}
+	}
+	// A non-dry-run report must NOT carry the DRY-RUN label.
+	if strings.Contains(got, "DRY-RUN") {
+		t.Errorf("non-dry-run table should not show DRY-RUN label:\n%s", got)
+	}
+}
+
+func TestRenderReportTableDryRun(t *testing.T) {
+	r := sampleReport()
+	r.DryRun = true
+	var buf bytes.Buffer
+	RenderReportTable(&buf, r)
+	got := buf.String()
+	if !strings.Contains(got, "DRY-RUN") {
+		t.Errorf("dry-run table must show DRY-RUN label:\n%s", got)
+	}
+	if !strings.Contains(got, "nothing written") {
+		t.Errorf("dry-run table should state nothing was written:\n%s", got)
+	}
+}
+
+func TestRenderReportLine(t *testing.T) {
+	got := RenderReportLine(sampleReport())
+	for _, want := range []string{
+		"dream:",
+		"merged 2", "deduped 1", "paths-cleaned 3", "pruned 4", "distilled 5",
+		"4.0KB→2.0KB", "9→7 files",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("one-line summary missing %q: %q", want, got)
+		}
+	}
+	if strings.Contains(got, "DRY-RUN") {
+		t.Errorf("non-dry-run line should not show DRY-RUN: %q", got)
+	}
+}
+
+func TestRenderReportLineDryRun(t *testing.T) {
+	r := sampleReport()
+	r.DryRun = true
+	got := RenderReportLine(r)
+	if !strings.Contains(got, "DRY-RUN") {
+		t.Errorf("dry-run line must show DRY-RUN: %q", got)
+	}
+}
+
+func TestRenderReportZeroValue(t *testing.T) {
+	// The zero value is a valid "nothing changed" report and must render cleanly.
+	var buf bytes.Buffer
+	RenderReportTable(&buf, dream.Report{})
+	if line := RenderReportLine(dream.Report{}); !strings.Contains(line, "merged 0") {
+		t.Errorf("zero-value line should render zero counts: %q", line)
+	}
+	if !strings.Contains(buf.String(), "0B → 0B") {
+		t.Errorf("zero-value table should render 0B → 0B:\n%s", buf.String())
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0B"},
+		{512, "512B"},
+		{1024, "1.0KB"},
+		{1536, "1.5KB"},
+		{1048576, "1.0MB"},
+	}
+	for _, c := range cases {
+		if got := formatBytes(c.in); got != c.want {
+			t.Errorf("formatBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDreamHasDryRun(t *testing.T) {
+	cases := []struct {
+		line string
+		want bool
+	}{
+		{"/dream", false},
+		{"/dream --dry-run", true},
+		{"/dream  --dry-run", true},
+		{"/dream --dryrun", false},
+		{"/dream extra --dry-run", true},
+	}
+	for _, c := range cases {
+		if got := dreamHasDryRun(c.line); got != c.want {
+			t.Errorf("dreamHasDryRun(%q) = %v, want %v", c.line, got, c.want)
+		}
+	}
+}
+
+// TestRunDreamRendersCannedReport exercises the parse+render path via the spawn
+// seam with a canned Report, without spawning a real LLM-backed dream.
+func TestRunDreamRendersCannedReport(t *testing.T) {
+	orig := spawnDream
+	t.Cleanup(func() { spawnDream = orig })
+	spawnDream = func(_ context.Context, _ string, dryRun bool) (dreamSubprocessResult, error) {
+		r := sampleReport()
+		r.DryRun = dryRun
+		return dreamSubprocessResult{report: r}, nil
+	}
+
+	var buf bytes.Buffer
+	runDream(&buf, replDeps{}, "/dream")
+	got := buf.String()
+	if !strings.Contains(got, "dream report") || !strings.Contains(got, "merged") {
+		t.Errorf("runDream should render the full table:\n%s", got)
+	}
+	if strings.Contains(got, "DRY-RUN") {
+		t.Errorf("non-dry-run runDream should not show DRY-RUN:\n%s", got)
+	}
+}
+
+func TestRunDreamDryRunLabel(t *testing.T) {
+	orig := spawnDream
+	t.Cleanup(func() { spawnDream = orig })
+	spawnDream = func(_ context.Context, _ string, dryRun bool) (dreamSubprocessResult, error) {
+		r := sampleReport()
+		r.DryRun = dryRun
+		return dreamSubprocessResult{report: r}, nil
+	}
+	var buf bytes.Buffer
+	runDream(&buf, replDeps{}, "/dream --dry-run")
+	if !strings.Contains(buf.String(), "DRY-RUN") {
+		t.Errorf("/dream --dry-run should render DRY-RUN label:\n%s", buf.String())
+	}
+}
+
+// TestRunDreamFailure asserts a subprocess failure (exit 1 / unparseable stdout)
+// prints a clear error and does not crash the REPL (SPEC §6.1).
+func TestRunDreamFailure(t *testing.T) {
+	orig := spawnDream
+	t.Cleanup(func() { spawnDream = orig })
+	spawnDream = func(_ context.Context, _ string, _ bool) (dreamSubprocessResult, error) {
+		return dreamSubprocessResult{}, errFake
+	}
+	var buf bytes.Buffer
+	runDream(&buf, replDeps{}, "/dream")
+	if !strings.Contains(buf.String(), "dream failed") {
+		t.Errorf("failed run should print an error:\n%s", buf.String())
+	}
+}
+
+var errFake = &fakeErr{}
+
+type fakeErr struct{}
+
+func (*fakeErr) Error() string { return "boom" }
+
+func TestDreamLockHeld(t *testing.T) {
+	// No memory root → never held.
+	if dreamLockHeld("") {
+		t.Fatal("empty memoryRoot must read as not held")
+	}
+	root := t.TempDir()
+	// No lock file yet → not held.
+	if dreamLockHeld(root) {
+		t.Fatal("missing lock must read as not held")
+	}
+	// Acquire a real lock via the dream package → held.
+	lock, err := dream.AcquireLock(root)
+	if err != nil {
+		t.Fatalf("AcquireLock: %v", err)
+	}
+	if !dreamLockHeld(root) {
+		t.Error("a freshly acquired lock must read as held")
+	}
+	// Release → not held.
+	if err := lock.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if dreamLockHeld(root) {
+		t.Error("a released lock must read as not held")
+	}
+}
+
+// TestRunDreamLockedNotice asserts the manual command surfaces the locked
+// message and does NOT spawn when a live lock is present (SPEC §6.1).
+func TestRunDreamLockedNotice(t *testing.T) {
+	root := t.TempDir()
+	lock, err := dream.AcquireLock(root)
+	if err != nil {
+		t.Fatalf("AcquireLock: %v", err)
+	}
+	t.Cleanup(func() { _ = lock.Release() })
+
+	orig := spawnDream
+	t.Cleanup(func() { spawnDream = orig })
+	spawned := false
+	spawnDream = func(_ context.Context, _ string, _ bool) (dreamSubprocessResult, error) {
+		spawned = true
+		return dreamSubprocessResult{}, nil
+	}
+	var buf bytes.Buffer
+	runDream(&buf, replDeps{memoryRoot: root}, "/dream")
+	if spawned {
+		t.Error("runDream must not spawn while a live lock is held")
+	}
+	if !strings.Contains(buf.String(), "已有 dream 在运行") {
+		t.Errorf("locked run should print the locked notice:\n%s", buf.String())
+	}
+}

--- a/internal/cli/repl/repl.go
+++ b/internal/cli/repl/repl.go
@@ -439,6 +439,17 @@ func runREPL(in io.Reader, out io.Writer, deps replDeps) error {
 				deps.agentCtx.Messages, deps.live.ContextWindow)
 			continue
 		}
+		if line == "/dream" || strings.HasPrefix(line, "/dream ") {
+			// /dream is intercepted here (like /memory/status) because it spawns the
+			// process-isolated consolidation subprocess (pigo --dream) and renders the
+			// returned Report against live state (deps.cwd / deps.memoryRoot) — work a
+			// string→string Action closure cannot do. It never mutates the shared
+			// context, so no session re-save/leaf reset is needed. The
+			// exact-or-space-prefix guard keeps "/dreamer" from matching, and
+			// "/dream --dry-run" runs the same analysis without writing.
+			runDream(out, deps, line)
+			continue
+		}
 		if line == "/goal" || strings.HasPrefix(line, "/goal ") {
 			// /goal is intercepted here (like /compact) because it must run one or
 			// more agent streams and mutate the shared context/goal state — none of


### PR DESCRIPTION
## Summary
- Intercept `/dream` and `/dream --dry-run` in the REPL loop (mirrors `/compact` `/memory`): spawn the process-isolated `pigo --dream [--dream-dry-run] -C <cwd>` subprocess, show a progress line, capture the single-line Report JSON on stdout, and render a full-table change report.
- Full table: merged / deduped / paths-cleaned / pruned / distilled, bytes + files before→after, reconciled counts, and Notes. `--dry-run` reflects `report.DryRun` with a clear DRY-RUN label ("nothing written").
- Error handling per SPEC §6.1: a pre-spawn read-only lock check surfaces "已有 dream 在运行" when a background dream holds a live lock; subprocess exit 1 or unparseable stdout prints a clear error without crashing the REPL. Subprocess bounded by a 10min timeout (SPEC §6.3).
- `RenderReportLine(report)` exported for reuse by the startup background trigger (#526). Added `/dream` to the `/help` command list.

Closes #525

## Test plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./internal/cli/repl/... ./internal/dream/... ./internal/cli/prompts/...` green
- [x] Renderer unit tests: full table + one-line, DRY-RUN label, zero-value, byte formatting
- [x] Parse+render path via spawn seam with canned JSON (no real LLM), failure path, lock-held notice