### PR TITLE
feat(dream): startup background auto-consolidation trigger

### DIFF
--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -131,6 +131,11 @@ type cliOptions struct {
 	// (defaults when the tables are absent) for downstream memory/checkpoint/
 	// compaction wiring to consume. See config.MemorySettings.
 	memory config.MemorySettings
+	// dreamCfg is the resolved [dream] configuration (enabled / interval /
+	// recent-sessions), populated by applyFileConfig from the [dream] table with
+	// defaults applied. The interactive REPL consumes it to decide the startup
+	// background auto-consolidation (US-008). Like memory it has no CLI flags.
+	dreamCfg dream.Config
 }
 
 func main() {
@@ -270,6 +275,10 @@ func applyFileConfig(opts *cliOptions, cfg config.FileConfig, changed func(strin
 	// are resolved (with defaults) and overlaid unconditionally — an absent set
 	// of tables yields the default-safe MemorySettings.
 	opts.memory = cfg.ResolveMemorySettings()
+	// The [dream] table also has no CLI flags; normalize it (defaults applied when
+	// the table is absent) so the interactive startup trigger has a resolved
+	// Config. NewConfig treats a nil enabled as true, so dream is on by default.
+	opts.dreamCfg = dream.NewConfig(cfg.Dream.Enabled, cfg.Dream.IntervalDays, cfg.Dream.RecentSessions)
 }
 
 // dispatch runs the resolved command and returns a process exit code, writing
@@ -392,6 +401,7 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			ConfigPrompts:     opts.configPrompts,
 			CliPrompts:        opts.promptTemplates,
 			NoPromptTemplates: opts.noPromptTemplates,
+			Dream:             opts.dreamCfg,
 		}); err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
 			return 1

--- a/internal/cli/repl/dream_startup.go
+++ b/internal/cli/repl/dream_startup.go
@@ -1,0 +1,58 @@
+// This file wires the startup background trigger for /dream memory
+// consolidation (US-008, FR-4/FR-17): when an interactive REPL session starts,
+// if [dream].enabled and a consolidation is due (per dream.State.Due), the dream
+// subprocess is spawned in the BACKGROUND so it never delays the first user
+// response, and a non-intrusive one-line summary is printed on completion.
+//
+// The decision + goroutine live in dream.Scheduler; this file only supplies the
+// CLI-side spawn seam (reusing spawnDream from dream_repl.go) and the one-line
+// notice renderer (RenderReportLine). The subprocess's O_EXCL lock enforces
+// single-instance, so a second trigger just yields a skipped child (silent).
+package repl
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/smallnest/pigo/internal/cli/ui"
+	"github.com/smallnest/pigo/internal/dream"
+)
+
+// dreamStartupScheduler owns the startup auto-trigger decision. It is stateless
+// (dream.Scheduler is a zero-size type), so a package value is enough; tests
+// exercise this path through the spawnDream seam rather than replacing it.
+var dreamStartupScheduler dream.Scheduler
+
+// maybeStartBackgroundDream launches an auto-consolidation in the background at
+// interactive session startup when dream is enabled and due. It never blocks:
+// the due check is a single state.json read and any spawn runs in a goroutine,
+// so the first prompt is served immediately (SPEC FR-4 / §8.2). The completion
+// notice is a single dim line via RenderReportLine; a skipped, no-op, or failed
+// run prints nothing (SPEC §6.1).
+//
+// out is written to from the background goroutine, so callers must pass a writer
+// safe for a late async line (the REPL uses os.Stdout, where a one-line notice
+// simply appears in scrollback). It is a no-op when memoryRoot is empty (dream
+// state has nowhere to live) or dream is disabled/not due.
+func maybeStartBackgroundDream(out io.Writer, memoryRoot, projectDir string, cfg dream.Config) bool {
+	if memoryRoot == "" {
+		return false
+	}
+	return dreamStartupScheduler.MaybeRunBackground(context.Background(), dream.BackgroundDeps{
+		MemoryRoot: memoryRoot,
+		ProjectDir: projectDir,
+		Config:     cfg,
+		Spawn: func(ctx context.Context, dir string) (dream.Report, error) {
+			// Bound the background run like a manual /dream (SPEC §6.3): a hung
+			// LLM-backed pass is killed rather than leaking a goroutine forever.
+			ctx, cancel := context.WithTimeout(ctx, dreamRunTimeout)
+			defer cancel()
+			res, err := spawnDream(ctx, dir, false)
+			return res.report, err
+		},
+		OnReport: func(r dream.Report) {
+			fmt.Fprintln(out, ui.Colorize(ui.Enabled(), ui.Dim, RenderReportLine(r)))
+		},
+	})
+}

