### PR TITLE
feat(dream): distill new memories from recent session JSONL

### DIFF
--- a/internal/cli/headless/session.go
+++ b/internal/cli/headless/session.go
@@ -137,8 +137,22 @@ func openHeadlessSession(resumeID, model, providerName, sysPrompt string) (agent
 		Model:        model,
 		Provider:     providerName,
 		SystemPrompt: sysPrompt,
+		Cwd:          headlessCwd(),
 	}
 	return nil, headlessSession{store: store, header: header, curLeaf: "", persisted: 0, model: model, provider: providerName}, nil
+}
+
+// headlessCwd returns the absolute working directory the run executes in, used
+// to attribute the session to a project (SessionHeader.Cwd → project id) so a
+// later /dream pass can distill this session under the right project scope. An
+// unresolvable cwd yields "" (the session stays unattributed) rather than
+// aborting the run.
+func headlessCwd() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return wd
 }
 
 // persist appends the messages produced during the run — everything in

--- a/internal/dream/consolidator.go
+++ b/internal/dream/consolidator.go
@@ -50,28 +50,103 @@ func (c *llmConsolidator) Consolidate(ctx context.Context, in ConsolidateInput) 
 	if c.complete == nil {
 		return ConsolidateResult{}, fmt.Errorf("dream: llmConsolidator has no completion function")
 	}
+
+	var res ConsolidateResult
 	eligible := eligibleFiles(in.Plan)
-	if len(eligible) == 0 {
-		// Nothing the model could act on (empty library, or only MEMORY.md /
-		// duplicates). Skip the call entirely.
-		return ConsolidateResult{}, nil
-	}
-	budget := c.bodyBudget
-	if budget <= 0 {
-		budget = defaultBodyBudget
-	}
-	prompt := buildConsolidatePrompt(in, eligible, budget)
+	if len(eligible) > 0 {
+		budget := c.bodyBudget
+		if budget <= 0 {
+			budget = defaultBodyBudget
+		}
+		prompt := buildConsolidatePrompt(in, eligible, budget)
 
-	raw, err := c.complete(ctx, dreamSystemPrompt, prompt)
+		raw, err := c.complete(ctx, dreamSystemPrompt, prompt)
+		if err != nil {
+			return ConsolidateResult{}, fmt.Errorf("dream: model completion: %w", err)
+		}
+
+		allowed := make(map[string]struct{}, len(eligible))
+		for _, f := range eligible {
+			allowed[filepath.Clean(f.Path)] = struct{}{}
+		}
+		res = parseConsolidateResponse(raw, allowed)
+	}
+
+	// Distillation pass (SPEC §5.3, PRD US-005/FR-13): a SEPARATE model call over
+	// the recent-session transcripts the Runner collected. It runs even when the
+	// library is empty (nothing to merge/prune) so a first-time distill can seed
+	// memory from sessions. A hard model failure aborts the run; a well-formed
+	// call yielding nothing simply adds no entries (Runner records the no-op).
+	if strings.TrimSpace(in.Transcripts) != "" {
+		if err := c.distill(ctx, in, &res); err != nil {
+			return ConsolidateResult{}, err
+		}
+	}
+	return res, nil
+}
+
+// distill runs the JSONL distillation model call and folds the resulting new
+// entries into res: it prompts the distiller with the transcripts plus a summary
+// of the existing library (so the model avoids re-proposing known facts), parses
+// the response into path-guarded NewEntry writes deduped against the existing
+// memory, and bumps res.Distilled by the number added. A hard model/transport
+// error is returned so the Runner marks the run failed (SPEC §5.5); an
+// unparseable or empty response adds nothing and is not an error (conservative
+// KEEP, PRD FR-14).
+func (c *llmConsolidator) distill(ctx context.Context, in ConsolidateInput, res *ConsolidateResult) error {
+	prompt := buildDistillPrompt(in)
+	raw, err := c.complete(ctx, dreamDistillSystemPrompt, prompt)
 	if err != nil {
-		return ConsolidateResult{}, fmt.Errorf("dream: model completion: %w", err)
+		return fmt.Errorf("dream: distill completion: %w", err)
+	}
+	entries, notes := parseDistillResponse(raw, in.Plan.Files, in.MemoryRoot, in.ProjectDir)
+	res.NewEntries = append(res.NewEntries, entries...)
+	res.Distilled += len(entries)
+	res.Notes = append(res.Notes, notes...)
+	return nil
+}
+
+// buildDistillPrompt renders the distiller's user prompt: the target scope, a
+// compact list of the titles/paths of existing memories (so the model does not
+// re-propose known facts), and the recent-session transcripts. Existing bodies
+// are summarized (path + leading text) rather than dumped in full to keep the
+// prompt bounded; the Go side still enforces near-duplicate rejection.
+func buildDistillPrompt(in ConsolidateInput) string {
+	var b strings.Builder
+	b.WriteString("# Memory distillation request\n\n")
+	if in.ProjectDir != "" {
+		b.WriteString("Current project: ")
+		b.WriteString(in.ProjectDir)
+		b.WriteByte('\n')
+	} else {
+		b.WriteString("Scope: global only\n")
 	}
 
-	allowed := make(map[string]struct{}, len(eligible))
-	for _, f := range eligible {
-		allowed[filepath.Clean(f.Path)] = struct{}{}
+	existing := eligibleFiles(in.Plan)
+	if len(existing) > 0 {
+		b.WriteString(fmt.Sprintf("\n## Existing memories (%d) — do NOT re-propose these\n\n", len(existing)))
+		for _, f := range existing {
+			b.WriteString("- ")
+			b.WriteString(clip(strings.TrimSpace(firstNonEmptyLine(f.Body)), 120))
+			b.WriteByte('\n')
+		}
 	}
-	return parseConsolidateResponse(raw, allowed), nil
+
+	b.WriteString("\n## Recent session transcripts\n\n")
+	b.WriteString(in.Transcripts)
+	b.WriteString("\n\nReturn the JSON object described in your instructions. Extract only genuinely new, durable facts. When in doubt, return no entries.\n")
+	return b.String()
+}
+
+// firstNonEmptyLine returns the first non-blank line of s (trimmed), or "" when
+// s is entirely blank. Used to label an existing memory in the distill prompt.
+func firstNonEmptyLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			return t
+		}
+	}
+	return ""
 }
 
 // eligibleFiles is the subset of plan files the model may act on: it excludes

