### PR TITLE
feat(responses): tool/function calls for Responses driver

### DIFF
--- a/docs/issue#0541.html
+++ b/docs/issue#0541.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0541</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/541">#541</a> &mdash; Responses 驱动 — 工具/函数调用 &mdash; 2026-08-02</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Terminal tool calls parsed from <code>response.completed</code>; stream events only drive incremental partials</h3>
+      <p><strong>Ambiguity:</strong> A streamed tool call surfaces both as an <code>output_item.done</code> event (per finalized function_call) and inside the final <code>response.completed</code> envelope. The spec doesn't say which is authoritative for the terminal message.</p>
+      <p><strong>Choice:</strong> <code>mapResponse</code> re-parses tool calls from <code>resp.Output</code> for the terminal <code>StreamDoneEvent</code>; the accumulated <code>toolCalls</code> slice from <code>output_item.done</code> only feeds interim <code>StreamToolCallEvent</code> partials (and a fallback when no completed event arrives).</p>
+      <p><strong>Rationale:</strong> Reusing <code>mapResponse</code> keeps the streamed terminal message byte-identical to the non-streamed path, and both interim and terminal tool calls derive from one <code>toolCallContent</code> mapper so they can't diverge.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Tool-result backfill keyed on the model's <code>call_id</code></h3>
+      <p><strong>Ambiguity:</strong> The Responses API pairs a request and its result across turns; the spec doesn't prescribe the pairing key.</p>
+      <p><strong>Choice:</strong> A prior <code>AssistantMessage</code>'s <code>ToolCallContent</code> replays as a <code>function_call</code> input item (id/name/arguments), and the following <code>ToolResultMessage</code> replays as a <code>function_call_output</code> item — both keyed by the same <code>call_id</code>.</p>
+      <p><strong>Rationale:</strong> <code>call_id</code> is the API's own correlation handle, so replaying it verbatim lets the model pair request and result without pigo inventing an id scheme.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Message replay dispatched by type via <code>appendInputItems</code></h3>
+      <p><strong>Ambiguity:</strong> #539/#540 replayed every message as plain text; tool turns need structured items instead.</p>
+      <p><strong>Choice:</strong> A type switch replays <code>ToolResultMessage</code> → function_call_output, <code>AssistantMessage</code> → text + function_call items, and everything else → a role-tagged text message (the prior behavior).</p>
+      <p><strong>Rationale:</strong> Localizes the tool wire format in one function and leaves the text path unchanged for non-tool turns.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None — implementation followed the issue spec (tools sent as Responses functions, tool calls parsed to pigo types, results backfilled, multi-turn round-trip covered by stub tests).</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> <code>strict:false</code> for function tools</h3>
+      <p><strong>Alternatives:</strong> Enable Responses strict-function mode for schema-validated arguments.</p>
+      <p><strong>Chosen:</strong> Pass <code>strict=false</code> to <code>ToolParamOfFunction</code>.</p>
+      <p><strong>Why:</strong> pigo tool JSON Schemas aren't authored against the strict contract (which demands <code>additionalProperties:false</code>, all fields required, etc.); enabling strict would reject valid pigo tools at the wire.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Malformed/empty tool schema falls back to an empty object schema</h3>
+      <p><strong>Alternatives:</strong> Error out, or drop the tool, when its schema is empty or not a JSON object.</p>
+      <p><strong>Chosen:</strong> Fall back to <code>{}</code> so the tool still reaches the wire with a valid (if permissive) parameter schema.</p>
+      <p><strong>Why:</strong> A tool with a degenerate schema is still callable; silently dropping it would make the model unaware of a capability the user registered.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Function-call argument delta events are ignored</h3>
+      <p>The stream switch handles <code>output_item.done</code> (finalized call) but not <code>ResponseFunctionCallArgumentsDeltaEvent</code>. Incremental argument text isn't shown token-by-token — the pending call surfaces only once it finalizes. Acceptable for this milestone; confirm whether live argument streaming is wanted later.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Tool-result content is text-only</h3>
+      <p><code>function_call_output</code> is built from <code>contentText</code>, so non-text tool results (images/structured blocks) are flattened to their text portion. Rich tool-result content depends on the image work in #542.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/provider/responses.go
+++ b/internal/provider/responses.go
@@ -23,6 +23,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -112,6 +113,7 @@ func (d *responsesDriver) pump(ctx context.Context, stream *AssistantMessageEven
 	defer sse.Close()
 
 	var text strings.Builder
+	var toolCalls []agentcore.ToolCallContent
 	var completed *responses.Response
 	for sse.Next() {
 		if ctx.Err() != nil {
@@ -123,8 +125,24 @@ func (d *responsesDriver) pump(ctx context.Context, stream *AssistantMessageEven
 			text.WriteString(variant.Delta)
 			partial := d.newPartial()
 			partial.Content = append(partial.Content, agentcore.NewTextContent(text.String()))
+			partial.Content = appendToolCalls(partial.Content, toolCalls)
 			if err := stream.Emit(ctx, StreamTextEvent{Partial: partial}); err != nil {
 				return
+			}
+		case responses.ResponseOutputItemDoneEvent:
+			// A finalized function_call item carries the model's tool request
+			// (name + arguments + call_id). Accumulate it and surface a tool-call
+			// partial so the TUI can show the pending call before the run ends.
+			if fc := variant.Item.AsFunctionCall(); fc.Type == "function_call" {
+				toolCalls = append(toolCalls, toolCallContent(fc))
+				partial := d.newPartial()
+				if t := text.String(); t != "" {
+					partial.Content = append(partial.Content, agentcore.NewTextContent(t))
+				}
+				partial.Content = appendToolCalls(partial.Content, toolCalls)
+				if err := stream.Emit(ctx, StreamToolCallEvent{Partial: partial}); err != nil {
+					return
+				}
 			}
 		case responses.ResponseCompletedEvent:
 			r := variant.Response
@@ -150,6 +168,10 @@ func (d *responsesDriver) pump(ctx context.Context, stream *AssistantMessageEven
 		msg.StopReason = agentcore.StopReasonEndTurn
 		if t := text.String(); t != "" {
 			msg.Content = append(msg.Content, agentcore.NewTextContent(t))
+		}
+		msg.Content = appendToolCalls(msg.Content, toolCalls)
+		if len(toolCalls) > 0 {
+			msg.StopReason = agentcore.StopReasonToolUse
 		}
 	}
 	stream.Emit(ctx, StreamDoneEvent{Message: msg})
@@ -181,8 +203,9 @@ func (d *responsesDriver) newPartial() agentcore.AssistantMessage {
 }
 
 // mapResponse materializes a completed Responses API result into pigo's
-// AssistantMessage: text content, usage (when present), diagnostics, and a
-// natural end_turn stop (this milestone has no tool/length stops yet).
+// AssistantMessage: text content, tool calls, usage (when present),
+// diagnostics, and a stop reason (tool_use when the model requested a tool,
+// otherwise end_turn).
 func (d *responsesDriver) mapResponse(resp *responses.Response) agentcore.AssistantMessage {
 	msg := d.newPartial()
 	msg.StopReason = agentcore.StopReasonEndTurn
@@ -190,6 +213,16 @@ func (d *responsesDriver) mapResponse(resp *responses.Response) agentcore.Assist
 	msg.ResponseModel = string(resp.Model)
 	if text := resp.OutputText(); text != "" {
 		msg.Content = append(msg.Content, agentcore.NewTextContent(text))
+	}
+	var sawToolCall bool
+	for _, item := range resp.Output {
+		if fc := item.AsFunctionCall(); fc.Type == "function_call" {
+			msg.Content = append(msg.Content, toolCallContent(fc))
+			sawToolCall = true
+		}
+	}
+	if sawToolCall {
+		msg.StopReason = agentcore.StopReasonToolUse
 	}
 	if resp.Usage.InputTokens != 0 || resp.Usage.OutputTokens != 0 {
 		msg.Usage = &agentcore.Usage{
@@ -200,10 +233,29 @@ func (d *responsesDriver) mapResponse(resp *responses.Response) agentcore.Assist
 	return msg
 }
 
-// buildResponsesParams maps a CompletionRequest onto Responses API params. For
-// this milestone the system prompt becomes Instructions and each message's text
-// becomes an input item with the matching role; non-text content is deferred to
-// later milestones (tools #541, images #542).
+// toolCallContent maps a Responses function_call item into a pigo
+// ToolCallContent, keyed by the model's call_id so the tool result can be
+// backfilled against it on the next turn. Arguments ride verbatim as raw JSON.
+func toolCallContent(fc responses.ResponseFunctionToolCall) agentcore.ToolCallContent {
+	return agentcore.NewToolCallContent(fc.CallID, fc.Name, json.RawMessage(fc.Arguments))
+}
+
+// appendToolCalls appends each accumulated tool call to a content list. Kept
+// separate so the streaming partial and the terminal message build identical
+// content from the same source.
+func appendToolCalls(content agentcore.ContentList, calls []agentcore.ToolCallContent) agentcore.ContentList {
+	for _, c := range calls {
+		content = append(content, c)
+	}
+	return content
+}
+
+// buildResponsesParams maps a CompletionRequest onto Responses API params. The
+// system prompt becomes Instructions; pigo tools become Responses function
+// tools; and each message is replayed as the matching input item(s): assistant
+// tool calls as function_call items, tool results as function_call_output
+// items, and text as a role-tagged message. Non-text message content (images)
+// is deferred to #542.
 func buildResponsesParams(req CompletionRequest) responses.ResponseNewParams {
 	params := responses.ResponseNewParams{
 		Model: shared.ResponsesModel(req.Model),
@@ -211,17 +263,68 @@ func buildResponsesParams(req CompletionRequest) responses.ResponseNewParams {
 	if sp := strings.TrimSpace(req.Context.SystemPrompt); sp != "" {
 		params.Instructions = openai.String(sp)
 	}
+	if tools := buildResponsesTools(req.Context.Tools); len(tools) > 0 {
+		params.Tools = tools
+	}
 
 	items := make(responses.ResponseInputParam, 0, len(req.Context.Messages))
 	for _, m := range req.Context.Messages {
-		text := messageText(m)
-		if text == "" {
-			continue
-		}
-		items = append(items, responses.ResponseInputItemParamOfMessage(text, responsesRole(m.Role())))
+		items = appendInputItems(items, m)
 	}
 	params.Input = responses.ResponseNewParamsInputUnion{OfInputItemList: items}
 	return params
+}
+
+// buildResponsesTools converts pigo tools into Responses function tools. Each
+// tool's JSON Schema becomes the function parameters; a schema that is empty or
+// not a JSON object falls back to an empty object schema so the wire stays
+// valid. Strict mode is off: pigo schemas are not authored against the Responses
+// strict-function contract (which requires additionalProperties:false etc.).
+func buildResponsesTools(tools []agentcore.AgentTool) []responses.ToolUnionParam {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]responses.ToolUnionParam, 0, len(tools))
+	for _, t := range tools {
+		params := map[string]any{}
+		if raw := t.Schema(); len(raw) > 0 {
+			if err := json.Unmarshal(raw, &params); err != nil {
+				params = map[string]any{}
+			}
+		}
+		tool := responses.ToolParamOfFunction(t.Name(), params, false)
+		if desc := t.Description(); desc != "" {
+			tool.OfFunction.Description = openai.String(desc)
+		}
+		out = append(out, tool)
+	}
+	return out
+}
+
+// appendInputItems replays one pigo message as its Responses input item(s).
+func appendInputItems(items responses.ResponseInputParam, m agentcore.Message) responses.ResponseInputParam {
+	switch msg := m.(type) {
+	case agentcore.ToolResultMessage:
+		// A tool result is backfilled against the model's call_id so the model
+		// can pair it with the request it issued the previous turn.
+		items = append(items, responses.ResponseInputItemParamOfFunctionCallOutput(
+			msg.ToolCallID, contentText(msg.Content)))
+	case agentcore.AssistantMessage:
+		if text := contentText(msg.Content); text != "" {
+			items = append(items, responses.ResponseInputItemParamOfMessage(
+				text, responses.EasyInputMessageRoleAssistant))
+		}
+		for _, call := range msg.ToolCalls() {
+			items = append(items, responses.ResponseInputItemParamOfFunctionCall(
+				string(call.Arguments), call.ID, call.Name))
+		}
+	default:
+		if text := messageText(m); text != "" {
+			items = append(items, responses.ResponseInputItemParamOfMessage(
+				text, responsesRole(m.Role())))
+		}
+	}
+	return items
 }
 
 // responsesRole maps a pigo message role to the Responses API input role. Tool
@@ -256,4 +359,11 @@ func collectText(b *strings.Builder, content agentcore.ContentList) {
 			b.WriteString(tc.Text)
 		}
 	}
+}
+
+// contentText concatenates the text blocks of a content list.
+func contentText(content agentcore.ContentList) string {
+	var b strings.Builder
+	collectText(&b, content)
+	return b.String()
 }

--- a/internal/provider/responses_test.go
+++ b/internal/provider/responses_test.go
@@ -347,3 +347,251 @@ func textOf(m agentcore.AssistantMessage) string {
 	}
 	return b.String()
 }
+
+// fakeTool is a minimal AgentTool for exercising tool-schema serialization; it
+// never executes in these transport-level tests.
+type fakeTool struct {
+	name   string
+	desc   string
+	schema json.RawMessage
+}
+
+func (t fakeTool) Name() string                               { return t.name }
+func (t fakeTool) Description() string                        { return t.desc }
+func (t fakeTool) Schema() json.RawMessage                    { return t.schema }
+func (t fakeTool) ExecutionMode() agentcore.ToolExecutionMode { return agentcore.ToolExecutionParallel }
+func (t fakeTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+	return agentcore.AgentToolResult{}, nil
+}
+
+// functionCallDoneFrame is a response.output_item.done SSE frame carrying a
+// finalized function_call item (the model's tool request).
+func functionCallDoneFrame(callID, name, argsJSON string) string {
+	frame := map[string]any{
+		"type":            "response.output_item.done",
+		"output_index":    0,
+		"sequence_number": 5,
+		"item": map[string]any{
+			"type":      "function_call",
+			"id":        "fc_1",
+			"call_id":   callID,
+			"name":      name,
+			"arguments": argsJSON,
+			"status":    "completed",
+		},
+	}
+	b, _ := json.Marshal(frame)
+	return string(b)
+}
+
+// completedToolFrame is a response.completed frame whose output is a single
+// function_call item (no assistant text) plus token usage.
+func completedToolFrame(id, model, callID, name, argsJSON string) string {
+	frame := map[string]any{
+		"type":            "response.completed",
+		"sequence_number": 99,
+		"response": map[string]any{
+			"id":    id,
+			"model": model,
+			"output": []any{map[string]any{
+				"type":      "function_call",
+				"id":        "fc_1",
+				"call_id":   callID,
+				"name":      name,
+				"arguments": argsJSON,
+				"status":    "completed",
+			}},
+			"usage": map[string]any{
+				"input_tokens":          5,
+				"output_tokens":         2,
+				"input_tokens_details":  map[string]any{"cached_tokens": 0},
+				"output_tokens_details": map[string]any{"reasoning_tokens": 0},
+			},
+		},
+	}
+	b, _ := json.Marshal(frame)
+	return string(b)
+}
+
+// A pigo tool must reach the wire as a Responses function tool: type "function",
+// its name, JSON-Schema parameters, and description.
+func TestResponsesDriverSendsToolSchema(t *testing.T) {
+	var gotBody string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Body != nil {
+			b, _ := io.ReadAll(r.Body)
+			gotBody = string(b)
+		}
+		return sseResponse(completedFrame("ok", "resp_1", "gpt-4o", 1, 1)), nil
+	})
+	d := newResponsesTestDriver("https://api.openai.test/v1", rt)
+
+	tool := fakeTool{
+		name:   "read_file",
+		desc:   "reads a file",
+		schema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`),
+	}
+	stream, err := d.StreamCompletion(context.Background(), CompletionRequest{
+		Model: "gpt-4o",
+		Context: LlmContext{
+			Messages: agentcore.MessageList{userMsg("read a.go")},
+			Tools:    []agentcore.AgentTool{tool},
+		},
+		Config: StreamConfig{APIKey: "sk-test"},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned early error: %v", err)
+	}
+	drain(t, stream)
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(gotBody), &payload); err != nil {
+		t.Fatalf("request body not valid JSON: %v", err)
+	}
+	tools, ok := payload["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("tools = %v, want a single-element array", payload["tools"])
+	}
+	tool0 := tools[0].(map[string]any)
+	if tool0["type"] != "function" {
+		t.Errorf("tool type = %v, want function", tool0["type"])
+	}
+	if tool0["name"] != "read_file" {
+		t.Errorf("tool name = %v, want read_file", tool0["name"])
+	}
+	if tool0["description"] != "reads a file" {
+		t.Errorf("tool description = %v, want %q", tool0["description"], "reads a file")
+	}
+	params, ok := tool0["parameters"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool parameters missing or not an object: %v", tool0["parameters"])
+	}
+	props, ok := params["properties"].(map[string]any)
+	if !ok || props["path"] == nil {
+		t.Errorf("tool parameters.properties.path missing: %v", params)
+	}
+}
+
+// A function_call in the completed response must be parsed into a pigo
+// ToolCallContent (id + name + raw arguments) and set StopReason=tool_use; a
+// StreamToolCallEvent must also surface the pending call mid-stream.
+func TestResponsesDriverParsesToolCall(t *testing.T) {
+	args := `{"path":"a.go"}`
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return sseResponse(
+			functionCallDoneFrame("call_abc", "read_file", args),
+			completedToolFrame("resp_7", "gpt-4o", "call_abc", "read_file", args),
+		), nil
+	})
+	d := newResponsesTestDriver("https://api.openai.test/v1", rt)
+
+	stream, err := d.StreamCompletion(context.Background(), CompletionRequest{
+		Model:   "gpt-4o",
+		Context: LlmContext{Messages: agentcore.MessageList{userMsg("read a.go")}},
+		Config:  StreamConfig{APIKey: "sk-test"},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned early error: %v", err)
+	}
+
+	var sawToolCallEvent bool
+	for ev := range stream.Events() {
+		if _, ok := ev.(StreamToolCallEvent); ok {
+			sawToolCallEvent = true
+		}
+	}
+	if !sawToolCallEvent {
+		t.Error("expected a StreamToolCallEvent mid-stream")
+	}
+	msg, err := stream.Result(context.Background())
+	if err != nil {
+		t.Fatalf("stream result error: %v", err)
+	}
+
+	calls := msg.ToolCalls()
+	if len(calls) != 1 {
+		t.Fatalf("got %d tool calls, want 1", len(calls))
+	}
+	if calls[0].ID != "call_abc" || calls[0].Name != "read_file" {
+		t.Errorf("tool call = id:%q name:%q, want call_abc/read_file", calls[0].ID, calls[0].Name)
+	}
+	if string(calls[0].Arguments) != args {
+		t.Errorf("tool call arguments = %q, want %q", calls[0].Arguments, args)
+	}
+	if msg.StopReason != agentcore.StopReasonToolUse {
+		t.Errorf("stop reason = %q, want tool_use", msg.StopReason)
+	}
+}
+
+// On a follow-up turn, a prior assistant tool call must be replayed as a
+// function_call input item and its result as a function_call_output item, both
+// keyed by the same call_id, so the model can pair request and result.
+func TestResponsesDriverBackfillsToolResult(t *testing.T) {
+	var gotBody string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Body != nil {
+			b, _ := io.ReadAll(r.Body)
+			gotBody = string(b)
+		}
+		return sseResponse(completedFrame("done", "resp_2", "gpt-4o", 8, 3)), nil
+	})
+	d := newResponsesTestDriver("https://api.openai.test/v1", rt)
+
+	assistant := agentcore.AssistantMessage{
+		RoleField: agentcore.RoleAssistant,
+		Content: agentcore.ContentList{
+			agentcore.NewToolCallContent("call_abc", "read_file", json.RawMessage(`{"path":"a.go"}`)),
+		},
+	}
+	result := agentcore.ToolResultMessage{
+		RoleField:  agentcore.RoleToolResult,
+		ToolCallID: "call_abc",
+		ToolName:   "read_file",
+		Content:    agentcore.ContentList{agentcore.NewTextContent("package main")},
+	}
+	stream, err := d.StreamCompletion(context.Background(), CompletionRequest{
+		Model: "gpt-4o",
+		Context: LlmContext{Messages: agentcore.MessageList{
+			userMsg("read a.go"), assistant, result,
+		}},
+		Config: StreamConfig{APIKey: "sk-test"},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned early error: %v", err)
+	}
+	drain(t, stream)
+
+	var payload struct {
+		Input []map[string]any `json:"input"`
+	}
+	if err := json.Unmarshal([]byte(gotBody), &payload); err != nil {
+		t.Fatalf("request body not valid JSON: %v", err)
+	}
+	var sawCall, sawOutput bool
+	for _, item := range payload.Input {
+		switch item["type"] {
+		case "function_call":
+			sawCall = true
+			if item["call_id"] != "call_abc" || item["name"] != "read_file" {
+				t.Errorf("function_call item = %v, want call_abc/read_file", item)
+			}
+			if item["arguments"] != `{"path":"a.go"}` {
+				t.Errorf("function_call arguments = %v, want the raw args JSON string", item["arguments"])
+			}
+		case "function_call_output":
+			sawOutput = true
+			if item["call_id"] != "call_abc" {
+				t.Errorf("function_call_output call_id = %v, want call_abc", item["call_id"])
+			}
+			if item["output"] != "package main" {
+				t.Errorf("function_call_output output = %v, want %q", item["output"], "package main")
+			}
+		}
+	}
+	if !sawCall {
+		t.Error("wire input missing the replayed function_call item")
+	}
+	if !sawOutput {
+		t.Error("wire input missing the function_call_output item")
+	}
+}


### PR DESCRIPTION
## Summary
- Serialize pigo tools as Responses API function tools (name, description, JSON-Schema parameters; strict=false)
- Parse model function_call output into pigo ToolCallContent (id + name + raw arguments), set StopReason=tool_use
- Emit StreamToolCallEvent mid-stream from finalized output_item.done events
- Backfill prior tool calls/results as function_call + function_call_output items keyed by call_id for multi-turn round-trips

Closes #541

## Test plan
- [x] TestResponsesDriverSendsToolSchema — pigo tool reaches wire as a function tool
- [x] TestResponsesDriverParsesToolCall — function_call parsed to pigo tool call + tool_use stop
- [x] TestResponsesDriverBackfillsToolResult — call/result replayed keyed by call_id
- [x] go build ./... && go vet ./internal/provider/ && go test ./internal/provider/ clean