--- a/internal/cli/repl/dream_startup_test.go
+++ b/internal/cli/repl/dream_startup_test.go
@@ -1,0 +1,111 @@
+package repl
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/smallnest/pigo/internal/dream"
+)
+
+// seedDueDreamState writes a state.json under memoryRoot old enough that a
+// 7-day-interval dream is due, so maybeStartBackgroundDream will spawn.
+func seedDueDreamState(t *testing.T, memoryRoot string) {
+	t.Helper()
+	if err := dream.SaveState(memoryRoot, dream.State{
+		LastRunAt:  time.Now().Add(-30 * 24 * time.Hour),
+		LastStatus: "ok",
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+}
+
+func TestMaybeStartBackgroundDream_NoticeOnChanges(t *testing.T) {
+	root := t.TempDir()
+	seedDueDreamState(t, root)
+
+	orig := spawnDream
+	t.Cleanup(func() { spawnDream = orig })
+	done := make(chan struct{})
+	spawnDream = func(_ context.Context, dir string, dryRun bool) (dreamSubprocessResult, error) {
+		defer close(done)
+		if dryRun {
+			t.Errorf("background trigger must not run in dry-run mode")
+		}
+		if dir != "/proj/y" {
+			t.Errorf("spawn got dir %q, want /proj/y", dir)
+		}
+		return dreamSubprocessResult{report: dream.Report{Merged: 3}}, nil
+	}
+
+	var buf bytes.Buffer
+	if !maybeStartBackgroundDream(&buf, root, "/proj/y", dream.NewConfig(nil, 7, 20)) {
+		t.Fatal("due+enabled dream should launch a background run")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("spawn not invoked within timeout")
+	}
+	// The notice writes asynchronously after spawn returns; poll briefly.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && buf.Len() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := buf.String(); !strings.Contains(got, "dream:") || !strings.Contains(got, "merged 3") {
+		t.Fatalf("one-line notice missing/incorrect: %q", got)
+	}
+}
+
+func TestMaybeStartBackgroundDream_DisabledNoSpawn(t *testing.T) {
+	root := t.TempDir()
+	seedDueDreamState(t, root)
+
+	orig := spawnDream
+	t.Cleanup(func() { spawnDream = orig })
+	spawnDream = func(context.Context, string, bool) (dreamSubprocessResult, error) {
+		t.Fatal("disabled dream must not spawn a subprocess")
+		return dreamSubprocessResult{}, nil
+	}
+
+	enabledFalse := false
+	var buf bytes.Buffer
+	if maybeStartBackgroundDream(&buf, root, "/proj/y", dream.NewConfig(&enabledFalse, 7, 20)) {
+		t.Fatal("disabled dream must not launch")
+	}
+}
+
+func TestMaybeStartBackgroundDream_EmptyRootNoSpawn(t *testing.T) {
+	orig := spawnDream
+	t.Cleanup(func() { spawnDream = orig })
+	spawnDream = func(context.Context, string, bool) (dreamSubprocessResult, error) {
+		t.Fatal("empty memory root must not spawn")
+		return dreamSubprocessResult{}, nil
+	}
+	var buf bytes.Buffer
+	if maybeStartBackgroundDream(&buf, "", "/proj/y", dream.NewConfig(nil, 7, 20)) {
+		t.Fatal("empty memory root must not launch")
+	}
+}
+
+func TestMaybeStartBackgroundDream_NeverRunNoSpawn(t *testing.T) {
+	// A fresh memory root (no state.json) is "never run" → not due → no spawn.
+	root := filepath.Join(t.TempDir(), "empty")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	orig := spawnDream
+	t.Cleanup(func() { spawnDream = orig })
+	spawnDream = func(context.Context, string, bool) (dreamSubprocessResult, error) {
+		t.Fatal("never-run state must not spawn (first run is manual)")
+		return dreamSubprocessResult{}, nil
+	}
+	var buf bytes.Buffer
+	if maybeStartBackgroundDream(&buf, root, "/proj/y", dream.NewConfig(nil, 7, 20)) {
+		t.Fatal("never-run dream must not launch")
+	}
+}

--- a/internal/cli/repl/dream_startup_test.go
+++ b/internal/cli/repl/dream_startup_test.go
@@ -6,11 +6,39 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/smallnest/pigo/internal/dream"
 )
