### PR TITLE
feat(provider): Responses API driver — streaming text (#540)

### DIFF
--- a/docs/issue#0540.html
+++ b/docs/issue#0540.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0540</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/540">#540</a> &mdash; Responses 驱动 — 流式输出 &mdash; 2026-08-02</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Terminal message built from <code>response.completed</code>, deltas only drive incremental partials</h3>
+      <p><strong>Ambiguity:</strong> A streamed run produces both incremental <code>output_text.delta</code> events and a final <code>response.completed</code> envelope. The spec (US-004) requires "final aggregation == non-streamed result" but doesn't say which source is authoritative.</p>
+      <p><strong>Choice:</strong> Accumulate deltas into a running text partial for each <code>StreamTextEvent</code>, but map the terminal <code>StreamDoneEvent</code> from the completed envelope via the existing <code>mapResponse</code> (id, model, usage, text).</p>
+      <p><strong>Rationale:</strong> The completed envelope is the same payload the non-streaming path (#539) maps, so reusing <code>mapResponse</code> guarantees byte-identical final messages across streaming and non-streaming — satisfying the acceptance criterion by construction rather than by matching two independent code paths.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Fallback to accumulated delta text when no <code>completed</code> event arrives</h3>
+      <p><strong>Ambiguity:</strong> The spec doesn't cover a stream that ends cleanly (no transport error, no error event) but never sent <code>response.completed</code>.</p>
+      <p><strong>Choice:</strong> If <code>completed</code> is nil at end-of-stream, build the terminal message from the accumulated delta text with <code>StopReason=end_turn</code>.</p>
+      <p><strong>Rationale:</strong> Preserves whatever text the user already saw rather than dropping it or forcing an error; a truncated-but-clean stream is not a failure.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Error events emitted via a background-context helper</h3>
+      <p><strong>Ambiguity:</strong> Context cancellation must "promptly stop the stream" (US-004), but emitting a terminal error on the pigo stream itself honors ctx — a cancelled ctx would drop the very error that reports the cancellation.</p>
+      <p><strong>Choice:</strong> Added <code>emitError</code> which emits the terminal <code>StreamErrorEvent</code> using <code>context.Background()</code>, so the terminal error always lands regardless of the caller's ctx state.</p>
+      <p><strong>Rationale:</strong> The consumer must always see a terminal event with <code>StopReason=error</code>; silently closing on a cancelled ctx would surface as <code>ErrStreamIncomplete</code> instead of a clear cancellation error.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <div class="item">
+      <h3><span class="label label-deviation">Deviation</span> #539's non-streaming <code>client.Responses.New</code> call replaced by <code>NewStreaming</code></h3>
+      <p><strong>Spec (prior milestone):</strong> #539 shipped a non-streaming skeleton that called <code>Responses.New</code> and derived a single text partial from the final message.</p>
+      <p><strong>Implemented:</strong> <code>pump</code> now calls <code>Responses.NewStreaming</code> and consumes the SSE event union; the single-shot text partial is gone. The <code>textContent</code> helper that supported it was removed as dead code.</p>
+      <p><strong>Why:</strong> #540 is explicitly the milestone that makes the driver stream; the non-streaming call was scaffolding. The wire body now sets <code>stream:true</code> (asserted in tests).</p>
+    </div>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Test stubs emit SSE frames instead of a single JSON body</h3>
+      <p><strong>Alternatives:</strong> Keep #539's JSON-body stub for the endpoint/mapping test and only add SSE stubs for new streaming tests.</p>
+      <p><strong>Chosen:</strong> Converted all driver tests to a shared <code>sseResponse</code> / <code>deltaFrame</code> / <code>completedFrame</code> helper set that mirrors the real <code>text/event-stream</code> wire format.</p>
+      <p><strong>Why:</strong> The driver no longer has a non-streaming path, so a JSON-body stub would exercise nothing real — the ssestream decoder would silently yield zero events. SSE stubs test the actual code path.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Per-delta partial carries full accumulated text, not just the delta</h3>
+      <p><strong>Alternatives:</strong> Emit each <code>StreamTextEvent</code> carrying only the newest delta and let the consumer concatenate.</p>
+      <p><strong>Chosen:</strong> Each partial carries the text accumulated so far (<code>Hello</code> → <code>Hello, </code> → <code>Hello, world</code>).</p>
+      <p><strong>Why:</strong> Matches the existing partial semantics elsewhere in pigo (partials are cumulative snapshots), so the TUI renders a partial directly without tracking prior state. Verified by the incremental-delta test.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> <code>response.failed</code> event carries no detail in the terminal error</h3>
+      <p>A <code>ResponseFailedEvent</code> is mapped to a flat <code>"response failed"</code> message; its embedded <code>Response</code> may carry a richer error/status. If failed-run diagnostics matter downstream, consider surfacing the response's error detail. Deferred as out of scope for the text streaming milestone.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Reasoning/tool-call stream events are ignored this milestone</h3>
+      <p>The event switch only handles text deltas, completed, failed, and error. Function-call argument deltas (#541) and reasoning summary deltas (#542) fall through silently — intentional for #540 but worth confirming those milestones layer onto this same switch rather than replacing <code>pump</code>.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/provider/responses.go
+++ b/internal/provider/responses.go
@@ -4,10 +4,11 @@
 // Responses API (POST {base_url}/responses) via the official
 // github.com/openai/openai-go SDK.
 //
-// This milestone covers non-streaming text: a plain prompt in, assistant text
-// out, mapped into pigo's AssistantMessage the same way OpenAIDecoder does
-// (API/Provider tags, Usage, ResponseID/ResponseModel, StopReason=end_turn).
-// Streaming (#540), tools (#541), and images/reasoning (#542) layer on later.
+// This milestone covers streaming text: a plain prompt in, assistant text out,
+// consumed from the Responses SSE stream and mapped into pigo's AssistantMessage
+// the same way OpenAIDecoder does (API/Provider tags, Usage,
+// ResponseID/ResponseModel, StopReason=end_turn). Tools (#541) and
+// images/reasoning (#542) layer on later.
 //
 // Failure model (FR-13): only the earliest "cannot build the stream" case
 // (missing API key) is a returned error. Every runtime failure — including a
@@ -63,9 +64,9 @@ func NewOpenAIResponsesProvider(name, baseURL string, models []Model) *responses
 func (d *responsesDriver) Name() string    { return d.name }
 func (d *responsesDriver) Models() []Model { return d.models }
 
-// StreamCompletion issues a Responses API call and surfaces the result on an
-// AssistantMessageEventStream. For this milestone the call is non-streaming: the
-// stream carries a start, one text event, and a terminal done event.
+// StreamCompletion issues a streaming Responses API call and surfaces the result
+// on an AssistantMessageEventStream: a start event, incremental text events as
+// deltas arrive, and a terminal done event carrying the aggregated message.
 func (d *responsesDriver) StreamCompletion(ctx context.Context, req CompletionRequest) (*AssistantMessageEventStream, error) {
 	if d.requiresAuth && strings.TrimSpace(req.Config.APIKey) == "" {
 		// Early "cannot build the stream": reference the provider, never a value.
@@ -89,9 +90,17 @@ func (d *responsesDriver) StreamCompletion(ctx context.Context, req CompletionRe
 	return stream, nil
 }
 
-// pump runs the blocking SDK call and translates its outcome into stream events.
-// It always closes the stream. A failed call becomes a terminal error event
-// (dual failure model), not a returned error.
+// pump consumes the Responses SSE stream and translates events into pigo stream
+// events. It always closes the stream. Every runtime failure (transport error,
+// context cancellation, or an upstream error/failed event) becomes a terminal
+// StreamErrorEvent (dual failure model), not a returned error.
+//
+// Incremental text.delta events emit a StreamTextEvent carrying the accumulated
+// text so far, so the TUI renders tokens as they arrive. The terminal message is
+// built from the authoritative response.completed payload via mapResponse, so
+// the final aggregation matches the non-streamed result exactly. If no completed
+// event arrives (a truncated stream that still ended cleanly), the accumulated
+// delta text is used as a fallback.
 func (d *responsesDriver) pump(ctx context.Context, stream *AssistantMessageEventStream, client *openai.Client, params responses.ResponseNewParams) {
 	defer stream.Close()
 
@@ -99,32 +108,66 @@ func (d *responsesDriver) pump(ctx context.Context, stream *AssistantMessageEven
 		return
 	}
 
-	resp, err := client.Responses.New(ctx, params)
-	if err != nil {
-		stream.Emit(context.Background(), StreamErrorEvent{
-			Message: agentcore.AssistantMessage{
-				RoleField:    agentcore.RoleAssistant,
-				API:          "openai",
-				Provider:     d.name,
-				StopReason:   agentcore.StopReasonError,
-				ErrorMessage: err.Error(),
-			},
-			Err: fmt.Errorf("%s: %w", d.name, err),
-		})
-		return
-	}
+	sse := client.Responses.NewStreaming(ctx, params)
+	defer sse.Close()
 
-	// Build the final message once; derive the interim text partial from it so
-	// the streamed delta and the terminal message can never diverge.
-	msg := d.mapResponse(resp)
-	if text := textContent(msg); text != "" {
-		partial := d.newPartial()
-		partial.Content = append(partial.Content, agentcore.NewTextContent(text))
-		if err := stream.Emit(ctx, StreamTextEvent{Partial: partial}); err != nil {
+	var text strings.Builder
+	var completed *responses.Response
+	for sse.Next() {
+		if ctx.Err() != nil {
+			d.emitError(stream, ctx.Err())
+			return
+		}
+		switch variant := sse.Current().AsAny().(type) {
+		case responses.ResponseTextDeltaEvent:
+			text.WriteString(variant.Delta)
+			partial := d.newPartial()
+			partial.Content = append(partial.Content, agentcore.NewTextContent(text.String()))
+			if err := stream.Emit(ctx, StreamTextEvent{Partial: partial}); err != nil {
+				return
+			}
+		case responses.ResponseCompletedEvent:
+			r := variant.Response
+			completed = &r
+		case responses.ResponseFailedEvent:
+			d.emitError(stream, fmt.Errorf("response failed"))
+			return
+		case responses.ResponseErrorEvent:
+			d.emitError(stream, fmt.Errorf("%s", variant.Message))
 			return
 		}
 	}
+	if err := sse.Err(); err != nil {
+		d.emitError(stream, err)
+		return
+	}
+
+	var msg agentcore.AssistantMessage
+	if completed != nil {
+		msg = d.mapResponse(completed)
+	} else {
+		msg = d.newPartial()
+		msg.StopReason = agentcore.StopReasonEndTurn
+		if t := text.String(); t != "" {
+			msg.Content = append(msg.Content, agentcore.NewTextContent(t))
+		}
+	}
 	stream.Emit(ctx, StreamDoneEvent{Message: msg})
+}
+
+// emitError emits a terminal StreamErrorEvent tagged for this provider. Uses a
+// background context so the emit isn't dropped when ctx is already cancelled.
+func (d *responsesDriver) emitError(stream *AssistantMessageEventStream, err error) {
+	stream.Emit(context.Background(), StreamErrorEvent{
+		Message: agentcore.AssistantMessage{
+			RoleField:    agentcore.RoleAssistant,
+			API:          "openai",
+			Provider:     d.name,
+			StopReason:   agentcore.StopReasonError,
+			ErrorMessage: err.Error(),
+		},
+		Err: fmt.Errorf("%s: %w", d.name, err),
+	})
 }
 
 // newPartial builds an empty assistant message tagged for this provider, the
@@ -213,11 +256,4 @@ func collectText(b *strings.Builder, content agentcore.ContentList) {
 			b.WriteString(tc.Text)
 		}
 	}
-}
-
-// textContent returns the concatenated text blocks of an assistant message.
-func textContent(m agentcore.AssistantMessage) string {
-	var b strings.Builder
-	collectText(&b, m.Content)
-	return b.String()
 }

--- a/internal/provider/responses_test.go
+++ b/internal/provider/responses_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -38,6 +39,42 @@ func jsonResponse(status int, body string) *http.Response {
 	}
 }
 
+// sseResponse builds a 200 text/event-stream response whose body is the given
+// SSE data frames, mirroring how the Responses API streams events. Each frame is
+// a JSON object carrying its own "type" discriminator.
+func sseResponse(frames ...string) *http.Response {
+	var b strings.Builder
+	for _, f := range frames {
+		b.WriteString("data: ")
+		b.WriteString(f)
+		b.WriteString("\n\n")
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(b.String())),
+	}
+}
+
+// completedFrame is a response.completed SSE frame whose embedded Response yields
+// the given output text, id, model, and token usage — the authoritative terminal
+// payload the driver maps into its final message.
+func completedFrame(text, id, model string, inTok, outTok int) string {
+	return `{"type":"response.completed","sequence_number":99,"response":{` +
+		`"id":"` + id + `","model":"` + model + `",` +
+		`"output":[{"type":"message","role":"assistant","status":"completed",` +
+		`"content":[{"type":"output_text","text":"` + text + `"}]}],` +
+		`"usage":{"input_tokens":` + itoa(inTok) + `,"output_tokens":` + itoa(outTok) +
+		`,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`
+}
+
+func deltaFrame(delta string) string {
+	return `{"type":"response.output_text.delta","item_id":"msg_1","output_index":0,` +
+		`"content_index":0,"sequence_number":1,"logprobs":[],"delta":"` + delta + `"}`
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }
+
 // drain collects the terminal message from a stream, mirroring how the loop
 // consumes a provider stream.
 func drain(t *testing.T, stream *AssistantMessageEventStream) agentcore.AssistantMessage {
@@ -66,8 +103,11 @@ func TestResponsesDriverPostsToResponsesEndpoint(t *testing.T) {
 			b, _ := io.ReadAll(r.Body)
 			gotBody = string(b)
 		}
-		const body = `{"id":"resp_123","model":"gpt-4o","output":[{"type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hi there"}]}],"usage":{"input_tokens":11,"output_tokens":7,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}`
-		return jsonResponse(http.StatusOK, body), nil
+		return sseResponse(
+			deltaFrame("hi "),
+			deltaFrame("there"),
+			completedFrame("hi there", "resp_123", "gpt-4o", 11, 7),
+		), nil
 	})
 	d := newResponsesTestDriver("https://api.openai.test/v1", rt)
 
@@ -102,6 +142,10 @@ func TestResponsesDriverPostsToResponsesEndpoint(t *testing.T) {
 	if payload["model"] != "gpt-4o" {
 		t.Errorf("model = %v, want gpt-4o", payload["model"])
 	}
+	// A streaming call must set stream:true on the wire.
+	if payload["stream"] != true {
+		t.Errorf("stream = %v, want true", payload["stream"])
+	}
 
 	if got := textOf(msg); got != "hi there" {
 		t.Errorf("assistant text = %q, want %q", got, "hi there")
@@ -117,6 +161,91 @@ func TestResponsesDriverPostsToResponsesEndpoint(t *testing.T) {
 	}
 	if msg.API != "openai" || msg.Provider != "openai" {
 		t.Errorf("tags = api:%q provider:%q, want openai/openai", msg.API, msg.Provider)
+	}
+}
+
+// The driver must emit incremental text partials as deltas arrive, and each
+// partial must carry the text accumulated so far (not just the latest delta), so
+// the terminal message equals the concatenation the caller already rendered.
+func TestResponsesDriverStreamsIncrementalDeltas(t *testing.T) {
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return sseResponse(
+			deltaFrame("Hello"),
+			deltaFrame(", "),
+			deltaFrame("world"),
+			completedFrame("Hello, world", "resp_9", "gpt-4o", 3, 4),
+		), nil
+	})
+	d := newResponsesTestDriver("https://api.openai.test/v1", rt)
+
+	stream, err := d.StreamCompletion(context.Background(), CompletionRequest{
+		Model:   "gpt-4o",
+		Context: LlmContext{Messages: agentcore.MessageList{userMsg("hi")}},
+		Config:  StreamConfig{APIKey: "sk-test"},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned early error: %v", err)
+	}
+
+	var textPartials []string
+	for ev := range stream.Events() {
+		if te, ok := ev.(StreamTextEvent); ok {
+			textPartials = append(textPartials, textOf(te.Partial))
+		}
+	}
+	msg, err := stream.Result(context.Background())
+	if err != nil {
+		t.Fatalf("stream result error: %v", err)
+	}
+
+	want := []string{"Hello", "Hello, ", "Hello, world"}
+	if len(textPartials) != len(want) {
+		t.Fatalf("got %d text partials %q, want %d %q", len(textPartials), textPartials, len(want), want)
+	}
+	for i := range want {
+		if textPartials[i] != want[i] {
+			t.Errorf("partial[%d] = %q, want %q", i, textPartials[i], want[i])
+		}
+	}
+	// Final aggregation must match the completed payload, i.e. the last partial.
+	if got := textOf(msg); got != "Hello, world" {
+		t.Errorf("final text = %q, want %q", got, "Hello, world")
+	}
+}
+
+// A cancelled context must terminate the stream with an error rather than
+// yielding a normal end_turn message. The transport cancels mid-flight (after
+// the stream has started) and reports the cancellation, mirroring how an
+// in-progress SSE read aborts when the caller cancels.
+func TestResponsesDriverContextCancelStopsStream(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		cancel()
+		return nil, context.Canceled
+	})
+	d := newResponsesTestDriver("https://api.openai.test/v1", rt)
+
+	stream, err := d.StreamCompletion(ctx, CompletionRequest{
+		Model:   "gpt-4o",
+		Context: LlmContext{Messages: agentcore.MessageList{userMsg("hi")}},
+		Config:  StreamConfig{APIKey: "sk-test"},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion should not early-error on cancel: %v", err)
+	}
+
+	var sawError bool
+	for ev := range stream.Events() {
+		if _, ok := ev.(StreamErrorEvent); ok {
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Fatal("expected a terminal StreamErrorEvent after context cancel")
+	}
+	msg, _ := stream.Result(context.Background())
+	if msg.StopReason != agentcore.StopReasonError {
+		t.Errorf("stop reason = %q, want error", msg.StopReason)
 	}
 }
 
@@ -146,6 +275,46 @@ func TestResponsesDriverUpstreamErrorRidesStream(t *testing.T) {
 	}
 	if !sawError {
 		t.Fatal("expected a terminal StreamErrorEvent for a 401 response")
+	}
+	msg, _ := stream.Result(context.Background())
+	if msg.StopReason != agentcore.StopReasonError {
+		t.Errorf("stop reason = %q, want error", msg.StopReason)
+	}
+}
+
+// An in-band error event (type "error") mid-stream must ride the stream as a
+// terminal error, carrying the event's message. This is a distinct path from a
+// transport-level non-2xx (which surfaces via the stream's Err()).
+func TestResponsesDriverInStreamErrorEvent(t *testing.T) {
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return sseResponse(
+			deltaFrame("partial"),
+			`{"type":"error","code":"server_error","message":"boom","param":"","sequence_number":2}`,
+		), nil
+	})
+	d := newResponsesTestDriver("https://api.openai.test/v1", rt)
+
+	stream, err := d.StreamCompletion(context.Background(), CompletionRequest{
+		Model:   "gpt-4o",
+		Context: LlmContext{Messages: agentcore.MessageList{userMsg("hi")}},
+		Config:  StreamConfig{APIKey: "sk-test"},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion should not early-error: %v", err)
+	}
+
+	var errEvent *StreamErrorEvent
+	for ev := range stream.Events() {
+		if se, ok := ev.(StreamErrorEvent); ok {
+			e := se
+			errEvent = &e
+		}
+	}
+	if errEvent == nil {
+		t.Fatal("expected a terminal StreamErrorEvent for an in-band error event")
+	}
+	if !strings.Contains(errEvent.Message.ErrorMessage, "boom") {
+		t.Errorf("error message = %q, want to contain %q", errEvent.Message.ErrorMessage, "boom")
 	}
 	msg, _ := stream.Result(context.Background())
 	if msg.StopReason != agentcore.StopReasonError {


### PR DESCRIPTION
## Summary
- Rewrite the `resp_api` driver `pump` from non-streaming `Responses.New` to `Responses.NewStreaming`, consuming the Responses SSE event union.
- Text deltas emit cumulative `StreamTextEvent` partials (each carries the full accumulated text so the TUI renders a partial directly).
- Terminal message is built from the authoritative `response.completed` envelope via the existing `mapResponse`, guaranteeing streaming/non-streaming parity by construction (US-004).
- Fallback: a clean stream that never sent `completed` builds the terminal message from accumulated delta text with `end_turn`.
- Dual failure model (FR-13): context cancellation, in-band `error` events, and transport/non-2xx failures ride the stream as a terminal `StreamErrorEvent` with `StopReason=error`; only a missing API key is an early returned error.
- Driver tests converted to real `text/event-stream` stubs (`sseResponse`/`deltaFrame`/`completedFrame`).

Closes #540

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/provider/`
- [x] `go test ./internal/provider/` (streaming incremental deltas, final aggregation == completed payload, context-cancel terminal error, in-band error event, upstream 401, missing-key early error)
- [x] Wire body asserts `stream:true`, `instructions`, `model`