### PR TITLE
fix(bash): platform-aware shell resolution on Windows (#518)

### DIFF
--- a/internal/agenttool/bash_tool.go
+++ b/internal/agenttool/bash_tool.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -90,7 +91,9 @@ func (t *BashTool) Name() string { return "bash" }
 // Description implements AgentTool.
 func (t *BashTool) Description() string {
 	return "Run a shell command, streaming stdout/stderr. Supports a timeout " +
-		"and cancellation. A non-zero exit code is reported as an error."
+		"and cancellation. A non-zero exit code is reported as an error. " +
+		"On Windows the command runs under bash if available (Git Bash/WSL), " +
+		"else PowerShell, else cmd — prefer portable commands."
 }
 
 // Schema implements AgentTool.
@@ -111,11 +114,33 @@ func (t *BashTool) ExecutionMode() agentcore.ToolExecutionMode {
 	return agentcore.ToolExecutionSequential
 }
 
-func (t *BashTool) shell() string {
-	if t.Shell != "" {
-		return t.Shell
+// shellLookPath resolves a program on PATH. It is a package var so tests can
+// simulate a Windows box with or without bash installed.
+var shellLookPath = exec.LookPath
+
+// resolveShell picks the interpreter and the flag that makes it read the command
+// from the next argument. An explicit shell (BashTool.Shell) is always honored as
+// a POSIX-style "<shell> -c <command>".
+//
+// On Windows with no explicit shell, the naive "bash -c" hardcode fails on stock
+// machines that have no bash on PATH — the model then retries bash blindly and
+// every call errors (issue #518). So we prefer a real bash when one is present
+// (Git Bash / WSL / MSYS), since commands are authored in bash syntax, and fall
+// back to PowerShell, then cmd, so a command still runs on a bare Windows box.
+func resolveShell(explicit, goos string, lookPath func(string) (string, error)) (shell, flag string) {
+	if explicit != "" {
+		return explicit, "-c"
 	}
-	return "bash"
+	if goos == "windows" {
+		if p, err := lookPath("bash"); err == nil {
+			return p, "-c"
+		}
+		if p, err := lookPath("powershell"); err == nil {
+			return p, "-Command"
+		}
+		return "cmd", "/C"
+	}
+	return "bash", "-c"
 }
 
 // streamWriter forwards each written chunk to onUpdate as a growing partial
@@ -161,7 +186,8 @@ func (t *BashTool) Execute(ctx context.Context, id string, args json.RawMessage,
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(runCtx, t.shell(), "-c", a.Command)
+	shell, flag := resolveShell(t.Shell, runtime.GOOS, shellLookPath)
+	cmd := exec.CommandContext(runCtx, shell, flag, a.Command)
 	if t.Dir != "" {
 		cmd.Dir = t.Dir
 	}
@@ -191,6 +217,15 @@ func (t *BashTool) Execute(ctx context.Context, id string, args json.RawMessage,
 	if ctx.Err() == context.Canceled {
 		return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent(output)}},
 			fmt.Errorf("bash: command canceled\n%s", output)
+	}
+
+	// A missing interpreter (no bash/powershell/cmd on PATH) surfaces as an
+	// *exec.Error before the command ever runs. Report it with actionable
+	// guidance instead of a bare "code -1", so the model stops retrying blindly.
+	var execErr *exec.Error
+	if errors.As(err, &execErr) {
+		return agentcore.AgentToolResult{Content: agentcore.ContentList{agentcore.NewTextContent(output)}},
+			fmt.Errorf("bash: could not start shell %q: %v. On Windows install Git Bash or WSL (or configure a shell); commands are bash syntax", shell, execErr.Err)
 	}
 
 	if err != nil {

--- a/internal/agenttool/bash_tool_test.go
+++ b/internal/agenttool/bash_tool_test.go
@@ -229,3 +229,44 @@ func TestTruncateBashOutputByteCount(t *testing.T) {
 	}
 }
 
+// TestResolveShell covers the platform-aware interpreter selection (issue #518).
+// It injects goos + a lookPath stub so every branch runs regardless of the host.
+func TestResolveShell(t *testing.T) {
+	found := func(name string) func(string) (string, error) {
+		return func(s string) (string, error) {
+			if s == name {
+				return `C:\bin\` + s, nil
+			}
+			return "", fmt.Errorf("not found")
+		}
+	}
+	none := func(string) (string, error) { return "", fmt.Errorf("not found") }
+
+	tests := []struct {
+		name           string
+		explicit, goos string
+		lookPath       func(string) (string, error)
+		wantFlag       string
+		wantShellHas   string // substring the resolved shell must contain
+	}{
+		{"explicit honored on windows", "zsh", "windows", none, "-c", "zsh"},
+		{"explicit honored on linux", "fish", "linux", none, "-c", "fish"},
+		{"non-windows always bash", "", "linux", none, "-c", "bash"},
+		{"darwin always bash", "", "darwin", none, "-c", "bash"},
+		{"windows with bash", "", "windows", found("bash"), "-c", "bash"},
+		{"windows falls back to powershell", "", "windows", found("powershell"), "-Command", "powershell"},
+		{"windows falls back to cmd", "", "windows", none, "/C", "cmd"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			shell, flag := resolveShell(tc.explicit, tc.goos, tc.lookPath)
+			if flag != tc.wantFlag {
+				t.Errorf("flag = %q, want %q", flag, tc.wantFlag)
+			}
+			if !strings.Contains(shell, tc.wantShellHas) {
+				t.Errorf("shell = %q, want to contain %q", shell, tc.wantShellHas)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## Summary
- Replace the hardcoded `bash -c` interpreter with `resolveShell`: honors an explicit shell, uses `bash -c` on non-Windows, and on Windows prefers real bash (Git Bash/WSL/MSYS) → PowerShell (`-Command`) → cmd (`/C`).
- Detect a missing interpreter (`*exec.Error`) and return actionable guidance instead of a bare `code -1`, so the model stops retrying bash blindly.
- Update the tool description to note the Windows fallback and nudge portable commands.
- Add OS-agnostic `TestResolveShell` covering every branch via an injected `lookPath`.

Fixes the "window下经常无脑bash然后失败" loop: on stock Windows without bash on PATH, every bash call previously failed and the model kept retrying bash.

Closes #518

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/agenttool/...`
- [x] `go test ./internal/agenttool/...`