### PR TITLE
feat(provider): add Novita AI as a built-in provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,7 @@ git push origin v0.2.0
 | `huggingface` | `HF_TOKEN` | `https://router.huggingface.co/v1` | openai |
 | `fireworks` | `FIREWORKS_API_KEY` | `https://api.fireworks.ai/inference` | openai |
 | `together` | `TOGETHER_API_KEY` | `https://api.together.ai/v1` | openai |
+| `novita` | `NOVITA_API_KEY` | `https://api.novita.ai/openai/v1` | openai |
 | `opencode` | `OPENCODE_API_KEY` | `https://opencode.ai/zen` | openai |
 | `opencode-go` | `OPENCODE_API_KEY` | `https://opencode.ai/zen/go` | openai |
 | `kimi-coding` | `KIMI_API_KEY` | `https://api.kimi.com/coding` | openai |

--- a/internal/provider/presets.go
+++ b/internal/provider/presets.go
@@ -150,9 +150,9 @@ var PresetCatalog = []PresetModel{
 	{Provider: "together", ID: "meta-llama/Llama-3.3-70B-Instruct-Turbo", DisplayName: "Llama 3.3 70B Turbo (Together)"},
 
 	// --- Novita AI (OpenAI-compatible gateway; ids from novita.ai/docs/guides/llm-recommended) ---
-	{Provider: "novita", ID: "moonshotai/kimi-k3", DisplayName: "Kimi K3 (Novita)"},
+	{Provider: "novita", ID: "deepseek/deepseek-v4-pro", DisplayName: "DeepSeek V4 Pro (Novita)"},
 	{Provider: "novita", ID: "zai-org/glm-5.2", DisplayName: "GLM 5.2 (Novita)"},
-	{Provider: "novita", ID: "deepseek/deepseek-v4-flash-0731", DisplayName: "DeepSeek V4 Flash 0731 (Novita)"},
+	{Provider: "novita", ID: "moonshotai/kimi-k3", DisplayName: "Kimi K3 (Novita)"},
 
 	// --- MiniMax (Anthropic-protocol; ids from pi minimax.models.ts) ---
 	{Provider: "minimax", ID: "MiniMax-M2.7", DisplayName: "MiniMax-M2.7"},

--- a/internal/provider/presets.go
+++ b/internal/provider/presets.go
@@ -51,6 +51,7 @@ var PresetProviders = []struct {
 	{Name: "zai", EnvVar: "ZAI_API_KEY"},
 	{Name: "fireworks", EnvVar: "FIREWORKS_API_KEY"},
 	{Name: "together", EnvVar: "TOGETHER_API_KEY"},
+	{Name: "novita", EnvVar: "NOVITA_API_KEY"},
 	{Name: "minimax", EnvVar: "MINIMAX_API_KEY"},
 	{Name: "xiaomi", EnvVar: "XIAOMI_API_KEY"},
 	{Name: "qianfan", EnvVar: "QIANFAN_API_KEY"},
@@ -147,6 +148,11 @@ var PresetCatalog = []PresetModel{
 	{Provider: "together", ID: "deepseek-ai/DeepSeek-V4-Pro", DisplayName: "DeepSeek V4 Pro (Together)"},
 	{Provider: "together", ID: "Qwen/Qwen3.7-Max", DisplayName: "Qwen3.7 Max (Together)"},
 	{Provider: "together", ID: "meta-llama/Llama-3.3-70B-Instruct-Turbo", DisplayName: "Llama 3.3 70B Turbo (Together)"},
+
+	// --- Novita AI (OpenAI-compatible gateway; ids from novita.ai/docs/guides/llm-recommended) ---
+	{Provider: "novita", ID: "deepseek/deepseek-v4-pro", DisplayName: "DeepSeek V4 Pro (Novita)"},
+	{Provider: "novita", ID: "qwen/qwen3.5-397b-a17b", DisplayName: "Qwen3.5 397B (Novita)"},
+	{Provider: "novita", ID: "meta-llama/llama-3.1-8b-instruct", DisplayName: "Llama 3.1 8B (Novita)"},
 
 	// --- MiniMax (Anthropic-protocol; ids from pi minimax.models.ts) ---
 	{Provider: "minimax", ID: "MiniMax-M2.7", DisplayName: "MiniMax-M2.7"},

--- a/internal/provider/presets.go
+++ b/internal/provider/presets.go
@@ -150,9 +150,9 @@ var PresetCatalog = []PresetModel{
 	{Provider: "together", ID: "meta-llama/Llama-3.3-70B-Instruct-Turbo", DisplayName: "Llama 3.3 70B Turbo (Together)"},
 
 	// --- Novita AI (OpenAI-compatible gateway; ids from novita.ai/docs/guides/llm-recommended) ---
-	{Provider: "novita", ID: "deepseek/deepseek-v4-pro", DisplayName: "DeepSeek V4 Pro (Novita)"},
-	{Provider: "novita", ID: "qwen/qwen3.5-397b-a17b", DisplayName: "Qwen3.5 397B (Novita)"},
-	{Provider: "novita", ID: "meta-llama/llama-3.1-8b-instruct", DisplayName: "Llama 3.1 8B (Novita)"},
+	{Provider: "novita", ID: "moonshotai/kimi-k3", DisplayName: "Kimi K3 (Novita)"},
+	{Provider: "novita", ID: "zai-org/glm-5.2", DisplayName: "GLM 5.2 (Novita)"},
+	{Provider: "novita", ID: "deepseek/deepseek-v4-flash-0731", DisplayName: "DeepSeek V4 Flash 0731 (Novita)"},
 
 	// --- MiniMax (Anthropic-protocol; ids from pi minimax.models.ts) ---
 	{Provider: "minimax", ID: "MiniMax-M2.7", DisplayName: "MiniMax-M2.7"},

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -212,6 +212,13 @@ var providerRegistry = []ProviderSpec{
 		AuthScheme:     AuthBearer,
 	},
 	{
+		Name:           "novita",
+		EnvVars:        []string{"NOVITA_API_KEY"},
+		DefaultBaseURL: "https://api.novita.ai/openai/v1",
+		Protocol:       ProtocolOpenAI,
+		AuthScheme:     AuthBearer,
+	},
+	{
 		Name:           "opencode",
 		EnvVars:        []string{"OPENCODE_API_KEY"},
 		DefaultBaseURL: "https://opencode.ai/zen",

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -121,7 +121,7 @@ func TestRegistryContainsAllExpectedProviders(t *testing.T) {
 		"anthropic", "openai", "ant-ling", "deepseek", "nvidia", "google",
 		"groq", "cerebras", "xai", "openrouter", "vercel-ai-gateway", "zai",
 		"zai-coding-cn", "mistral", "minimax", "minimax-cn", "moonshotai",
-		"moonshotai-cn", "huggingface", "fireworks", "together", "opencode",
+		"moonshotai-cn", "huggingface", "fireworks", "together", "novita", "opencode",
 		"opencode-go", "kimi-coding", "xiaomi", "xiaomi-token-plan-cn",
 		"xiaomi-token-plan-ams", "xiaomi-token-plan-sgp",
 		"qianfan", "volcengine", "dashscope", "hunyuan",


### PR DESCRIPTION
## Summary

Adds Novita AI as a built-in OpenAI-compatible provider, following the existing pattern used for `groq`/`together`/`fireworks`/`cerebras` (plain OpenAI-compatible + Bearer auth, no special-auth branch).

## Changes

- `internal/provider/registry.go`: register `novita` (`NOVITA_API_KEY`, base URL `https://api.novita.ai/openai/v1`, OpenAI protocol, Bearer auth)
- `internal/provider/presets.go`: add preset entries for three current Novita models (DeepSeek V4 Pro, GLM 5.2, Kimi K3), ids sourced from novita.ai/docs/guides/llm-recommended
- `README.md`: add `novita` row to the built-in provider table
- `internal/provider/registry_test.go`: add `novita` to the expected-providers list

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` (32 packages) all pass
- `gofmt -l` clean on changed files
- `pigo --provider novita --model deepseek/deepseek-v4-pro --print 'Reply with OK.' --no-tools` succeeds against the live Novita API (HTTP 200, finish reason `length`, usage present)