### PR TITLE
OpenAI Responses API driver — non-streaming text (#539)

### DIFF
--- a/docs/issue#0539.html
+++ b/docs/issue#0539.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0539</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/539">#539</a> &mdash; Responses API driver — non-streaming text &mdash; 2026-08-02</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Non-streaming call still produces a full <code>AssistantMessageEventStream</code></h3>
+      <p><strong>Ambiguity:</strong> This milestone is explicitly non-streaming, but the <code>Provider</code> interface only speaks streams.</p>
+      <p><strong>Choice:</strong> A goroutine runs the blocking <code>client.Responses.New</code> and emits <code>start → text → done</code> onto an unbuffered stream, mirroring <code>transport.go</code>'s <code>pump</code>.</p>
+      <p><strong>Rationale:</strong> <code>StreamCompletion</code> returns promptly and the streaming milestone (#540) layers on without touching the interface or its callers.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Only a missing API key is an early returned error</h3>
+      <p><strong>Ambiguity:</strong> The SDK's <code>New</code> returns a Go error for any non-2xx; the dual failure model (FR-13) reserves the returned error for "cannot build the stream".</p>
+      <p><strong>Choice:</strong> Pre-flight key check returns an error; every SDK/HTTP failure (401, 5xx, transport) is emitted as a terminal <code>StreamErrorEvent</code> with <code>StopReason=error</code>.</p>
+      <p><strong>Rationale:</strong> Matches the Chat Completions driver's observable behavior exactly, so exit-code mapping is identical across protocols.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Reuse the OpenAIDecoder identity tags</h3>
+      <p><strong>Choice:</strong> Mapped messages carry <code>API:"openai"</code>, <code>Provider: d.name</code>, <code>ResponseID</code>/<code>ResponseModel</code>, and <code>Usage</code> when non-zero — identical to <code>OpenAIDecoder.partial()</code>.</p>
+      <p><strong>Rationale:</strong> Downstream observability/replay treats resp_api and chat responses uniformly.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None — implementation followed the spec as written.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Text partial derived from the final message, not a second <code>OutputText()</code> call</h3>
+      <p><strong>Alternatives:</strong> Call <code>resp.OutputText()</code> independently for the text event and the done message.</p>
+      <p><strong>Chosen:</strong> Build the terminal message once, then derive the interim text partial from its content (single source of truth).</p>
+      <p><strong>Why:</strong> A streamed delta that can diverge from the terminal message is a latent bug class; deriving both from one value removes it. (Accepted review finding.)</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Text-only message mapping this milestone</h3>
+      <p><strong>Alternatives:</strong> Map tool calls and images now.</p>
+      <p><strong>Chosen:</strong> Concatenate text blocks per message; skip non-text content.</p>
+      <p><strong>Why:</strong> Scope is US-003 (non-streaming text); tools land in #541 and images/reasoning in #542. Role mapping is exercised end-to-end by those multi-turn tests.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Empty <code>base_url</code> behavior</h3>
+      <p>The driver only omits <code>WithBaseURL</code> when empty, so the SDK would fall back to <code>api.openai.com</code>. #543 owns the agreed rule (resp_api with no base_url must error), so the driver itself stays permissive.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/coder/websocket v1.8.13
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/openai/openai-go v1.12.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/pflag v1.0.10
@@ -50,6 +51,10 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark v1.8.2 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
+github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
@@ -105,6 +107,16 @@ github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=

--- a/internal/provider/responses.go
+++ b/internal/provider/responses.go
@@ -1,0 +1,223 @@
+// This file implements the OpenAI Responses API driver (US-003, #539), the
+// backing for --protocol openai/resp_api. Unlike openAICompatDriver (which
+// hand-rolls the Chat Completions wire format), this driver speaks the
+// Responses API (POST {base_url}/responses) via the official
+// github.com/openai/openai-go SDK.
+//
+// This milestone covers non-streaming text: a plain prompt in, assistant text
+// out, mapped into pigo's AssistantMessage the same way OpenAIDecoder does
+// (API/Provider tags, Usage, ResponseID/ResponseModel, StopReason=end_turn).
+// Streaming (#540), tools (#541), and images/reasoning (#542) layer on later.
+//
+// Failure model (FR-13): only the earliest "cannot build the stream" case
+// (missing API key) is a returned error. Every runtime failure — including a
+// non-2xx from the endpoint — rides the returned stream as a terminal
+// StreamErrorEvent, matching the chat driver's observable behavior.
+//
+// Base URL + auth: the SDK client is pointed at the resolved base_url and given
+// the resolved key via option.WithBaseURL / option.WithAPIKey rather than
+// reading the environment, so ResolveBaseURL precedence is preserved. A custom
+// *http.Client may be injected (option.WithHTTPClient) for tests.
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/responses"
+	"github.com/openai/openai-go/shared"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// responsesDriver is the Provider backing --protocol openai/resp_api. It holds
+// the provider identity, the resolved endpoint, the model catalog, and whether
+// an API key is required, and builds an openai-go client per request.
+type responsesDriver struct {
+	name    string
+	baseURL string
+	models  []Model
+	// requiresAuth reports whether an API key must be present. Public OpenAI /
+	// Azure require it; a local gateway may not.
+	requiresAuth bool
+	// clientOpts are extra SDK options; tests inject option.WithHTTPClient here
+	// to stub the transport.
+	clientOpts []option.RequestOption
+}
+
+// NewOpenAIResponsesProvider builds a Responses API provider targeting baseURL.
+// baseURL must be the fully resolved endpoint (e.g. https://api.openai.com/v1);
+// the SDK appends the /responses path.
+func NewOpenAIResponsesProvider(name, baseURL string, models []Model) *responsesDriver {
+	return &responsesDriver{
+		name:         name,
+		baseURL:      baseURL,
+		models:       models,
+		requiresAuth: true,
+	}
+}
+
+func (d *responsesDriver) Name() string    { return d.name }
+func (d *responsesDriver) Models() []Model { return d.models }
+
+// StreamCompletion issues a Responses API call and surfaces the result on an
+// AssistantMessageEventStream. For this milestone the call is non-streaming: the
+// stream carries a start, one text event, and a terminal done event.
+func (d *responsesDriver) StreamCompletion(ctx context.Context, req CompletionRequest) (*AssistantMessageEventStream, error) {
+	if d.requiresAuth && strings.TrimSpace(req.Config.APIKey) == "" {
+		// Early "cannot build the stream": reference the provider, never a value.
+		return nil, fmt.Errorf("%s: missing API key", d.name)
+	}
+
+	opts := make([]option.RequestOption, 0, len(d.clientOpts)+2)
+	if d.baseURL != "" {
+		opts = append(opts, option.WithBaseURL(d.baseURL))
+	}
+	if key := strings.TrimSpace(req.Config.APIKey); key != "" {
+		opts = append(opts, option.WithAPIKey(key))
+	}
+	opts = append(opts, d.clientOpts...)
+	client := openai.NewClient(opts...)
+
+	params := buildResponsesParams(req)
+
+	stream := NewAssistantMessageEventStream(0)
+	go d.pump(ctx, stream, &client, params)
+	return stream, nil
+}
+
+// pump runs the blocking SDK call and translates its outcome into stream events.
+// It always closes the stream. A failed call becomes a terminal error event
+// (dual failure model), not a returned error.
+func (d *responsesDriver) pump(ctx context.Context, stream *AssistantMessageEventStream, client *openai.Client, params responses.ResponseNewParams) {
+	defer stream.Close()
+
+	if err := stream.Emit(ctx, StreamStartEvent{Partial: d.newPartial()}); err != nil {
+		return
+	}
+
+	resp, err := client.Responses.New(ctx, params)
+	if err != nil {
+		stream.Emit(context.Background(), StreamErrorEvent{
+			Message: agentcore.AssistantMessage{
+				RoleField:    agentcore.RoleAssistant,
+				API:          "openai",
+				Provider:     d.name,
+				StopReason:   agentcore.StopReasonError,
+				ErrorMessage: err.Error(),
+			},
+			Err: fmt.Errorf("%s: %w", d.name, err),
+		})
+		return
+	}
+
+	// Build the final message once; derive the interim text partial from it so
+	// the streamed delta and the terminal message can never diverge.
+	msg := d.mapResponse(resp)
+	if text := textContent(msg); text != "" {
+		partial := d.newPartial()
+		partial.Content = append(partial.Content, agentcore.NewTextContent(text))
+		if err := stream.Emit(ctx, StreamTextEvent{Partial: partial}); err != nil {
+			return
+		}
+	}
+	stream.Emit(ctx, StreamDoneEvent{Message: msg})
+}
+
+// newPartial builds an empty assistant message tagged for this provider, the
+// seed for start/text partials (mirrors OpenAIDecoder.partial()'s identity).
+func (d *responsesDriver) newPartial() agentcore.AssistantMessage {
+	return agentcore.AssistantMessage{
+		RoleField: agentcore.RoleAssistant,
+		API:       "openai",
+		Provider:  d.name,
+	}
+}
+
+// mapResponse materializes a completed Responses API result into pigo's
+// AssistantMessage: text content, usage (when present), diagnostics, and a
+// natural end_turn stop (this milestone has no tool/length stops yet).
+func (d *responsesDriver) mapResponse(resp *responses.Response) agentcore.AssistantMessage {
+	msg := d.newPartial()
+	msg.StopReason = agentcore.StopReasonEndTurn
+	msg.ResponseID = resp.ID
+	msg.ResponseModel = string(resp.Model)
+	if text := resp.OutputText(); text != "" {
+		msg.Content = append(msg.Content, agentcore.NewTextContent(text))
+	}
+	if resp.Usage.InputTokens != 0 || resp.Usage.OutputTokens != 0 {
+		msg.Usage = &agentcore.Usage{
+			InputTokens:  int(resp.Usage.InputTokens),
+			OutputTokens: int(resp.Usage.OutputTokens),
+		}
+	}
+	return msg
+}
+
+// buildResponsesParams maps a CompletionRequest onto Responses API params. For
+// this milestone the system prompt becomes Instructions and each message's text
+// becomes an input item with the matching role; non-text content is deferred to
+// later milestones (tools #541, images #542).
+func buildResponsesParams(req CompletionRequest) responses.ResponseNewParams {
+	params := responses.ResponseNewParams{
+		Model: shared.ResponsesModel(req.Model),
+	}
+	if sp := strings.TrimSpace(req.Context.SystemPrompt); sp != "" {
+		params.Instructions = openai.String(sp)
+	}
+
+	items := make(responses.ResponseInputParam, 0, len(req.Context.Messages))
+	for _, m := range req.Context.Messages {
+		text := messageText(m)
+		if text == "" {
+			continue
+		}
+		items = append(items, responses.ResponseInputItemParamOfMessage(text, responsesRole(m.Role())))
+	}
+	params.Input = responses.ResponseNewParamsInputUnion{OfInputItemList: items}
+	return params
+}
+
+// responsesRole maps a pigo message role to the Responses API input role. Tool
+// results are surfaced as user turns for this text milestone.
+func responsesRole(role string) responses.EasyInputMessageRole {
+	switch role {
+	case agentcore.RoleAssistant:
+		return responses.EasyInputMessageRoleAssistant
+	default:
+		return responses.EasyInputMessageRoleUser
+	}
+}
+
+// messageText concatenates the text blocks of a message, ignoring non-text
+// content (handled in later milestones).
+func messageText(m agentcore.Message) string {
+	var b strings.Builder
+	switch msg := m.(type) {
+	case agentcore.UserMessage:
+		collectText(&b, msg.Content)
+	case agentcore.AssistantMessage:
+		collectText(&b, msg.Content)
+	case agentcore.ToolResultMessage:
+		collectText(&b, msg.Content)
+	}
+	return b.String()
+}
+
+func collectText(b *strings.Builder, content agentcore.ContentList) {
+	for _, c := range content {
+		if tc, ok := c.(agentcore.TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+}
+
+// textContent returns the concatenated text blocks of an assistant message.
+func textContent(m agentcore.AssistantMessage) string {
+	var b strings.Builder
+	collectText(&b, m.Content)
+	return b.String()
+}

--- a/internal/provider/responses_test.go
+++ b/internal/provider/responses_test.go
@@ -1,0 +1,180 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/option"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// roundTripFunc adapts a function to http.RoundTripper so a test can stub the
+// SDK transport without a live endpoint.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// newResponsesTestDriver builds a resp_api driver whose SDK client is pointed at
+// the given stub round-tripper, capturing the request path the SDK targets.
+func newResponsesTestDriver(baseURL string, rt roundTripFunc) *responsesDriver {
+	d := NewOpenAIResponsesProvider("openai", baseURL, nil)
+	d.clientOpts = []option.RequestOption{
+		option.WithHTTPClient(&http.Client{Transport: rt}),
+	}
+	return d
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// drain collects the terminal message from a stream, mirroring how the loop
+// consumes a provider stream.
+func drain(t *testing.T, stream *AssistantMessageEventStream) agentcore.AssistantMessage {
+	t.Helper()
+	for range stream.Events() {
+	}
+	msg, err := stream.Result(context.Background())
+	if err != nil {
+		t.Fatalf("stream result error: %v", err)
+	}
+	return msg
+}
+
+func userMsg(text string) agentcore.UserMessage {
+	return agentcore.UserMessage{
+		RoleField: agentcore.RoleUser,
+		Content:   agentcore.ContentList{agentcore.NewTextContent(text)},
+	}
+}
+
+func TestResponsesDriverPostsToResponsesEndpoint(t *testing.T) {
+	var gotPath, gotBody string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		gotPath = r.URL.Path
+		if r.Body != nil {
+			b, _ := io.ReadAll(r.Body)
+			gotBody = string(b)
+		}
+		const body = `{"id":"resp_123","model":"gpt-4o","output":[{"type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hi there"}]}],"usage":{"input_tokens":11,"output_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}`
+		return jsonResponse(http.StatusOK, body), nil
+	})
+	d := newResponsesTestDriver("https://api.openai.test/v1", rt)
+
+	req := CompletionRequest{
+		Model: "gpt-4o",
+		Context: LlmContext{
+			SystemPrompt: "be terse",
+			Messages:     agentcore.MessageList{userMsg("hello")},
+		},
+		Config: StreamConfig{APIKey: "sk-test"},
+	}
+	stream, err := d.StreamCompletion(context.Background(), req)
+	if err != nil {
+		t.Fatalf("StreamCompletion returned early error: %v", err)
+	}
+	msg := drain(t, stream)
+
+	if !strings.HasSuffix(gotPath, "/responses") {
+		t.Errorf("request path = %q, want to end with /responses", gotPath)
+	}
+	// The prompt and system instruction must reach the wire body.
+	if !strings.Contains(gotBody, "hello") {
+		t.Errorf("request body missing prompt: %q", gotBody)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(gotBody), &payload); err != nil {
+		t.Fatalf("request body not valid JSON: %v", err)
+	}
+	if payload["instructions"] != "be terse" {
+		t.Errorf("instructions = %v, want %q", payload["instructions"], "be terse")
+	}
+	if payload["model"] != "gpt-4o" {
+		t.Errorf("model = %v, want gpt-4o", payload["model"])
+	}
+
+	if got := textOf(msg); got != "hi there" {
+		t.Errorf("assistant text = %q, want %q", got, "hi there")
+	}
+	if msg.StopReason != agentcore.StopReasonEndTurn {
+		t.Errorf("stop reason = %q, want end_turn", msg.StopReason)
+	}
+	if msg.ResponseID != "resp_123" {
+		t.Errorf("response id = %q, want resp_123", msg.ResponseID)
+	}
+	if msg.Usage == nil || msg.Usage.InputTokens != 11 || msg.Usage.OutputTokens != 7 {
+		t.Errorf("usage = %+v, want {11 7}", msg.Usage)
+	}
+	if msg.API != "openai" || msg.Provider != "openai" {
+		t.Errorf("tags = api:%q provider:%q, want openai/openai", msg.API, msg.Provider)
+	}
+}
+
+// A non-2xx from the endpoint must ride the stream as a terminal error event,
+// not be returned from StreamCompletion (dual failure model, FR-13).
+func TestResponsesDriverUpstreamErrorRidesStream(t *testing.T) {
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusUnauthorized, `{"error":{"message":"bad key"}}`), nil
+	})
+	d := newResponsesTestDriver("https://api.openai.test/v1", rt)
+
+	req := CompletionRequest{
+		Model:   "gpt-4o",
+		Context: LlmContext{Messages: agentcore.MessageList{userMsg("hello")}},
+		Config:  StreamConfig{APIKey: "sk-test"},
+	}
+	stream, err := d.StreamCompletion(context.Background(), req)
+	if err != nil {
+		t.Fatalf("StreamCompletion should not early-error on upstream failure: %v", err)
+	}
+
+	var sawError bool
+	for ev := range stream.Events() {
+		if _, ok := ev.(StreamErrorEvent); ok {
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Fatal("expected a terminal StreamErrorEvent for a 401 response")
+	}
+	msg, _ := stream.Result(context.Background())
+	if msg.StopReason != agentcore.StopReasonError {
+		t.Errorf("stop reason = %q, want error", msg.StopReason)
+	}
+}
+
+// A missing API key is the one early "cannot build the stream" error.
+func TestResponsesDriverMissingKeyIsEarlyError(t *testing.T) {
+	d := NewOpenAIResponsesProvider("openai", "https://api.openai.test/v1", nil)
+	_, err := d.StreamCompletion(context.Background(), CompletionRequest{
+		Model:  "gpt-4o",
+		Config: StreamConfig{APIKey: "  "},
+	})
+	if err == nil {
+		t.Fatal("expected early error for missing API key")
+	}
+	if !strings.Contains(err.Error(), "missing API key") {
+		t.Errorf("error = %q, want to mention missing API key", err.Error())
+	}
+}
+
+// textOf returns the concatenated text content of an assistant message.
+func textOf(m agentcore.AssistantMessage) string {
+	var b bytes.Buffer
+	for _, c := range m.Content {
+		if tc, ok := c.(agentcore.TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary
- Pin `github.com/openai/openai-go` v1.12.0 and add an SDK-based Responses driver (`internal/provider/responses.go`) backing `--protocol openai/resp_api`.
- `StreamCompletion` POSTs to `{base_url}/responses`, maps a plain-text prompt into pigo's `AssistantMessage` (text, usage, ResponseID/Model, `end_turn`) over an `AssistantMessageEventStream`, reusing the OpenAIDecoder identity tags (`API:"openai"`, `Provider`).
- Failure model matches the chat driver (FR-13): only a missing API key is an early returned error; upstream/transport failures ride the stream as a terminal `StreamErrorEvent`.
- Base URL + API key injected via `option.With*` so `ResolveBaseURL` precedence is preserved and the transport is stubbable in tests.
- Not yet wired into `ResolveProvider` — that is #543.

Closes #539

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./internal/provider/` clean
- [x] `go test ./internal/provider/` green (new: endpoint path `/responses`, body maps instructions+model+prompt, text/usage/id mapping, upstream 401 rides stream as error, missing-key early error)