+
+// syncWriter is a concurrency-safe writer whose first Write closes done, so a
+// test can wait for the async one-line notice and then read it under the same
+// lock the background goroutine wrote it under (bytes.Buffer is not safe for
+// concurrent use).
+type syncWriter struct {
+	mu   sync.Mutex
+	buf  bytes.Buffer
+	done chan struct{}
+	once sync.Once
+}
+
+func newSyncWriter() *syncWriter { return &syncWriter{done: make(chan struct{})} }
+
+func (w *syncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	n, err := w.buf.Write(p)
+	w.once.Do(func() { close(w.done) })
+	return n, err
+}
+
+func (w *syncWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
 
 // seedDueDreamState writes a state.json under memoryRoot old enough that a
 // 7-day-interval dream is due, so maybeStartBackgroundDream will spawn.
@@ -30,9 +58,7 @@ func TestMaybeStartBackgroundDream_NoticeOnChanges(t *testing.T) {
 
 	orig := spawnDream
 	t.Cleanup(func() { spawnDream = orig })
-	done := make(chan struct{})
 	spawnDream = func(_ context.Context, dir string, dryRun bool) (dreamSubprocessResult, error) {
-		defer close(done)
 		if dryRun {
 			t.Errorf("background trigger must not run in dry-run mode")
 		}
@@ -42,21 +68,16 @@ func TestMaybeStartBackgroundDream_NoticeOnChanges(t *testing.T) {
 		return dreamSubprocessResult{report: dream.Report{Merged: 3}}, nil
 	}
 
-	var buf bytes.Buffer
-	if !maybeStartBackgroundDream(&buf, root, "/proj/y", dream.NewConfig(nil, 7, 20)) {
+	w := newSyncWriter()
+	if !maybeStartBackgroundDream(w, root, "/proj/y", dream.NewConfig(nil, 7, 20)) {
 		t.Fatal("due+enabled dream should launch a background run")
 	}
 	select {
-	case <-done:
+	case <-w.done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("spawn not invoked within timeout")
+		t.Fatal("one-line notice not written within timeout")
 	}
-	// The notice writes asynchronously after spawn returns; poll briefly.
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) && buf.Len() == 0 {
-		time.Sleep(10 * time.Millisecond)
-	}
-	if got := buf.String(); !strings.Contains(got, "dream:") || !strings.Contains(got, "merged 3") {
+	if got := w.String(); !strings.Contains(got, "dream:") || !strings.Contains(got, "merged 3") {
 		t.Fatalf("one-line notice missing/incorrect: %q", got)
 	}
 }

--- a/internal/cli/repl/interactive.go
+++ b/internal/cli/repl/interactive.go
@@ -19,6 +19,7 @@ import (
 	"github.com/smallnest/pigo/internal/cli/headless"
 	"github.com/smallnest/pigo/internal/cli/prompts"
 	"github.com/smallnest/pigo/internal/cli/run"
+	"github.com/smallnest/pigo/internal/dream"
 	"github.com/smallnest/pigo/internal/plugin"
 	"github.com/smallnest/pigo/internal/provider"
 	"github.com/smallnest/pigo/internal/runtime"
@@ -75,6 +76,11 @@ type Options struct {
 	// settings, CLI); built-in slash commands are unaffected. Independent of
 	// --no-skills.
 	NoPromptTemplates bool
+
+	// Dream is the resolved [dream] configuration (US-008). Run uses it to decide
+	// whether to launch the startup background consolidation; a zero value
+	// (Enabled false) disables the auto-trigger entirely.
+	Dream dream.Config
 }
 
 // Run starts the line-based REPL over a persisted session. It keeps
@@ -90,6 +96,14 @@ func Run(opts Options) error {
 	if err != nil {
 		return err
 	}
+
+	// Resolve the launch directory once (pigo does not cd during a session). It is
+	// the trust key, the directory side-effect tools are gated against, and — new
+	// for #526 — the value stamped onto a fresh SessionHeader.Cwd so the session is
+	// attributed to a project and a later /dream pass can distill it under the
+	// right scope (mirrors headless.headlessCwd). An unresolvable cwd yields ""
+	// (the session stays unattributed) rather than aborting the session.
+	cwd, cwdErr := os.Getwd()
 
 	// Establish the session: resume an existing one or create a fresh header.
 	now := time.Now().UTC()
@@ -129,6 +143,7 @@ func Run(opts Options) error {
 			Model:        opts.Model,
 			Provider:     opts.ProviderName,
 			SystemPrompt: opts.SysPrompt,
+			Cwd:          cwd,
 		}
 	}
 
@@ -150,9 +165,8 @@ func Run(opts Options) error {
 	// launch directory. A load failure (e.g. a corrupted trust.json) is
 	// non-fatal: trust is disabled (mgr stays nil) and the REPL still runs -
 	// the store is surfaced rather than silently overwritten. cwd is captured
-	// once since pigo does not cd during a session; if it cannot be resolved
+	// once above since pigo does not cd during a session; if it cannot be resolved
 	// trust is disabled too, since an empty cwd would silently never match.
-	cwd, cwdErr := os.Getwd()
 	mgr, mgrErr := trust.NewManager(trust.DefaultPath())
 	if mgrErr != nil {
 		fmt.Fprintf(os.Stderr, "pigo: trust store unavailable, trust disabled: %v\n", mgrErr)
@@ -196,6 +210,14 @@ func Run(opts Options) error {
 	if len(history) > 0 {
 		replayTranscript(os.Stdout, history)
 	}
+
+	// Startup background consolidation (US-008, FR-4/FR-17): if dream is enabled
+	// and due, spawn `pigo --dream` in a goroutine now so it runs while the user
+	// works — it never blocks the first prompt, and prints a one-line notice on
+	// completion. The dream state/lock live under dream.ResolveMemoryRoot (the
+	// same root the subprocess consolidates), independent of whether the memory
+	// tool is wired into this session. Not-due / disabled is a cheap no-op.
+	maybeStartBackgroundDream(os.Stdout, dream.ResolveMemoryRoot(), cwd, opts.Dream)
 
 	return runREPL(os.Stdin, os.Stdout, replDeps{
 		store:     store,

--- a/internal/cli/tui/session.go
+++ b/internal/cli/tui/session.go
@@ -142,6 +142,11 @@ func newRunSessionWithStore(store *session.Store, opts Options) (*runSession, []
 		history = msgs
 	} else {
 		agentCtx = &agentcore.AgentContext{SystemPrompt: opts.SysPrompt, Tools: opts.Tools}
+		// Stamp the launch directory onto a fresh session (#526/#524) so the
+		// session is attributed to a project and a later /dream pass can distill it
+		// under the right scope, mirroring headless/REPL. An unresolvable cwd
+		// yields "" (session stays unattributed) rather than aborting.
+		wd, _ := os.Getwd()
 		header = session.SessionHeader{
 			ID:           session.NewID(now),
 			CreatedAt:    now,
@@ -149,6 +154,7 @@ func newRunSessionWithStore(store *session.Store, opts Options) (*runSession, []
 			Model:        opts.Model,
 			Provider:     opts.ProviderName,
 			SystemPrompt: opts.SysPrompt,
+			Cwd:          wd,
 		}
 	}
 

--- a/internal/dream/scheduler.go
+++ b/internal/dream/scheduler.go
@@ -1,0 +1,103 @@
+package dream
+
+import (
+	"context"
+	"time"
+)
+
+// BackgroundSpawn launches one dream consolidation subprocess for projectDir and
+// returns its decoded Report. Implementations live in the CLI layer (they shell
+// out to `pigo --dream -C <projectDir>` and parse the stdout Report), so this
+// package stays free of os/exec concerns and there is no import cycle back
+// through the CLI. A non-nil error means the run failed; background failures are
+// silent to the user (the subprocess itself records last_status="failed"), so
+// MaybeRunBackground swallows the error rather than surfacing it.
+type BackgroundSpawn func(ctx context.Context, projectDir string) (Report, error)
+
+// BackgroundDeps carries everything MaybeRunBackground needs to decide on and run
+// a startup auto-consolidation without pulling process/exec or presentation
+// concerns into this package.
+type BackgroundDeps struct {
+	// MemoryRoot is the dream state root read to decide whether a run is due. It
+	// must match the root the subprocess consolidates (dream.ResolveMemoryRoot),
+	// so the parent's Due check sees the same last_run_at the child updates.
+	MemoryRoot string
+	// ProjectDir is the working directory attributed to the run (project scope).
+	ProjectDir string
+	// Config is the resolved [dream] configuration (enabled / interval).
+	Config Config
+	// Now supplies the current time for the due check; nil uses time.Now. It is a
+	// seam so tests can drive Due deterministically.
+	Now func() time.Time
+	// Spawn launches the subprocess. When nil, MaybeRunBackground does nothing.
+	Spawn BackgroundSpawn
+	// OnReport is invoked (from the background goroutine) with the completed
+	// report only when the run produced actual changes — worth a one-line notice.
+	// A skipped run (another dream held the lock → all-zero report) or a no-op run
+	// yields no call, keeping the trigger non-intrusive. Nil disables the notice.
+	OnReport func(Report)
+}
+
+// Scheduler owns the startup auto-trigger decision (SPEC §2.1 Scheduler
+// component). It is stateless: Due reads state.json on demand and
+// MaybeRunBackground spawns at most one background run per call. The
+// single-instance guarantee is enforced by the subprocess's O_EXCL lock, not
+// here — a second trigger simply results in a skipped child.
+type Scheduler struct{}
+
+// Due reports whether an auto-triggered consolidation is warranted now. It is
+// cheap by design (SPEC §8.2 zero-startup-overhead): when dream is disabled it
+// returns immediately without touching the filesystem; otherwise it reads
+// state.json once and defers to State.Due (which also returns false for a
+// never-run zero LastRunAt, so the first-ever run is never auto-triggered).
+func (Scheduler) Due(memoryRoot string, cfg Config, now time.Time) bool {
+	if !cfg.Enabled {
+		return false
+	}
+	st, _ := LoadState(memoryRoot)
+	return st.Due(cfg, now)
+}
+
+// MaybeRunBackground checks (cheaply) whether a consolidation is due and, if so,
+// spawns it in a detached goroutine and returns immediately — it never blocks
+// the caller, so the first interactive response is never delayed (SPEC FR-4 /
+// §8.2). It returns true when a background run was launched. When dream is
+// disabled or not due it returns false after at most a single state.json read
+// (no goroutine, no subprocess).
+//
+// On completion the goroutine surfaces a one-line notice via OnReport only for a
+// run that changed something; a skipped run (lock held elsewhere → zero report),
+// a no-op run, or a failed run is silent (SPEC §6.1 background row).
+func (s Scheduler) MaybeRunBackground(ctx context.Context, deps BackgroundDeps) bool {
+	if deps.Spawn == nil {
+		return false
+	}
+	now := time.Now
+	if deps.Now != nil {
+		now = deps.Now
+	}
+	if !s.Due(deps.MemoryRoot, deps.Config, now()) {
+		return false
+	}
+	go func() {
+		rep, err := deps.Spawn(ctx, deps.ProjectDir)
+		if err != nil {
+			// Background failure: silent. The subprocess already recorded
+			// last_status="failed"; we do not interrupt the user with an error.
+			return
+		}
+		if deps.OnReport != nil && reportHasChanges(rep) {
+			deps.OnReport(rep)
+		}
+	}()
+	return true
+}
+
+// reportHasChanges reports whether r reflects any actual mutation. A background
+// run that skipped (lock contention) or found nothing to do produces an all-zero
+// report, which is not worth a startup notice.
+func reportHasChanges(r Report) bool {
+	return r.Merged > 0 || r.Deduped > 0 || r.PathsCleaned > 0 ||
+		r.Pruned > 0 || r.Distilled > 0 ||
+		r.Reconciled.Indexed > 0 || r.Reconciled.Pruned > 0
+}

--- a/internal/dream/scheduler_test.go
+++ b/internal/dream/scheduler_test.go
@@ -1,0 +1,211 @@
+package dream
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fixedNow returns a func yielding t, for the Now seam.
+func fixedNow(t time.Time) func() time.Time { return func() time.Time { return t } }
+
+// writeDueState seeds a state.json under memoryRoot with a LastRunAt old enough
+// that Due(cfg, now) is true for the default interval.
+func writeDueState(t *testing.T, memoryRoot string, lastRun time.Time) {
+	t.Helper()
+	if err := SaveState(memoryRoot, State{LastRunAt: lastRun, LastStatus: "ok"}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+}
+
+func TestSchedulerDue(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 1, 20, 12, 0, 0, 0, time.UTC)
+	cfg := NewConfig(nil, 7, 20) // enabled, 7-day interval
+
+	var s Scheduler
+
+	// Disabled → never due, and cheap (no state read needed).
+	disabled := NewConfig(boolPtr(false), 7, 20)
+	if s.Due(root, disabled, now) {
+		t.Fatal("disabled config must not be due")
+	}
+
+	// No state file (never run) → not due (first run is manual, spec §11.1).
+	if s.Due(root, cfg, now) {
+		t.Fatal("never-run state must not be due")
+	}
+
+	// Last run within the interval → not due.
+	writeDueState(t, root, now.Add(-3*24*time.Hour))
+	if s.Due(root, cfg, now) {
+		t.Fatal("run 3d ago with 7d interval must not be due")
+	}
+
+	// Last run older than the interval → due.
+	writeDueState(t, root, now.Add(-8*24*time.Hour))
+	if !s.Due(root, cfg, now) {
+		t.Fatal("run 8d ago with 7d interval must be due")
+	}
+}
+
+func TestMaybeRunBackground_NotSpawnedWhenDisabled(t *testing.T) {
+	root := t.TempDir()
+	writeDueState(t, root, time.Now().Add(-30*24*time.Hour)) // would be due if enabled
+
+	var spawned bool
+	launched := Scheduler{}.MaybeRunBackground(context.Background(), BackgroundDeps{
+		MemoryRoot: root,
+		Config:     NewConfig(boolPtr(false), 7, 20),
+		Now:        fixedNow(time.Now()),
+		Spawn: func(context.Context, string) (Report, error) {
+			spawned = true
+			return Report{}, nil
+		},
+	})
+	if launched {
+		t.Fatal("MaybeRunBackground returned true for disabled dream")
+	}
+	if spawned {
+		t.Fatal("subprocess must not be spawned when disabled")
+	}
+}
+
+func TestMaybeRunBackground_NotSpawnedWhenNotDue(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 2, 1, 9, 0, 0, 0, time.UTC)
+	writeDueState(t, root, now.Add(-1*24*time.Hour)) // 1 day ago, interval 7d → not due
+
+	var spawned bool
+	launched := Scheduler{}.MaybeRunBackground(context.Background(), BackgroundDeps{
+		MemoryRoot: root,
+		Config:     NewConfig(nil, 7, 20),
+		Now:        fixedNow(now),
+		Spawn: func(context.Context, string) (Report, error) {
+			spawned = true
+			return Report{}, nil
+		},
+	})
+	if launched || spawned {
+		t.Fatalf("not-due run must not launch/spawn (launched=%v spawned=%v)", launched, spawned)
+	}
+}
+
+func TestMaybeRunBackground_SpawnsAndNoticesOnChanges(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 2, 10, 9, 0, 0, 0, time.UTC)
+	writeDueState(t, root, now.Add(-10*24*time.Hour)) // due
+
+	var (
+		mu       sync.Mutex
+		gotDir   string
+		reported *Report
+		done     = make(chan struct{})
+	)
+	launched := Scheduler{}.MaybeRunBackground(context.Background(), BackgroundDeps{
+		MemoryRoot: root,
+		ProjectDir: "/proj/x",
+		Config:     NewConfig(nil, 7, 20),
+		Now:        fixedNow(now),
+		Spawn: func(_ context.Context, dir string) (Report, error) {
+			mu.Lock()
+			gotDir = dir
+			mu.Unlock()
+			return Report{Merged: 2, Deduped: 1}, nil
+		},
+		OnReport: func(r Report) {
+			mu.Lock()
+			reported = &r
+			mu.Unlock()
+			close(done)
+		},
+	})
+	if !launched {
+		t.Fatal("due run must launch a background spawn")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnReport not called within timeout")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if gotDir != "/proj/x" {
+		t.Fatalf("spawn got dir %q, want /proj/x", gotDir)
+	}
+	if reported == nil || reported.Merged != 2 {
+		t.Fatalf("OnReport got %+v, want Merged=2", reported)
+	}
+}
+
+func TestMaybeRunBackground_SkippedRunIsSilent(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)
+	writeDueState(t, root, now.Add(-10*24*time.Hour)) // due
+
+	spawnDone := make(chan struct{})
+	var noticed bool
+	var mu sync.Mutex
+	Scheduler{}.MaybeRunBackground(context.Background(), BackgroundDeps{
+		MemoryRoot: root,
+		Config:     NewConfig(nil, 7, 20),
+		Now:        fixedNow(now),
+		Spawn: func(context.Context, string) (Report, error) {
+			// A skipped/lock-held run emits an all-zero report with no error.
+			defer close(spawnDone)
+			return Report{}, nil
+		},
+		OnReport: func(Report) {
+			mu.Lock()
+			noticed = true
+			mu.Unlock()
+		},
+	})
+	<-spawnDone
+	// Give the goroutine a moment past Spawn to (not) call OnReport.
+	time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if noticed {
+		t.Fatal("all-zero (skipped/no-op) report must not produce a notice")
+	}
+}
+
+func TestMaybeRunBackground_FailureIsSilent(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 3, 5, 9, 0, 0, 0, time.UTC)
+	writeDueState(t, root, now.Add(-10*24*time.Hour)) // due
+
+	spawnDone := make(chan struct{})
+	var noticed bool
+	var mu sync.Mutex
+	Scheduler{}.MaybeRunBackground(context.Background(), BackgroundDeps{
+		MemoryRoot: root,
+		Config:     NewConfig(nil, 7, 20),
+		Now:        fixedNow(now),
+		Spawn: func(context.Context, string) (Report, error) {
+			defer close(spawnDone)
+			return Report{Merged: 5}, errors.New("boom")
+		},
+		OnReport: func(Report) {
+			mu.Lock()
+			noticed = true
+			mu.Unlock()
+		},
+	})
+	<-spawnDone
+	time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if noticed {
+		t.Fatal("a failed background run must be silent (no notice)")
+	}
+}
+
+func TestMaybeRunBackground_NilSpawn(t *testing.T) {
+	if (Scheduler{}).MaybeRunBackground(context.Background(), BackgroundDeps{}) {
+		t.Fatal("nil Spawn must yield false (no-op)")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `dream.Scheduler` (`Due` / `MaybeRunBackground`): at interactive REPL startup, when `[dream].enabled` and a run is due (`State.Due`), spawn `pigo --dream` in a non-blocking goroutine so the first response is never delayed; print a one-line `RenderReportLine` notice on completion.
- Skipped (lock-held → all-zero report), no-op, and failed background runs are silent. Zero startup overhead when disabled/not-due (single `state.json` read). Single-instance enforced by the subprocess `O_EXCL` lock; first run (zero `LastRunAt`) is never auto-triggered.
- Thread resolved `[dream]` config through `cmd/pigo` → `repl.Options`.
- Stamp `SessionHeader.Cwd` on fresh interactive REPL and TUI sessions (mirroring headless) so interactive sessions are attributed to a project for project-scoped distillation (NEW_WORK from #524).

Closes #526

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` (new: `internal/dream/scheduler_test.go`, `internal/cli/repl/dream_startup_test.go`)
- [x] enabled=false / not-due / never-run / empty-root → no spawn; due+enabled → spawn; skipped & failed → silent; changes → one-line notice

## Known follow-up
- The background trigger is wired into the line REPL path only. The default full-screen TUI path is not yet wired (an async plain-stdout line would corrupt the bubbletea alt-screen; it needs a tea.Msg-based notice). See NEW_WORK.