### PR TITLE
feat(responses): image input + reasoning for Responses driver

### DIFF
--- a/docs/issue#0542.html
+++ b/docs/issue#0542.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0542</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #FAF9F6; color: #1a1a1a; padding: 2.5rem 2rem; line-height: 1.7; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-top: 2rem; margin-bottom: 0.75rem; padding-bottom: 0.375rem; border-bottom: 1px solid #E8E4DE; display: flex; align-items: center; gap: 0.5rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; } .dot.deviation { background: #D97757; } .dot.tradeoff { background: #4A6FA5; } .dot.question { background: #D4A843; }
+    .item { background: #FFFFFF; border: 1px solid #E8E4DE; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 0.75rem; box-shadow: 0 1px 3px rgba(0,0,0,0.03); }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label { display: inline-block; font-size: 0.6875rem; font-weight: 500; padding: 0.125rem 0.5rem; border-radius: 4px; margin-right: 0.375rem; }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+    code { background: #F0EEE9; padding: 0.05rem 0.3rem; border-radius: 3px; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/542">#542</a> &mdash; Responses 驱动 — 图片/reasoning &mdash; 2026-08-02</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> All streaming partials built through one <code>buildPartial</code> helper</h3>
+      <p><strong>Ambiguity:</strong> Adding a reasoning (thinking) block means every partial-emit site must now assemble thinking + text + tool calls in a consistent order. The spec says reasoning should render "like the chat driver" but doesn't prescribe how partials are constructed.</p>
+      <p><strong>Choice:</strong> Introduced <code>buildPartial(thinking, text, toolCalls)</code> and routed all four emit sites (text delta, reasoning delta, tool-call done, and the no-<code>completed</code> fallback) through it.</p>
+      <p><strong>Rationale:</strong> A single builder guarantees every cumulative snapshot orders content identically (thinking → text → tool calls) and can't drift as new event types are added; it also collapsed the three previously-duplicated inline partial constructions.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> <code>minimal</code> thinking level collapses to reasoning effort <code>low</code></h3>
+      <p><strong>Ambiguity:</strong> pigo's <code>ThinkingLevel</code> enum has six values (off/minimal/low/medium/high/xhigh); the Responses API <code>reasoning.effort</code> field accepts only low/medium/high.</p>
+      <p><strong>Choice:</strong> <code>responsesReasoningEffort</code> maps minimal→low, low→low, medium→medium, high/xhigh→high, and off/unset→"" (no reasoning param emitted).</p>
+      <p><strong>Rationale:</strong> The chat driver forwards "minimal" verbatim, but the Responses API would reject it; low is the nearest supported floor. Emitting "" for off/unset keeps a non-reasoning request byte-identical to before this change.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Reasoning enabled ⇒ request an <code>auto</code> summary</h3>
+      <p><strong>Ambiguity:</strong> The Responses API only returns a reasoning summary if one is requested; the spec says "reasoning 输出（若返回）与 chat 驱动一致地呈现" but doesn't say to request it.</p>
+      <p><strong>Choice:</strong> When effort is non-empty, set <code>Reasoning{Effort: effort, Summary: ReasoningSummaryAuto}</code>.</p>
+      <p><strong>Rationale:</strong> Without a summary request the model reasons but returns nothing to render; <code>auto</code> lets the API pick an appropriate summary granularity so a thinking block actually appears — satisfying the "presented like the chat driver" criterion.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Images replayed only on non-assistant (user) messages</h3>
+      <p><strong>Ambiguity:</strong> The issue says "图片 content part 映射为 Responses-API input items" without naming which message roles carry images.</p>
+      <p><strong>Choice:</strong> Image handling lives in the <code>default</code> (user) branch of <code>appendInputItems</code> via <code>imageInputParts</code>; the assistant and tool-result branches are unchanged.</p>
+      <p><strong>Rationale:</strong> Images flow in on user turns in pigo, matching the chat driver's <code>openAIUserContent</code> which only builds multimodal parts for user content. Assistant/tool-result image replay is not a real path today.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None — implementation followed the issue spec (image content parts mapped to input_image data URIs, thinking level mapped to reasoning.effort, reasoning output surfaced as a thinking block, and unit tests covering one image-input request and one reasoning-enabled request).</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> <code>image_url</code> data URI vs. file upload / hosted URL</h3>
+      <p><strong>Alternatives:</strong> Upload the image via the Files API and reference a <code>file_id</code>, or pass a hosted <code>image_url</code>.</p>
+      <p><strong>Chosen:</strong> Inline <code>data:&lt;mime&gt;;base64,&lt;data&gt;</code> URI on an <code>input_image</code> part, with detail <code>auto</code>.</p>
+      <p><strong>Why:</strong> pigo already holds image bytes as base64 in <code>ImageContent</code>; a data URI is a stateless single-request mapping that matches the chat driver's <code>image_url</code> approach and needs no extra upload round-trip or lifecycle management.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Reasoning parsed from <code>response.completed</code>, deltas only feed interim partials</h3>
+      <p><strong>Alternatives:</strong> Aggregate the terminal thinking block from the accumulated <code>reasoning_summary_text.delta</code> events.</p>
+      <p><strong>Chosen:</strong> <code>mapResponse</code> re-reads reasoning from <code>resp.Output</code> (via <code>item.AsReasoning()</code>) for the terminal message; the delta events only drive interim <code>StreamThinkingEvent</code> partials.</p>
+      <p><strong>Why:</strong> Same principle as #540/#541 — the completed envelope is authoritative, so the streamed terminal message stays byte-identical to a non-streamed one. Delta accumulation would risk drift between the two paths.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Streaming reasoning-delta path not covered by a dedicated test</h3>
+      <p>The <code>ResponseReasoningSummaryTextDeltaEvent</code> case shares <code>buildPartial</code> with the (tested) text-delta path, and the reasoning <em>output parse</em> is tested via <code>response.completed</code>. But no test asserts a mid-stream <code>StreamThinkingEvent</code> fires from a reasoning delta frame. Acceptable for this milestone; confirm whether a streaming-thinking assertion is wanted.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Tool-result and assistant messages still flatten images to text</h3>
+      <p>Only user-role messages emit image parts. A <code>ToolResultMessage</code> carrying an image is still serialized text-only via <code>function_call_output</code> (inherited from #541), and assistant messages replay text + tool calls only. Confirm no flow needs image round-tripping on those roles.</p>
+    </div>
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Image detail hard-coded to <code>auto</code></h3>
+      <p>Every <code>input_image</code> part uses detail <code>auto</code>; pigo's <code>ImageContent</code> carries no detail hint. If callers need <code>high</code>/<code>low</code> control (cost vs. fidelity), a mapping would need to be added upstream. Verify <code>auto</code> is an acceptable default.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/internal/provider/responses.go
+++ b/internal/provider/responses.go
@@ -113,6 +113,7 @@ func (d *responsesDriver) pump(ctx context.Context, stream *AssistantMessageEven
 	defer sse.Close()
 
 	var text strings.Builder
+	var thinking strings.Builder
 	var toolCalls []agentcore.ToolCallContent
 	var completed *responses.Response
 	for sse.Next() {
@@ -123,10 +124,17 @@ func (d *responsesDriver) pump(ctx context.Context, stream *AssistantMessageEven
 		switch variant := sse.Current().AsAny().(type) {
 		case responses.ResponseTextDeltaEvent:
 			text.WriteString(variant.Delta)
-			partial := d.newPartial()
-			partial.Content = append(partial.Content, agentcore.NewTextContent(text.String()))
-			partial.Content = appendToolCalls(partial.Content, toolCalls)
+			partial := d.buildPartial(thinking.String(), text.String(), toolCalls)
 			if err := stream.Emit(ctx, StreamTextEvent{Partial: partial}); err != nil {
+				return
+			}
+		case responses.ResponseReasoningSummaryTextDeltaEvent:
+			// The model's reasoning summary streams as its own text deltas, distinct
+			// from the answer text; accumulate it into a thinking block so the TUI
+			// renders reasoning the same way the chat driver does.
+			thinking.WriteString(variant.Delta)
+			partial := d.buildPartial(thinking.String(), text.String(), toolCalls)
+			if err := stream.Emit(ctx, StreamThinkingEvent{Partial: partial}); err != nil {
 				return
 			}
 		case responses.ResponseOutputItemDoneEvent:
@@ -135,11 +143,7 @@ func (d *responsesDriver) pump(ctx context.Context, stream *AssistantMessageEven
 			// partial so the TUI can show the pending call before the run ends.
 			if fc := variant.Item.AsFunctionCall(); fc.Type == "function_call" {
 				toolCalls = append(toolCalls, toolCallContent(fc))
-				partial := d.newPartial()
-				if t := text.String(); t != "" {
-					partial.Content = append(partial.Content, agentcore.NewTextContent(t))
-				}
-				partial.Content = appendToolCalls(partial.Content, toolCalls)
+				partial := d.buildPartial(thinking.String(), text.String(), toolCalls)
 				if err := stream.Emit(ctx, StreamToolCallEvent{Partial: partial}); err != nil {
 					return
 				}
@@ -164,17 +168,30 @@ func (d *responsesDriver) pump(ctx context.Context, stream *AssistantMessageEven
 	if completed != nil {
 		msg = d.mapResponse(completed)
 	} else {
-		msg = d.newPartial()
+		msg = d.buildPartial(thinking.String(), text.String(), toolCalls)
 		msg.StopReason = agentcore.StopReasonEndTurn
-		if t := text.String(); t != "" {
-			msg.Content = append(msg.Content, agentcore.NewTextContent(t))
-		}
-		msg.Content = appendToolCalls(msg.Content, toolCalls)
 		if len(toolCalls) > 0 {
 			msg.StopReason = agentcore.StopReasonToolUse
 		}
 	}
 	stream.Emit(ctx, StreamDoneEvent{Message: msg})
+}
+
+// buildPartial assembles a cumulative snapshot message for a streaming partial:
+// an optional thinking block (reasoning summary so far), the accumulated answer
+// text, then any finalized tool calls — in the order the TUI should render them.
+// All four emit sites in pump build partials through this one helper so they
+// can't diverge.
+func (d *responsesDriver) buildPartial(thinking, text string, toolCalls []agentcore.ToolCallContent) agentcore.AssistantMessage {
+	msg := d.newPartial()
+	if thinking != "" {
+		msg.Content = append(msg.Content, agentcore.NewThinkingContent(thinking))
+	}
+	if text != "" {
+		msg.Content = append(msg.Content, agentcore.NewTextContent(text))
+	}
+	msg.Content = appendToolCalls(msg.Content, toolCalls)
+	return msg
 }
 
 // emitError emits a terminal StreamErrorEvent tagged for this provider. Uses a
@@ -203,14 +220,17 @@ func (d *responsesDriver) newPartial() agentcore.AssistantMessage {
 }
 
 // mapResponse materializes a completed Responses API result into pigo's
-// AssistantMessage: text content, tool calls, usage (when present),
-// diagnostics, and a stop reason (tool_use when the model requested a tool,
-// otherwise end_turn).
+// AssistantMessage: a reasoning summary (as a thinking block, when present),
+// text content, tool calls, usage (when present), diagnostics, and a stop reason
+// (tool_use when the model requested a tool, otherwise end_turn).
 func (d *responsesDriver) mapResponse(resp *responses.Response) agentcore.AssistantMessage {
 	msg := d.newPartial()
 	msg.StopReason = agentcore.StopReasonEndTurn
 	msg.ResponseID = resp.ID
 	msg.ResponseModel = string(resp.Model)
+	if thinking := reasoningText(resp); thinking != "" {
+		msg.Content = append(msg.Content, agentcore.NewThinkingContent(thinking))
+	}
 	if text := resp.OutputText(); text != "" {
 		msg.Content = append(msg.Content, agentcore.NewTextContent(text))
 	}
@@ -240,6 +260,23 @@ func toolCallContent(fc responses.ResponseFunctionToolCall) agentcore.ToolCallCo
 	return agentcore.NewToolCallContent(fc.CallID, fc.Name, json.RawMessage(fc.Arguments))
 }
 
+// reasoningText concatenates the summary text of every reasoning item in a
+// completed response. The Responses API returns the model's reasoning as one or
+// more reasoning items, each carrying summary parts; pigo surfaces the joined
+// text as a single thinking block, mirroring how the chat driver renders
+// accumulated reasoning_content.
+func reasoningText(resp *responses.Response) string {
+	var b strings.Builder
+	for _, item := range resp.Output {
+		if r := item.AsReasoning(); r.Type == "reasoning" {
+			for _, s := range r.Summary {
+				b.WriteString(s.Text)
+			}
+		}
+	}
+	return b.String()
+}
+
 // appendToolCalls appends each accumulated tool call to a content list. Kept
 // separate so the streaming partial and the terminal message build identical
 // content from the same source.
@@ -251,17 +288,23 @@ func appendToolCalls(content agentcore.ContentList, calls []agentcore.ToolCallCo
 }
 
 // buildResponsesParams maps a CompletionRequest onto Responses API params. The
-// system prompt becomes Instructions; pigo tools become Responses function
-// tools; and each message is replayed as the matching input item(s): assistant
-// tool calls as function_call items, tool results as function_call_output
-// items, and text as a role-tagged message. Non-text message content (images)
-// is deferred to #542.
+// system prompt becomes Instructions; the thinking level becomes a reasoning
+// effort (with an auto summary so reasoning is returned); pigo tools become
+// Responses function tools; and each message is replayed as the matching input
+// item(s): assistant tool calls as function_call items, tool results as
+// function_call_output items, and text (plus any images) as a role-tagged
+// message.
 func buildResponsesParams(req CompletionRequest) responses.ResponseNewParams {
 	params := responses.ResponseNewParams{
 		Model: shared.ResponsesModel(req.Model),
 	}
 	if sp := strings.TrimSpace(req.Context.SystemPrompt); sp != "" {
 		params.Instructions = openai.String(sp)
+	}
+	if effort := responsesReasoningEffort(req.Config.ThinkingLevel); effort != "" {
+		// Requesting a summary makes the API return the model's reasoning so pigo
+		// can render it as a thinking block, matching the chat driver.
+		params.Reasoning = shared.ReasoningParam{Effort: effort, Summary: shared.ReasoningSummaryAuto}
 	}
 	if tools := buildResponsesTools(req.Context.Tools); len(tools) > 0 {
 		params.Tools = tools
@@ -319,12 +362,67 @@ func appendInputItems(items responses.ResponseInputParam, m agentcore.Message) r
 				string(call.Arguments), call.ID, call.Name))
 		}
 	default:
-		if text := messageText(m); text != "" {
+		// A user (or other non-assistant) message with images is replayed as a
+		// content-part list (input_text + input_image data URIs); a text-only
+		// message stays a plain string.
+		if parts, ok := imageInputParts(m); ok {
+			items = append(items, responses.ResponseInputItemParamOfMessage(parts, responsesRole(m.Role())))
+		} else if text := messageText(m); text != "" {
 			items = append(items, responses.ResponseInputItemParamOfMessage(
 				text, responsesRole(m.Role())))
 		}
 	}
 	return items
+}
+
+// imageInputParts builds a Responses content-part list for a message that
+// carries at least one image: leading input_text (the concatenated text, if
+// any) followed by one input_image per image, each as a data URI. It returns
+// ok=false when the message has no images, so the caller keeps the plain-text
+// path.
+func imageInputParts(m agentcore.Message) (responses.ResponseInputMessageContentListParam, bool) {
+	content := messageContent(m)
+	var hasImage bool
+	for _, c := range content {
+		if _, ok := c.(agentcore.ImageContent); ok {
+			hasImage = true
+			break
+		}
+	}
+	if !hasImage {
+		return nil, false
+	}
+	parts := make(responses.ResponseInputMessageContentListParam, 0, len(content)+1)
+	if text := contentText(content); text != "" {
+		parts = append(parts, responses.ResponseInputContentParamOfInputText(text))
+	}
+	for _, c := range content {
+		img, ok := c.(agentcore.ImageContent)
+		if !ok {
+			continue
+		}
+		part := responses.ResponseInputContentParamOfInputImage(responses.ResponseInputImageDetailAuto)
+		part.OfInputImage.ImageURL = openai.String(fmt.Sprintf("data:%s;base64,%s", img.MimeType, img.Data))
+		parts = append(parts, part)
+	}
+	return parts, true
+}
+
+// responsesReasoningEffort maps pigo's thinking level to a Responses API
+// reasoning effort. The Responses reasoning field supports only low/medium/high,
+// so "minimal" collapses to "low" (unlike the chat driver, which forwards
+// "minimal" verbatim). off/unset yields "", signalling no reasoning param.
+func responsesReasoningEffort(level agentcore.ThinkingLevel) shared.ReasoningEffort {
+	switch level {
+	case agentcore.ThinkingMinimal, agentcore.ThinkingLow:
+		return shared.ReasoningEffortLow
+	case agentcore.ThinkingMedium:
+		return shared.ReasoningEffortMedium
+	case agentcore.ThinkingHigh, agentcore.ThinkingXHigh:
+		return shared.ReasoningEffortHigh
+	default:
+		return ""
+	}
 }
 
 // responsesRole maps a pigo message role to the Responses API input role. Tool
@@ -338,18 +436,25 @@ func responsesRole(role string) responses.EasyInputMessageRole {
 	}
 }
 
+// messageContent returns the content list of a message regardless of its
+// concrete role type, so callers can inspect it for images.
+func messageContent(m agentcore.Message) agentcore.ContentList {
+	switch msg := m.(type) {
+	case agentcore.UserMessage:
+		return msg.Content
+	case agentcore.AssistantMessage:
+		return msg.Content
+	case agentcore.ToolResultMessage:
+		return msg.Content
+	}
+	return nil
+}
+
 // messageText concatenates the text blocks of a message, ignoring non-text
 // content (handled in later milestones).
 func messageText(m agentcore.Message) string {
 	var b strings.Builder
-	switch msg := m.(type) {
-	case agentcore.UserMessage:
-		collectText(&b, msg.Content)
-	case agentcore.AssistantMessage:
-		collectText(&b, msg.Content)
-	case agentcore.ToolResultMessage:
-		collectText(&b, msg.Content)
-	}
+	collectText(&b, messageContent(m))
 	return b.String()
 }
 

--- a/internal/provider/responses_test.go
+++ b/internal/provider/responses_test.go
@@ -595,3 +595,162 @@ func TestResponsesDriverBackfillsToolResult(t *testing.T) {
 		t.Error("wire input missing the function_call_output item")
 	}
 }
+
+// completedReasoningFrame is a response.completed frame whose output carries a
+// reasoning item (summary text) followed by the assistant message text.
+func completedReasoningFrame(id, model, summary, text string) string {
+	frame := map[string]any{
+		"type":            "response.completed",
+		"sequence_number": 99,
+		"response": map[string]any{
+			"id":    id,
+			"model": model,
+			"output": []any{
+				map[string]any{
+					"type": "reasoning",
+					"id":   "rs_1",
+					"summary": []any{map[string]any{
+						"type": "summary_text",
+						"text": summary,
+					}},
+				},
+				map[string]any{
+					"type":   "message",
+					"role":   "assistant",
+					"status": "completed",
+					"content": []any{map[string]any{
+						"type": "output_text",
+						"text": text,
+					}},
+				},
+			},
+			"usage": map[string]any{
+				"input_tokens":          3,
+				"output_tokens":         4,
+				"input_tokens_details":  map[string]any{"cached_tokens": 0},
+				"output_tokens_details": map[string]any{"reasoning_tokens": 2},
+			},
+		},
+	}
+	b, _ := json.Marshal(frame)
+	return string(b)
+}
+
+// A user message carrying an image must reach the wire as a message whose
+// content is a part list: an input_text part plus an input_image part whose
+// image_url is the base64 data URI.
+func TestResponsesDriverSendsImageInput(t *testing.T) {
+	var gotBody string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Body != nil {
+			b, _ := io.ReadAll(r.Body)
+			gotBody = string(b)
+		}
+		return sseResponse(completedFrame("ok", "resp_1", "gpt-4o", 1, 1)), nil
+	})
+	d := newResponsesTestDriver("https://api.openai.test/v1", rt)
+
+	imgMsg := agentcore.UserMessage{
+		RoleField: agentcore.RoleUser,
+		Content: agentcore.ContentList{
+			agentcore.NewTextContent("what is this?"),
+			agentcore.NewImageContent("aGVsbG8=", "image/png"),
+		},
+	}
+	stream, err := d.StreamCompletion(context.Background(), CompletionRequest{
+		Model:   "gpt-4o",
+		Context: LlmContext{Messages: agentcore.MessageList{imgMsg}},
+		Config:  StreamConfig{APIKey: "sk-test"},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned early error: %v", err)
+	}
+	drain(t, stream)
+
+	var payload struct {
+		Input []struct {
+			Type    string           `json:"type"`
+			Role    string           `json:"role"`
+			Content []map[string]any `json:"content"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal([]byte(gotBody), &payload); err != nil {
+		t.Fatalf("request body not valid JSON: %v", err)
+	}
+	if len(payload.Input) != 1 {
+		t.Fatalf("got %d input items, want 1", len(payload.Input))
+	}
+	parts := payload.Input[0].Content
+	var sawText, sawImage bool
+	for _, p := range parts {
+		switch p["type"] {
+		case "input_text":
+			sawText = true
+			if p["text"] != "what is this?" {
+				t.Errorf("input_text = %v, want %q", p["text"], "what is this?")
+			}
+		case "input_image":
+			sawImage = true
+			if p["image_url"] != "data:image/png;base64,aGVsbG8=" {
+				t.Errorf("input_image image_url = %v, want the data URI", p["image_url"])
+			}
+		}
+	}
+	if !sawText {
+		t.Error("wire input missing the input_text part")
+	}
+	if !sawImage {
+		t.Error("wire input missing the input_image part")
+	}
+}
+
+// A request with a thinking level must set the reasoning.effort (and an auto
+// summary) on the wire, and a reasoning item in the completed response must be
+// parsed into a leading ThinkingContent block.
+func TestResponsesDriverReasoning(t *testing.T) {
+	var gotBody string
+	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Body != nil {
+			b, _ := io.ReadAll(r.Body)
+			gotBody = string(b)
+		}
+		return sseResponse(completedReasoningFrame("resp_9", "gpt-4o", "let me think", "the answer")), nil
+	})
+	d := newResponsesTestDriver("https://api.openai.test/v1", rt)
+
+	stream, err := d.StreamCompletion(context.Background(), CompletionRequest{
+		Model:   "gpt-4o",
+		Context: LlmContext{Messages: agentcore.MessageList{userMsg("solve it")}},
+		Config:  StreamConfig{APIKey: "sk-test", ThinkingLevel: agentcore.ThinkingMedium},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned early error: %v", err)
+	}
+	msg := drain(t, stream)
+
+	var payload struct {
+		Reasoning struct {
+			Effort  string `json:"effort"`
+			Summary string `json:"summary"`
+		} `json:"reasoning"`
+	}
+	if err := json.Unmarshal([]byte(gotBody), &payload); err != nil {
+		t.Fatalf("request body not valid JSON: %v", err)
+	}
+	if payload.Reasoning.Effort != "medium" {
+		t.Errorf("reasoning.effort = %q, want medium", payload.Reasoning.Effort)
+	}
+	if payload.Reasoning.Summary != "auto" {
+		t.Errorf("reasoning.summary = %q, want auto", payload.Reasoning.Summary)
+	}
+
+	var thinking string
+	for _, c := range msg.Content {
+		if tc, ok := c.(agentcore.ThinkingContent); ok {
+			thinking = tc.Thinking
+		}
+	}
+	if thinking != "let me think" {
+		t.Errorf("thinking content = %q, want %q", thinking, "let me think")
+	}
+}


### PR DESCRIPTION
## Summary
- Map image content parts on user messages to Responses `input_image` data URIs (`data:<mime>;base64,<data>`, detail `auto`).
- Map pigo thinking level to `reasoning.effort` (minimal→low, low→low, medium→medium, high/xhigh→high; off/unset→no reasoning param) with `reasoning.summary=auto` so the model returns a renderable reasoning summary.
- Surface reasoning as a thinking block, parsed authoritatively from `response.completed`; streaming deltas only feed interim partials.
- Consolidate all four streaming partial-emit sites through one `buildPartial` helper so thinking/text/tool-call ordering can't drift.

Closes #542

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/provider/`
- [x] `go test ./internal/provider/` (TestResponsesDriverSendsImageInput, TestResponsesDriverReasoning)
- [x] `gofmt -l` clean