### PR TITLE
feat: 添加工具策略和允许列表配置功能

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ interactive REPL/TUI.
 ## [Unreleased]
 
 ### Added
+- **Tool-level admission control**: `--allowed-tools` / `--disallowed-tools`
+  (repeatable, comma-separated, case-insensitive) narrow the tool set handed to
+  the model, filling the gap between the full set and `--no-tools`. Deny wins
+  over allow on conflict; task sub-agents inherit the boundary; an unknown tool
+  name aborts with exit code 2 instead of being silently ignored. Because
+  filtering happens at the tool-registration layer — before the side-effect
+  confirmation gate — `--approve` waives confirmation prompts but cannot widen
+  the boundary. Also configurable as `allowed_tools` / `disallowed_tools` in
+  `config.toml`.
 - **Self-update**: `pigo update` with no package name (or flags-only calls such
   as `pigo update --check`) now upgrades the pigo binary itself to the latest
   GitHub Release, replacing the executable in place (with a `sudo` hint when the

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ pigo 可以读写文件、执行命令、检索代码、抓取网页，并借助
 - **stream-json 输出**：逐行 JSON 事件，首个事件携带 `session_id`，便于调用方关联。
 - **系统提示词分层组装**：base 指令 + 环境块 + `AGENTS.md`（general→specific）+ `--append-system-prompt`。
 - **项目信任**：副作用工具（bash/write/edit）在未信任目录需确认，`--approve` 一次性授权。
+- **工具级准入**：`--allowed-tools` / `--disallowed-tools` 划定工具边界（黑名单优先、子 Agent 继承、`--approve` 不可绕过）。
 - **技能与插件**：`~/.agents/skills` 下的 `/slash` 命令、`~/.pigo/plugins` 下的外部插件。
 - **提示词模板**：`~/.pigo/prompts`、项目 `.pigo/prompts`（受信任时）、config `prompts`、`--prompt-template` 下的可复用 `/name` 模板，支持 `$1`/`$@`/`${1:-default}`/`${@:N}` 等参数语法。
 - **上下文自动压缩**：接近上下文窗口上限时自动摘要，亦可 `/compact` 手动触发。
@@ -159,6 +160,8 @@ pigo -m ollama/qwen2.5-coder -u http://localhost:11434/v1 -p "解释 main.go 做
 | `--protocol` | `-P` | `""` | 强制线路协议：`openai` \| `anthropic`（默认由 model id 推断） |
 | `--output-format` | `-o` | `text` | 输出格式：`text` \| `stream-json` |
 | `--no-tools` | `-n` | `false` | 禁用内置文件/shell 工具（同时跳过插件发现） |
+| `--allowed-tools` | | `nil` | 工具白名单：只把这些工具交给模型；可重复、可逗号分隔、大小写不敏感；为空表示不限制 |
+| `--disallowed-tools` | | `nil` | 工具黑名单：从模型的工具集中移除这些工具；同名冲突时**优先于** `--allowed-tools` |
 | `--list-sessions` | `-l` | `false` | 列出已存储的会话并退出 |
 | `--resume` | `-r` | `""` | 续跑指定 id 的会话 |
 | `--continue` | `-c` | `false` | 续跑最近一次的会话 |
@@ -259,7 +262,7 @@ pigo -P anthropic -m claude-3-5-sonnet-20241022 -p "..."
 
 ## 内置工具
 
-工具集根植于当前工作目录，`--no-tools` 可整体禁用。
+工具集根植于当前工作目录，`--no-tools` 可整体禁用，`--allowed-tools` / `--disallowed-tools` 可做工具级准入（见下方[工具级准入](#工具级准入)）。
 
 | 工具 | 说明 |
 |------|------|
@@ -268,12 +271,50 @@ pigo -P anthropic -m claude-3-5-sonnet-20241022 -p "..."
 | `edit` | 精确字符串替换（`old_string` 需唯一，除非 `replace_all`），返回 diff |
 | `grep` | 正则检索文件内容，支持 glob 过滤，跳过 `.gitignore` 路径 |
 | `find` | 按文件名 glob 查找文件，跳过 `.gitignore` 路径 |
-| `bash` | 执行 shell 命令，流式 stdout/stderr，支持超时与取消 |
+| `bash` | 执行 shell 命令，流式 stdout/stderr，支持超时与取消；`run_in_background` 可转入后台 |
+| `bash_output` | 读取后台 bash 任务的增量输出 |
+| `kill_bash` | 终止后台 bash 任务 |
 | `todo` | 记录/更新结构化任务清单，每次提交整份列表（pending/in_progress/completed） |
 | `webfetch` | 抓取 URL 并转为精简 Markdown 正文，HTTP 自动升级 HTTPS |
 | `websearch` | 联网搜索并返回标题/URL/摘要，按凭证自动选后端（`TAVILY_API_KEY`→Tavily，`BRAVE_API_KEY`→Brave，否则回落无 key 的 DuckDuckGo），支持 `allowed_domains`/`blocked_domains` 过滤 |
+| `memory_search` | 检索持久化记忆（`memory.enabled = false` 或 `--no-tools` 时不注册） |
+| `task` | 派发通用子 Agent，子 Agent 继承父级工具边界且不能再次派发 |
 
 > `bash` / `write` / `edit` 属于"副作用工具"，在未信任目录下需确认（见[项目信任](#项目信任)）。
+
+### 工具级准入
+
+`--no-tools` 是全有或全无，`--allowed-tools` / `--disallowed-tools` 提供中间态：
+
+```bash
+# 只准读：白名单
+pigo --allowed-tools read,grep -p "这个仓库的架构是什么"
+
+# 什么都行，就是别碰 shell：黑名单
+pigo --disallowed-tools bash,bash_output,kill_bash -p "帮我改下 README"
+
+# 大小写不敏感，Claude Code 的写法直接可用
+pigo --allowed-tools Read,Grep -p "..."
+
+# 也可重复传参
+pigo --allowed-tools read --allowed-tools grep -p "..."
+```
+
+语义要点：
+
+- **黑名单优先。** 同一工具同时出现在两侧时被移除（fail-closed）。
+- **白名单是硬边界，`--approve` 不能绕过。** 过滤发生在工具注册层，早于副作用确认门，所以边界外的工具从未被宣传给模型、也无法被调用。`--approve` 只免掉逐次确认，不放行边界外工具。
+- **子 Agent 继承边界。** `task` 派发的子 Agent 同样受约束，否则"让子 Agent 去跑 bash"就是一条现成的逃逸路径。
+- **拼错立即报错。** 未知工具名会打印全部可用名并以退出码 2 终止，绝不静默忽略——静默忽略会让你以为限制住了而其实没有。
+- **暂不支持参数级匹配。** `Bash(git log:*)`、`Read(src/**)` 这类 Claude Code 语法本期不支持，写成该形式会被当作未知工具名报错。
+- 屏蔽 `read` 时系统提示不再注入 `<available_skills>`，因为模型需要 `read` 才能加载技能正文。
+
+也可在 `config.toml` 中声明默认边界（命令行传入时整体替换文件值，而非合并）：
+
+```toml
+allowed_tools = ["read", "grep"]
+disallowed_tools = ["bash"]
+```
 
 ---
 
@@ -322,6 +363,7 @@ REPL 中的内置斜杠命令包括 `/model`、`/models`、`/think`、`/help`、
 
 - 首次在某目录启动 REPL 时会提示是否信任。
 - `--approve` / `-a` 为本次运行一次性授予会话级信任，跳过首次提示并免逐次确认。
+- `--approve` **只免掉确认，不放大权限**：`--allowed-tools` / `--disallowed-tools` 划定的边界是硬边界（见[工具级准入](#工具级准入)），边界外的工具不在工具集中，`-a` 也无法调用。
 
 ---
 

--- a/cmd/pigo/main.go
+++ b/cmd/pigo/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -136,6 +137,16 @@ type cliOptions struct {
 	// defaults applied. The interactive REPL consumes it to decide the startup
 	// background auto-consolidation (US-008). Like memory it has no CLI flags.
 	dreamCfg dream.Config
+	// allowedTools and disallowedTools are the --allowed-tools/--disallowed-tools
+	// values: the tool-level admission boundary for the run, filling the gap
+	// between "all tools" and --no-tools. Each is repeatable and each value may be
+	// comma-separated. Names match case-insensitively, and deny wins over allow
+	// when a name appears on both sides (fail-closed). The boundary is enforced at
+	// the tool-registration layer in run.SetupEnv, strictly before the
+	// BeforeToolCall confirmation gate, so --approve waives confirmation prompts
+	// but can never widen the boundary.
+	allowedTools    []string
+	disallowedTools []string
 }
 
 func main() {
@@ -164,6 +175,8 @@ func main() {
 	flag.StringVar(&opts.provider, "provider", "", "select a built-in provider by name (e.g. deepseek, minimax); uses its default base URL, protocol, and API-key env var (see --help provider list)")
 	flag.StringVarP(&opts.outputFmt, "output-format", "o", "text", "output format: text | stream-json")
 	flag.BoolVarP(&opts.noTools, "no-tools", "n", false, "disable the built-in file/shell tools")
+	flag.StringArrayVar(&opts.allowedTools, "allowed-tools", nil, "restrict the model to these tools (repeatable, comma-separated, case-insensitive); empty means no restriction and --disallowed-tools wins on conflict")
+	flag.StringArrayVar(&opts.disallowedTools, "disallowed-tools", nil, "remove these tools from the model's set (repeatable, comma-separated, case-insensitive); takes precedence over --allowed-tools")
 	flag.BoolVarP(&opts.listSessions, "list-sessions", "l", false, "list stored interactive sessions and exit")
 	flag.StringVarP(&opts.resumeID, "resume", "r", "", "resume the interactive session with this id")
 	flag.BoolVarP(&opts.continueLast, "continue", "c", false, "resume the most recent interactive session")
@@ -266,6 +279,17 @@ func applyFileConfig(opts *cliOptions, cfg config.FileConfig, changed func(strin
 	if cfg.SystemPrompt != "" && !changed("system-prompt") {
 		opts.systemPrompt = cfg.SystemPrompt
 	}
+	// The tool boundary follows the standard precedence (CLI > file > default)
+	// rather than the additive treatment prompts get below. Merging would be the
+	// wrong semantics for a security boundary: a user passing --allowed-tools to
+	// widen what the file narrowed must actually get the wider set, not the
+	// intersection.
+	if len(cfg.AllowedTools) > 0 && !changed("allowed-tools") {
+		opts.allowedTools = cfg.AllowedTools
+	}
+	if len(cfg.DisallowedTools) > 0 && !changed("disallowed-tools") {
+		opts.disallowedTools = cfg.DisallowedTools
+	}
 	// prompts (settings tier) are additive with --prompt-template (CLI tier,
 	// wired in #339), so they are always passed through when present.
 	if len(cfg.Prompts) > 0 {
@@ -339,10 +363,10 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 			fmt.Fprintln(errOut, "pigo: no prompt (use -p \"...\" or positional args)")
 			return 2
 		}
-		env, err := run.SetupEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.apiKey, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt, opts.memory.Memory.Enabled)
+		env, err := run.SetupEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.apiKey, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt, opts.memory.Memory.Enabled, run.NewToolPolicy(opts.allowedTools, opts.disallowedTools))
 		if err != nil {
 			fmt.Fprintf(errOut, "pigo: %v\n", err)
-			return 1
+			return setupExitCode(err)
 		}
 		if env.Plugins != nil {
 			defer env.Plugins.Close()
@@ -415,10 +439,10 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		return 2
 	}
 
-	env, err := run.SetupEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.apiKey, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt, opts.memory.Memory.Enabled)
+	env, err := run.SetupEnv(opts.model, opts.baseURL, opts.protocol, opts.provider, opts.apiKey, opts.noTools, opts.noSkills, opts.systemPrompt, opts.appendSystemPrompt, opts.memory.Memory.Enabled, run.NewToolPolicy(opts.allowedTools, opts.disallowedTools))
 	if err != nil {
 		fmt.Fprintf(errOut, "pigo: %v\n", err)
-		return 1
+		return setupExitCode(err)
 	}
 	if env.Plugins != nil {
 		defer env.Plugins.Close()
@@ -435,6 +459,17 @@ func dispatch(ctx context.Context, opts cliOptions, out, errOut io.Writer) int {
 		ThinkingLevel: opts.thinkingLevel,
 		ResumeID:      resumeID,
 	}, out, errOut)
+}
+
+// setupExitCode maps a run.SetupEnv failure to a process exit code. A bad tool
+// policy is a usage error (2), matching --cwd and --output-format; everything
+// else — provider resolution, prompt assembly — is a runtime failure (1).
+func setupExitCode(err error) int {
+	var policyErr *run.ToolPolicyError
+	if errors.As(err, &policyErr) {
+		return 2
+	}
+	return 1
 }
 
 // runDream executes the subprocess memory-consolidation pass (SPEC §4.1/§4.2).

--- a/cmd/pigo/main_test.go
+++ b/cmd/pigo/main_test.go
@@ -8,6 +8,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -128,7 +130,7 @@ func TestCwdChdirRootsEnv(t *testing.T) {
 		t.Fatalf("EvalSymlinks: %v", err)
 	}
 
-	env, err := run.SetupEnv("openrouter/free", "", "", "", "", true /*noTools*/, true /*noSkills*/, "", nil, false /*memEnabled*/)
+	env, err := run.SetupEnv("openrouter/free", "", "", "", "", true /*noTools*/, true /*noSkills*/, "", nil, false /*memEnabled*/, run.ToolPolicy{})
 	if err != nil {
 		t.Fatalf("SetupEnv: %v", err)
 	}
@@ -253,6 +255,61 @@ func TestApplyFileConfigPrompts(t *testing.T) {
 	applyFileConfig(&opts, cfg, func(string) bool { return false })
 	if len(opts.configPrompts) != 2 || opts.configPrompts[0] != "./my-prompts" || opts.configPrompts[1] != "/abs/x.md" {
 		t.Errorf("opts.configPrompts = %v, want [./my-prompts /abs/x.md]", opts.configPrompts)
+	}
+}
+
+// The tool boundary follows CLI > file > default like the other scalar flags,
+// rather than the additive treatment `prompts` gets: merging would prevent a CLI
+// flag from widening a boundary the config file narrowed.
+func TestApplyFileConfigToolPolicy(t *testing.T) {
+	t.Run("fills unset flags", func(t *testing.T) {
+		var opts cliOptions
+		cfg := config.FileConfig{
+			AllowedTools:    []string{"read", "grep"},
+			DisallowedTools: []string{"bash"},
+		}
+		applyFileConfig(&opts, cfg, changedSet())
+		if len(opts.allowedTools) != 2 || opts.allowedTools[0] != "read" {
+			t.Errorf("allowedTools = %v, want [read grep]", opts.allowedTools)
+		}
+		if len(opts.disallowedTools) != 1 || opts.disallowedTools[0] != "bash" {
+			t.Errorf("disallowedTools = %v, want [bash]", opts.disallowedTools)
+		}
+	})
+
+	t.Run("CLI replaces file value wholesale", func(t *testing.T) {
+		opts := cliOptions{allowedTools: []string{"bash"}}
+		cfg := config.FileConfig{AllowedTools: []string{"read"}, DisallowedTools: []string{"write"}}
+		applyFileConfig(&opts, cfg, changedSet("allowed-tools"))
+		if len(opts.allowedTools) != 1 || opts.allowedTools[0] != "bash" {
+			t.Errorf("CLI --allowed-tools must win outright, got %v", opts.allowedTools)
+		}
+		if len(opts.disallowedTools) != 1 || opts.disallowedTools[0] != "write" {
+			t.Errorf("unset --disallowed-tools should take the config value, got %v", opts.disallowedTools)
+		}
+	})
+
+	t.Run("absent config leaves the boundary open", func(t *testing.T) {
+		var opts cliOptions
+		applyFileConfig(&opts, config.FileConfig{}, changedSet())
+		if opts.allowedTools != nil || opts.disallowedTools != nil {
+			t.Errorf("empty config must not constrain tools, got %v / %v", opts.allowedTools, opts.disallowedTools)
+		}
+	})
+}
+
+// setupExitCode maps a bad tool policy to the usage exit code (2) and everything
+// else to a runtime failure (1), so a typo is distinguishable from e.g. a
+// provider-resolution error.
+func TestSetupExitCode(t *testing.T) {
+	if got := setupExitCode(&run.ToolPolicyError{UnknownAllowed: []string{"raed"}}); got != 2 {
+		t.Errorf("setupExitCode(ToolPolicyError) = %d, want 2 (usage error)", got)
+	}
+	if got := setupExitCode(errors.New("provider boom")); got != 1 {
+		t.Errorf("setupExitCode(generic) = %d, want 1", got)
+	}
+	if got := setupExitCode(fmt.Errorf("wrapped: %w", &run.ToolPolicyError{})); got != 2 {
+		t.Errorf("setupExitCode must unwrap, got %d, want 2", got)
 	}
 }
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -23,6 +23,22 @@ approve = false
 # Disable the built-in file/shell tools.
 no_tools = false
 
+# Tool-level admission control (the middle ground between "all tools" and
+# no_tools). Names match case-insensitively, so "Read" hits the built-in "read".
+# disallowed_tools wins when a name appears in both lists (fail-closed).
+#
+# A boundary declared here is a HARD boundary: filtering happens at the tool-
+# registration layer, so `approve = true` waives per-call confirmation but can
+# never let the model reach a tool outside the boundary. Task sub-agents inherit
+# it too. An unknown tool name aborts startup with exit code 2 rather than being
+# silently ignored.
+#
+# Passing --allowed-tools/--disallowed-tools on the command line REPLACES these
+# values wholesale (it does not merge), so a CLI flag can widen what the file
+# narrowed. Parameter-level forms such as Bash(git log:*) are not supported yet.
+# allowed_tools = ["read", "grep"]
+# disallowed_tools = ["bash", "bash_output", "kill_bash"]
+
 # Disable skill discovery (do not load skills under ~/.agents/skills as /skill-name commands).
 no_skills = false
 

--- a/docs/web/features.html
+++ b/docs/web/features.html
@@ -116,12 +116,17 @@ pigo -u http://localhost:11434/v1 -m qwen3
           <tr><td><code>grep</code></td><td data-en="Search file contents by regex" data-zh="按正则搜索文件内容"></td></tr>
           <tr><td><code>find</code></td><td data-en="Locate files by glob pattern" data-zh="按 glob 模式查找文件"></td></tr>
           <tr><td><code>bash</code></td><td data-en="Run shell commands (gated by approval policy)" data-zh="执行 shell 命令（受批准策略约束）"></td></tr>
+          <tr><td><code>bash_output</code></td><td data-en="Drain incremental output from a background bash job" data-zh="读取后台 bash 任务的增量输出"></td></tr>
+          <tr><td><code>kill_bash</code></td><td data-en="Terminate a background bash job" data-zh="终止后台 bash 任务"></td></tr>
           <tr><td><code>todo</code></td><td data-en="Track a live task list across the turn" data-zh="跨轮次跟踪实时任务清单"></td></tr>
           <tr><td><code>webfetch</code></td><td data-en="Fetch a URL and convert to text" data-zh="抓取网页并转为文本"></td></tr>
+          <tr><td><code>websearch</code></td><td data-en="Search the web (backend auto-selected from available credentials)" data-zh="联网搜索（按可用凭证自动选择后端）"></td></tr>
         </tbody>
       </table>
       <p data-en="Tools carry an approval policy. By default pigo asks before running <code>bash</code> or writing files; pass <code>--approve</code> to auto-approve in trusted contexts, or <code>--no-tools</code> to run the model with no tools at all (pure chat)."
          data-zh="工具带有批准策略。默认情况下 pigo 在执行 <code>bash</code> 或写文件前会先询问；在可信场景下用 <code>--approve</code> 自动批准，或用 <code>--no-tools</code> 让模型完全不带工具运行（纯对话）。"></p>
+      <p data-en="For anything between the full set and nothing, <code>--allowed-tools</code> and <code>--disallowed-tools</code> gate admission per tool (repeatable, comma-separated, case-insensitive, so <code>Read</code> hits <code>read</code>). Deny wins over allow on conflict, task sub-agents inherit the boundary, and a misspelled tool name aborts startup with exit code 2 rather than being silently ignored. The boundary is enforced at the tool-registration layer &mdash; before the approval gate &mdash; so <code>--approve</code> waives confirmation prompts but can never widen it. Parameter-level forms such as <code>Bash(git log:*)</code> are not supported yet."
+         data-zh="要在全部工具与完全没有工具之间取中间态，用 <code>--allowed-tools</code> 与 <code>--disallowed-tools</code> 做工具级准入（可重复、可逗号分隔、大小写不敏感，因此 <code>Read</code> 能命中 <code>read</code>）。同名冲突时黑名单优先，task 子 Agent 继承同一边界，拼错工具名会以退出码 2 终止启动而非被静默忽略。该边界在工具注册层生效 —— 早于批准门 —— 所以 <code>--approve</code> 只免掉确认弹窗，永远无法放大边界。<code>Bash(git log:*)</code> 这类参数级写法暂不支持。"></p>
       <div class="note" data-en="<strong>vs. competitors:</strong> Aider focuses on edit/commit; pigo's built-ins span search, shell, task tracking, and web fetch in one binary — and plugin- and skill-provided tools use the exact same schema-validated contract, so extensions are first-class, not bolted on."
            data-zh="<strong>与竞品对比：</strong>Aider 聚焦于编辑与提交；pigo 的内置工具在单个二进制里覆盖搜索、shell、任务跟踪与网页抓取 —— 且插件与 skill 提供的工具遵循完全相同的 schema 校验契约，因此扩展是一等公民，而非外挂。"></div>
 

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -39,6 +39,13 @@ type FileConfig struct {
 	NoSkills      bool   `toml:"no_skills"`
 	Approve       bool   `toml:"approve"`
 	SystemPrompt  string `toml:"system_prompt"`
+	// AllowedTools and DisallowedTools are the tool-level admission boundary:
+	// the config-file tier of --allowed-tools / --disallowed-tools. Names match
+	// case-insensitively and DisallowedTools wins when a name appears in both.
+	// A CLI flag replaces the file value wholesale rather than merging with it,
+	// so passing --allowed-tools can widen a boundary the file narrowed.
+	AllowedTools    []string `toml:"allowed_tools"`
+	DisallowedTools []string `toml:"disallowed_tools"`
 	// Prompts is the config.toml `prompts` array: paths (files or dirs) to load
 	// prompt templates from at the settings tier (mirrors pi's settings prompts).
 	Prompts []string `toml:"prompts"`

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -62,9 +62,12 @@ type Env struct {
 // value is literal text) and layered onto the end of the prompt (mirrors pi's
 // --append-system-prompt). apiKey is the resolved credential (CLI --api-key or
 // config.toml) used as the override for sub-agent credential resolution so
-// dispatched task children authenticate the same way the parent does. It
-// returns an error rather than exiting so the caller owns exit-code mapping.
-func SetupEnv(model, baseURL, protocol, providerName, apiKey string, noTools, noSkills bool, systemPrompt string, appendSystemPrompt []string, memEnabled bool) (Env, error) {
+// dispatched task children authenticate the same way the parent does. policy is
+// the --allowed-tools/--disallowed-tools boundary; it is validated against the
+// fully assembled tool set and then applied, so an unknown tool name is a usage
+// error rather than a silently ineffective boundary. It returns an error rather
+// than exiting so the caller owns exit-code mapping.
+func SetupEnv(model, baseURL, protocol, providerName, apiKey string, noTools, noSkills bool, systemPrompt string, appendSystemPrompt []string, memEnabled bool, policy ToolPolicy) (Env, error) {
 	cwd, _ := os.Getwd()
 	prov, resolvedName, err := provider.ResolveProvider(model, baseURL, protocol, providerName, os.Getenv)
 	if err != nil {
@@ -103,7 +106,7 @@ func SetupEnv(model, baseURL, protocol, providerName, apiKey string, noTools, no
 		childCreds := provider.NewCredentialStore(nil)
 		childCreds.SetOverride(resolvedName, apiKey)
 		factory := func() runtime.RunConfig {
-			childTools := BuiltinToolsExcept(cwd, false, "task")
+			childTools := ChildToolSet(cwd, policy)
 			return runtime.RunConfig{
 				LoopConfig: runtime.LoopConfig{
 					Model:     model,
@@ -127,6 +130,20 @@ func SetupEnv(model, baseURL, protocol, providerName, apiKey string, noTools, no
 		} else {
 			fmt.Fprintf(os.Stderr, "pigo: plugin discovery failed: %v\n", err)
 		}
+	}
+	// Enforce the --allowed-tools/--disallowed-tools boundary now that the set is
+	// complete. Validation must happen here rather than at flag-parse time: plugin
+	// and memory tool names only exist at runtime, so an earlier check would reject
+	// legitimate names. Filtering here — at the registration layer, before the
+	// BeforeToolCall confirmation gate — is what makes the boundary structural: a
+	// removed tool is never advertised and never dispatchable, so --approve cannot
+	// widen it.
+	if err := ValidateToolPolicy(tools, policy); err != nil {
+		return Env{}, err
+	}
+	tools = ApplyToolPolicy(tools, policy)
+	if len(tools) == 0 && !noTools && !policy.IsZero() {
+		fmt.Fprintln(os.Stderr, "pigo: warning: the tool policy removed every tool; the model will run without tools")
 	}
 	// Load skills once (shared between prompt injection and /skill-name
 	// registration). A partial parse error still yields the skills that DID load,

--- a/internal/cli/run/toolpolicy.go
+++ b/internal/cli/run/toolpolicy.go
@@ -1,0 +1,208 @@
+package run
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// ToolPolicy is the user-declared tool boundary for a run: the --allowed-tools
+// whitelist and the --disallowed-tools blacklist, already normalized by
+// SplitToolNames. It is passed as one value rather than two adjacent []string
+// parameters so the two lists cannot be swapped at a call site — silently
+// inverting a security boundary is exactly the bug that must be impossible.
+//
+// The zero value means "no restriction" and every operation on it is a no-op.
+type ToolPolicy struct {
+	Allow []string
+	Deny  []string
+}
+
+// NewToolPolicy normalizes raw flag values into a policy.
+func NewToolPolicy(allowed, disallowed []string) ToolPolicy {
+	return ToolPolicy{Allow: SplitToolNames(allowed), Deny: SplitToolNames(disallowed)}
+}
+
+// IsZero reports whether the policy constrains nothing.
+func (p ToolPolicy) IsZero() bool { return len(p.Allow) == 0 && len(p.Deny) == 0 }
+
+// SplitToolNames normalizes raw --allowed-tools / --disallowed-tools values into
+// a flat list of tool names. Each value may itself be a comma-separated list, so
+// `--allowed-tools "read,grep"` and `--allowed-tools read --allowed-tools grep`
+// are equivalent. Entries are lowercased and trimmed, and empty entries dropped,
+// so `"read, ,grep"` yields [read grep]. Matching is case-insensitive on purpose:
+// users coming from Claude Code write `Read`/`Bash`, which must hit pigo's
+// `read`/`bash`.
+func SplitToolNames(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		for _, part := range strings.Split(v, ",") {
+			if n := normalizeToolName(part); n != "" {
+				out = append(out, n)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// normalizeToolName is the single definition of how a tool name is compared:
+// surrounding whitespace is insignificant and case is ignored.
+func normalizeToolName(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// ToolPolicyError reports --allowed-tools / --disallowed-tools entries that name
+// no existing tool. It is a usage error — the caller maps it to exit code 2 —
+// because silently ignoring a typo is the worst outcome available: the user
+// believes a boundary is in force when it is not.
+type ToolPolicyError struct {
+	// UnknownAllowed and UnknownDisallowed are the unrecognized names from each
+	// flag. Both are reported in one error so a user with two typos fixes both in
+	// one round rather than one per run.
+	UnknownAllowed    []string
+	UnknownDisallowed []string
+	// Available is the sorted set of names that would have been accepted.
+	Available []string
+}
+
+func (e *ToolPolicyError) Error() string {
+	var parts []string
+	if len(e.UnknownAllowed) > 0 {
+		parts = append(parts, fmt.Sprintf("--allowed-tools: unknown tool %s", quoteNames(e.UnknownAllowed)))
+	}
+	if len(e.UnknownDisallowed) > 0 {
+		parts = append(parts, fmt.Sprintf("--disallowed-tools: unknown tool %s", quoteNames(e.UnknownDisallowed)))
+	}
+	return fmt.Sprintf("%s (available: %s)", strings.Join(parts, "; "), strings.Join(e.Available, ", "))
+}
+
+// quoteNames renders names as a comma-separated quoted list.
+func quoteNames(names []string) string {
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[i] = fmt.Sprintf("%q", n)
+	}
+	return strings.Join(out, ", ")
+}
+
+// ValidateToolPolicy checks every allow/deny entry against the assembled tool
+// set. It must run AFTER the full set exists (builtins + memory + task +
+// plugins), because plugin and memory tool names are only known at runtime;
+// validating right after flag parsing would reject legitimate plugin names.
+//
+// An empty tool set (--no-tools) skips validation entirely: there is nothing to
+// constrain, and reporting every name as unknown would be noise.
+func ValidateToolPolicy(tools []agentcore.AgentTool, policy ToolPolicy) error {
+	if len(tools) == 0 || policy.IsZero() {
+		return nil
+	}
+	known := toolNameSet(tools)
+	unknownAllow := unknownNames(known, policy.Allow)
+	unknownDeny := unknownNames(known, policy.Deny)
+	if len(unknownAllow) == 0 && len(unknownDeny) == 0 {
+		return nil
+	}
+	available := make([]string, 0, len(known))
+	for n := range known {
+		available = append(available, n)
+	}
+	sort.Strings(available)
+	return &ToolPolicyError{
+		UnknownAllowed:    unknownAllow,
+		UnknownDisallowed: unknownDeny,
+		Available:         available,
+	}
+}
+
+// unknownNames returns the entries of names absent from known, preserving input
+// order and dropping duplicates so a name repeated twice is reported once.
+func unknownNames(known map[string]struct{}, names []string) []string {
+	var out []string
+	seen := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		if _, ok := known[n]; ok {
+			continue
+		}
+		if _, dup := seen[n]; dup {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	return out
+}
+
+// toolNameSet indexes a tool set by normalized name.
+func toolNameSet(tools []agentcore.AgentTool) map[string]struct{} {
+	set := make(map[string]struct{}, len(tools))
+	for _, t := range tools {
+		set[normalizeToolName(t.Name())] = struct{}{}
+	}
+	return set
+}
+
+// ApplyToolPolicy narrows a tool set to the allow list and then removes the deny
+// list. Both empty means no restriction and the input is returned unchanged, so
+// the default path is a true no-op.
+//
+// Deny runs after allow, which makes deny win when a name appears on both sides.
+// That ordering is deliberate: the fail-closed reading of a contradictory policy
+// is "do not run it".
+//
+// This filters the set handed to the model, so it sits at the tool-registration
+// layer — strictly before the BeforeToolCall confirmation gate. A removed tool is
+// never advertised and never dispatchable, which is why --approve (which only
+// waives per-call confirmation) cannot widen the boundary.
+func ApplyToolPolicy(tools []agentcore.AgentTool, policy ToolPolicy) []agentcore.AgentTool {
+	if len(tools) == 0 || policy.IsZero() {
+		return tools
+	}
+	allowSet := nameSet(policy.Allow)
+	denySet := nameSet(policy.Deny)
+	out := make([]agentcore.AgentTool, 0, len(tools))
+	for _, t := range tools {
+		name := normalizeToolName(t.Name())
+		if len(allowSet) > 0 {
+			if _, ok := allowSet[name]; !ok {
+				continue
+			}
+		}
+		if _, denied := denySet[name]; denied {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// nameSet indexes already-normalized names for lookup.
+func nameSet(names []string) map[string]struct{} {
+	if len(names) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		set[n] = struct{}{}
+	}
+	return set
+}
+
+// ChildToolSet builds the tool set for a task sub-agent: the builtins with
+// "task" removed (the nesting guard capping delegation depth at one), narrowed by
+// the parent's policy.
+//
+// Inheriting the policy is load-bearing, not a nicety. A child that ignored it
+// would be a one-line escape from the boundary: under --disallowed-tools bash the
+// model could dispatch a sub-agent and run bash there instead. Any future spawn
+// path must route through here for the same reason.
+func ChildToolSet(cwd string, policy ToolPolicy) []agentcore.AgentTool {
+	return ApplyToolPolicy(BuiltinToolsExcept(cwd, false, "task"), policy)
+}

--- a/internal/cli/run/toolpolicy_setup_test.go
+++ b/internal/cli/run/toolpolicy_setup_test.go
@@ -1,0 +1,163 @@
+package run
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writePolicySkill drops a minimal valid skill into dir so LoadSkills has
+// something to advertise.
+func writePolicySkill(t *testing.T, dir, name, description string) {
+	t.Helper()
+	body := "---\nname: " + name + "\ndescription: " + description + "\n---\nDo the thing."
+	if err := os.WriteFile(filepath.Join(dir, name+".md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write skill %s: %v", name, err)
+	}
+}
+
+// setupToolNames runs SetupEnv with a policy and returns the resulting tool
+// names. The provider is never contacted, so a stub model id is fine; --no-skills
+// keeps the run independent of the machine's skills directory.
+func setupToolNames(t *testing.T, policy ToolPolicy) []string {
+	t.Helper()
+	t.Setenv("OPENROUTER_API_KEY", "test-key")
+	t.Setenv("PIGO_HOME", t.TempDir()) // isolate plugin/skill discovery
+	env, err := SetupEnv("openrouter/free", "", "", "", "", false /*noTools*/, true /*noSkills*/, "", nil, false /*memEnabled*/, policy)
+	if err != nil {
+		t.Fatalf("SetupEnv: %v", err)
+	}
+	return names(env.Tools)
+}
+
+// contains reports whether name is in the set.
+func contains(set []string, name string) bool {
+	for _, n := range set {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSetupEnvAppliesAllowList confirms a whitelist narrows the advertised set.
+// The `task` tool is expected to survive only when explicitly allowed.
+func TestSetupEnvAppliesAllowList(t *testing.T) {
+	got := setupToolNames(t, NewToolPolicy([]string{"read,grep"}, nil))
+	want := []string{"read", "grep"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("tool set = %q, want exactly %q", got, want)
+	}
+}
+
+// TestSetupEnvAppliesDenyList confirms a blacklist removes the named tools while
+// leaving everything else — including the side-effect tools not named — in place.
+func TestSetupEnvAppliesDenyList(t *testing.T) {
+	got := setupToolNames(t, NewToolPolicy(nil, []string{"bash", "bash_output", "kill_bash"}))
+	for _, denied := range []string{"bash", "bash_output", "kill_bash"} {
+		if contains(got, denied) {
+			t.Errorf("%q survived the deny list: %q", denied, got)
+		}
+	}
+	for _, kept := range []string{"read", "write", "edit", "grep"} {
+		if !contains(got, kept) {
+			t.Errorf("%q was removed but was not denied: %q", kept, got)
+		}
+	}
+}
+
+// TestSetupEnvDenyWinsOverAllow is the fail-closed guarantee: a tool named on
+// both sides is removed.
+func TestSetupEnvDenyWinsOverAllow(t *testing.T) {
+	got := setupToolNames(t, NewToolPolicy([]string{"read", "bash"}, []string{"bash"}))
+	if contains(got, "bash") {
+		t.Errorf("bash was on both lists and must be removed, got %q", got)
+	}
+	if !contains(got, "read") {
+		t.Errorf("read was allowed and not denied, so it must survive, got %q", got)
+	}
+}
+
+// TestSetupEnvUnconstrainedIsUnchanged is the zero-regression check: no policy
+// means the full built-in set, including the side-effect tools.
+func TestSetupEnvUnconstrainedIsUnchanged(t *testing.T) {
+	got := setupToolNames(t, ToolPolicy{})
+	for _, want := range []string{"read", "write", "edit", "grep", "find", "bash", "todo", "webfetch", "websearch", "task"} {
+		if !contains(got, want) {
+			t.Errorf("unconstrained run is missing %q: %q", want, got)
+		}
+	}
+}
+
+// TestSetupEnvRejectsUnknownToolName confirms a typo aborts setup with a
+// ToolPolicyError, which is what maps to exit code 2 rather than a run that
+// silently ignores the boundary.
+func TestSetupEnvRejectsUnknownToolName(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "test-key")
+	t.Setenv("PIGO_HOME", t.TempDir())
+	_, err := SetupEnv("openrouter/free", "", "", "", "", false, true, "", nil, false, NewToolPolicy([]string{"raed"}, nil))
+	if err == nil {
+		t.Fatal("SetupEnv = nil error, want a failure for the misspelled tool name")
+	}
+	var policyErr *ToolPolicyError
+	if !errors.As(err, &policyErr) {
+		t.Fatalf("error type = %T, want *ToolPolicyError", err)
+	}
+}
+
+// TestChildToolSetInheritsPolicy closes the sub-agent escape hatch: a child
+// dispatched by the task tool must not regain a tool the parent's policy removed,
+// or `--disallowed-tools bash` would be bypassable by delegating.
+func TestChildToolSetInheritsPolicy(t *testing.T) {
+	child := names(ChildToolSet("/tmp", NewToolPolicy(nil, []string{"bash"})))
+	if contains(child, "bash") {
+		t.Errorf("child regained the denied bash tool: %q", child)
+	}
+	if contains(child, "task") {
+		t.Errorf("child must not contain task (nesting guard): %q", child)
+	}
+	if !contains(child, "read") {
+		t.Errorf("child lost an un-denied tool: %q", child)
+	}
+
+	allowOnly := names(ChildToolSet("/tmp", NewToolPolicy([]string{"read"}, nil)))
+	if strings.Join(allowOnly, ",") != "read" {
+		t.Errorf("child under an allow list = %q, want exactly [read]", allowOnly)
+	}
+
+	// With no policy the child is the plain nesting-guarded builtin set.
+	unconstrained := names(ChildToolSet("/tmp", ToolPolicy{}))
+	if !contains(unconstrained, "bash") || contains(unconstrained, "task") {
+		t.Errorf("unconstrained child set = %q, want builtins minus task", unconstrained)
+	}
+}
+
+// TestSetupEnvSkillsGatedOnFilteredReadTool covers the ordering dependency: the
+// <available_skills> block is advertised only when `read` survives the policy,
+// because the model needs read to load a skill body. Filtering must therefore
+// happen before the system prompt is built.
+func TestSetupEnvSkillsGatedOnFilteredReadTool(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "test-key")
+	t.Setenv("PIGO_HOME", t.TempDir())
+	skillsDir := t.TempDir()
+	t.Setenv("PIGO_SKILLS_DIR", skillsDir)
+	writePolicySkill(t, skillsDir, "weather", "get the weather")
+
+	withRead, err := SetupEnv("openrouter/free", "", "", "", "", false, false, "", nil, false, ToolPolicy{})
+	if err != nil {
+		t.Fatalf("SetupEnv (unconstrained): %v", err)
+	}
+	if !strings.Contains(withRead.SysPrompt, "<available_skills>") {
+		t.Fatal("unconstrained run must advertise skills; the fixture or gate is wrong")
+	}
+
+	withoutRead, err := SetupEnv("openrouter/free", "", "", "", "", false, false, "", nil, false, NewToolPolicy(nil, []string{"read"}))
+	if err != nil {
+		t.Fatalf("SetupEnv (read denied): %v", err)
+	}
+	if strings.Contains(withoutRead.SysPrompt, "available_skills") {
+		t.Error("denying read must suppress <available_skills>: the model could not load a skill body")
+	}
+}

--- a/internal/cli/run/toolpolicy_test.go
+++ b/internal/cli/run/toolpolicy_test.go
@@ -1,0 +1,176 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/smallnest/pigo/internal/agentcore"
+)
+
+// policyTool is a minimal AgentTool whose only meaningful property is its name —
+// the tool policy matches on nothing else.
+type policyTool struct{ name string }
+
+func (t policyTool) Name() string        { return t.name }
+func (t policyTool) Description() string { return "stub" }
+func (t policyTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object"}`)
+}
+func (t policyTool) ExecutionMode() agentcore.ToolExecutionMode {
+	return agentcore.ToolExecutionParallel
+}
+func (t policyTool) Execute(ctx context.Context, id string, args json.RawMessage, onUpdate agentcore.ToolUpdateFunc) (agentcore.AgentToolResult, error) {
+	return agentcore.AgentToolResult{}, nil
+}
+
+// toolSet builds a tool set from names.
+func toolSet(names ...string) []agentcore.AgentTool {
+	out := make([]agentcore.AgentTool, 0, len(names))
+	for _, n := range names {
+		out = append(out, policyTool{name: n})
+	}
+	return out
+}
+
+// names extracts the tool names from a set, for comparison.
+func names(tools []agentcore.AgentTool) []string {
+	out := make([]string, 0, len(tools))
+	for _, t := range tools {
+		out = append(out, t.Name())
+	}
+	return out
+}
+
+// TestSplitToolNames covers the accepted input forms: a single value, repeated
+// flags, comma-separated values, mixed forms, and whitespace/empty entries.
+func TestSplitToolNames(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil", nil, nil},
+		{"single", []string{"read"}, []string{"read"}},
+		{"repeated flag", []string{"read", "grep"}, []string{"read", "grep"}},
+		{"comma", []string{"read,grep"}, []string{"read", "grep"}},
+		{"mixed", []string{"read,grep", "bash"}, []string{"read", "grep", "bash"}},
+		{"whitespace and empties", []string{"read, ,grep", "  bash  "}, []string{"read", "grep", "bash"}},
+		{"case folded", []string{"Read", "BASH"}, []string{"read", "bash"}},
+		{"only empties", []string{"", " ", ",,"}, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SplitToolNames(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("SplitToolNames(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("SplitToolNames(%q) = %q, want %q", tc.in, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestApplyToolPolicy covers allow-only, deny-only, the overlap (deny wins), the
+// unconstrained no-op, and filtering down to an empty set.
+func TestApplyToolPolicy(t *testing.T) {
+	all := toolSet("read", "write", "bash", "grep")
+	tests := []struct {
+		name   string
+		policy ToolPolicy
+		want   []string
+	}{
+		{"unconstrained is a no-op", ToolPolicy{}, []string{"read", "write", "bash", "grep"}},
+		{"allow only", NewToolPolicy([]string{"read,grep"}, nil), []string{"read", "grep"}},
+		{"deny only", NewToolPolicy(nil, []string{"bash"}), []string{"read", "write", "grep"}},
+		{"deny wins over allow", NewToolPolicy([]string{"read,bash"}, []string{"bash"}), []string{"read"}},
+		{"case-insensitive allow", NewToolPolicy([]string{"Read", "GREP"}, nil), []string{"read", "grep"}},
+		{"case-insensitive deny", NewToolPolicy(nil, []string{"Bash"}), []string{"read", "write", "grep"}},
+		{"filters to empty", NewToolPolicy([]string{"read"}, []string{"read"}), nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := names(ApplyToolPolicy(all, tc.policy))
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("ApplyToolPolicy = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplyToolPolicyEmptyToolSet confirms an empty input (--no-tools) is left
+// alone rather than being treated as "everything denied".
+func TestApplyToolPolicyEmptyToolSet(t *testing.T) {
+	if got := ApplyToolPolicy(nil, NewToolPolicy([]string{"read"}, nil)); got != nil {
+		t.Errorf("ApplyToolPolicy(nil, ...) = %v, want nil", got)
+	}
+}
+
+// TestValidateToolPolicyAccepts confirms known names — including case variants —
+// pass validation.
+func TestValidateToolPolicyAccepts(t *testing.T) {
+	all := toolSet("read", "bash")
+	for _, policy := range []ToolPolicy{
+		{},
+		NewToolPolicy([]string{"read"}, nil),
+		NewToolPolicy([]string{"Read"}, []string{"BASH"}),
+		NewToolPolicy(nil, []string{"bash"}),
+	} {
+		if err := ValidateToolPolicy(all, policy); err != nil {
+			t.Errorf("ValidateToolPolicy(%+v) = %v, want nil", policy, err)
+		}
+	}
+}
+
+// TestValidateToolPolicyReportsAllUnknown is the anti-typo guarantee: every bad
+// name from both flags is reported in one error, alongside the available names,
+// so a user with two typos fixes both in one round.
+func TestValidateToolPolicyReportsAllUnknown(t *testing.T) {
+	all := toolSet("read", "bash", "grep")
+	err := ValidateToolPolicy(all, NewToolPolicy([]string{"raed,gerp"}, []string{"bahs"}))
+	if err == nil {
+		t.Fatal("ValidateToolPolicy = nil, want an error for the misspelled names")
+	}
+	var policyErr *ToolPolicyError
+	if !errors.As(err, &policyErr) {
+		t.Fatalf("error type = %T, want *ToolPolicyError (exit-code mapping depends on it)", err)
+	}
+	if len(policyErr.UnknownAllowed) != 2 {
+		t.Errorf("UnknownAllowed = %q, want both misspellings", policyErr.UnknownAllowed)
+	}
+	if len(policyErr.UnknownDisallowed) != 1 {
+		t.Errorf("UnknownDisallowed = %q, want the one misspelling", policyErr.UnknownDisallowed)
+	}
+	msg := err.Error()
+	for _, want := range []string{`"raed"`, `"gerp"`, `"bahs"`, "available:", "read", "bash", "grep"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message %q is missing %q", msg, want)
+		}
+	}
+}
+
+// TestValidateToolPolicyDeduplicatesUnknown confirms a name repeated across
+// values is reported once.
+func TestValidateToolPolicyDeduplicatesUnknown(t *testing.T) {
+	err := ValidateToolPolicy(toolSet("read"), NewToolPolicy([]string{"raed", "raed"}, nil))
+	var policyErr *ToolPolicyError
+	if !errors.As(err, &policyErr) {
+		t.Fatalf("error = %v, want *ToolPolicyError", err)
+	}
+	if len(policyErr.UnknownAllowed) != 1 {
+		t.Errorf("UnknownAllowed = %q, want one entry", policyErr.UnknownAllowed)
+	}
+}
+
+// TestValidateToolPolicySkipsEmptyToolSet confirms --no-tools does not turn every
+// policy name into an error.
+func TestValidateToolPolicySkipsEmptyToolSet(t *testing.T) {
+	if err := ValidateToolPolicy(nil, NewToolPolicy([]string{"anything"}, nil)); err != nil {
+		t.Errorf("ValidateToolPolicy(nil tools) = %v, want nil", err)
+	}
+}

--- a/tasks/prd-tool-allowlist-flags.md
+++ b/tasks/prd-tool-allowlist-flags.md
@@ -1,0 +1,204 @@
+# PRD: 工具白名单 / 黑名单 CLI 参数（--allowed-tools / --disallowed-tools）
+
+## 1. Introduction/Overview
+
+pigo 目前对"模型能用哪些工具"只有一个**全有或全无**的开关：`--no-tools`（`cmd/pigo/main.go:166`）。要么全部内置工具可用，要么一个都不给。中间态完全缺失——用户没法说"这次只准读文件，别碰 bash"，也没法说"随便用，就是别写文件"。
+
+对标 Claude Code，它提供 `--allowedTools` / `--disallowedTools` 做工具级准入控制。pigo 侧其实已经有现成的地基：
+
+- `internal/runtime/skills.go:37` 的 `AllowedTools stringList`（技能 frontmatter 的 `allowed-tools`）
+- `internal/runtime/skills.go:357` 的 `filterToolsByName(tools, allow)` 过滤器
+- `internal/runtime/skills.go:96` 的 `stringList.UnmarshalYAML`——已能同时吃 YAML 列表和 `A, B` 标量
+
+但这套机制**只作用于技能派生出的子 Agent**（`skills.go:255`），管不到主会话。本特性把同等能力提到 CLI 层，让主会话也能被约束。
+
+本 PRD 还要解决一个当前存在的**假安全感**风险：`--approve`（`main.go:170`）会免掉副作用工具的逐次确认。如果白名单只是"软提示"、被 `-a` 一把绕过，那用户以为限住了、其实没限住，比不做更危险。所以本特性明确把白名单定义为**硬边界**。
+
+读者假设为初级开发者或 AI agent，术语尽量展开。
+
+## 2. Goals
+
+- 提供工具级准入控制：`--allowed-tools`（白名单）与 `--disallowed-tools`（黑名单），补齐 `--no-tools` 之外的中间态。
+- 黑名单优先于白名单：同一工具同时出现在两侧时，**拒绝**胜出（fail-closed）。
+- 工具名匹配**大小写不敏感**，让 Claude Code 习惯的 `Read` / `Bash` 写法能直接命中 pigo 的 `read` / `bash`。
+- 白名单是**硬边界**：`--approve` 只能免掉确认弹窗，不能让边界外的工具运行。
+- 拼错工具名**立即报错退出**，绝不静默忽略——静默忽略会制造"我以为限制住了"的错觉。
+- 复用现有 `filterToolsByName`，不新造平行机制。
+- 支持 `config.toml` 声明默认边界，遵循既有 CLI > 文件 > 默认 的精度覆盖。
+
+## 3. User Stories
+
+### US-001: 注册两个 CLI 参数并解析多种输入形式
+**Description:** As a pigo 用户, I want 用 `--allowed-tools` / `--disallowed-tools` 在命令行声明工具边界 so that 我能在不改配置文件的前提下按次收紧本次运行的权限。
+
+**Acceptance Criteria:**
+- [ ] `cliOptions` 新增 `allowedTools []string` 与 `disallowedTools []string` 两个字段，带说明其语义与优先级的注释
+- [ ] 用 `flag.StringArrayVar` 注册 `--allowed-tools` 与 `--disallowed-tools`（无短选项，避免与现有 `-a`/`-n` 冲突）
+- [ ] 参数**可重复**：`--allowed-tools read --allowed-tools grep` 等价于两项
+- [ ] 单个参数值支持**逗号分隔**：`--allowed-tools "read,grep"` 解析为两项
+- [ ] 逗号切分后逐项 `TrimSpace`，空串项被丢弃：`--allowed-tools "read, ,grep"` 得到 `[read grep]`
+- [ ] `pigo --help` 中两个参数各有一行说明，写明"黑名单优先"
+- [ ] 单元测试覆盖：单值、重复传参、逗号形式、混合形式、含空白与空项
+- [ ] `go build ./...` 与 `go test ./cmd/...` 通过
+
+### US-002: 工具名规范化与未知名校验
+**Description:** As a pigo 用户, I want 写 `Read` 也能命中内置的 `read`、写错名字时立刻收到报错 so that 我不会因为大小写或拼写问题得到一个"看起来限制住了、其实没限住"的会话。
+
+**Acceptance Criteria:**
+- [ ] 新增纯函数完成规范化：对输入工具名做 `TrimSpace` + `strings.ToLower`
+- [ ] 校验发生在**工具集组装完成之后**（此时才知道全量可用工具名，含 MCP / 子 Agent / 插件工具）
+- [ ] 任一 `--allowed-tools` / `--disallowed-tools` 项不在可用工具名集合中时，向 stderr 打印 `pigo: --allowed-tools: unknown tool "xxx" (available: ...)` 并 `os.Exit(2)`
+- [ ] 报错信息列出全部可用工具名，便于用户自我纠正
+- [ ] 多个未知名时一次性全部列出，而非报第一个就退出
+- [ ] 单元测试覆盖：大小写变体命中、未知名报错、多个未知名合并报错、空列表不校验
+- [ ] Typecheck/lint 通过
+
+### US-003: 工具集过滤（黑名单优先）
+**Description:** As a pigo 用户, I want 声明的边界真正作用到交给模型的工具清单上 so that 模型连边界外工具的存在都感知不到。
+
+**Acceptance Criteria:**
+- [ ] 新增纯函数 `ApplyToolPolicy(tools []agentcore.AgentTool, allow, deny []string) []agentcore.AgentTool`，位于工具组装所在包
+- [ ] `allow` 非空时只保留名字（规范化后）在 `allow` 中的工具；`allow` 为空表示"不限制"
+- [ ] `deny` 非空时移除名字在 `deny` 中的工具，**且在 allow 之后执行**——同名同时出现在两侧时工具被移除
+- [ ] 两者都为空时返回原切片，行为与当前完全一致（零回归）
+- [ ] 与 `--no-tools` 组合：`--no-tools` 仍是全局优先，工具集为空时本过滤是 no-op
+- [ ] 过滤后工具集为空时向 stderr 打印一行警告（不退出），提示模型将无工具可用
+- [ ] 单元测试覆盖：纯白名单、纯黑名单、两者交叠、两者都空、过滤到空集
+- [ ] Typecheck/lint 通过
+
+### US-004: 接入主会话的三条运行路径
+**Description:** As a pigo 用户, I want 无论用 TUI、REPL 还是无头 `-p` 模式，边界都同样生效 so that 我不会因为换了个前端就意外获得更大权限。
+
+**Acceptance Criteria:**
+- [ ] `allowedTools` / `disallowedTools` 从 `cliOptions` 透传进 `dispatch`，再进入三条路径共用的工具组装点
+- [ ] TUI 路径生效：会话构建时的工具注册表已被过滤
+- [ ] REPL 路径（`--no-tui` 或非 TTY）生效
+- [ ] 无头 `-p` 路径生效
+- [ ] 三条路径共用同一个过滤调用点（不复制粘贴三份逻辑）
+- [ ] 集成测试或表驱动测试断言：三条路径在相同参数下得到相同的工具名集合
+- [ ] Typecheck/lint 通过
+
+### US-005: `read` 被屏蔽时不注入 `<available_skills>`
+**Description:** As a pigo 用户, I want 屏蔽 `read` 后系统提示里不再宣传技能 so that 模型不会去调用它根本加载不了的技能。
+
+**Acceptance Criteria:**
+- [ ] 系统提示构建时的 `ReadToolAvailable` 判定（`internal/runtime/prompt.go:61`）基于**过滤后**的工具集，而非过滤前
+- [ ] `--disallowed-tools read` 时 `<available_skills>` 块不出现在系统提示中
+- [ ] `--allowed-tools bash`（不含 read）时同样不出现
+- [ ] 现有测试 `TestBuildSystemPromptInjectsSkills`（`internal/runtime/prompt_test.go:230`）仍通过
+- [ ] 新增测试：过滤掉 read 后断言提示中无 `available_skills`
+- [ ] Typecheck/lint 通过
+
+### US-006: 白名单是硬边界，`--approve` 不得绕过
+**Description:** As a pigo 用户, I want `--approve` 只免掉确认弹窗、不能放行边界外的工具 so that 我的白名单是真实的安全边界而不是心理安慰。
+
+**Acceptance Criteria:**
+- [ ] `--allowed-tools read --approve` 时 `bash` / `write` / `edit` 均不在工具集中，模型无法调用
+- [ ] `--disallowed-tools bash --approve` 时 `bash` 不在工具集中
+- [ ] 边界内的副作用工具（如 `--allowed-tools write --approve`）仍按 `--approve` 语义免逐次确认——两个机制正交，互不削弱
+- [ ] 因为过滤发生在工具注册层、早于 `BeforeToolCall` 确认门（`internal/agenttool/tool_executor.go:109`），所以"绕过"在架构上不可能，而非靠运行时检查兜住
+- [ ] 测试断言上述三种组合的最终工具名集合
+- [ ] README 明确写出这条优先级关系
+- [ ] Typecheck/lint 通过
+
+### US-007: config.toml 支持默认边界
+**Description:** As a pigo 用户, I want 在 `config.toml` 里声明常用边界 so that 我不必每次敲一长串命令行参数。
+
+**Acceptance Criteria:**
+- [ ] `FileConfig`（`internal/cli/config/config.go:30`）新增 `AllowedTools []string \`toml:"allowed_tools"\`` 与 `DisallowedTools []string \`toml:"disallowed_tools"\``
+- [ ] `applyFileConfig`（`cmd/pigo/main.go` 内）遵循既有精度覆盖：仅当对应 flag 未被显式传入（`changed("allowed-tools")` 为 false）时才用文件值
+- [ ] CLI 传入时**整体替换**文件值，而非与文件值合并——合并语义会让"我想放宽"变成"放不宽"
+- [ ] 配置缺失（零值）时行为与当前完全一致
+- [ ] `config.toml.example` 补上两个键的注释示例，说明黑名单优先
+- [ ] 单元测试参照 `TestApplyFileConfig_FillsUnsetFlags` / `TestApplyFileConfig_CLIWins`（`cmd/pigo/main_test.go:179,225`）的模式，覆盖填充与 CLI 优先两种情形
+- [ ] Typecheck/lint 通过
+
+### US-008: 文档更新
+**Description:** As a pigo 用户, I want 在 README 和文档站查到这两个参数的准确语义 so that 我不必读源码去猜黑白名单谁优先。
+
+**Acceptance Criteria:**
+- [ ] README CLI 参数表（`README.md:155-171` 区域）新增两行
+- [ ] README「内置工具」章节（`README.md:260`）说明可用这两个参数做工具级准入，并列出全部合法工具名
+- [ ] README「项目信任」章节补一句：白名单是硬边界，`--approve` 只免确认、不放行边界外工具
+- [ ] `docs/web/features.html` 的参数说明同步新增两项
+- [ ] `CHANGELOG.md` 的 `## [Unreleased]` → `### Added` 补一条
+- [ ] 文档中明确声明**本期不支持** `Bash(git log:*)` 这类参数级匹配，写成该形式会被当作未知工具名报错
+
+## 4. Functional Requirements
+
+- FR-1: 系统必须提供 `--allowed-tools` 参数，接受工具名列表，声明模型可用工具的白名单。
+- FR-2: 系统必须提供 `--disallowed-tools` 参数，接受工具名列表，声明模型禁用工具的黑名单。
+- FR-3: 两个参数必须支持重复传入，多次传入的值累加。
+- FR-4: 两个参数的单个值必须支持逗号分隔，切分后逐项去除首尾空白，丢弃空项。
+- FR-5: 系统必须在匹配工具名时忽略大小写（输入与工具 `Name()` 均转小写后比较）。
+- FR-6: 当白名单非空时，系统必须只把名字命中白名单的工具交给模型。
+- FR-7: 当黑名单非空时，系统必须从工具集中移除名字命中黑名单的工具。
+- FR-8: 黑名单必须在白名单之后生效，使同名同时出现在两侧时该工具被移除。
+- FR-9: 当任一参数包含不存在的工具名时，系统必须向 stderr 报错并以退出码 2 终止。
+- FR-10: 报错信息必须一次性列出全部未知名，并附上当前全部可用工具名。
+- FR-11: 当两个参数均为空时，系统行为必须与本特性引入前完全一致。
+- FR-12: 过滤后工具集为空时，系统必须向 stderr 打印警告，但不终止运行。
+- FR-13: 过滤必须发生在工具注册层，早于 `BeforeToolCall` 确认门，使 `--approve` 在架构上无法放行边界外的工具。
+- FR-14: 过滤必须同等作用于 TUI、REPL、无头 `-p` 三条运行路径，且三者共用同一调用点。
+- FR-15: 系统提示的 `ReadToolAvailable` 判定必须基于过滤后的工具集，使 `read` 被屏蔽时不注入 `<available_skills>`。
+- FR-16: `FileConfig` 必须新增 `allowed_tools` 与 `disallowed_tools` 两个 TOML 键。
+- FR-17: 当对应命令行参数未被显式传入时，系统必须采用配置文件中的值；显式传入时命令行值整体替换文件值。
+- FR-18: 校验必须在工具集组装完成后执行，使 MCP / 子 Agent / 插件工具的名字也被纳入合法名集合。
+
+## 5. Non-Goals (Out of Scope)
+
+- **不支持参数级细粒度匹配**：`Bash(git log:*)`、`Read(src/**)` 这类 Claude Code 语法本期不做。它需要一套独立的参数匹配器，并且必须在 `BeforeToolCall` 层拦截调用参数而非在注册层过滤工具，是另一个量级的工程。本期写成该形式一律按未知工具名报错。
+- **不引入 `--permission-mode`**：`default` / `acceptEdits` / `bypassPermissions` / `plan` 这套模式概念不做，`--approve` 保持现状。
+- **不做环境变量入口**：不引入 `PIGO_ALLOWED_TOOLS`。
+- **不做 TUI 运行时切换**：不新增 `/tools` 斜杠命令，边界在进程启动时确定、整个会话不变。
+- **不改动技能层的 `allowed-tools`**：`internal/runtime/skills.go` 的技能 frontmatter 过滤保持原样，两者独立。本期不定义"CLI 边界与技能子 Agent 边界如何叠加"，因为子 Agent 从父工具集派生，天然继承 CLI 边界即可。
+- **不改动 hooks 机制**：`PreToolUse` hook 的拦截能力与本特性正交，不做整合。
+- **不改动 `SideEffectTools` 分类**：副作用工具的判定表保持原样。
+- **不做持久化的项目级边界**：不引入 `.pigo/` 项目层的工具边界配置，只做全局 `config.toml`。
+
+## 6. Design Considerations
+
+无 UI 变更，纯 CLI 与配置层。
+
+复用点：
+- `internal/runtime/skills.go:357` 的 `filterToolsByName` 已实现"空列表即不限制"的白名单语义，`ApplyToolPolicy` 的 allow 分支可直接复用其逻辑或以其为原型（注意它当前是大小写敏感的，本期需要不敏感版本）。
+- `internal/runtime/skills.go:96` 的 `stringList.UnmarshalYAML` 已实现"标量按逗号切分"的容错，FR-4 的 CLI 侧切分逻辑与它形状相同，可考虑提取共用的 `splitAndTrim` 辅助函数避免两处实现漂移。
+- 错误退出遵循 `--cwd` 的既有模式（`cmd/pigo/main.go:216-220`）：向 stderr 打印 `pigo: <flag>: <reason>` 后 `os.Exit(2)`。
+
+## 7. Technical Considerations
+
+**校验时序是关键约束。** 工具名合法性校验必须在工具集组装完成之后，因为合法名集合包含运行时才确定的工具（MCP 工具、子 Agent 工具、插件工具）。若在 `flag.Parse()` 之后立刻校验，会把合法的插件工具名误报为未知。这意味着 `os.Exit(2)` 的位置不在 `main`，而在三条路径共用的组装点之后——需要一个能把校验错误上抛到 `dispatch` 返回码的路径。
+
+**当前全部内置工具名**（供 FR-10 报错文案与文档使用）：
+
+`read`、`write`、`edit`、`grep`、`find`、`ls`、`bash`、`bash_output`、`kill_bash`、`todo`、`webfetch`、`websearch`、`memory_search`、`goal_complete`、`goal_blocked`
+
+注意 README 现有的工具表（`README.md:264-274`）只列了 9 个，缺 `ls`、`bash_output`、`kill_bash`、`memory_search`，以及仅在 goal 模式注册的 `goal_complete` / `goal_blocked`。US-008 补文档时需要处理这个既存缺口，并明确 goal 类工具是否属于可被边界约束的范围。
+
+**`--no-tools` 的交互。** `--no-tools` 使内置工具集为空（`internal/cli/run/run.go:67,77`），此时过滤是 no-op。但插件工具在 `--no-tools` 下也被跳过，所以两者组合的最终结果是空集，FR-12 的警告会触发——这是符合预期的，不应该额外特判。
+
+**已有的 `BuiltinToolsExcept`**（`internal/cli/run/run.go`，紧跟 `BuiltinTools`）是一个编译期调用方使用的排除辅助函数。它与本特性目标接近但入口不同（非用户可配）。实现时应评估是否能让 `ApplyToolPolicy` 与它归一，避免仓库里存在两套语义相近的过滤器。
+
+## 8. Success Metrics
+
+- `pigo --allowed-tools read -p "..."` 后模型的可用工具清单恰好为 `[read]`，可通过 `--output-format stream-json` 的事件流或调试输出核验。
+- `pigo --allowed-tools read,bash --disallowed-tools bash -p "..."` 后 `bash` 不可用（黑名单优先生效）。
+- `pigo --allowed-tools raed -p "..."`（拼错）退出码为 2，stderr 含 `unknown tool "raed"` 与可用名列表。
+- 不传任何新参数时，`go test ./...` 全绿，无行为回归。
+- `--allowed-tools read --approve` 下 `bash` / `write` / `edit` 均无法被调用。
+
+## 9. Open Questions
+
+以下三条在实现中已解决，保留结论备查：
+
+- **`goal_complete` / `goal_blocked` 是否可被屏蔽？** 已解决：**不可**，且无需特判。这两个工具由 `goalToolRegistry`（`internal/cli/goal/goal.go:274`）在 goal 运行时叠加到会话注册表之上，从不进入 `Env.Tools`。校验只认 `Env.Tools` 里的名字，所以 `--disallowed-tools goal_complete` 会得到"unknown tool"报错——恰好就是期望行为，goal 模式的收敛路径无法被用户误伤。
+- **子 Agent 是否继承边界？** 已解决：**继承**。`ChildToolSet`（`internal/cli/run/toolpolicy.go`）把策略应用到子工具集上，堵住了"让子 Agent 去跑 bash"这条逃逸路径。`TestChildToolSetInheritsPolicy` 锁死该行为。
+- **过滤后为空是否按 `--no-tools` 处理？** 已解决：**不特判**，只打警告。`hasReadTool` 自然返回 false，`<available_skills>` 自然不注入，无需额外分支。
+
+仍开放：
+
+- 是否需要 `pigo --list-tools` 之类的只读查询，让用户在不发起对话的前提下确认当前生效的工具集？本期未做。当前的验证方式是拼错一个名字，从报错信息里读出全部可用工具名——可用但迂回。
+- 进程隔离子 Agent（`--subagent-rpc`）当前从 RPC 的 `tools` 名单重建工具集，且 `run.BuiltinTools(cwd, false)` 不读 `--no-tools`。该模式在生产中未被任何代码路径启用（`SubAgentIsolationProcess` 无非测试引用），故本期未接入策略；若将来启用，需要把策略一并透传过 RPC 边界。
+
+
+


### PR DESCRIPTION
- 新增 toolpolicy 模块实现工具调用策略和允许列表机制
- 扩展 CLI 配置以支持工具白名单相关参数
- 更新主程序入口和测试用例以集成新策略功能
- 提供示例配置文件并完善文档说明