--- a/internal/dream/distill.go
+++ b/internal/dream/distill.go
@@ -1,0 +1,411 @@
+package dream
+
+// This file implements the JSONL distillation step of a /dream run (SPEC §5.3,
+// PRD US-005 / FR-13): it selects the current project's recent sessions, reads
+// their transcripts (truncated to a token/byte budget, SPEC §8.2), and — via the
+// LLM distiller in consolidator.go — turns durable facts into new memory
+// entries, deduped against the existing library so nothing already recorded is
+// re-added.
+//
+// The deterministic half lives here (session-window selection, project filter,
+// transcript rendering, dedup, path construction); the semantic half (which
+// facts are durable) is a separate LLM call driven by the llmConsolidator. This
+// keeps the merge/prune pass and its parser (consolidator.go) untouched: the
+// Runner gathers the transcripts, the consolidator runs a distinct distill
+// completion with its own prompt/schema, and the distilled NewEntries are folded
+// into the same ConsolidateResult the Runner already applies (wiring choice "b"
+// from #523: a separate step appended to the result, chosen over folding it into
+// the merge/prune prompt so each concern keeps its own input, prompt and schema
+// and the well-tested merge/prune parser is not perturbed).
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/session"
+)
+
+// defaultTranscriptBudget bounds the total bytes of session transcript text fed
+// to the distiller, keeping the distill prompt within the model context even on
+// long or numerous recent sessions (SPEC §8.2 token budget). Sessions are added
+// most-recent-first until the budget is reached.
+const defaultTranscriptBudget = 24000
+
+// distillNewEntryTypes is the closed set of durable memory types the distiller
+// may emit (PRD FR-13: user / feedback / project / reference). Ephemeral kinds
+// (checkpoint / progress) are intentionally excluded — one-shot task state is
+// not distilled into long-term memory.
+var distillNewEntryTypes = map[string]struct{}{
+	"user":      {},
+	"feedback":  {},
+	"project":   {},
+	"reference": {},
+}
+
+// SessionSource is the read-only view of the session store the distiller needs:
+// list session headers and load a session's messages. *session.Store satisfies
+// it; tests inject a stub so no real session files (or LLM) are required.
+type SessionSource interface {
+	List() ([]session.SessionHeader, error)
+	Load(id string) (session.SessionHeader, agentcore.MessageList, error)
+}
+
+// resolveSessionStore opens the default session store rooted at
+// $PIGO_HOME/sessions (else ~/.pigo/sessions), mirroring
+// headless.SessionStore's resolution. It is duplicated here rather than imported
+// to keep internal/dream free of a dependency on the CLI assembly layer, exactly
+// as ResolveMemoryRoot duplicates the memory-root resolution. A resolution
+// failure yields a nil source and no error: distillation then degrades to a
+// no-op rather than failing the whole dream run.
+func resolveSessionStore() (SessionSource, error) {
+	dir := os.Getenv("PIGO_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, nil
+		}
+		dir = filepath.Join(home, ".pigo")
+	}
+	store, err := session.NewStore(filepath.Join(dir, "sessions"))
+	if err != nil {
+		return nil, nil
+	}
+	return store, nil
+}
+
+// sessionMatchesProject reports whether a session belongs to the project rooted
+// at projectDir. Attribution is by the session's recorded Cwd: two directories
+// belong to the same project when their stable project ids match (the same id
+// internal/memory and BuildPlan derive). A session with an empty Cwd is
+// unattributed and never matches; an empty projectDir (a global-only run) has no
+// project to match, so nothing is selected.
+func sessionMatchesProject(h session.SessionHeader, projectDir string) bool {
+	if projectDir == "" || h.Cwd == "" {
+		return false
+	}
+	return projectID(h.Cwd) == projectID(projectDir)
+}
+
+// collectRecentSessions selects the recent sessions to distill, applying the
+// SPEC §5.3 combined window over the project-filtered set:
+//   - state.LastRunAt non-zero → every matching session updated strictly after
+//     the last run (incremental distillation since the last dream).
+//   - state.LastRunAt zero (never run) → the most-recent recentN matching
+//     sessions by UpdatedAt descending (a bounded first-run window).
+//
+// recentN falls back to DefaultRecentSessions when non-positive. The result is
+// ordered most-recent-first so transcript budgeting keeps the freshest context.
+func collectRecentSessions(sessions []session.SessionHeader, state State, projectDir string, recentN int) []session.SessionHeader {
+	if recentN <= 0 {
+		recentN = DefaultRecentSessions
+	}
+	var matched []session.SessionHeader
+	for _, h := range sessions {
+		if sessionMatchesProject(h, projectDir) {
+			matched = append(matched, h)
+		}
+	}
+	// Most-recent-first regardless of the source ordering.
+	sort.SliceStable(matched, func(i, j int) bool {
+		return matched[i].UpdatedAt.After(matched[j].UpdatedAt)
+	})
+
+	if !state.LastRunAt.IsZero() {
+		var out []session.SessionHeader
+		for _, h := range matched {
+			if h.UpdatedAt.After(state.LastRunAt) {
+				out = append(out, h)
+			}
+		}
+		return out
+	}
+	if len(matched) > recentN {
+		matched = matched[:recentN]
+	}
+	return matched
+}
+
+// collectTranscripts selects the recent project sessions (collectRecentSessions)
+// and renders their messages into a single transcript string truncated to
+// budget bytes (SPEC §8.2). It returns "" when the source is nil or no session
+// matches — the no-matching-sessions no-op (SPEC §5.5): the caller then records
+// Distilled=0 with a "无新增" note. A per-session load error is skipped rather
+// than failing the run (a single corrupt session must not abort distillation).
+func collectTranscripts(src SessionSource, state State, projectDir string, recentN, budget int) string {
+	if src == nil {
+		return ""
+	}
+	if budget <= 0 {
+		budget = defaultTranscriptBudget
+	}
+	headers, err := src.List()
+	if err != nil {
+		return ""
+	}
+	selected := collectRecentSessions(headers, state, projectDir, recentN)
+	if len(selected) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, h := range selected {
+		if b.Len() >= budget {
+			break
+		}
+		_, msgs, err := src.Load(h.ID)
+		if err != nil {
+			continue
+		}
+		section := renderTranscript(h, msgs)
+		if section == "" {
+			continue
+		}
+		remaining := budget - b.Len()
+		if len(section) > remaining {
+			section = truncateBody(section, remaining)
+		}
+		b.WriteString(section)
+		b.WriteString("\n")
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// renderTranscript renders one session's messages as a compact, role-tagged
+// transcript for the distiller. Tool-result bodies are included but bounded so a
+// single huge tool output cannot dominate the budget; empty messages are
+// skipped. The header line carries the session id and update time for context.
+func renderTranscript(h session.SessionHeader, msgs agentcore.MessageList) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("## Session %s (updated %s)\n", h.ID, h.UpdatedAt.UTC().Format("2006-01-02")))
+	wrote := false
+	for _, m := range msgs {
+		var role, text string
+		switch mm := m.(type) {
+		case agentcore.UserMessage:
+			role, text = "user", agentcore.ContentToText(mm.Content)
+		case agentcore.AssistantMessage:
+			role, text = "assistant", agentcore.ContentToText(mm.Content)
+		case agentcore.ToolResultMessage:
+			role, text = "tool", clip(agentcore.ContentToText(mm.Content), 500)
+		case agentcore.CompactionMessage:
+			role, text = "summary", mm.Summary
+		default:
+			continue
+		}
+		text = strings.TrimSpace(text)
+		if text == "" {
+			continue
+		}
+		b.WriteString(role)
+		b.WriteString(": ")
+		b.WriteString(text)
+		b.WriteString("\n")
+		wrote = true
+	}
+	if !wrote {
+		return ""
+	}
+	return b.String()
+}
+
+// clip trims s to at most n bytes on a rune boundary, appending an ellipsis when
+// truncation occurred. Used to bound individual tool-result bodies inside a
+// transcript so one large output does not crowd out the rest.
+func clip(s string, n int) string {
+	if n <= 0 || len(s) <= n {
+		return s
+	}
+	cut := n
+	for cut > 0 && !isRuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "…"
+}
+
+// distilledEntry mirrors one element of the distiller's strict-JSON output: a
+// proposed new memory entry with its semantic type, target scope, a short title
+// (turned into a filename slug) and the Markdown body to persist.
+type distilledEntry struct {
+	Type  string `json:"type"`
+	Scope string `json:"scope"`
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+// distillResponse is the full strict-JSON schema the distill prompt requires.
+type distillResponse struct {
+	Entries []distilledEntry `json:"entries"`
+	Notes   []string         `json:"notes"`
+}
+
+// parseDistillResponse turns the distiller's text into concrete NewEntry writes,
+// deduped against the existing memory bodies. It is conservative by
+// construction: an unparseable response, an unknown/ephemeral type, an empty
+// body, or an entry that is a near-duplicate of an existing memory (or of an
+// already-accepted new entry) is dropped rather than written (PRD FR-13/FR-14).
+// It never errors; a hard model failure is handled by the caller.
+//
+// memoryRoot + projectDir place each entry within the scope the Runner's
+// withinScope guard permits: global entries under <root>/global/<type>/, project
+// entries under <root>/projects/<id>/<type>/. A "project" entry on a global-only
+// run (empty projectDir) has nowhere valid to live and is skipped.
+func parseDistillResponse(raw string, existing []MemoryFile, memoryRoot, projectDir string) ([]NewEntry, []string) {
+	body := extractJSONObject(raw)
+	if body == "" {
+		return nil, nil
+	}
+	var resp distillResponse
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		return nil, nil
+	}
+
+	// Precompute token sets of existing bodies for near-duplicate rejection.
+	existingTokens := make([]map[string]struct{}, 0, len(existing))
+	for _, f := range existing {
+		existingTokens = append(existingTokens, tokenize(f.Body))
+	}
+
+	var out []NewEntry
+	var notes []string
+	acceptedTokens := make([]map[string]struct{}, 0)
+	usedPaths := make(map[string]struct{})
+
+	for _, e := range resp.Entries {
+		typ := strings.ToLower(strings.TrimSpace(e.Type))
+		if _, ok := distillNewEntryTypes[typ]; !ok {
+			continue
+		}
+		body := strings.TrimSpace(e.Body)
+		if body == "" {
+			continue
+		}
+		scopeDir, ok := distillScopeDir(e.Scope, projectDir)
+		if !ok {
+			continue
+		}
+		tok := tokenize(body)
+		if isNearDup(tok, existingTokens) || isNearDup(tok, acceptedTokens) {
+			notes = append(notes, fmt.Sprintf("distill: skipped near-duplicate of existing memory (%s)", firstLine(e.Title, body)))
+			continue
+		}
+		path := distillPath(memoryRoot, scopeDir, typ, e.Title, body, usedPaths)
+		usedPaths[filepath.Clean(path)] = struct{}{}
+		acceptedTokens = append(acceptedTokens, tok)
+		out = append(out, NewEntry{Path: path, Body: ensureTrailingNewline(body)})
+	}
+
+	for _, n := range resp.Notes {
+		if s := strings.TrimSpace(n); s != "" {
+			notes = append(notes, s)
+		}
+	}
+	return out, notes
+}
+
+// distillScopeDir maps a requested scope ("global"/"project") to its on-disk
+// scope directory relative to the memory root. A "project" scope requires a
+// project dir; without one the entry cannot be placed and ok is false. An empty
+// or unrecognized scope defaults to global (the safe, always-valid target).
+func distillScopeDir(scope, projectDir string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(scope)) {
+	case "project", "projects":
+		if projectDir == "" {
+			return "", false
+		}
+		return filepath.Join("projects", projectID(projectDir)), true
+	default:
+		return "global", true
+	}
+}
+
+// distillPath builds the absolute file path for a new distilled entry:
+// <memoryRoot>/<scopeDir>/<type>/<slug>.md. The slug derives from the title
+// (sanitized) or, when absent, a short content hash, so a re-run of the same
+// durable fact lands on a stable path (and is caught by the near-dup check
+// against the now-existing file, keeping distillation idempotent). If the path
+// is already taken within this run, a short body hash disambiguates it.
+func distillPath(memoryRoot, scopeDir, typ, title, body string, used map[string]struct{}) string {
+	slug := slugify(title)
+	if slug == "" {
+		slug = shortHash(body)
+	}
+	name := slug + ".md"
+	path := filepath.Join(memoryRoot, scopeDir, typ, name)
+	if _, taken := used[filepath.Clean(path)]; taken {
+		path = filepath.Join(memoryRoot, scopeDir, typ, slug+"-"+shortHash(body)+".md")
+	}
+	return path
+}
+
+// isNearDup reports whether tok is at or above NearDupThreshold Jaccard
+// similarity with any set in others — the same conservative near-duplicate
+// signal the deterministic plan uses for merge candidates, reused here so a
+// distilled fact that already lives in memory is not re-added (PRD FR-13).
+func isNearDup(tok map[string]struct{}, others []map[string]struct{}) bool {
+	for _, o := range others {
+		if jaccard(tok, o) >= NearDupThreshold {
+			return true
+		}
+	}
+	return false
+}
+
+// slugify turns a title into a lowercase, dash-separated filename stem of ASCII
+// alphanumerics, bounding the length so paths stay reasonable. Non-alphanumeric
+// runs collapse to a single dash; leading/trailing dashes are trimmed. A title
+// with no usable characters yields "".
+func slugify(title string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(title)) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash && b.Len() > 0 {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	slug := strings.Trim(b.String(), "-")
+	const maxLen = 60
+	if len(slug) > maxLen {
+		slug = strings.Trim(slug[:maxLen], "-")
+	}
+	return slug
+}
+
+// firstLine returns a short human-readable label for a note: the trimmed title
+// when present, else the first line of body, truncated.
+func firstLine(title, body string) string {
+	s := strings.TrimSpace(title)
+	if s == "" {
+		s = strings.TrimSpace(body)
+	}
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	return clip(s, 60)
+}
+
+// ensureTrailingNewline guarantees body ends with exactly one newline so written
+// memory files match the one-entry-per-file convention and diff cleanly.
+func ensureTrailingNewline(body string) string {
+	return strings.TrimRight(body, "\n") + "\n"
+}
+
+// shortHash returns the first 8 hex chars of sha256(s), a stable disambiguator
+// for slugs derived from identical/absent titles.
+func shortHash(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])[:8]
+}

