### PR TITLE
docs: document three openai protocol wire variants

### DIFF
--- a/docs/issue#0545.html
+++ b/docs/issue#0545.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Implementation Notes — Issue #0545</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #FAF9F6;
+      color: #1a1a1a;
+      padding: 2.5rem 2rem;
+      line-height: 1.7;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .meta { color: #8B8680; font-size: 0.8125rem; margin-bottom: 2rem; }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.375rem;
+      border-bottom: 1px solid #E8E4DE;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+    .dot.design { background: #5B8A72; }
+    .dot.deviation { background: #D97757; }
+    .dot.tradeoff { background: #4A6FA5; }
+    .dot.question { background: #D4A843; }
+    .item {
+      background: #FFFFFF;
+      border: 1px solid #E8E4DE;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.03);
+    }
+    .item h3 { font-size: 0.875rem; font-weight: 600; margin-bottom: 0.375rem; }
+    .item p { font-size: 0.8125rem; color: #4A4540; margin-bottom: 0.375rem; }
+    .label {
+      display: inline-block;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      padding: 0.125rem 0.5rem;
+      border-radius: 4px;
+      margin-right: 0.375rem;
+    }
+    .label-design { background: #F5F8F6; color: #5B8A72; border: 1px solid #5B8A72; }
+    .label-deviation { background: #FFF5F0; color: #D97757; border: 1px solid #D97757; }
+    .label-tradeoff { background: #F0F4F8; color: #4A6FA5; border: 1px solid #4A6FA5; }
+    .label-question { background: #FDF8F0; color: #D4A843; border: 1px solid #D4A843; }
+    .none { color: #B0AAA4; font-style: italic; font-size: 0.8125rem; }
+    code { background: #F0EEE9; padding: 0.1rem 0.3rem; border-radius: 3px; font-size: 0.8em; }
+    .footer { text-align: center; margin-top: 2.5rem; color: #B0AAA4; font-size: 0.6875rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Implementation Notes</h1>
+    <p class="meta">Issue <a href="https://github.com/smallnest/pigo/issues/545">#545</a> &mdash; configuration.html 说明三个 protocol 值 (US-009) &mdash; 2026-08-02</p>
+
+    <h2><span class="dot design"></span> Design Decisions</h2>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Dedicated "OpenAI wire variants" subsection + table</h3>
+      <p><strong>Ambiguity:</strong> The AC required listing <code>openai</code> / <code>openai/chat</code> / <code>openai/resp_api</code> with a one-line meaning each, but not where in the doc.</p>
+      <p><strong>Choice:</strong> Added an <code>&lt;h3&gt;</code> "OpenAI wire variants" with a two-column table right after "Selecting a provider", plus a when-to-choose paragraph and a runnable example block.</p>
+      <p><strong>Rationale:</strong> The Providers section already discusses protocols and base-url; placing the variant table there keeps related material together and matches the page's existing table + copy-wrap idiom.</p>
+    </div>
+
+    <div class="item">
+      <h3><span class="label label-design">Decision</span> Also updated the config-key row and the resolution list</h3>
+      <p><strong>Ambiguity:</strong> AC named only the variant explanation, but the existing <code>protocol</code> key row and the resolution pseudocode still read "openai / anthropic".</p>
+      <p><strong>Choice:</strong> Updated line 69's <code>protocol</code> row and the <code>--protocol</code> resolution step to enumerate all four accepted values.</p>
+      <p><strong>Rationale:</strong> Leaving the two-value description would contradict the new section; consistency across the page prevents confusion.</p>
+    </div>
+
+    <h2><span class="dot deviation"></span> Deviations</h2>
+    <p class="none">None — implementation followed the spec as written.</p>
+
+    <h2><span class="dot tradeoff"></span> Tradeoffs</h2>
+
+    <div class="item">
+      <h3><span class="label label-tradeoff">Tradeoff</span> Table for the three values vs inline bullet list</h3>
+      <p><strong>Alternatives:</strong> (a) a two-column table mapping value → wire format/endpoint; (b) a <code>&lt;ul&gt;</code> of bilingual list items.</p>
+      <p><strong>Chosen:</strong> (a) the table — it aligns each value with its endpoint clearly and mirrors the neighboring "Built-in providers" table style.</p>
+      <p><strong>Why:</strong> The endpoint mapping (<code>/chat/completions</code> vs <code>/responses</code>) is the key takeaway; a table makes the correspondence scannable.</p>
+    </div>
+
+    <h2><span class="dot question"></span> Open Questions</h2>
+
+    <div class="item">
+      <h3><span class="label label-question">Question</span> Should the base-url requirement be repeated per row?</h3>
+      <p><strong>Assumption:</strong> Stating "Both <code>openai</code> and <code>openai/resp_api</code> require an explicit <code>--base-url</code>" once in the prose paragraph is sufficient.</p>
+      <p><strong>Verify:</strong> Whether readers want that constraint surfaced directly in the table rows too — currently kept in prose to avoid table clutter.</p>
+    </div>
+
+    <p class="footer">Generated by goal-workflow /note-it</p>
+  </div>
+</body>
+</html>

--- a/docs/web/configuration.html
+++ b/docs/web/configuration.html
@@ -66,7 +66,7 @@
           <tr><td><code>base_url</code></td><td data-en="OpenAI-compatible endpoint" data-zh="OpenAI 兼容端点"></td></tr>
           <tr><td><code>api_key</code></td><td data-en="Inline key (prefer env vars)" data-zh="内联密钥（建议改用环境变量）"></td></tr>
           <tr><td><code>provider</code></td><td data-en="Force a named provider" data-zh="强制指定 provider"></td></tr>
-          <tr><td><code>protocol</code></td><td data-en="Wire protocol (openai / anthropic)" data-zh="通信协议（openai / anthropic）"></td></tr>
+          <tr><td><code>protocol</code></td><td data-en="Wire protocol (openai / openai/chat / openai/resp_api / anthropic)" data-zh="通信协议（openai / openai/chat / openai/resp_api / anthropic）"></td></tr>
           <tr><td><code>output_format</code></td><td data-en="text or json" data-zh="text 或 json"></td></tr>
           <tr><td><code>thinking_level</code></td><td data-en="Reasoning effort" data-zh="推理强度"></td></tr>
           <tr><td><code>approve</code></td><td data-en="Auto-approve tool calls" data-zh="自动批准工具调用"></td></tr>
@@ -85,7 +85,7 @@
       <p data-en="Resolution runs top to bottom; the first match wins:"
          data-zh="解析自上而下，命中即止："></p>
       <pre><code>1. --provider &lt;name&gt;      # 显式指定，最高优先级
-2. --protocol openai|anthropic
+2. --protocol openai|openai/chat|openai/resp_api|anthropic
 3. 预置目录 (preset catalog) 中的已知模型 id
 4. ollama/ 或 nvidia/ 前缀，或端口 11434 → 本地 / NVIDIA
 5. 按模型名前缀推断 (claude-* → anthropic, gpt-* → openai …)
@@ -143,6 +143,32 @@ pigo -u http://localhost:11434/v1 -m qwen3</code></pre>
         <button class="copy-btn" data-copy='pigo -m claude-opus-4-7
 pigo --provider groq -m llama-3.3-70b
 pigo -u http://localhost:11434/v1 -m qwen3'>Copy</button>
+      </div>
+
+      <h3 data-en="OpenAI wire variants" data-zh="OpenAI 通信变体"></h3>
+      <p data-en="The <code>--protocol</code> / <code>protocol</code> value accepts three OpenAI wire variants in addition to <code>anthropic</code>. They select which HTTP endpoint pigo speaks to against your <code>--base-url</code>:"
+         data-zh="<code>--protocol</code> / <code>protocol</code> 除 <code>anthropic</code> 外还接受三个 OpenAI 通信变体，它们决定 pigo 针对你的 <code>--base-url</code> 调用哪个 HTTP 端点："></p>
+      <table>
+        <thead><tr>
+          <th data-en="Value" data-zh="取值"></th>
+          <th data-en="Wire format / endpoint" data-zh="通信格式 / 端点"></th>
+        </tr></thead>
+        <tbody>
+          <tr><td><code>openai</code></td><td data-en="Chat Completions — POST <code>{base_url}/chat/completions</code> (alias of <code>openai/chat</code>)" data-zh="Chat Completions —— POST <code>{base_url}/chat/completions</code>（<code>openai/chat</code> 的别名）"></td></tr>
+          <tr><td><code>openai/chat</code></td><td data-en="Chat Completions — POST <code>{base_url}/chat/completions</code>" data-zh="Chat Completions —— POST <code>{base_url}/chat/completions</code>"></td></tr>
+          <tr><td><code>openai/resp_api</code></td><td data-en="Responses API — POST <code>{base_url}/responses</code> (official openai-go SDK)" data-zh="Responses API —— POST <code>{base_url}/responses</code>（官方 openai-go SDK）"></td></tr>
+        </tbody>
+      </table>
+      <p data-en="<strong>When to choose which:</strong> use <code>openai</code> / <code>openai/chat</code> for the widely-supported Chat Completions endpoint — it works with virtually every OpenAI-compatible gateway. Choose <code>openai/resp_api</code> only when your endpoint implements OpenAI's newer Responses API (<code>/responses</code>), e.g. to use server-side reasoning or the stateful response object. Both <code>openai</code> and <code>openai/resp_api</code> require an explicit <code>--base-url</code>."
+         data-zh="<strong>如何选择：</strong>面向广泛支持的 Chat Completions 端点时用 <code>openai</code> / <code>openai/chat</code>，几乎所有 OpenAI 兼容网关都支持它。仅当你的端点实现了 OpenAI 较新的 Responses API（<code>/responses</code>）时才选 <code>openai/resp_api</code>，例如需要服务端 reasoning 或有状态的 response 对象。<code>openai</code> 与 <code>openai/resp_api</code> 都要求显式提供 <code>--base-url</code>。"></p>
+      <div class="copy-wrap">
+        <pre><code># Chat Completions（默认 OpenAI 变体）
+pigo --protocol openai -u https://my-gateway/v1 -m my-model
+
+# Responses API（官方 SDK，需端点支持 /responses）
+pigo --protocol openai/resp_api -u https://my-gateway/v1 -m my-model</code></pre>
+        <button class="copy-btn" data-copy='pigo --protocol openai -u https://my-gateway/v1 -m my-model
+pigo --protocol openai/resp_api -u https://my-gateway/v1 -m my-model'>Copy</button>
       </div>
 
       <h2 data-en="Nested tables" data-zh="嵌套表"></h2>


### PR DESCRIPTION
## Summary
- `docs/web/configuration.html` gains an "OpenAI wire variants" section listing `openai` / `openai/chat` / `openai/resp_api`, each with its endpoint meaning (EN + ZH `data-*`)
- Added guidance on when to choose the Responses API (`/responses`) vs Chat Completions (`/chat/completions`), noting both require `--base-url`
- Updated the `protocol` config-key row and the `--protocol` resolution step to enumerate all four accepted values
- Markup validated (tag balance clean)

Closes #545

## Test plan
- [x] HTML tag balance validated
- [x] All new elements carry both `data-en` and `data-zh`
- [x] Follows existing table + copy-wrap idiom