--- a/internal/dream/distill_test.go
+++ b/internal/dream/distill_test.go
@@ -1,0 +1,290 @@
+package dream
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+	"github.com/smallnest/pigo/internal/session"
+)
+
+// stubSessions is an in-memory SessionSource for distill tests: it lists the
+// headers it was given and returns canned messages per id, so no real session
+// files (or LLM) are touched.
+type stubSessions struct {
+	headers []session.SessionHeader
+	msgs    map[string]agentcore.MessageList
+}
+
+func (s *stubSessions) List() ([]session.SessionHeader, error) { return s.headers, nil }
+
+func (s *stubSessions) Load(id string) (session.SessionHeader, agentcore.MessageList, error) {
+	for _, h := range s.headers {
+		if h.ID == id {
+			return h, s.msgs[id], nil
+		}
+	}
+	return session.SessionHeader{}, nil, os.ErrNotExist
+}
+
+func userMsg(text string) agentcore.UserMessage {
+	return agentcore.UserMessage{RoleField: agentcore.RoleUser, Content: agentcore.ContentList{agentcore.NewTextContent(text)}}
+}
+
+func asstMsg(text string) agentcore.AssistantMessage {
+	return agentcore.AssistantMessage{RoleField: agentcore.RoleAssistant, Content: agentcore.ContentList{agentcore.NewTextContent(text)}}
+}
+
+// TestCollectRecentSessionsFirstRunWindow: never-run (zero LastRunAt) selects the
+// most-recent recentN matching sessions, ordered most-recent-first, filtered to
+// the active project.
+func TestCollectRecentSessionsFirstRunWindow(t *testing.T) {
+	proj := t.TempDir()
+	other := t.TempDir()
+	base := time.Now().UTC()
+	headers := []session.SessionHeader{
+		{ID: "s1", Cwd: proj, UpdatedAt: base.Add(-3 * time.Hour)},
+		{ID: "s2", Cwd: proj, UpdatedAt: base.Add(-1 * time.Hour)},
+		{ID: "s3", Cwd: other, UpdatedAt: base}, // different project, excluded
+		{ID: "s4", Cwd: proj, UpdatedAt: base.Add(-2 * time.Hour)},
+		{ID: "s5", Cwd: "", UpdatedAt: base}, // unattributed, excluded
+	}
+	got := collectRecentSessions(headers, State{}, proj, 2)
+	if len(got) != 2 {
+		t.Fatalf("got %d sessions, want 2 (recentN cap)", len(got))
+	}
+	if got[0].ID != "s2" || got[1].ID != "s4" {
+		t.Fatalf("wrong window/order: %s, %s (want s2, s4 most-recent-first)", got[0].ID, got[1].ID)
+	}
+}
+
+// TestCollectRecentSessionsIncremental: a non-zero LastRunAt selects only
+// matching sessions updated strictly after it (incremental distillation).
+func TestCollectRecentSessionsIncremental(t *testing.T) {
+	proj := t.TempDir()
+	base := time.Now().UTC()
+	last := base.Add(-2 * time.Hour)
+	headers := []session.SessionHeader{
+		{ID: "old", Cwd: proj, UpdatedAt: base.Add(-3 * time.Hour)}, // before last run
+		{ID: "new1", Cwd: proj, UpdatedAt: base.Add(-1 * time.Hour)},
+		{ID: "new2", Cwd: proj, UpdatedAt: base},
+	}
+	got := collectRecentSessions(headers, State{LastRunAt: last}, proj, 20)
+	if len(got) != 2 {
+		t.Fatalf("got %d, want 2 (only after LastRunAt)", len(got))
+	}
+	for _, h := range got {
+		if !h.UpdatedAt.After(last) {
+			t.Fatalf("session %s not after LastRunAt", h.ID)
+		}
+	}
+}
+
+// TestCollectRecentSessionsGlobalOnlyNoMatch: an empty projectDir (global-only
+// run) matches nothing, so the window is empty (no-op path).
+func TestCollectRecentSessionsGlobalOnlyNoMatch(t *testing.T) {
+	proj := t.TempDir()
+	headers := []session.SessionHeader{{ID: "s1", Cwd: proj, UpdatedAt: time.Now().UTC()}}
+	if got := collectRecentSessions(headers, State{}, "", 20); len(got) != 0 {
+		t.Fatalf("global-only run must match no sessions, got %d", len(got))
+	}
+}
+
+// TestCollectTranscriptsNoSourceOrNoMatch: nil source or no matching session
+// yields "" so the caller records Distilled=0 with a "无新增" note.
+func TestCollectTranscriptsNoSourceOrNoMatch(t *testing.T) {
+	if got := collectTranscripts(nil, State{}, t.TempDir(), 20, 0); got != "" {
+		t.Fatalf("nil source must yield empty transcript, got %q", got)
+	}
+	src := &stubSessions{headers: []session.SessionHeader{{ID: "s1", Cwd: t.TempDir(), UpdatedAt: time.Now().UTC()}}}
+	// Ask for a different (empty) project → no match.
+	if got := collectTranscripts(src, State{}, "", 20, 0); got != "" {
+		t.Fatalf("no matching session must yield empty transcript, got %q", got)
+	}
+}
+
+// TestCollectTranscriptsRendersRoleTagged: matching sessions are rendered into a
+// role-tagged transcript containing the session id and message text.
+func TestCollectTranscriptsRendersRoleTagged(t *testing.T) {
+	proj := t.TempDir()
+	src := &stubSessions{
+		headers: []session.SessionHeader{{ID: "sess-abc", Cwd: proj, UpdatedAt: time.Now().UTC()}},
+		msgs: map[string]agentcore.MessageList{
+			"sess-abc": {userMsg("I always use tabs not spaces"), asstMsg("noted")},
+		},
+	}
+	got := collectTranscripts(src, State{}, proj, 20, 0)
+	for _, want := range []string{"sess-abc", "user: I always use tabs", "assistant: noted"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("transcript missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
+// TestParseDistillResponseNewEntries: a canned JSON response yields NewEntry
+// writes under the right scope/type dirs, and ephemeral/unknown types are
+// dropped.
+func TestParseDistillResponseNewEntries(t *testing.T) {
+	root := "/mem"
+	proj := t.TempDir()
+	pid := projectID(proj)
+	raw := "```json\n" + `{
+	  "entries": [
+	    {"type": "user", "scope": "global", "title": "Tabs preference", "body": "Developer prefers tabs over spaces."},
+	    {"type": "project", "scope": "project", "title": "Arch", "body": "The runner is deterministic; the consolidator is the LLM half."},
+	    {"type": "todo", "scope": "global", "title": "bad", "body": "ephemeral one-shot task"},
+	    {"type": "user", "scope": "global", "title": "empty", "body": "   "}
+	  ],
+	  "notes": ["distilled 2"]
+	}` + "\n```"
+
+	entries, notes := parseDistillResponse(raw, nil, root, proj)
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2 (todo + empty dropped): %+v", len(entries), entries)
+	}
+	byPath := map[string]string{}
+	for _, e := range entries {
+		byPath[e.Path] = e.Body
+	}
+	wantGlobal := filepath.Join(root, "global", "user", "tabs-preference.md")
+	wantProj := filepath.Join(root, "projects", pid, "project", "arch.md")
+	if _, ok := byPath[wantGlobal]; !ok {
+		t.Fatalf("missing global user entry at %s; got %v", wantGlobal, byPath)
+	}
+	if body, ok := byPath[wantProj]; !ok {
+		t.Fatalf("missing project entry at %s; got %v", wantProj, byPath)
+	} else if !strings.HasSuffix(body, "\n") {
+		t.Fatalf("body must end with newline: %q", body)
+	}
+	if strings.Join(notes, "|") == "" {
+		t.Fatal("expected distill notes surfaced")
+	}
+}
+
+// TestParseDistillResponseProjectScopeNeedsProjectDir: a "project"-scoped entry on
+// a global-only run (empty projectDir) has nowhere valid to live and is skipped.
+func TestParseDistillResponseProjectScopeNeedsProjectDir(t *testing.T) {
+	raw := `{"entries":[{"type":"project","scope":"project","title":"x","body":"y"}]}`
+	entries, _ := parseDistillResponse(raw, nil, "/mem", "")
+	if len(entries) != 0 {
+		t.Fatalf("project entry on global-only run must be skipped, got %+v", entries)
+	}
+}
+
+// TestParseDistillResponseDedupAgainstExisting: an entry that is a near-duplicate
+// of an existing memory is dropped (FR-13).
+func TestParseDistillResponseDedupAgainstExisting(t *testing.T) {
+	existing := []MemoryFile{{Body: "Developer prefers tabs over spaces in all files"}}
+	raw := `{"entries":[{"type":"user","scope":"global","title":"tabs","body":"Developer prefers tabs over spaces in all files"}]}`
+	entries, notes := parseDistillResponse(raw, existing, "/mem", "")
+	if len(entries) != 0 {
+		t.Fatalf("near-duplicate of existing memory must be dropped, got %+v", entries)
+	}
+	if len(notes) == 0 || !strings.Contains(strings.Join(notes, "|"), "near-duplicate") {
+		t.Fatalf("expected a near-duplicate skip note, got %v", notes)
+	}
+}
+
+// TestParseDistillResponseUnparseable: an unparseable response adds nothing and
+// is not an error (conservative KEEP).
+func TestParseDistillResponseUnparseable(t *testing.T) {
+	entries, notes := parseDistillResponse("the model rambled with no json", nil, "/mem", "")
+	if entries != nil || notes != nil {
+		t.Fatalf("unparseable response must yield nothing, got %+v / %v", entries, notes)
+	}
+}
+
+// TestRunDistillsThroughRunner: an integration test with a stub session source
+// and a stub completer-backed llmConsolidator distills a durable fact into a new
+// on-disk memory entry, counts it, and reports it.
+func TestRunDistillsThroughRunner(t *testing.T) {
+	root := t.TempDir()
+	proj := t.TempDir()
+
+	src := &stubSessions{
+		headers: []session.SessionHeader{{ID: "s1", Cwd: proj, UpdatedAt: time.Now().UTC()}},
+		msgs:    map[string]agentcore.MessageList{"s1": {userMsg("always run tests with gotestsum")}},
+	}
+	// llmConsolidator whose distill completion returns one durable fact. The
+	// merge/prune completion is not reached because there are no eligible files.
+	cons := &llmConsolidator{complete: func(_ context.Context, _, _ string) (string, error) {
+		return `{"entries":[{"type":"user","scope":"global","title":"Test runner","body":"Always run tests with gotestsum."}],"notes":["one fact"]}`, nil
+	}}
+	r := &Runner{MemoryRoot: root, Consolidator: cons, Sessions: src}
+
+	rep, err := r.Run(context.Background(), RunOptions{ProjectDir: proj})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rep.Distilled != 1 {
+		t.Fatalf("Distilled = %d, want 1", rep.Distilled)
+	}
+	newPath := filepath.Join(root, "global", "user", "test-runner.md")
+	raw, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("distilled entry not written at %s: %v", newPath, err)
+	}
+	if !strings.Contains(string(raw), "gotestsum") {
+		t.Fatalf("distilled body wrong: %q", raw)
+	}
+}
+
+// TestRunDryRunDistillsButWritesNothing: a dry-run still runs the distill pass
+// and reports the count, but writes no new memory files and updates no state.
+func TestRunDryRunDistillsButWritesNothing(t *testing.T) {
+	root := t.TempDir()
+	proj := t.TempDir()
+
+	src := &stubSessions{
+		headers: []session.SessionHeader{{ID: "s1", Cwd: proj, UpdatedAt: time.Now().UTC()}},
+		msgs:    map[string]agentcore.MessageList{"s1": {userMsg("my stack is Go plus SQLite")}},
+	}
+	cons := &llmConsolidator{complete: func(_ context.Context, _, _ string) (string, error) {
+		return `{"entries":[{"type":"user","scope":"global","title":"Stack","body":"Stack is Go plus SQLite."}],"notes":[]}`, nil
+	}}
+	r := &Runner{MemoryRoot: root, Consolidator: cons, Sessions: src}
+
+	rep, err := r.Run(context.Background(), RunOptions{ProjectDir: proj, DryRun: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rep.Distilled != 1 {
+		t.Fatalf("dry-run Distilled = %d, want 1 (still reported)", rep.Distilled)
+	}
+	if _, err := os.Stat(filepath.Join(root, "global", "user", "stack.md")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run must not write the distilled entry (err=%v)", err)
+	}
+	st, _ := LoadState(root)
+	if !st.LastRunAt.IsZero() || st.LastStatus != "" {
+		t.Fatalf("dry-run must not update state: %+v", st)
+	}
+}
+
+// TestRunNoDurableFactsNoOp: when distillation adds nothing, the report records
+// Distilled=0 with the "无新增" note (SPEC §5.5).
+func TestRunNoDurableFactsNoOp(t *testing.T) {
+	root := t.TempDir()
+	proj := t.TempDir()
+	src := &stubSessions{
+		headers: []session.SessionHeader{{ID: "s1", Cwd: proj, UpdatedAt: time.Now().UTC()}},
+		msgs:    map[string]agentcore.MessageList{"s1": {userMsg("some transient chatter")}},
+	}
+	cons := &llmConsolidator{complete: func(_ context.Context, _, _ string) (string, error) {
+		return `{"entries":[],"notes":[]}`, nil
+	}}
+	r := &Runner{MemoryRoot: root, Consolidator: cons, Sessions: src}
+	rep, err := r.Run(context.Background(), RunOptions{ProjectDir: proj})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rep.Distilled != 0 {
+		t.Fatalf("Distilled = %d, want 0", rep.Distilled)
+	}
+	if !strings.Contains(strings.Join(rep.Notes, "|"), "无新增") {
+		t.Fatalf("expected '无新增' no-op note, got %v", rep.Notes)
+	}
+}

--- a/internal/dream/prompt.go
+++ b/internal/dream/prompt.go
@@ -47,3 +47,44 @@ Output format:
   }
 - Every "keep"/"remove"/"path" MUST be one of the input paths. "remove" must not contain the "keep" path.
 - If there is nothing to merge or prune, return {"merges": [], "prunes": [], "notes": []}. Returning an empty result is the correct, safe answer when in doubt.`
+
+// dreamDistillSystemPrompt is the fixed system instruction for the JSONL
+// distillation pass (SPEC §5.3, PRD US-005 / FR-13). It is a SEPARATE model call
+// from the merge/prune pass above: its input is recent session transcripts plus
+// a list of memories that already exist, and its only job is to propose NEW
+// durable memory entries that are not already captured. The Go side then dedups
+// each proposal against the existing library and path-guards every write, so the
+// model only ever supplies type/scope/title/body — never a filesystem path.
+const dreamDistillSystemPrompt = `You are the memory-distillation agent for pigo ("dream"). You read recent session transcripts between a developer and an AI coding agent, and extract DURABLE facts worth remembering for future sessions.
+
+You are also given a list of memories that ALREADY EXIST. Do NOT propose anything already covered by an existing memory — only genuinely new, not-yet-recorded facts.
+
+What counts as a durable fact (extract these):
+- user: stable preferences, conventions, working style, environment the developer states ("I prefer X", "always run tests with Y", "my stack is Z").
+- feedback: corrections or standing instructions the developer gave the agent that should persist.
+- project: durable facts about the project's architecture, invariants, key decisions, or layout.
+- reference: stable pointers to important resources (a canonical doc, a command, an API) that will remain relevant.
+
+What to IGNORE (never distill these):
+- One-shot task state, TODOs, "now do X" instructions, or anything tied to a single session's in-progress work.
+- Ephemeral context: transient errors already fixed, scratch reasoning, temporary file paths.
+- Anything you are not confident is durable. When unsure, SKIP it. Recording noise is worse than missing a fact.
+
+Hard rules:
+- BE CONSERVATIVE and specific. Prefer zero entries over speculative ones. Only emit a fact you could justify keeping for months.
+- NEVER invent facts. Every entry must be grounded in the transcripts.
+- Each entry's body is a short, self-contained Markdown note (a sentence or a few bullet points). Do not include a filesystem path or a filename.
+- Classify each entry's "type" as exactly one of: user, feedback, project, reference.
+- Classify each entry's "scope" as "project" (specific to the current project) or "global" (applies across all the developer's work). When unsure, use "project".
+- Give each entry a short "title" (a few words) used only to name its file.
+
+Output format:
+- Respond with a SINGLE JSON object and nothing else. No prose, no Markdown code fences.
+- Schema:
+  {
+    "entries": [
+      { "type": "user|feedback|project|reference", "scope": "project|global", "title": "<short title>", "body": "<self-contained markdown note>" }
+    ],
+    "notes": ["<short human-readable summary of what was distilled>", ...]
+  }
+- If there is nothing durable to add, return {"entries": [], "notes": []}. An empty result is the correct, safe answer when in doubt.`

--- a/internal/dream/runner.go
+++ b/internal/dream/runner.go
@@ -36,6 +36,12 @@ type ConsolidateInput struct {
 	Plan       Plan   `json:"plan"`
 	MemoryRoot string `json:"memory_root"`
 	ProjectDir string `json:"project_dir"`
+	// Transcripts is the collected, budget-truncated text of the current
+	// project's recent session JSONL, gathered deterministically by the Runner
+	// (SPEC §5.3). It is the input to the separate distillation pass; an empty
+	// string means there is nothing to distill (no matching sessions), so the
+	// Consolidator skips the distill call entirely (SPEC §5.5 no-op).
+	Transcripts string `json:"transcripts,omitempty"`
 }
 
 // NewEntry is a distilled memory file the Consolidator wants created. Path must
@@ -89,6 +95,11 @@ type Runner struct {
 	// resolve via ResolveMemoryRoot (PIGO_HOME / ~/.pigo). Tests set it to a temp
 	// dir; production leaves it empty.
 	MemoryRoot string
+	// Sessions is the source of recent session transcripts for the distillation
+	// pass (SPEC §5.3). nil resolves the default store at $PIGO_HOME/sessions (or
+	// ~/.pigo/sessions); tests inject a stub. If it cannot be resolved,
+	// distillation degrades to a no-op rather than failing the run.
+	Sessions SessionSource
 }
 
 // RunOptions are the per-invocation parameters mirroring the CLI flags. ProjectDir
@@ -97,6 +108,10 @@ type Runner struct {
 type RunOptions struct {
 	DryRun     bool
 	ProjectDir string
+	// RecentSessions is the first-run distillation window: when dream has never
+	// run, the most-recent RecentSessions project sessions are distilled (SPEC
+	// §5.3). Non-positive falls back to DefaultRecentSessions (20).
+	RecentSessions int
 }
 
 // Run executes one consolidation pass and returns the change Report. The flow is
@@ -145,10 +160,26 @@ func (r *Runner) Run(ctx context.Context, opts RunOptions) (Report, error) {
 	if cons == nil {
 		cons = nopConsolidator{}
 	}
+
+	// Gather the current project's recent session transcripts for the distill
+	// pass (SPEC §5.3). This is deterministic Runner work, mirroring BuildPlan:
+	// the Consolidator runs the semantic distill call over these transcripts. A
+	// nil/unresolvable source or no matching session yields "" → the Consolidator
+	// skips distillation and Distilled stays 0 (SPEC §5.5 no-op).
+	src := r.Sessions
+	if src == nil {
+		if resolved, rerr := resolveSessionStore(); rerr == nil {
+			src = resolved
+		}
+	}
+	state, _ := LoadState(memoryRoot)
+	transcripts := collectTranscripts(src, state, opts.ProjectDir, opts.RecentSessions, defaultTranscriptBudget)
+
 	cres, err := cons.Consolidate(ctx, ConsolidateInput{
-		Plan:       plan,
-		MemoryRoot: memoryRoot,
-		ProjectDir: opts.ProjectDir,
+		Plan:        plan,
+		MemoryRoot:  memoryRoot,
+		ProjectDir:  opts.ProjectDir,
+		Transcripts: transcripts,
 	})
 	if err != nil {
 		// The runner surfaces the error; the parent/scheduler (node #8) maps a
@@ -164,6 +195,13 @@ func (r *Runner) Run(ctx context.Context, opts RunOptions) (Report, error) {
 	rep.Pruned = cres.Pruned
 	rep.Distilled = cres.Distilled
 	rep.Notes = append(rep.Notes, cres.Notes...)
+
+	// Distillation no-op: no durable facts were added (no matching sessions or
+	// nothing worth keeping). Record the "无新增" note so the report reflects the
+	// step ran with no additions (SPEC §5.5, PRD FR-13).
+	if rep.Distilled == 0 {
+		rep.Notes = append(rep.Notes, "distill: 无新增")
+	}
 
 	if opts.DryRun {
 		// Predict the deterministic counters without touching disk or state, and

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -75,6 +75,13 @@ type SessionHeader struct {
 	// (US-006, #122). Empty for a session created from scratch. It records
 	// lineage only; a fork is otherwise a fully independent session file.
 	ParentSession string `json:"parentSession,omitempty"`
+	// Cwd is the absolute working directory the session ran in, recorded so a
+	// session can be attributed to a project (its stable project id derives from
+	// this path). Used by /dream distillation to select the current project's
+	// recent sessions (SPEC §5.3 / §11.3). Optional and additive: older schemas
+	// omit it and still load; a session with an empty Cwd is treated as
+	// unattributed and never matches a project-scoped distill.
+	Cwd string `json:"cwd,omitempty"`
 	// ContextFrom is the id of the session this one inherited its collapsed
 	// context from (#480, "infinite context"). Empty when the session started
 	// with no inherited checkpoint. Optional and additive: older schemas (v1/v2/v3)


### PR DESCRIPTION
## Summary
- Add the JSONL distillation pass to `/dream` (SPEC §5.3, PRD US-005/FR-13): a separate LLM step over the current project's recent session transcripts that proposes durable `user`/`feedback`/`project`/`reference` facts.
- Window selection: incremental (sessions updated after `LastRunAt`) or a bounded first-run window (most-recent `RecentSessions`, default 20), filtered to the active project via a stable project id; transcripts rendered role-tagged and truncated to a byte budget (SPEC §8.2).
- Proposals are deduped against the existing library (Jaccard near-dup, FR-13), path-guarded into scope, and folded into `ConsolidateResult.NewEntries` so the existing Runner writeback applies them. `Report.Distilled` reflects the count and is still reported in dry-run (no writes); a no-op records `distill: 无新增`.
- Prerequisite (SPEC §11.3): additive, backward-compatible `Cwd` field on `SessionHeader` for project attribution, populated on fresh headless sessions.

Closes #524

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/dream/... ./cmd/...` green (incl. `-race`)
- [x] Unit: window selection (with/without LastRunAt, project filter, no-match no-op) + distill parser (canned JSON, ephemeral/unknown types dropped, dedup, unparseable KEEP)
- [x] Integration through Runner with stub session source + stub completer: NewEntry written on disk, Distilled counted; dry-run writes nothing; no-durable-facts no-op note